### PR TITLE
[github] Add Deno publish to autorelease script

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -12,6 +12,15 @@ jobs:
     environment: publish
 
     steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: 'openai'
+          repositories: 'openai-node,openai-deno-build'
+
       - uses: actions/checkout@v3
 
       - uses: stainless-api/trigger-release-please@v1
@@ -48,4 +57,6 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
         run: |
           bash ./scripts/git-publish-deno.sh
-        env: {}
+        env:
+          DENO_PUSH_REMOTE_URL: https://username:${{ steps.generate_token.outputs.token }}@github.com/openai/openai-deno-build.git
+          DENO_PUSH_BRANCH: main


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Adds publishing to `openai-deno-build` (and by proxy, `https://deno.land/x/openai`) a part of our release pipeline. This means every new release will automatically be published to Deno.

I tested this works by creating a [manual workflow](https://github.com/openai/openai-node/pull/516) to publish to Deno, and testing it [works](https://github.com/openai/openai-deno-build/commit/1371b3456e1ad2ae01a0efc6b7dad1f9a65a6c27).

## Additional context & links
