### PR TITLE
Fix ERR_FR_MAX_BODY_LENGTH_EXCEEDED issue by setting default maxBodyLength

### DIFF
--- a/configuration.ts
+++ b/configuration.ts
@@ -102,6 +102,9 @@ export class Configuration {
             'Authorization': `Bearer ${this.apiKey}`,
             ...this.baseOptions.headers,
         }
+        if (this.baseOptions.maxBodyLength == null) {
+            this.baseOptions.maxBodyLength = 25 * 1024 * 1024; // 25MB
+        }
         if (this.organization) {
             this.baseOptions.headers['OpenAI-Organization'] = this.organization;
         }

--- a/dist/configuration.js
+++ b/dist/configuration.js
@@ -29,6 +29,9 @@ class Configuration {
             this.baseOptions = {};
         }
         this.baseOptions.headers = Object.assign({ 'User-Agent': `OpenAI/NodeJS/${packageJson.version}`, 'Authorization': `Bearer ${this.apiKey}` }, this.baseOptions.headers);
+        if (this.baseOptions.maxBodyLength == null) {
+            this.baseOptions.maxBodyLength = 25 * 1024 * 1024; // 25MB
+        }
         if (this.organization) {
             this.baseOptions.headers['OpenAI-Organization'] = this.organization;
         }


### PR DESCRIPTION
This PR addresses the issue [#167](https://github.com/openai/openai-node/issues/167), where a `ERR_FR_MAX_BODY_LENGTH_EXCEEDED` error is thrown when the `createTranscription` function is used with an audio file larger than 10 MB but smaller than 25 MB.

This is because the library uses `axios` which defaults to a 10 MB body limit. 

The issue is resolved by setting a default `maxBodyLength` of 25 MB if it is not already set. This ensures that the limit aligns with OpenAI's maximum file size limit.
