### PR TITLE
fix: invalid url error if env `OPENAI_BASE_URL` is empty string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ export class OpenAI extends Core.APIClient {
       apiKey,
       organization,
       ...opts,
-      baseURL: baseURL ?? `https://api.openai.com/v1`,
+      baseURL: baseURL?.trim() || `https://api.openai.com/v1`,
     };
 
     if (!options.dangerouslyAllowBrowser && Core.isRunningInBrowser()) {


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
