### PR TITLE
Fix ChatCompletionResponse type bug

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -125,7 +125,7 @@ export interface ChatCompletionResponseMessage {
      * @type {string}
      * @memberof ChatCompletionResponseMessage
      */
-    'content'?: string;
+    'content'?: string | null;
     /**
      * 
      * @type {ChatCompletionRequestMessageFunctionCall}


### PR DESCRIPTION
Fixed the types for `ChatCompletionResponseMessage` content field, which is sometimes coming back as null for requests with a function call in the response.

Actual response:
```
{
    "role": "assistant",
    "content": null,
    "function_call": {
        "name": "myFunctionName",
        "arguments": "{\n  \"input\": \"my input data\"\n}"
    }
}
```