### PR TITLE
added cleanObject to defaultHeaders

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -1019,6 +1019,31 @@ export function debug(action: string, ...args: any[]) {
   }
 }
 
+/** This function removes any properties that are undefined or empty string,
+ * This can be used with headers, as to not send empty header properties if there are any, 
+ * provided by the user.
+ */
+export function cleanObject<T>(options: T) {
+  const cleanedOptions: Partial<T> = {};
+  type keyType = keyof typeof options;
+
+  for (const key in options) {
+    if (Object.prototype.hasOwnProperty.call(options, key)) {
+      const value = options[key as keyType];
+
+      // Check if the value is not an empty string or undefined
+      if (
+        (typeof value != "undefined" && typeof value !== "string") ||
+        value !== ""
+      ) {
+        cleanedOptions[key as keyType] = value; // Copy non-empty properties to the cleaned object
+      }
+    }
+  }
+
+  return cleanedOptions;
+}
+
 /**
  * https://stackoverflow.com/a/2117523
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,11 +158,11 @@ export class OpenAI extends Core.APIClient {
   }
 
   protected override defaultHeaders(opts: Core.FinalRequestOptions): Core.Headers {
-    return {
+    return Core.cleanObject({
       ...super.defaultHeaders(opts),
       'OpenAI-Organization': this.organization,
       ...this._options.defaultHeaders,
-    };
+    });
   }
 
   protected override authHeaders(opts: Core.FinalRequestOptions): Core.Headers {


### PR DESCRIPTION
- [X] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
adding cleanObject to defaultHeaders,
this can help if people wants to remove header properties, from the configuration, by setting them to be empty string, or undefined. instead of it sending that useless value.

## Additional context & links
in my case, where i need it, is that i'm using a middle tool called langchainjs, which allows for setting defaultHeader as a property, but i can't reach the class to override that getDefaultHeader function.
and i want to delete headers like
X-stainless-* because they get blocked in some openai capable apis


Thanks for all the hardwork you put into this awsome tool