### PR TITLE
[github] Add a manual workflow to publish openai-deno-build

### DIFF
--- a/.github/workflows/publish-deno.yml
+++ b/.github/workflows/publish-deno.yml
@@ -11,6 +11,15 @@ jobs:
     environment: publish
 
     steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: 'openai'
+          repositories: 'openai-node,openai-deno-build'
+
       - uses: actions/checkout@v3
 
       - name: Set up Node
@@ -27,17 +36,9 @@ jobs:
         run: |
           yarn install
 
-      - name: Generate a token
-        id: generate_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - name: Publish to Deno
         run: |
           bash ./scripts/git-publish-deno.sh
         env:
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-          DENO_PUSH_REMOTE_URL: git@github.com:openai/openai-deno-build.git
+          DENO_PUSH_REMOTE_URL: https://username:${{ steps.generate_token.outputs.token }}@github.com/openai/openai-deno-build.git
           DENO_PUSH_BRANCH: main

--- a/.github/workflows/publish-deno.yml
+++ b/.github/workflows/publish-deno.yml
@@ -1,0 +1,43 @@
+# workflow for re-running publishing to Deno in case it fails for some reason
+# you can run this workflow by navigating to https://www.github.com/openai/openai-node/actions/workflows/publish-deno.yml
+name: Publish Deno
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    environment: publish
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Install dependencies
+        run: |
+          yarn install
+
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Publish to Deno
+        run: |
+          bash ./scripts/git-publish-deno.sh
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          DENO_PUSH_REMOTE_URL: git@github.com:openai/openai-deno-build.git
+          DENO_PUSH_BRANCH: main

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -8,6 +8,7 @@ jobs:
   publish:
     name: publish
     runs-on: ubuntu-latest
+    environment: publish
 
     steps:
       - uses: actions/checkout@v3
@@ -16,11 +17,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
-
-      - name: Set up Deno
-        uses: denoland/setup-deno@v1
-        with:
-          deno-version: v1.x
 
       - name: Install dependencies
         run: |
@@ -31,8 +27,3 @@ jobs:
           bash ./bin/publish-npm
         env:
           NPM_TOKEN: ${{ secrets.OPENAI_NPM_TOKEN || secrets.NPM_TOKEN }}
-
-      - name: Publish to Deno
-        run: |
-          bash ./scripts/git-publish-deno.sh
-        env: {}

--- a/scripts/git-publish-deno.sh
+++ b/scripts/git-publish-deno.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -exuo pipefail
 
-# This script pushes the contents of the `deno`` directory to the `deno` branch,
+# This script pushes the contents of the `deno` directory to the `deno` branch,
 # and creates a `vx.x.x-deno` tag, so that Deno users can
 # import OpenAI from "https://raw.githubusercontent.com/openai/openai-node/vx.x.x-deno/mod.ts"
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Adds a new GitHub workflow that can be run manually to publish the latest tag to the `openai-deno-build` repo. All pushes to that repo are published to `https://deno.land/x/openai`.

The publishing to the Deno repo will happen using the credentials of the newly set up ["OpenAI Open Source" GitHub App](https://github.com/apps/openai-open-source). I've added the secrets `APP_ID` and `APP_PRIVATE_KEY` to the `publish` environment.

I've tested this works by:
- Forking the `openai-node` and `openai-deno-build` repos
- Creating my own GitHub App that is installed in both
- Running the workflow, and confirming that the latest tag is pushed from the source repo to the destination repo

If this manual publishing step works correctly, I will update the `create-releases.yml` workflow to use the same steps to enable auto-publishing. To ensure we don't publish broken tags to `https://deno.land/x/openai`, I will disable webhooks on the `openai-deno-build` repo until I'm sure the publishing from `openai-node` to `openai-deno-build` works correctly.

## Additional context & links
