### PR TITLE
Accessibility of 'on' property in the 'stream' type

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -16,6 +16,7 @@
 import type { Configuration } from './configuration';
 import type { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
 import globalAxios from 'axios';
+import type { Readable } from 'stream';
 // Some imports not used depending on template conditions
 // @ts-ignore
 import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
@@ -356,11 +357,18 @@ export interface CreateChatCompletionRequest {
 export type CreateChatCompletionRequestStop = Array<string> | string;
 
 /**
+ * @type ReadableChatStream
+ * Provide "on" property when using stream response type
+ */
+type ReadableChatStream = Omit<Readable, keyof Readable> & { on: Readable['on'] };
+
+/**
  * 
  * @export
  * @interface CreateChatCompletionResponse
+ * @extends ReadableChatStream
  */
-export interface CreateChatCompletionResponse {
+export interface CreateChatCompletionResponse extends ReadableChatStream{
     /**
      * 
      * @type {string}

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -9,8 +9,10 @@
  * https://openapi-generator.tech
  * Do not edit the class manually.
  */
+/// <reference types="node" />
 import type { Configuration } from './configuration';
 import type { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
+import type { Readable } from 'stream';
 import type { RequestArgs } from './base';
 import { BaseAPI } from './base';
 /**
@@ -338,11 +340,19 @@ export interface CreateChatCompletionRequest {
  */
 export declare type CreateChatCompletionRequestStop = Array<string> | string;
 /**
+ * @type ReadableChatStream
+ * Provide "on" property when using stream response type
+ */
+declare type ReadableChatStream = Omit<Readable, keyof Readable> & {
+    on: Readable['on'];
+};
+/**
  *
  * @export
  * @interface CreateChatCompletionResponse
+ * @extends ReadableChatStream
  */
-export interface CreateChatCompletionResponse {
+export interface CreateChatCompletionResponse extends ReadableChatStream {
     /**
      *
      * @type {string}
@@ -2866,3 +2876,4 @@ export declare class OpenAIApi extends BaseAPI {
      */
     retrieveModel(model: string, options?: AxiosRequestConfig): Promise<import("axios").AxiosResponse<Model, any>>;
 }
+export {};


### PR DESCRIPTION
This pull request aims to address the issue mentioned in #107. Credit goes to @SunghyunKwon for suggesting a solution to fix this bug.

Previously, when accessing the on property on data in the given code snippet:

```ts
completion.data.on('data', (data: Buffer) => {
  console.log(data.toString());
});
```

TypeScript would raise an error. However, with the changes proposed in this pull request, the TypeScript error will be resolved, allowing the code to compile successfully.