### PR TITLE
Added 'vision' to FileCreateParam purpose enum to support image files…

### DIFF
--- a/src/resources/files.ts
+++ b/src/resources/files.ts
@@ -194,7 +194,7 @@ export interface FileCreateParams {
    * [Batch API](https://platform.openai.com/docs/guides/batch), and "fine-tune" for
    * [Fine-tuning](https://platform.openai.com/docs/api-reference/fine-tuning).
    */
-  purpose: 'assistants' | 'batch' | 'fine-tune';
+  purpose: 'assistants' | 'batch' | 'fine-tune' | 'vision';
 }
 
 export interface FileListParams {


### PR DESCRIPTION
Added `vision` as a new purpose when uploading a new file to support images for assistant use as specified in the [documentation](https://platform.openai.com/docs/api-reference/files/create)
