### PR TITLE
fix: Correct findDoubleNewlineIndex to iterate to the second last pos…

### DIFF
--- a/src/streaming.ts
+++ b/src/streaming.ts
@@ -264,7 +264,7 @@ function findDoubleNewlineIndex(buffer: Uint8Array): number {
   const newline = 0x0a; // \n
   const carriage = 0x0d; // \r
 
-  for (let i = 0; i < buffer.length - 2; i++) {
+  for (let i = 0; i < buffer.length - 1; i++) {
     if (buffer[i] === newline && buffer[i + 1] === newline) {
       // \n\n
       return i + 2;


### PR DESCRIPTION
…ition

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

findDoubleNewlineIndex cannot find “\n\n” at the end, so correct findDoubleNewlineIndex to iterate to the second last position.

## Additional context & links
