### PR TITLE
Add the default accept value for chat completions

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -190,7 +190,7 @@ export abstract class APIClient {
    */
   protected defaultHeaders(opts: FinalRequestOptions): Headers {
     return {
-      Accept: 'application/json',
+      Accept: 'application/json, text/plain, */*',
       'Content-Type': 'application/json',
       'User-Agent': this.getUserAgent(),
       ...getPlatformHeaders(),


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Add the default headers **Accept** for chat completions.

## Additional context & links

I found the stream requesting unavailable after upgrading from 3.x to 4.x. I checked both versions of the request header. And I found that the default Accept of version 3.x is "application/json, text/plain, */*", but the default in version 4.x is only "application/json".

![c99a93306d6fc403c2796f40940d9b1](https://github.com/openai/openai-node/assets/50446880/ec830ed8-3ced-4bcd-b208-0db77b21015e)

When I tried to rewrite the request header in 4.x, I found that the request completed successfully.

![image](https://github.com/openai/openai-node/assets/50446880/bcdd34c8-7132-4a3c-b8d9-15fbed0f2db6)

Of course, I am not requesting api.openapi.com directly, but I think this "Accept " value should be relaxed to make it compatible with more third-party systems.


