### PR TITLE
Remove $ from npm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The OpenAI Node.js library provides convenient access to the OpenAI API from Nod
 ## Installation
 
 ```bash
-$ npm install openai
+npm install openai
 ```
 
 ## Usage


### PR DESCRIPTION
It can be pretty annoying to use the built in copy command in Github and get the $ sign with the copy and end up with this in the terminal:

![Screenshot 2023-03-07 200317](https://user-images.githubusercontent.com/1312916/223539656-214539bf-3ae1-4a12-869a-b423fefb3ac4.png)
