### PR TITLE
Fix Whisper non-json `response_format`

### DIFF
--- a/src/resources/audio/index.ts
+++ b/src/resources/audio/index.ts
@@ -2,5 +2,10 @@
 
 export { Audio } from './audio';
 export { SpeechCreateParams, Speech } from './speech';
-export { Transcription, TranscriptionCreateParams, Transcriptions } from './transcriptions';
-export { Translation, TranslationCreateParams, Translations } from './translations';
+export {
+  Transcription,
+  VerboseTranscription,
+  TranscriptionCreateParams,
+  Transcriptions,
+} from './transcriptions';
+export { Translation, VerboseTranslation, TranslationCreateParams, Translations } from './translations';

--- a/src/resources/audio/transcriptions.ts
+++ b/src/resources/audio/transcriptions.ts
@@ -4,18 +4,42 @@ import * as Core from 'openai/core';
 import { APIResource } from 'openai/resource';
 import * as TranscriptionsAPI from 'openai/resources/audio/transcriptions';
 import { type Uploadable, multipartFormRequestOptions } from 'openai/core';
+import { WhisperSegment } from './types';
 
 export class Transcriptions extends APIResource {
   /**
    * Transcribes audio into the input language.
    */
-  create(body: TranscriptionCreateParams, options?: Core.RequestOptions): Core.APIPromise<Transcription> {
+  create(
+    body: TranscriptionCreateParams & { response_format: 'json' },
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<Transcription>;
+  create(
+    body: TranscriptionCreateParams & { response_format: 'verbose_json' },
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<VerboseTranscription>;
+  create(
+    body: TranscriptionCreateParams & { response_format: 'srt' | 'text' | 'vtt' },
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<string>;
+  create(
+    body: TranscriptionCreateParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<Transcription | VerboseTranscription | string> {
     return this._client.post('/audio/transcriptions', multipartFormRequestOptions({ body, ...options }));
   }
 }
 
 export interface Transcription {
   text: string;
+}
+
+export interface VerboseTranscription extends Transcription {
+  text: string;
+  task: 'transcribe';
+  language: string;
+  duration: number;
+  segments: WhisperSegment[];
 }
 
 export interface TranscriptionCreateParams {

--- a/src/resources/audio/translations.ts
+++ b/src/resources/audio/translations.ts
@@ -4,18 +4,42 @@ import * as Core from 'openai/core';
 import { APIResource } from 'openai/resource';
 import * as TranslationsAPI from 'openai/resources/audio/translations';
 import { type Uploadable, multipartFormRequestOptions } from 'openai/core';
+import { WhisperSegment } from './types';
 
 export class Translations extends APIResource {
   /**
    * Translates audio into English.
    */
-  create(body: TranslationCreateParams, options?: Core.RequestOptions): Core.APIPromise<Translation> {
+  create(
+    body: TranslationCreateParams & { response_format: 'json' },
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<Translation>;
+  create(
+    body: TranslationCreateParams & { response_format: 'verbose_json' },
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<VerboseTranslation>;
+  create(
+    body: TranslationCreateParams & { response_format: 'srt' | 'text' | 'vtt' },
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<string>;
+  create(
+    body: TranslationCreateParams,
+    options?: Core.RequestOptions,
+  ): Core.APIPromise<Translation | VerboseTranslation | string> {
     return this._client.post('/audio/translations', multipartFormRequestOptions({ body, ...options }));
   }
 }
 
 export interface Translation {
   text: string;
+}
+
+export interface VerboseTranslation extends Translation {
+  text: string;
+  task: 'translate';
+  language: string;
+  duration: number;
+  segments: WhisperSegment[];
 }
 
 export interface TranslationCreateParams {

--- a/src/resources/audio/types.ts
+++ b/src/resources/audio/types.ts
@@ -1,0 +1,12 @@
+export interface WhisperSegment {
+  id: number;
+  seek: number;
+  start: number;
+  end: number;
+  text: string;
+  tokens: number[];
+  temperature: number;
+  avg_logprob: number;
+  compression_ratio: number;
+  no_speech_prob: number;
+}


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

I realized too late that these files are auto generated and I had already made the changes. Anyway, I think the PR describes the issue well. The output type is wrong for all `response_format` besides `json`. :(

## Additional context & links

`response_format: 'json'` should return this type: https://platform.openai.com/docs/api-reference/audio/json-object

`response_format: 'verbose_json'` should return this type: https://platform.openai.com/docs/api-reference/audio/verbose-json-object

the other response formats just return `string`
