### PR TITLE
Refactor contentLength to use byteLength

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -129,7 +129,7 @@ export abstract class APIClient {
       isMultipartBody(options.body) ? options.body.body
       : options.body ? JSON.stringify(options.body, null, 2)
       : null;
-    const contentLength = typeof body === 'string' ? body.length.toString() : null;
+    const contentLength = typeof body === 'string' ? Buffer.byteLength(body).toString() : null;
 
     const url = this.buildURL(path!, query);
     if ('timeout' in options) validatePositiveInteger('timeout', options.timeout);


### PR DESCRIPTION
The contentLength was previously calculated from the string length property.

This does not account for multi-byte characters.

Thus we will get the following error when using unicode characters such as, ¿:
```sh
 Request body length does not match content-length header
```