### PR TITLE
Move @types/node and @types/node-fetch to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
     "fix": "eslint --fix --ext ts,js ."
   },
   "dependencies": {
-    "@types/node": "^18.11.18",
-    "@types/node-fetch": "^2.6.4",
     "abort-controller": "^3.0.0",
     "agentkeepalive": "^4.2.1",
     "form-data-encoder": "1.7.2",
@@ -37,6 +35,8 @@
     "@swc/core": "^1.3.102",
     "@swc/jest": "^0.2.29",
     "@types/jest": "^29.4.0",
+    "@types/node": "^18.11.18",
+    "@types/node-fetch": "^2.6.4",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",
     "eslint": "^8.49.0",


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Move `@types/node` and `@types/node-fetch` to `devDependencies`. These type modules are not required for the production build of applications using this library and should therefore be listed as `devDependencies` instead of `dependencies`.

## Additional context & links
Unnecessary inclusion of type modules in dependencies can lead to bloated production builds. By moving them to devDependencies, we can keep the production build leaner.