### PR TITLE
Add repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "openai",
   "version": "2.0.0",
   "description": "Node.js library for the OpenAI API",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openai/openai-node.git"
+  },
   "keywords": [
     "openai",
     "open",


### PR DESCRIPTION
With the repository URL in package.json, people can access the repository from npm.