### PR TITLE
feat: Add bun documentation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ To learn how to use the OpenAI API, check out our [API Reference](https://platfo
 npm install openai
 ```
 
+You can install with bun using:
+```sh
+bun install openai
+```
+
 You can import in Deno via:
 
 <!-- x-release-please-start-version -->


### PR DESCRIPTION
## Changes being requested
- Add [bun](https://bun.sh) install information to `README`.

## Additional context & links
I noticed that the readme had install instructions for npm and Deno. I figured it would be helpful to have Bun as well.

I understand that there may be some hesitation to add another download method, but Bun has [more monthly installations](https://somsubhra.github.io/github-release-stats/?username=oven-sh&repository=bun&page=1&per_page=7) than [Deno](https://somsubhra.github.io/github-release-stats/?username=denoland&repository=deno&page=1&per_page=4), so if there's only room for one other non-npm option, it might make sense to keep Bun and drop Deno.