### PR TITLE
chore(azure): batch API is not a deployments endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -492,7 +492,6 @@ const _deployments_endpoints = new Set([
   '/audio/translations',
   '/audio/speech',
   '/images/generations',
-  '/batches',
 ]);
 
 const API_KEY_SENTINEL = '<Missing Key>';

--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -290,7 +290,7 @@ describe('azure request building', () => {
         fetch: testFetch,
       });
 
-      test('handles Batch', async () => {
+      test('handles batch', async () => {
         expect(
           await client.batches.create({
             completion_window: '24h',
@@ -298,7 +298,7 @@ describe('azure request building', () => {
             input_file_id: 'file-id',
           }),
         ).toStrictEqual({
-          url: `https://example.com/openai/deployments/${deployment}/batches?api-version=${apiVersion}`,
+          url: `https://example.com/openai/batches?api-version=${apiVersion}`,
         });
       });
 
@@ -423,7 +423,7 @@ describe('azure request building', () => {
         fetch: testFetch,
       });
 
-      test('Batch is not handled', async () => {
+      test('handles batch', async () => {
         expect(
           await client.batches.create({
             completion_window: '24h',


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Azure changed their mind and now the request path of the Batch API doesn't reference deployment names.

## Additional context & links
