### PR TITLE
[github] Update Node version to 18 in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -33,7 +33,7 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Set up Deno
         if: ${{ steps.release.outputs.releases_created }}

--- a/.github/workflows/publish-deno.yml
+++ b/.github/workflows/publish-deno.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Set up Deno
         uses: denoland/setup-deno@v1

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Bumps Node to v18 (LTS) in our CI workflows. I think this will unblock running CI on https://github.com/openai/openai-node/pull/402 which requires Node 18.