### PR TITLE
Support instantiating with apiKey:string

### DIFF
--- a/base.ts
+++ b/base.ts
@@ -50,8 +50,11 @@ export interface RequestArgs {
 export class BaseAPI {
     protected configuration: Configuration | undefined;
 
-    constructor(configuration?: Configuration, protected basePath: string = BASE_PATH, protected axios: AxiosInstance = globalAxios) {
+    constructor(configuration?: Configuration | string, protected basePath: string = BASE_PATH, protected axios: AxiosInstance = globalAxios) {
         if (configuration) {
+            if ('string' == typeof configuration) {
+                configuration = new Configuration({ apiKey: configuration });
+            }
             this.configuration = configuration;
             this.basePath = configuration.basePath || this.basePath;
         }


### PR DESCRIPTION
Don't force users to instantiate a Configuration object if all they need to provide is the API key.

This reduces the kickstart code to:
```
const { OpenAIApi } = require("openai");

const openai = new OpenAIApi(process.env.OPENAI_API_KEY);

const completion = await openai.createCompletion({
  model: "text-davinci-003",
  prompt: "Hello world",
});

console.log(completion.data.choices[0].text);
```

I would also advise to export a default factory instead of a constructor, so that users can:


```
const openai = require('openai')(process.env.OPENAI_API_KEY)

```

LMK if you're interested