### PR TITLE
Add Verbose Transcription Object Return Type to Audio Transcription Endpoint

### DIFF
--- a/src/resources/audio/transcriptions.ts
+++ b/src/resources/audio/transcriptions.ts
@@ -9,7 +9,7 @@ export class Transcriptions extends APIResource {
   /**
    * Transcribes audio into the input language.
    */
-  create(body: TranscriptionCreateParams, options?: Core.RequestOptions): Core.APIPromise<Transcription> {
+  create(body: TranscriptionCreateParams, options?: Core.RequestOptions): Core.APIPromise<Transcription | TranscriptionVerboseJson> {
     return this._client.post('/audio/transcriptions', multipartFormRequestOptions({ body, ...options }));
   }
 }
@@ -23,6 +23,111 @@ export interface Transcription {
    * The transcribed text.
    */
   text: string;
+}
+
+/**
+ * Represents a verbose JSON transcription response returned by the model, based on the provided input.
+ */
+export interface TranscriptionVerboseJson {
+  /**
+   * The language of the input audio.
+   */
+  language: string;
+
+  /**
+   * The duration of the input audio.
+   */
+  duration: number;
+
+  /**
+   * The transcribed text.
+   */
+  text: string;
+
+  /**
+   * Extracted words and their corresponding timestamps.
+   */
+  words?: VerboseJsonWord[];
+
+  /**
+   * Segments of the transcribed text and their corresponding details.
+   */
+  segments?: VerboseJsonSegment[];
+}
+
+/**
+ * Represents a verbose JSON word object.
+ */
+interface VerboseJsonWord {
+  /**
+   * The text content of the word.
+   */
+  word: string;
+
+  /**
+   * Start time of the word in seconds.
+   */
+  start: number;
+
+  /**
+   * End time of the word in seconds.
+   */
+  end: number;
+}
+
+/**
+ * Represents a verbose JSON segment object.
+ */
+interface VerboseJsonSegment {
+  /**
+   * Unique identifier of the segment.
+   */
+  id: number;
+
+  /**
+   * Seek offset of the segment.
+   */
+  seek: number;
+
+  /**
+   * Start time of the segment in seconds.
+   */
+  start: number;
+
+  /**
+   * End time of the segment in seconds.
+   */
+  end: number;
+
+  /**
+   * Text content of the segment.
+   */
+  text: string;
+
+  /**
+   * Array of token IDs for the text content.
+   */
+  tokens: number[];
+
+  /**
+   * Temperature parameter used for generating the segment.
+   */
+  temperature: number;
+
+  /**
+   * Average logprob of the segment. If the value is lower than -1, consider the logprobs failed.
+   */
+  avg_logprob: number;
+
+  /**
+   * Compression ratio of the segment. If the value is greater than 2.4, consider the compression failed.
+   */
+  compression_ratio: number;
+
+  /**
+   * Probability of no speech in the segment. If the value is higher than 1.0 and the avg_logprob is below -1, consider this segment silent.
+   */
+  no_speech_prob: number;
 }
 
 export interface TranscriptionCreateParams {


### PR DESCRIPTION
Hello 👋,

I've made some enhancements to the OpenAI Node SDK, specifically around the audio transcription endpoint, which I believe will make it more useful and align it closer to the API's capabilities as documented. This pull request is in response to the need identified in issue #702.

### What's Changed
Based on the [API documentation for the audio transcription endpoint](https://platform.openai.com/docs/api-reference/audio/createTranscription), there are two potential return types: a "transcription object" or a "verbose transcription object." The latter was not previously represented in the SDK. To address this, I've added the "verbose transcription object" as a possible return type for the `create` function in the transcription service. The updated function signature now looks like this:

```javascript
create(body: TranscriptionCreateParams, options?: Core.RequestOptions): Core.APIPromise<Transcription | TranscriptionVerboseJson> {
    return this._client.post('/audio/transcriptions', multipartFormRequestOptions({ body, ...options }));
}
```

### Points of Discussion
There are a couple of observations worth discussing, see the link [API documentation for verbose_json transcription object](https://platform.openai.com/docs/api-reference/audio/verbose-json-object):

1. Language Attribute Type: The API documentation lists the "language" attribute of the "verbose transcription object" as a "string". However, considering consistency and ease of use, I propose using an enum based on the [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes) standard, which is already used in the request body of this endpoint. This change could enhance the SDK's type safety and usability.

2. Duration Attribute Type: The "duration" attribute is documented as a "string," but in practice, the endpoint always returns it as a "number." My code reflects this reality, defining "duration" as a "number" in the interface. This adjustment deviates from the documentation but aligns with the actual behavior observed from the API, thus improving the SDK's accuracy.

![image](https://github.com/openai/openai-node/assets/34600137/d983ee5e-4818-41ec-b96b-e7a6a0bb9533)

```typescript
/**
 * Represents a verbose JSON transcription response returned by the model, based on the provided input.
 */
export interface TranscriptionVerboseJson {
  /**
   * The language of the input audio.
   */
  language: string;

  /**
   * The duration of the input audio.
   */
  duration: number;

  /**
   * The transcribed text.
   */
  text: string;

  /**
   * Extracted words and their corresponding timestamps.
   */
  words?: VerboseJsonWord[];

  /**
   * Segments of the transcribed text and their corresponding details.
   */
  segments?: VerboseJsonSegment[];
}
```

### Conclusion
These enhancements aim to make the SDK more reflective of the API's capabilities and more user-friendly. I'm open to feedback on these changes, especially regarding the proposed shift from string to enum for the "language" attribute and the adjustment of the "duration" attribute's type.

This pull request resolves issue #702.

Thank you for considering these improvements!

Best,
[Wellington Rogati](https://github.com/wrogati)