### PR TITLE
fix: error TS7006: Parameter 'ctrl' implicitly has an 'any' type.

### DIFF
--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -184,7 +184,7 @@ export class Stream<Item> implements AsyncIterable<Item> {
       async start() {
         iter = self[Symbol.asyncIterator]();
       },
-      async pull(ctrl) {
+      async pull(ctrl: ReadableStreamDefaultController) {
         try {
           const { value, done } = await iter.next();
           if (done) return ctrl.close();


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
fix error TS7006: Parameter 'ctrl' implicitly has an 'any' type.
by applying the correct type

## Additional context & links
https://github.com/openai/openai-node/issues/422
