### PR TITLE
docs: add bun to list of runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,5 +276,6 @@ The following runtimes are supported:
   Deno Deploy is not yet supported.
 - Cloudflare Workers.
 - Vercel Edge Runtime.
+- Bun v0.8 or later
 
 If you are interested in other runtime environments, please open or upvote an issue on GitHub.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ To learn how to use the OpenAI API, check out our [API Reference](https://platfo
 npm install --save openai
 # or
 yarn add openai
+# or
+bun add openai
 ```
 
 ## Usage

--- a/bin/check-test-server
+++ b/bin/check-test-server
@@ -38,6 +38,9 @@ else
   echo -e "  With yarn:"
   echo -e "    \$ ${YELLOW}yarn global add @stoplight/prism-cli${NC}"
   echo
+  echo -e "  With Bun:"
+  echo -e "    \$ ${YELLOW}bun add --global @stoplight/prism-cli${NC}"
+  echo
   echo -e "2. Run the mock server"
   echo
   echo -e "  To run the server, pass in the path of your OpenAPI"

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -75,7 +75,7 @@ const projects = {
     await fs.copyFile(packFile, `./${TAR_NAME}`);
     await run('bun', ['install', '-D', `./${TAR_NAME}`]);
 
-    await run('npm', ['run', 'tsc']);
+    await run('bun', ['run', 'tsc']);
 
     if (state.live) {
       await run('bun', ['test']);


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Add Bun to list of runtimes
- Add instructions for Bun package manager
- Update existing Bun ecosystem test where `npm` is used instead of `bun`

## Additional context & links

The `openai` package is now fully supported in Bun: https://bun.sh/blog/bun-v0.8.0#use-openai-in-bun

