### PR TITLE
Update transcriptions.ts, fix return type

### DIFF
--- a/src/resources/audio/transcriptions.ts
+++ b/src/resources/audio/transcriptions.ts
@@ -8,7 +8,7 @@ export class Transcriptions extends APIResource {
   /**
    * Transcribes audio into the input language.
    */
-  create(body: TranscriptionCreateParams, options?: Core.RequestOptions): Core.APIPromise<Transcription> {
+  create(body: TranscriptionCreateParams, options?: Core.RequestOptions): Core.APIPromise<string> {
     return this._client.post('/audio/transcriptions', Core.multipartFormRequestOptions({ body, ...options }));
   }
 }


### PR DESCRIPTION
## Changes being requested
The audio.transcriptions.create method returns a string, not a Transcription object as stipulated in the source code
The response type should be updated to `string`

## Additional context & links
```js
    const transcription = await client.audio.transcriptions.create({
      model: 'whisper-1',
      file: fs.createReadStream(filename),
      response_format: 'text',
    });

    // Transcription should be an object with a text property, but it returns a string
    console.log('Transcription:', transcription);
    console.log('Output type:`, typeof transcription);
```

Console output:
```
Transcription: This is a test audio file

Output type: string
```
