### PR TITLE
Fix return type from openaiAPI.audio.transcriptions.create to include string

### DIFF
--- a/src/resources/audio/transcriptions.ts
+++ b/src/resources/audio/transcriptions.ts
@@ -9,7 +9,7 @@ export class Transcriptions extends APIResource {
   /**
    * Transcribes audio into the input language.
    */
-  create(body: TranscriptionCreateParams, options?: Core.RequestOptions): Core.APIPromise<Transcription> {
+  create(body: TranscriptionCreateParams, options?: Core.RequestOptions): Core.APIPromise<Transcription|string> {
     return this.post('/audio/transcriptions', multipartFormRequestOptions({ body, ...options }));
   }
 }


### PR DESCRIPTION
Depending on the response_format, the output can either be a json block that is represented by the Transcription interface or a string. For example if you use response_format: vtt

Repro:


```
// transcribe.ts
import { ClientOptions, OpenAI } from 'openai';
const OPEN_AI_CONFIG: ClientOptions = {
  apiKey: process.env.OPENAI_API_KEY,
  organization: process.env.OPENAI_ORGANIZATION_ID,
};

const openaiAPI = new OpenAI(OPEN_AI_CONFIG);

async function main() {
  const params: OpenAI.Audio.Transcriptions.TranscriptionCreateParams = {
      file: fs.createReadStream('/tmp/intput.mp4'),
      model: 'whisper-1',
      response_format: 'vtt',
      language: 'en',
  }
  const response = await openaiAPI.audio.transcriptions.create(
      params,
  );
  console.log(typeof response);
  console.log(response);
}
await main();
```

Outputs:

```
string
00:17:24.220 --> 00:17:30.780
Do you have any questions specifically on anything? I don't think so. The only thing I was gonna let
...
```