### PR TITLE
[Azure] Fix AzureOpenAI export

### DIFF
--- a/scripts/utils/fix-index-exports.cjs
+++ b/scripts/utils/fix-index-exports.cjs
@@ -9,6 +9,6 @@ const indexJs =
 let before = fs.readFileSync(indexJs, 'utf8');
 let after = before.replace(
   /^\s*exports\.default\s*=\s*(\w+)/m,
-  'exports = module.exports = $1;\nexports.default = $1',
+  'exports = module.exports = $1;\nmodule.exports.AzureOpenAI = AzureOpenAI;\nexports.default = $1',
 );
 fs.writeFileSync(indexJs, after, 'utf8');


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
`AzureOpenAI` should be correctly exported. It is exported as part of the types but the runtime class is not exported:
![image](https://github.com/openai/openai-node/assets/6074665/b67e14d5-249c-41cb-baea-edba2af119cd)

EDIT: The PR also updates the type of the input `azureADTokenProvider` function to return a promise so the client can block until a token is requested and refreshed.

## Additional context & links
Currently, the exports in `src/index.ts` are being rewritten by a script to only export the `OpenAI` namespace. However, `AzureOpenAI` doesn't live in that namespace but still needs to be exported.