### PR TITLE
fix type for image_url

### DIFF
--- a/src/resources/chat/completions.ts
+++ b/src/resources/chat/completions.ts
@@ -285,7 +285,7 @@ export namespace ChatCompletionChunk {
 export type ChatCompletionContentPart = ChatCompletionContentPartText | ChatCompletionContentPartImage;
 
 export interface ChatCompletionContentPartImage {
-  image_url: ChatCompletionContentPartImage.ImageURL;
+  image_url: ChatCompletionContentPartImage.ImageURL | string
 
   /**
    * The type of the content part.


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
According to the official document, we can specify string url directory to the image_url for gpt-4-vision-preview.
So I made a PR to fix the type error

![スクリーンショット 2023-11-07 11 35 08](https://github.com/openai/openai-node/assets/1560508/cefa3cfe-4bee-42e4-b59e-ecf85564d509)

## Additional context & links
https://platform.openai.com/docs/guides/vision