### PR TITLE
fix: Added min and max length to `isAbsoluteUrl` regex

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -956,7 +956,7 @@ export const safeJSON = (text: string) => {
 };
 
 // https://stackoverflow.com/a/19709846
-const startsWithSchemeRegexp = new RegExp('^(?:[a-z]{1,50}+:)?//', 'i');
+const startsWithSchemeRegexp = new RegExp('^(?:[a-z]{1,50}:)?//', 'i');
 const isAbsoluteURL = (url: string): boolean => {
   return startsWithSchemeRegexp.test(url);
 };

--- a/src/core.ts
+++ b/src/core.ts
@@ -956,7 +956,7 @@ export const safeJSON = (text: string) => {
 };
 
 // https://stackoverflow.com/a/19709846
-const startsWithSchemeRegexp = new RegExp('^(?:[a-z]+:)?//', 'i');
+const startsWithSchemeRegexp = new RegExp('^(?:[a-z]{1,50}+:)?//', 'i');
 const isAbsoluteURL = (url: string): boolean => {
   return startsWithSchemeRegexp.test(url);
 };


### PR DESCRIPTION
## Changes being requested
The [`isAbsoluteUrl`](src/core.ts) function uses a regex to check whether a string is an absolute URL by essentially checking if it has a URI scheme:
```ts
const startsWithSchemeRegexp = new RegExp('^(?:[a-z]+:)?//', 'i');
const isAbsoluteURL = (url: string): boolean => {
  return startsWithSchemeRegexp.test(url);
};
```
The regex checks for the URI scheme by checking a set of `a-z` characters, then a colon `:` and then two backslashes `//`:
![image](https://github.com/openai/openai-node/assets/42250071/30c4fe82-de57-4455-a57e-cdd9dc7d8fae)
 
The issue with the regex for checking the amount of `a-z` characters is unbounded. This means an extremely long set of `a-z` characters can be passed and the regex will still try to test it, which wastes a lot of computation.
![image](https://github.com/openai/openai-node/assets/42250071/e36e9189-fcb5-44ec-80e6-71cf32f673f2)

Realistically [the longest official IANA URL scheme is about 36 characters](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml), so testing any URL scheme above 50 `a-z` characters is definitely a waste of time. 

In my pull request, I added a constraint to check for a maximum of 50 `a-z` characters.