### PR TITLE
Bugfix for iterPages

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -640,6 +640,7 @@ export abstract class AbstractPage<Item> implements AsyncIterable<Item> {
   hasNextPage(): boolean {
     const items = this.getPaginatedItems();
     if (!items.length) return false;
+    if (!(this.body as any)?.has_more) return false;
     return this.nextPageInfo() != null;
   }
 


### PR DESCRIPTION
During check of nextPage existence the field "has_more" might be used (gotten at body). Without it, iteration of, say all thread messages list brings to infinite loop.
Body field has unknown type (might be also detailed), so I used cast to "any" to skip linter/ts issues.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
