### PR TITLE
 Adding types for models accepted by OpenAI API endpoints

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -26,9 +26,9 @@ import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError } from './base';
 
 /**
  * @export
- * @type {CreateCompletionRequestModal}
+ * @type {CreateCompletionRequestModel}
  */
-export type CreateCompletionRequestModal =
+export type CreateCompletionRequestModel =
   | "text-davinci-003"
   | "text-davinci-002"
   | "text-curie-001"
@@ -41,17 +41,17 @@ export type CreateCompletionRequestModal =
 
 /**
  * @export
- * @type {CreateEditRequestModal}
+ * @type {CreateEditRequestModel}
  */
-export type CreateEditRequestModal =
+export type CreateEditRequestModel =
   | "text-davinci-edit-001"
   | "code-davinci-edit-001";
 
 /**
  * @export
- * @type {CreateChatCompletionRequestModal}
+ * @type {CreateChatCompletionRequestModel}
  */
-export type CreateChatCompletionRequestModal =
+export type CreateChatCompletionRequestModel =
   | "gpt-4"
   | "gpt-4-0314"
   | "gpt-4-32k"
@@ -61,9 +61,9 @@ export type CreateChatCompletionRequestModal =
 
 /**
  * @export
- * @type {CreateFineTuneRequestModal}
+ * @type {CreateFineTuneRequestModel}
  */
-export type CreateFineTuneRequestModal =
+export type CreateFineTuneRequestModel =
   | "davinci"
   | "curie"
   | "babbage"
@@ -71,31 +71,31 @@ export type CreateFineTuneRequestModal =
 
 /**
  * @export
- * @type {CreateEmbeddingRequestModal}
+ * @type {CreateEmbeddingRequestModel}
  */
-export type CreateEmbeddingRequestModal =
+export type CreateEmbeddingRequestModel =
   | "text-embedding-ada-002"
   | "text-search-ada-doc-001";
 
 /**
  * @export
- * @type {CreateModerationRequestModal}
+ * @type {CreateModerationRequestModel}
  */
-export type CreateModerationRequestModal =
+export type CreateModerationRequestModel =
   | "text-moderation-stable"
   | "text-moderation-latest";
 
 /**
  * @export
- * @type {CreateTranscriptionRequestModal}
+ * @type {CreateTranscriptionRequestModel}
  */
-export type CreateTranscriptionRequestModal = "whisper-1";
+export type CreateTranscriptionRequestModel = "whisper-1";
 
 /**
  * @export
- * @type {CreateTranslationRequestModal}
+ * @type {CreateTranslationRequestModel}
  */
-export type CreateTranslationRequestModal = "whisper-1";
+export type CreateTranslationRequestModel = "whisper-1";
 
 
 /**
@@ -355,7 +355,7 @@ export interface CreateChatCompletionRequest {
      * @type {string}
      * @memberof CreateChatCompletionRequest
      */
-    'model': CreateChatCompletionRequestModal;
+    'model': CreateChatCompletionRequestModel;
     /**
      * The messages to generate chat completions for, in the [chat format](/docs/guides/chat/introduction).
      * @type {Array<ChatCompletionRequestMessage>}
@@ -668,7 +668,7 @@ export interface CreateCompletionRequest {
      * @type {string}
      * @memberof CreateCompletionRequest
      */
-    'model': CreateCompletionRequestModal;
+    'model': CreateCompletionRequestModel;
     /**
      * 
      * @type {CreateCompletionRequestPrompt}
@@ -915,7 +915,7 @@ export interface CreateEditRequest {
      * @type {string}
      * @memberof CreateEditRequest
      */
-    'model': CreateEditRequestModal;
+    'model': CreateEditRequestModel;
     /**
      * The input text to use as a starting point for the edit.
      * @type {string}
@@ -989,7 +989,7 @@ export interface CreateEmbeddingRequest {
      * @type {string}
      * @memberof CreateEmbeddingRequest
      */
-    'model': CreateEmbeddingRequestModal;
+    'model': CreateEmbeddingRequestModel;
     /**
      * 
      * @type {CreateEmbeddingRequestInput}
@@ -1108,7 +1108,7 @@ export interface CreateFineTuneRequest {
      * @type {string}
      * @memberof CreateFineTuneRequest
      */
-    'model'?: CreateFineTuneRequestModal | null;
+    'model'?: CreateFineTuneRequestModel | null;
     /**
      * The number of epochs to train the model for. An epoch refers to one full cycle through the training dataset. 
      * @type {number}
@@ -1233,7 +1233,7 @@ export interface CreateModerationRequest {
      * @type {string}
      * @memberof CreateModerationRequest
      */
-    'model'?: CreateModerationRequestModal;
+    'model'?: CreateModerationRequestModel;
 }
 /**
  * @type CreateModerationRequestInput
@@ -2527,7 +2527,7 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createTranscription: async (file: File, model: CreateTranscriptionRequestModal, prompt?: string, responseFormat?: string, temperature?: number, language?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createTranscription: async (file: File, model: CreateTranscriptionRequestModel, prompt?: string, responseFormat?: string, temperature?: number, language?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'file' is not null or undefined
             assertParamExists('createTranscription', 'file', file)
             // verify required parameter 'model' is not null or undefined
@@ -2594,7 +2594,7 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createTranslation: async (file: File, model: CreateTranslationRequestModal, prompt?: string, responseFormat?: string, temperature?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createTranslation: async (file: File, model: CreateTranslationRequestModel, prompt?: string, responseFormat?: string, temperature?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'file' is not null or undefined
             assertParamExists('createTranslation', 'file', file)
             // verify required parameter 'model' is not null or undefined

--- a/api.ts
+++ b/api.ts
@@ -23,6 +23,81 @@ import type { RequestArgs } from './base';
 // @ts-ignore
 import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError } from './base';
 
+
+/**
+ * @export
+ * @type {CreateCompletionRequestModal}
+ */
+export type CreateCompletionRequestModal =
+  | "text-davinci-003"
+  | "text-davinci-002"
+  | "text-curie-001"
+  | "text-babbage-001"
+  | "text-ada-001"
+  | "davinci"
+  | "curie"
+  | "babbage"
+  | "ada";
+
+/**
+ * @export
+ * @type {CreateEditRequestModal}
+ */
+export type CreateEditRequestModal =
+  | "text-davinci-edit-001"
+  | "code-davinci-edit-001";
+
+/**
+ * @export
+ * @type {CreateChatCompletionRequestModal}
+ */
+export type CreateChatCompletionRequestModal =
+  | "gpt-4"
+  | "gpt-4-0314"
+  | "gpt-4-32k"
+  | "gpt-4-32k-0314"
+  | "gpt-3.5-turbo"
+  | "gpt-3.5-turbo-0301";
+
+/**
+ * @export
+ * @type {CreateFineTuneRequestModal}
+ */
+export type CreateFineTuneRequestModal =
+  | "davinci"
+  | "curie"
+  | "babbage"
+  | "ada";
+
+/**
+ * @export
+ * @type {CreateEmbeddingRequestModal}
+ */
+export type CreateEmbeddingRequestModal =
+  | "text-embedding-ada-002"
+  | "text-search-ada-doc-001";
+
+/**
+ * @export
+ * @type {CreateModerationRequestModal}
+ */
+export type CreateModerationRequestModal =
+  | "text-moderation-stable"
+  | "text-moderation-latest";
+
+/**
+ * @export
+ * @type {CreateTranscriptionRequestModal}
+ */
+export type CreateTranscriptionRequestModal = "whisper-1";
+
+/**
+ * @export
+ * @type {CreateTranslationRequestModal}
+ */
+export type CreateTranslationRequestModal = "whisper-1";
+
+
 /**
  * 
  * @export
@@ -280,7 +355,7 @@ export interface CreateChatCompletionRequest {
      * @type {string}
      * @memberof CreateChatCompletionRequest
      */
-    'model': string;
+    'model': CreateChatCompletionRequestModal;
     /**
      * The messages to generate chat completions for, in the [chat format](/docs/guides/chat/introduction).
      * @type {Array<ChatCompletionRequestMessage>}
@@ -593,7 +668,7 @@ export interface CreateCompletionRequest {
      * @type {string}
      * @memberof CreateCompletionRequest
      */
-    'model': string;
+    'model': CreateCompletionRequestModal;
     /**
      * 
      * @type {CreateCompletionRequestPrompt}
@@ -840,7 +915,7 @@ export interface CreateEditRequest {
      * @type {string}
      * @memberof CreateEditRequest
      */
-    'model': string;
+    'model': CreateEditRequestModal;
     /**
      * The input text to use as a starting point for the edit.
      * @type {string}
@@ -914,7 +989,7 @@ export interface CreateEmbeddingRequest {
      * @type {string}
      * @memberof CreateEmbeddingRequest
      */
-    'model': string;
+    'model': CreateEmbeddingRequestModal;
     /**
      * 
      * @type {CreateEmbeddingRequestInput}
@@ -1033,7 +1108,7 @@ export interface CreateFineTuneRequest {
      * @type {string}
      * @memberof CreateFineTuneRequest
      */
-    'model'?: string | null;
+    'model'?: CreateFineTuneRequestModal | null;
     /**
      * The number of epochs to train the model for. An epoch refers to one full cycle through the training dataset. 
      * @type {number}
@@ -1158,7 +1233,7 @@ export interface CreateModerationRequest {
      * @type {string}
      * @memberof CreateModerationRequest
      */
-    'model'?: string;
+    'model'?: CreateModerationRequestModal;
 }
 /**
  * @type CreateModerationRequestInput
@@ -2452,7 +2527,7 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createTranscription: async (file: File, model: string, prompt?: string, responseFormat?: string, temperature?: number, language?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createTranscription: async (file: File, model: CreateTranscriptionRequestModal, prompt?: string, responseFormat?: string, temperature?: number, language?: string, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'file' is not null or undefined
             assertParamExists('createTranscription', 'file', file)
             // verify required parameter 'model' is not null or undefined
@@ -2519,7 +2594,7 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createTranslation: async (file: File, model: string, prompt?: string, responseFormat?: string, temperature?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        createTranslation: async (file: File, model: CreateTranslationRequestModal, prompt?: string, responseFormat?: string, temperature?: number, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'file' is not null or undefined
             assertParamExists('createTranslation', 'file', file)
             // verify required parameter 'model' is not null or undefined
@@ -3993,5 +4068,3 @@ export class OpenAIApi extends BaseAPI {
         return OpenAIApiFp(this.configuration).retrieveModel(model, options).then((request) => request(this.axios, this.basePath));
     }
 }
-
-

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -16,9 +16,9 @@ import { BaseAPI } from './base';
 
 /**
  * @export
- * @type {CreateCompletionRequestModal}
+ * @type {CreateCompletionRequestModel}
  */
-export type CreateCompletionRequestModal =
+export type CreateCompletionRequestModel =
   | "text-davinci-003"
   | "text-davinci-002"
   | "text-curie-001"
@@ -31,17 +31,17 @@ export type CreateCompletionRequestModal =
 
 /**
  * @export
- * @type {CreateEditRequestModal}
+ * @type {CreateEditRequestModel}
  */
-export type CreateEditRequestModal =
+export type CreateEditRequestModel =
   | "text-davinci-edit-001"
   | "code-davinci-edit-001";
 
 /**
  * @export
- * @type {CreateChatCompletionRequestModal}
+ * @type {CreateChatCompletionRequestModel}
  */
-export type CreateChatCompletionRequestModal =
+export type CreateChatCompletionRequestModel =
   | "gpt-4"
   | "gpt-4-0314"
   | "gpt-4-32k"
@@ -51,9 +51,9 @@ export type CreateChatCompletionRequestModal =
 
 /**
  * @export
- * @type {CreateFineTuneRequestModal}
+ * @type {CreateFineTuneRequestModel}
  */
-export type CreateFineTuneRequestModal =
+export type CreateFineTuneRequestModel =
   | "davinci"
   | "curie"
   | "babbage"
@@ -61,31 +61,31 @@ export type CreateFineTuneRequestModal =
 
 /**
  * @export
- * @type {CreateEmbeddingRequestModal}
+ * @type {CreateEmbeddingRequestModel}
  */
-export type CreateEmbeddingRequestModal =
+export type CreateEmbeddingRequestModel =
   | "text-embedding-ada-002"
   | "text-search-ada-doc-001";
 
 /**
  * @export
- * @type {CreateModerationRequestModal}
+ * @type {CreateModerationRequestModel}
  */
-export type CreateModerationRequestModal =
+export type CreateModerationRequestModel =
   | "text-moderation-stable"
   | "text-moderation-latest";
 
 /**
  * @export
- * @type {CreateTranscriptionRequestModal}
+ * @type {CreateTranscriptionRequestModel}
  */
-export type CreateTranscriptionRequestModal = "whisper-1";
+export type CreateTranscriptionRequestModel = "whisper-1";
 
 /**
  * @export
- * @type {CreateTranslationRequestModal}
+ * @type {CreateTranslationRequestModel}
  */
-export type CreateTranslationRequestModal = "whisper-1";
+export type CreateTranslationRequestModel = "whisper-1";
 
 
 /**
@@ -338,7 +338,7 @@ export interface CreateChatCompletionRequest {
      * @type {string}
      * @memberof CreateChatCompletionRequest
      */
-    'model': CreateChatCompletionRequestModal;
+    'model': CreateChatCompletionRequestModel;
     /**
      * The messages to generate chat completions for, in the [chat format](/docs/guides/chat/introduction).
      * @type {Array<ChatCompletionRequestMessage>}
@@ -650,7 +650,7 @@ export interface CreateCompletionRequest {
      * @type {string}
      * @memberof CreateCompletionRequest
      */
-    'model': CreateCompletionRequestModal;
+    'model': CreateCompletionRequestModel;
     /**
      *
      * @type {CreateCompletionRequestPrompt}
@@ -895,7 +895,7 @@ export interface CreateEditRequest {
      * @type {string}
      * @memberof CreateEditRequest
      */
-    'model': CreateEditRequestModal;
+    'model': CreateEditRequestModel;
     /**
      * The input text to use as a starting point for the edit.
      * @type {string}
@@ -969,7 +969,7 @@ export interface CreateEmbeddingRequest {
      * @type {string}
      * @memberof CreateEmbeddingRequest
      */
-    'model': CreateEmbeddingRequestModal;
+    'model': CreateEmbeddingRequestModel;
     /**
      *
      * @type {CreateEmbeddingRequestInput}
@@ -1087,7 +1087,7 @@ export interface CreateFineTuneRequest {
      * @type {string}
      * @memberof CreateFineTuneRequest
      */
-    'model'?: CreateFineTuneRequestModal | null;
+    'model'?: CreateFineTuneRequestModel | null;
     /**
      * The number of epochs to train the model for. An epoch refers to one full cycle through the training dataset.
      * @type {number}
@@ -1208,7 +1208,7 @@ export interface CreateModerationRequest {
      * @type {string}
      * @memberof CreateModerationRequest
      */
-    'model'?: CreateModerationRequestModal;
+    'model'?: CreateModerationRequestModel;
 }
 /**
  * @type CreateModerationRequestInput
@@ -2296,7 +2296,7 @@ export declare const OpenAIApiFp: (configuration?: Configuration) => {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    createTranscription(file: File, model: CreateTranscriptionRequestModal, prompt?: string, responseFormat?: string, temperature?: number, language?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CreateTranscriptionResponse>>;
+    createTranscription(file: File, model: CreateTranscriptionRequestModel, prompt?: string, responseFormat?: string, temperature?: number, language?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CreateTranscriptionResponse>>;
     /**
      *
      * @summary Translates audio into into English.
@@ -2308,7 +2308,7 @@ export declare const OpenAIApiFp: (configuration?: Configuration) => {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    createTranslation(file: File, model: CreateTranslationRequestModal, prompt?: string, responseFormat?: string, temperature?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CreateTranslationResponse>>;
+    createTranslation(file: File, model: CreateTranslationRequestModel, prompt?: string, responseFormat?: string, temperature?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CreateTranslationResponse>>;
     /**
      *
      * @summary Delete a file.

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -13,6 +13,81 @@ import type { Configuration } from './configuration';
 import type { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
 import type { RequestArgs } from './base';
 import { BaseAPI } from './base';
+
+/**
+ * @export
+ * @type {CreateCompletionRequestModal}
+ */
+export type CreateCompletionRequestModal =
+  | "text-davinci-003"
+  | "text-davinci-002"
+  | "text-curie-001"
+  | "text-babbage-001"
+  | "text-ada-001"
+  | "davinci"
+  | "curie"
+  | "babbage"
+  | "ada";
+
+/**
+ * @export
+ * @type {CreateEditRequestModal}
+ */
+export type CreateEditRequestModal =
+  | "text-davinci-edit-001"
+  | "code-davinci-edit-001";
+
+/**
+ * @export
+ * @type {CreateChatCompletionRequestModal}
+ */
+export type CreateChatCompletionRequestModal =
+  | "gpt-4"
+  | "gpt-4-0314"
+  | "gpt-4-32k"
+  | "gpt-4-32k-0314"
+  | "gpt-3.5-turbo"
+  | "gpt-3.5-turbo-0301";
+
+/**
+ * @export
+ * @type {CreateFineTuneRequestModal}
+ */
+export type CreateFineTuneRequestModal =
+  | "davinci"
+  | "curie"
+  | "babbage"
+  | "ada";
+
+/**
+ * @export
+ * @type {CreateEmbeddingRequestModal}
+ */
+export type CreateEmbeddingRequestModal =
+  | "text-embedding-ada-002"
+  | "text-search-ada-doc-001";
+
+/**
+ * @export
+ * @type {CreateModerationRequestModal}
+ */
+export type CreateModerationRequestModal =
+  | "text-moderation-stable"
+  | "text-moderation-latest";
+
+/**
+ * @export
+ * @type {CreateTranscriptionRequestModal}
+ */
+export type CreateTranscriptionRequestModal = "whisper-1";
+
+/**
+ * @export
+ * @type {CreateTranslationRequestModal}
+ */
+export type CreateTranslationRequestModal = "whisper-1";
+
+
 /**
  *
  * @export
@@ -263,7 +338,7 @@ export interface CreateChatCompletionRequest {
      * @type {string}
      * @memberof CreateChatCompletionRequest
      */
-    'model': string;
+    'model': CreateChatCompletionRequestModal;
     /**
      * The messages to generate chat completions for, in the [chat format](/docs/guides/chat/introduction).
      * @type {Array<ChatCompletionRequestMessage>}
@@ -575,7 +650,7 @@ export interface CreateCompletionRequest {
      * @type {string}
      * @memberof CreateCompletionRequest
      */
-    'model': string;
+    'model': CreateCompletionRequestModal;
     /**
      *
      * @type {CreateCompletionRequestPrompt}
@@ -820,7 +895,7 @@ export interface CreateEditRequest {
      * @type {string}
      * @memberof CreateEditRequest
      */
-    'model': string;
+    'model': CreateEditRequestModal;
     /**
      * The input text to use as a starting point for the edit.
      * @type {string}
@@ -894,7 +969,7 @@ export interface CreateEmbeddingRequest {
      * @type {string}
      * @memberof CreateEmbeddingRequest
      */
-    'model': string;
+    'model': CreateEmbeddingRequestModal;
     /**
      *
      * @type {CreateEmbeddingRequestInput}
@@ -1012,7 +1087,7 @@ export interface CreateFineTuneRequest {
      * @type {string}
      * @memberof CreateFineTuneRequest
      */
-    'model'?: string | null;
+    'model'?: CreateFineTuneRequestModal | null;
     /**
      * The number of epochs to train the model for. An epoch refers to one full cycle through the training dataset.
      * @type {number}
@@ -1133,7 +1208,7 @@ export interface CreateModerationRequest {
      * @type {string}
      * @memberof CreateModerationRequest
      */
-    'model'?: string;
+    'model'?: CreateModerationRequestModal;
 }
 /**
  * @type CreateModerationRequestInput
@@ -2221,7 +2296,7 @@ export declare const OpenAIApiFp: (configuration?: Configuration) => {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    createTranscription(file: File, model: string, prompt?: string, responseFormat?: string, temperature?: number, language?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CreateTranscriptionResponse>>;
+    createTranscription(file: File, model: CreateTranscriptionRequestModal, prompt?: string, responseFormat?: string, temperature?: number, language?: string, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CreateTranscriptionResponse>>;
     /**
      *
      * @summary Translates audio into into English.
@@ -2233,7 +2308,7 @@ export declare const OpenAIApiFp: (configuration?: Configuration) => {
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    createTranslation(file: File, model: string, prompt?: string, responseFormat?: string, temperature?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CreateTranslationResponse>>;
+    createTranslation(file: File, model: CreateTranslationRequestModal, prompt?: string, responseFormat?: string, temperature?: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<CreateTranslationResponse>>;
     /**
      *
      * @summary Delete a file.


### PR DESCRIPTION
This pull request adds types for the models accepted by OpenAI API endpoints. By providing type annotations for these models, developers can more easily understand the structure of the data being passed to the API. Additionally, this will enable better error checking and help to prevent unexpected issues that could arise due to not knowing the available models.

The models were obtained from the OpenAI API documentation at the following [URL](https://platform.openai.com/docs/models/model-endpoint-compatibility)

I have created corresponding TypeScript types for accepted models for each endpoint, which have been added to the api.ts file in the root directory and api.d.ts in dist directory. The types have been named according to their corresponding endpoints, and all required fields have been included. 

Thank you for considering this pull request.