### PR TITLE
fix(accumulateDelta): AssistantStream accumulateDelta toolCall (#771)

### DIFF
--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -686,6 +686,20 @@ export class AssistantStream
         if (accValue.every((x) => typeof x === 'string' || typeof x === 'number')) {
           accValue.push(...deltaValue); // Use spread syntax for efficient addition
           continue;
+        } else if (accValue.every((x) => Core.isObj(x))) {
+          deltaValue.forEach(item => {
+            if (item.hasOwnProperty('index')) {
+              const obj = accValue.find((x: any) => x['index'] === item['index']);
+              if (obj) {
+                accValue[accValue.indexOf(obj)] = this.accumulateDelta(obj, item);
+              } else {
+                accValue.push(item);
+              }
+            } else {
+              accValue.push(item);
+            }
+          });
+          continue;
         }
       } else {
         throw Error(`Unhandled record type: ${key}, deltaValue: ${deltaValue}, accValue: ${accValue}`);


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

One solution I see for this problem is to call openai.beta.threads.runs.retrieve.
This PR fixes this bug and allows multiple toolCalls to return, so that calls can be listened to in toolCallCreated and toolCallDone, thus avoiding polling retrieve and improving efficiency.
In addition, with this modification, users no longer need to manually assemble the arguments string, they only need to use function.arguments in callTool in the toolCallDone callback.
```js
stream.on("toolCallDone",async (toolCall) =>{
  console.log(toolCall.function.arguments)
})
```



## Additional context & links

#771 

https://community.openai.com/t/how-to-properly-handle-the-function-call-in-assistant-streaming-node-js/687193 
