### PR TITLE
Various fixes for JSON Schema resolving

### DIFF
--- a/src/_vendor/zod-to-json-schema/Options.ts
+++ b/src/_vendor/zod-to-json-schema/Options.ts
@@ -10,7 +10,7 @@ export const ignoreOverride = Symbol('Let zodToJsonSchema decide on which parser
 
 export type Options<Target extends Targets = 'jsonSchema7'> = {
   name: string | undefined;
-  $refStrategy: 'root' | 'relative' | 'none' | 'seen';
+  $refStrategy: 'root' | 'relative' | 'none' | 'seen' | 'extract-to-root';
   basePath: string[];
   effectStrategy: 'input' | 'any';
   pipeStrategy: 'input' | 'output' | 'all';
@@ -20,7 +20,7 @@ export type Options<Target extends Targets = 'jsonSchema7'> = {
   target: Target;
   strictUnions: boolean;
   definitionPath: string;
-  definitions: Record<string, ZodSchema>;
+  definitions: Record<string, ZodSchema | ZodTypeDef>;
   errorMessages: boolean;
   markdownDescription: boolean;
   patternStrategy: 'escape' | 'preserve';

--- a/src/_vendor/zod-to-json-schema/Options.ts
+++ b/src/_vendor/zod-to-json-schema/Options.ts
@@ -17,6 +17,7 @@ export type Options<Target extends Targets = 'jsonSchema7'> = {
   dateStrategy: DateStrategy | DateStrategy[];
   mapStrategy: 'entries' | 'record';
   removeAdditionalStrategy: 'passthrough' | 'strict';
+  nullableStrategy: 'from-target' | 'property';
   target: Target;
   strictUnions: boolean;
   definitionPath: string;
@@ -45,6 +46,7 @@ export const defaultOptions: Options = {
   pipeStrategy: 'all',
   dateStrategy: 'format:date-time',
   mapStrategy: 'entries',
+  nullableStrategy: 'from-target',
   removeAdditionalStrategy: 'passthrough',
   definitionPath: 'definitions',
   target: 'jsonSchema7',

--- a/src/_vendor/zod-to-json-schema/README.md
+++ b/src/_vendor/zod-to-json-schema/README.md
@@ -1,0 +1,3 @@
+# Zod to Json Schema
+
+Vendored version of https://github.com/StefanTerdell/zod-to-json-schema that has been updated to generate JSON Schemas that are compatible with OpenAI's [strict mode](https://platform.openai.com/docs/guides/structured-outputs/supported-schemas)

--- a/src/_vendor/zod-to-json-schema/Refs.ts
+++ b/src/_vendor/zod-to-json-schema/Refs.ts
@@ -1,6 +1,7 @@
-import { ZodTypeDef } from 'zod';
+import type { ZodTypeDef } from 'zod';
 import { getDefaultOptions, Options, Targets } from './Options';
 import { JsonSchema7Type } from './parseDef';
+import { zodDef } from './util';
 
 export type Refs = {
   seen: Map<ZodTypeDef, Seen>;
@@ -33,9 +34,9 @@ export const getRefs = (options?: string | Partial<Options<Targets>>): Refs => {
     seenRefs: new Set(),
     seen: new Map(
       Object.entries(_options.definitions).map(([name, def]) => [
-        def._def,
+        zodDef(def),
         {
-          def: def._def,
+          def: zodDef(def),
           path: [..._options.basePath, _options.definitionPath, name],
           // Resolution of references will be forced even though seen, so it's ok that the schema is undefined here for now.
           jsonSchema: undefined,

--- a/src/_vendor/zod-to-json-schema/parsers/nullable.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/nullable.ts
@@ -17,7 +17,7 @@ export function parseNullableDef(def: ZodNullableDef, refs: Refs): JsonSchema7Nu
     ['ZodString', 'ZodNumber', 'ZodBigInt', 'ZodBoolean', 'ZodNull'].includes(def.innerType._def.typeName) &&
     (!def.innerType._def.checks || !def.innerType._def.checks.length)
   ) {
-    if (refs.target === 'openApi3') {
+    if (refs.target === 'openApi3' || refs.nullableStrategy === 'property') {
       return {
         type: primitiveMappings[def.innerType._def.typeName as keyof typeof primitiveMappings],
         nullable: true,

--- a/src/_vendor/zod-to-json-schema/util.ts
+++ b/src/_vendor/zod-to-json-schema/util.ts
@@ -1,0 +1,11 @@
+import type { ZodSchema, ZodTypeDef } from 'zod';
+
+export const zodDef = (zodSchema: ZodSchema | ZodTypeDef): ZodTypeDef => {
+  return '_def' in zodSchema ? zodSchema._def : zodSchema;
+};
+
+export function isEmptyObj(obj: Object | null | undefined): boolean {
+  if (!obj) return true;
+  for (const _k in obj) return false;
+  return true;
+}

--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -61,8 +61,6 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
     main.title = title;
   }
 
-  const rootRefPath = name ? [...refs.basePath, refs.definitionPath, name].join('/') : null;
-
   const combined: ReturnType<typeof zodToJsonSchema<Target>> =
     name === undefined ?
       definitions ?
@@ -74,13 +72,13 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
     : refs.nameStrategy === 'duplicate-ref' ?
       {
         ...main,
-        ...(definitions || refs.seenRefs.has(rootRefPath!) ?
+        ...(definitions || refs.seenRefs.size ?
           {
             [refs.definitionPath]: {
               ...definitions,
               // only actually duplicate the schema definition if it was ever referenced
               // otherwise the duplication is completely pointless
-              ...(refs.seenRefs.has(rootRefPath!) ? { [name]: main } : undefined),
+              ...(refs.seenRefs.size ? { [name]: main } : undefined),
             },
           }
         : undefined),

--- a/src/helpers/zod.ts
+++ b/src/helpers/zod.ts
@@ -14,6 +14,7 @@ function zodToJsonSchema(schema: z.ZodType, options: { name: string }): Record<s
     name: options.name,
     nameStrategy: 'duplicate-ref',
     $refStrategy: 'extract-to-root',
+    nullableStrategy: 'property',
   });
 }
 

--- a/src/helpers/zod.ts
+++ b/src/helpers/zod.ts
@@ -13,6 +13,7 @@ function zodToJsonSchema(schema: z.ZodType, options: { name: string }): Record<s
     openaiStrictMode: true,
     name: options.name,
     nameStrategy: 'duplicate-ref',
+    $refStrategy: 'extract-to-root',
   });
 }
 

--- a/tests/lib/__snapshots__/parser.test.ts.snap
+++ b/tests/lib/__snapshots__/parser.test.ts.snap
@@ -28,6 +28,34 @@ exports[`.parse() zod deserialises response_format 1`] = `
 "
 `;
 
+exports[`.parse() zod merged schemas 2`] = `
+"{
+  "id": "chatcmpl-9tyPgktyF5JgREIZd0XZI4XgrBAD2",
+  "object": "chat.completion",
+  "created": 1723127296,
+  "model": "gpt-4o-2024-08-06",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "{\\"person1\\":{\\"name\\":\\"Jane Doe\\",\\"phone_number\\":\\"+1234567890\\",\\"roles\\":[\\"other\\"],\\"description\\":\\"Engineer at OpenAI. Email: jane@openai.com\\"},\\"person2\\":{\\"name\\":\\"John Smith\\",\\"phone_number\\":\\"+0987654321\\",\\"differentField\\":\\"Engineer at OpenAI. Email: john@openai.com\\"}}",
+        "refusal": null
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 61,
+    "completion_tokens": 72,
+    "total_tokens": 133
+  },
+  "system_fingerprint": "fp_845eaabc1f"
+}
+"
+`;
+
 exports[`.parse() zod top-level recursive schemas 1`] = `
 "{
   "id": "chatcmpl-9taiMDrRVRIkk1Xg1yE82UjnYuZjt",

--- a/tests/lib/parser.test.ts
+++ b/tests/lib/parser.test.ts
@@ -267,5 +267,184 @@ describe('.parse()', () => {
         }
       `);
     });
+
+    test('merged schemas', async () => {
+      const personSchema = z.object({
+        name: z.string(),
+        phone_number: z.string().nullable(),
+      });
+
+      const contactPersonSchema = z.object({
+        person1: personSchema.merge(
+          z.object({
+            roles: z
+              .array(z.enum(['parent', 'child', 'sibling', 'spouse', 'friend', 'other']))
+              .describe('Any roles for which the contact is important, use other for custom roles'),
+            description: z
+              .string()
+              .nullable()
+              .describe('Open text for any other relevant information about what the contact does.'),
+          }),
+        ),
+        person2: personSchema.merge(
+          z.object({
+            differentField: z.string(),
+          }),
+        ),
+      });
+
+      expect(zodResponseFormat(contactPersonSchema, 'contactPerson').json_schema.schema)
+        .toMatchInlineSnapshot(`
+        {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "definitions": {
+            "contactPerson": {
+              "additionalProperties": false,
+              "properties": {
+                "person1": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "description": {
+                      "description": "Open text for any other relevant information about what the contact does.",
+                      "type": [
+                        "string",
+                        "null",
+                      ],
+                    },
+                    "name": {
+                      "type": "string",
+                    },
+                    "phone_number": {
+                      "type": [
+                        "string",
+                        "null",
+                      ],
+                    },
+                    "roles": {
+                      "description": "Any roles for which the contact is important, use other for custom roles",
+                      "items": {
+                        "enum": [
+                          "parent",
+                          "child",
+                          "sibling",
+                          "spouse",
+                          "friend",
+                          "other",
+                        ],
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "phone_number",
+                    "roles",
+                    "description",
+                  ],
+                  "type": "object",
+                },
+                "person2": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "differentField": {
+                      "type": "string",
+                    },
+                    "name": {
+                      "$ref": "#/definitions/contactPerson/properties/person1/properties/name",
+                    },
+                    "phone_number": {
+                      "$ref": "#/definitions/contactPerson/properties/person1/properties/phone_number",
+                    },
+                  },
+                  "required": [
+                    "name",
+                    "phone_number",
+                    "differentField",
+                  ],
+                  "type": "object",
+                },
+              },
+              "required": [
+                "person1",
+                "person2",
+              ],
+              "type": "object",
+            },
+          },
+          "properties": {
+            "person1": {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "description": "Open text for any other relevant information about what the contact does.",
+                  "type": [
+                    "string",
+                    "null",
+                  ],
+                },
+                "name": {
+                  "type": "string",
+                },
+                "phone_number": {
+                  "type": [
+                    "string",
+                    "null",
+                  ],
+                },
+                "roles": {
+                  "description": "Any roles for which the contact is important, use other for custom roles",
+                  "items": {
+                    "enum": [
+                      "parent",
+                      "child",
+                      "sibling",
+                      "spouse",
+                      "friend",
+                      "other",
+                    ],
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+              },
+              "required": [
+                "name",
+                "phone_number",
+                "roles",
+                "description",
+              ],
+              "type": "object",
+            },
+            "person2": {
+              "additionalProperties": false,
+              "properties": {
+                "differentField": {
+                  "type": "string",
+                },
+                "name": {
+                  "$ref": "#/definitions/contactPerson/properties/person1/properties/name",
+                },
+                "phone_number": {
+                  "$ref": "#/definitions/contactPerson/properties/person1/properties/phone_number",
+                },
+              },
+              "required": [
+                "name",
+                "phone_number",
+                "differentField",
+              ],
+              "type": "object",
+            },
+          },
+          "required": [
+            "person1",
+            "person2",
+          ],
+          "type": "object",
+        }
+      `);
+    });
   });
 });

--- a/tests/lib/parser.test.ts
+++ b/tests/lib/parser.test.ts
@@ -307,19 +307,15 @@ describe('.parse()', () => {
                   "properties": {
                     "description": {
                       "description": "Open text for any other relevant information about what the contact does.",
-                      "type": [
-                        "string",
-                        "null",
-                      ],
+                      "nullable": true,
+                      "type": "string",
                     },
                     "name": {
                       "type": "string",
                     },
                     "phone_number": {
-                      "type": [
-                        "string",
-                        "null",
-                      ],
+                      "nullable": true,
+                      "type": "string",
                     },
                     "roles": {
                       "description": "Any roles for which the contact is important, use other for custom roles",
@@ -376,10 +372,8 @@ describe('.parse()', () => {
               "type": "string",
             },
             "contactPerson_properties_person1_properties_phone_number": {
-              "type": [
-                "string",
-                "null",
-              ],
+              "nullable": true,
+              "type": "string",
             },
           },
           "properties": {
@@ -388,19 +382,15 @@ describe('.parse()', () => {
               "properties": {
                 "description": {
                   "description": "Open text for any other relevant information about what the contact does.",
-                  "type": [
-                    "string",
-                    "null",
-                  ],
+                  "nullable": true,
+                  "type": "string",
                 },
                 "name": {
                   "type": "string",
                 },
                 "phone_number": {
-                  "type": [
-                    "string",
-                    "null",
-                  ],
+                  "nullable": true,
+                  "type": "string",
                 },
                 "roles": {
                   "description": "Any roles for which the contact is important, use other for custom roles",

--- a/tests/lib/parser.test.ts
+++ b/tests/lib/parser.test.ts
@@ -444,6 +444,50 @@ describe('.parse()', () => {
           "type": "object",
         }
       `);
+
+      const completion = await makeSnapshotRequest(
+        (openai) =>
+          openai.beta.chat.completions.parse({
+            model: 'gpt-4o-2024-08-06',
+            messages: [
+              {
+                role: 'system',
+                content: 'You are a helpful assistant.',
+              },
+              {
+                role: 'user',
+                content:
+                  'jane doe, born nov 16, engineer at openai, jane@openai.com. john smith, born march 1, enigneer at openai, john@openai.com',
+              },
+            ],
+            response_format: zodResponseFormat(contactPersonSchema, 'contactPerson'),
+          }),
+        2,
+      );
+
+      expect(completion.choices[0]?.message).toMatchInlineSnapshot(`
+        {
+          "content": "{"person1":{"name":"Jane Doe","phone_number":"+1234567890","roles":["other"],"description":"Engineer at OpenAI. Email: jane@openai.com"},"person2":{"name":"John Smith","phone_number":"+0987654321","differentField":"Engineer at OpenAI. Email: john@openai.com"}}",
+          "parsed": {
+            "person1": {
+              "description": "Engineer at OpenAI. Email: jane@openai.com",
+              "name": "Jane Doe",
+              "phone_number": "+1234567890",
+              "roles": [
+                "other",
+              ],
+            },
+            "person2": {
+              "differentField": "Engineer at OpenAI. Email: john@openai.com",
+              "name": "John Smith",
+              "phone_number": "+0987654321",
+            },
+          },
+          "refusal": null,
+          "role": "assistant",
+          "tool_calls": [],
+        }
+      `);
     });
   });
 });

--- a/tests/lib/parser.test.ts
+++ b/tests/lib/parser.test.ts
@@ -352,10 +352,10 @@ describe('.parse()', () => {
                       "type": "string",
                     },
                     "name": {
-                      "$ref": "#/definitions/contactPerson/properties/person1/properties/name",
+                      "$ref": "#/definitions/contactPerson_properties_person1_properties_name",
                     },
                     "phone_number": {
-                      "$ref": "#/definitions/contactPerson/properties/person1/properties/phone_number",
+                      "$ref": "#/definitions/contactPerson_properties_person1_properties_phone_number",
                     },
                   },
                   "required": [
@@ -371,6 +371,15 @@ describe('.parse()', () => {
                 "person2",
               ],
               "type": "object",
+            },
+            "contactPerson_properties_person1_properties_name": {
+              "type": "string",
+            },
+            "contactPerson_properties_person1_properties_phone_number": {
+              "type": [
+                "string",
+                "null",
+              ],
             },
           },
           "properties": {
@@ -424,10 +433,10 @@ describe('.parse()', () => {
                   "type": "string",
                 },
                 "name": {
-                  "$ref": "#/definitions/contactPerson/properties/person1/properties/name",
+                  "$ref": "#/definitions/contactPerson_properties_person1_properties_name",
                 },
                 "phone_number": {
-                  "$ref": "#/definitions/contactPerson/properties/person1/properties/phone_number",
+                  "$ref": "#/definitions/contactPerson_properties_person1_properties_phone_number",
                 },
               },
               "required": [

--- a/tests/utils/mock-snapshots.ts
+++ b/tests/utils/mock-snapshots.ts
@@ -5,7 +5,10 @@ import { RequestInfo } from 'openai/_shims/auto/types';
 import { mockFetch } from './mock-fetch';
 import { Readable } from 'stream';
 
-export async function makeSnapshotRequest<T>(requestFn: (client: OpenAI) => Promise<T>): Promise<T> {
+export async function makeSnapshotRequest<T>(
+  requestFn: (client: OpenAI) => Promise<T>,
+  snapshotIndex = 1,
+): Promise<T> {
   if (process.env['UPDATE_API_SNAPSHOTS'] === '1') {
     var capturedResponseContent: string | null = null;
 
@@ -27,7 +30,7 @@ export async function makeSnapshotRequest<T>(requestFn: (client: OpenAI) => Prom
     return result;
   }
 
-  const qualifiedSnapshotName = `${expect.getState().currentTestName} 1`;
+  const qualifiedSnapshotName = [expect.getState().currentTestName, snapshotIndex].join(' ');
   const snapshotState = expect.getState()['snapshotState'];
   (snapshotState._uncheckedKeys as Set<string>).delete(qualifiedSnapshotName);
 


### PR DESCRIPTION
Fixes how `$ref`s are created by changing it from using references like `#/definitions/user/properties/name` to extracting it to a top-level definition, e.g. `#/definitions/user_properties_name`.

This is very ugly... but I'd rather guarantee the definition will always be unique 🤷 

I think	this doesn't really work correctly for nested refs, we're overly duplicative :(