### PR TITLE
docs: Fix incorrect use of stream api event

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ async function main() {
     stream: true,
   });
 
-  stream.on('chunk', (delta, snapshot) => {
-    process.stdout.write(delta.choices[0]?.delta?.content || '');
+  stream.on('chunk', (chunk, snapshot) => {
+    process.stdout.write(chunk.choices[0]?.delta?.content || '');
   });
 
   // or, equivalently:

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ async function main() {
     stream: true,
   });
 
-  stream.on('content', (delta, snapshot) => {
-    process.stdout.write(delta);
+  stream.on('chunk', (delta, snapshot) => {
+    process.stdout.write(chunk.choices[0]?.delta?.content || '');
   });
 
   // or, equivalently:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ async function main() {
   });
 
   stream.on('chunk', (delta, snapshot) => {
-    process.stdout.write(chunk.choices[0]?.delta?.content || '');
+    process.stdout.write(delta.choices[0]?.delta?.content || '');
   });
 
   // or, equivalently:


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ✓] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Update the use of stream API event
## Additional context & links
The example involved is about streaming response of Chat Completion, instead of Assistant.
As per https://github.com/openai/openai-node/blob/master/helpers.md#user-content-onchunk-chunk-chatcompletionchunk-snapshot-chatcompletionsnapshot---with-stream, the event "content" is for use with assistant API, while to obtain response chunk from Chat Completion API, "chunk" event should be used instead.
Also the "delta" object structure is different.