### PR TITLE
Compatibility with Azure Cognitive Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ All of the available API request functions additionally contain an optional fina
 ```javascript
 const completion = await openai.createCompletion(
   {
+    apiType: API_TYPE.Azure,
+    basePath: /** URL */,
     model: "text-davinci-003",
     prompt: "Hello world",
   },
@@ -57,6 +59,8 @@ API requests can potentially return errors due to invalid inputs or other issues
 ```javascript
 try {
   const completion = await openai.createCompletion({
+    apiType: API_TYPE.Azure,
+    basePath: /** URL */,    
     model: "text-davinci-003",
     prompt: "Hello world",
   });

--- a/api.ts
+++ b/api.ts
@@ -13,7 +13,7 @@
  */
 
 
-import type { Configuration } from './configuration';
+import { API_TYPE, Configuration } from './configuration';
 import type { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
 import globalAxios from 'axios';
 // Some imports not used depending on template conditions
@@ -1880,7 +1880,9 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -1914,9 +1916,11 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
-    
             localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -1950,9 +1954,11 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
-    
             localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -1986,10 +1992,12 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
-
-
-    
+            
             localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2014,18 +2022,17 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarPath = `/completions`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+            const baseOptions = configuration.baseOptions || {};
 
             const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
-    
             localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2045,6 +2052,9 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
          * @throws {RequiredError}
          */
         createEdit: async (createEditRequest: CreateEditRequest, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                throw new Error("This operation is not supported by the Azure OpenAI API yet.");
+            }
             // verify required parameter 'createEditRequest' is not null or undefined
             assertParamExists('createEdit', 'createEditRequest', createEditRequest)
             const localVarPath = `/edits`;
@@ -2059,9 +2069,8 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
-    
             localVarHeaderParameter['Content-Type'] = 'application/json';
+
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2095,9 +2104,11 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
-    
             localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2146,6 +2157,10 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
     
     
             localVarHeaderParameter['Content-Type'] = 'multipart/form-data';
+
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2179,9 +2194,11 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
-    
             localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2215,9 +2232,11 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
-    
             localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2291,6 +2310,10 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
     
     
             localVarHeaderParameter['Content-Type'] = 'multipart/form-data';
+
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2352,6 +2375,10 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
     
     
             localVarHeaderParameter['Content-Type'] = 'multipart/form-data';
+
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2385,9 +2412,11 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
-    
             localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2426,9 +2455,11 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
-    
             localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
 
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2497,6 +2528,10 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
     
     
             localVarHeaderParameter['Content-Type'] = 'multipart/form-data';
+
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2560,6 +2595,10 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
     
     
             localVarHeaderParameter['Content-Type'] = 'multipart/form-data';
+
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2594,7 +2633,9 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2628,7 +2669,9 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2662,7 +2705,9 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2693,7 +2738,9 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2723,7 +2770,9 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2792,7 +2841,9 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2822,7 +2873,9 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2857,7 +2910,9 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2891,7 +2946,9 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2925,7 +2982,9 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -2959,7 +3018,9 @@ export const OpenAIApiAxiosParamCreator = function (configuration?: Configuratio
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
 
-
+            if ([API_TYPE.Azure, API_TYPE.AzureAD].includes(configuration.apiType) ) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
     
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};

--- a/configuration.ts
+++ b/configuration.ts
@@ -127,7 +127,9 @@ export class Configuration {
 
                 break;
             }
-            case API_TYPE.AzureAD: {
+            case API_TYPE.AzureAD:
+            case API_TYPE.Azure:
+            {
                 this.baseOptions.headers = {
                     'api-key': this.apiKey,
                     ...this.baseOptions.headers,

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -9,7 +9,7 @@
  * https://openapi-generator.tech
  * Do not edit the class manually.
  */
-import type { Configuration } from './configuration';
+import { Configuration } from './configuration';
 import type { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
 import type { RequestArgs } from './base';
 import { BaseAPI } from './base';

--- a/dist/api.js
+++ b/dist/api.js
@@ -23,6 +23,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.OpenAIApi = exports.OpenAIApiFactory = exports.OpenAIApiFp = exports.OpenAIApiAxiosParamCreator = exports.CreateImageRequestResponseFormatEnum = exports.CreateImageRequestSizeEnum = exports.ChatCompletionResponseMessageRoleEnum = exports.ChatCompletionRequestMessageRoleEnum = void 0;
+const configuration_1 = require("./configuration");
 const axios_1 = require("axios");
 // Some imports not used depending on template conditions
 // @ts-ignore
@@ -75,6 +76,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarRequestOptions = Object.assign(Object.assign({ method: 'POST' }, baseOptions), options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -105,6 +109,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
             localVarHeaderParameter['Content-Type'] = 'application/json';
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -135,6 +142,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
             localVarHeaderParameter['Content-Type'] = 'application/json';
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -166,6 +176,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
             localVarHeaderParameter['Content-Type'] = 'application/json';
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -188,14 +201,14 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarPath = `/completions`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, common_1.DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+            const baseOptions = configuration.baseOptions || {};
             const localVarRequestOptions = Object.assign(Object.assign({ method: 'POST' }, baseOptions), options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
             localVarHeaderParameter['Content-Type'] = 'application/json';
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -213,6 +226,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
          * @throws {RequiredError}
          */
         createEdit: (createEditRequest, options = {}) => __awaiter(this, void 0, void 0, function* () {
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                throw new Error("This operation is not supported by the Azure OpenAI API yet.");
+            }
             // verify required parameter 'createEditRequest' is not null or undefined
             common_1.assertParamExists('createEdit', 'createEditRequest', createEditRequest);
             const localVarPath = `/edits`;
@@ -256,6 +272,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
             localVarHeaderParameter['Content-Type'] = 'application/json';
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -296,6 +315,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
                 localVarFormParams.append('purpose', purpose);
             }
             localVarHeaderParameter['Content-Type'] = 'multipart/form-data';
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), localVarFormParams.getHeaders()), headersFromBaseOptions), options.headers);
@@ -326,6 +348,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
             localVarHeaderParameter['Content-Type'] = 'application/json';
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -356,6 +381,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
             localVarHeaderParameter['Content-Type'] = 'application/json';
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -416,6 +444,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
                 localVarFormParams.append('user', user);
             }
             localVarHeaderParameter['Content-Type'] = 'multipart/form-data';
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), localVarFormParams.getHeaders()), headersFromBaseOptions), options.headers);
@@ -466,6 +497,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
                 localVarFormParams.append('user', user);
             }
             localVarHeaderParameter['Content-Type'] = 'multipart/form-data';
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), localVarFormParams.getHeaders()), headersFromBaseOptions), options.headers);
@@ -496,6 +530,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
             localVarHeaderParameter['Content-Type'] = 'application/json';
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -531,6 +568,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
             localVarHeaderParameter['Content-Type'] = 'application/json';
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -587,6 +627,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
                 localVarFormParams.append('language', language);
             }
             localVarHeaderParameter['Content-Type'] = 'multipart/form-data';
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), localVarFormParams.getHeaders()), headersFromBaseOptions), options.headers);
@@ -639,6 +682,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
                 localVarFormParams.append('temperature', temperature);
             }
             localVarHeaderParameter['Content-Type'] = 'multipart/form-data';
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), localVarFormParams.getHeaders()), headersFromBaseOptions), options.headers);
@@ -669,6 +715,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarRequestOptions = Object.assign(Object.assign({ method: 'DELETE' }, baseOptions), options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -698,6 +747,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarRequestOptions = Object.assign(Object.assign({ method: 'DELETE' }, baseOptions), options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -727,6 +779,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarRequestOptions = Object.assign(Object.assign({ method: 'GET' }, baseOptions), options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -753,6 +808,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarRequestOptions = Object.assign(Object.assign({ method: 'GET' }, baseOptions), options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -778,6 +836,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarRequestOptions = Object.assign(Object.assign({ method: 'GET' }, baseOptions), options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -836,6 +897,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarRequestOptions = Object.assign(Object.assign({ method: 'GET' }, baseOptions), options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -861,6 +925,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarRequestOptions = Object.assign(Object.assign({ method: 'GET' }, baseOptions), options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -891,6 +958,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarRequestOptions = Object.assign(Object.assign({ method: 'GET' }, baseOptions), options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -920,6 +990,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarRequestOptions = Object.assign(Object.assign({ method: 'GET' }, baseOptions), options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -949,6 +1022,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarRequestOptions = Object.assign(Object.assign({ method: 'GET' }, baseOptions), options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);
@@ -978,6 +1054,9 @@ exports.OpenAIApiAxiosParamCreator = function (configuration) {
             const localVarRequestOptions = Object.assign(Object.assign({ method: 'GET' }, baseOptions), options);
             const localVarHeaderParameter = {};
             const localVarQueryParameter = {};
+            if ([configuration_1.API_TYPE.Azure, configuration_1.API_TYPE.AzureAD].includes(configuration.apiType)) {
+                localVarQueryParameter['api-version'] = configuration.apiVersion;
+            }
             common_1.setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = Object.assign(Object.assign(Object.assign({}, localVarHeaderParameter), headersFromBaseOptions), options.headers);

--- a/dist/configuration.d.ts
+++ b/dist/configuration.d.ts
@@ -10,6 +10,7 @@
  * Do not edit the class manually.
  */
 export interface ConfigurationParameters {
+    apiType?: API_TYPE;
     apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
     organization?: string;
     username?: string;
@@ -17,9 +18,16 @@ export interface ConfigurationParameters {
     accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string) | ((name?: string, scopes?: string[]) => Promise<string>);
     basePath?: string;
     baseOptions?: any;
+    apiVersion?: any;
     formDataCtor?: new () => any;
 }
+export declare enum API_TYPE {
+    Azure = "azure",
+    OpenAi = "openai",
+    AzureAD = "azuread"
+}
 export declare class Configuration {
+    apiType?: API_TYPE;
     /**
      * parameter for apiKey security
      * @param name security name
@@ -68,6 +76,13 @@ export declare class Configuration {
      * @memberof Configuration
      */
     baseOptions?: any;
+    /**
+     * parameter for api version
+     *
+     * @type {any}
+     * @memberof Configuration
+     */
+    apiVersion?: any;
     /**
      * The FormData constructor that will be used to create multipart form data
      * requests. You can inject this here so that execution environments that

--- a/dist/configuration.js
+++ b/dist/configuration.js
@@ -13,10 +13,17 @@
  * Do not edit the class manually.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.Configuration = void 0;
+exports.Configuration = exports.API_TYPE = void 0;
 const packageJson = require("../package.json");
+var API_TYPE;
+(function (API_TYPE) {
+    API_TYPE["Azure"] = "azure";
+    API_TYPE["OpenAi"] = "openai";
+    API_TYPE["AzureAD"] = "azuread";
+})(API_TYPE = exports.API_TYPE || (exports.API_TYPE = {}));
 class Configuration {
     constructor(param = {}) {
+        this.apiType = param.apiType || API_TYPE.OpenAi;
         this.apiKey = param.apiKey;
         this.organization = param.organization;
         this.username = param.username;
@@ -24,11 +31,24 @@ class Configuration {
         this.accessToken = param.accessToken;
         this.basePath = param.basePath;
         this.baseOptions = param.baseOptions;
+        this.apiVersion = param.apiVersion;
         this.formDataCtor = param.formDataCtor;
         if (!this.baseOptions) {
             this.baseOptions = {};
         }
-        this.baseOptions.headers = Object.assign({ 'User-Agent': `OpenAI/NodeJS/${packageJson.version}`, 'Authorization': `Bearer ${this.apiKey}` }, this.baseOptions.headers);
+        switch (this.apiType) {
+            case API_TYPE.OpenAi: {
+                this.baseOptions.headers = Object.assign({ 'Authorization': `Bearer ${this.apiKey}` }, this.baseOptions.headers);
+                if (!this.apiVersion)
+                    throw new Error('Azure AD required apiVersion');
+                break;
+            }
+            case API_TYPE.AzureAD: {
+                this.baseOptions.headers = Object.assign({ 'api-key': this.apiKey }, this.baseOptions.headers);
+                break;
+            }
+        }
+        this.baseOptions.headers = Object.assign({ 'User-Agent': `OpenAI/NodeJS/${packageJson.version}` }, this.baseOptions.headers);
         if (this.organization) {
             this.baseOptions.headers['OpenAI-Organization'] = this.organization;
         }


### PR DESCRIPTION
compatibility with Azure Cognitive Services
- add enum APIType with Azure, AzureAD, OpenAI(default)
- add api-version in Path (Query search)
- set Authorization for OpenIA and api-key for Azure, AzureAD