### PR TITLE
[Azure] Refresh AAD token on retry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -485,6 +485,12 @@ export class AzureOpenAI extends OpenAI {
   }
 
   protected override async prepareOptions(opts: Core.FinalRequestOptions<unknown>): Promise<void> {
+    /**
+     * The user should provide a bearer token provider if they want
+     * to use Azure AD authentication. The user shouldn't set the
+     * Authorization header manually because the header is overwritten
+     * with the Azure AD token if a bearer token provider is provided.
+     */
     if (opts.headers?.['api-key']) {
       return super.prepareOptions(opts);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -485,7 +485,7 @@ export class AzureOpenAI extends OpenAI {
   }
 
   protected override async prepareOptions(opts: Core.FinalRequestOptions<unknown>): Promise<void> {
-    if (opts.headers?.['Authorization'] || opts.headers?.['api-key']) {
+    if (opts.headers?.['api-key']) {
       return super.prepareOptions(opts);
     }
     const token = await this._getAzureADToken();


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

The AAD token may need to be refreshed between retries so this fix makes sure to always call the token provider irrespective of whether the authorization header is being set.

## Additional context & links
