### PR TITLE
fix: runTools without stream should not emit user message events

### DIFF
--- a/src/lib/ChatCompletionRunner.ts
+++ b/src/lib/ChatCompletionRunner.ts
@@ -63,8 +63,12 @@ export class ChatCompletionRunner<ParsedT = null> extends AbstractChatCompletion
     return runner;
   }
 
-  override _addMessage(this: ChatCompletionRunner<ParsedT>, message: ChatCompletionMessageParam) {
-    super._addMessage(message);
+  override _addMessage(
+    this: ChatCompletionRunner<ParsedT>,
+    message: ChatCompletionMessageParam,
+    emit: boolean = true,
+  ) {
+    super._addMessage(message, emit);
     if (isAssistantMessage(message) && message.content) {
       this._emit('content', message.content as string);
     }

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -605,7 +605,6 @@ describe('resource completions', () => {
       await runner.done();
 
       expect(listener.messages).toEqual([
-        { role: 'user', content: 'tell me what the weather is like' },
         {
           role: 'assistant',
           content: null,
@@ -700,7 +699,6 @@ describe('resource completions', () => {
       await runner.done().catch(() => {});
 
       expect(listener.messages).toEqual([
-        { role: 'user', content: 'tell me what the weather is like' },
         {
           role: 'assistant',
           content: null,
@@ -855,10 +853,6 @@ describe('resource completions', () => {
       await runner.done();
 
       expect(listener.messages).toEqual([
-        {
-          role: 'user',
-          content: 'can you tell me how many properties are in {"a": 1, "b": 2, "c": 3}',
-        },
         {
           role: 'assistant',
           content: null,
@@ -1091,10 +1085,6 @@ describe('resource completions', () => {
 
       expect(listener.messages).toEqual([
         {
-          role: 'user',
-          content: 'can you tell me how many properties are in {"a": 1, "b": 2, "c": 3}',
-        },
-        {
           role: 'assistant',
           content: null,
           parsed: null,
@@ -1207,7 +1197,6 @@ describe('resource completions', () => {
       ]);
 
       expect(listener.messages).toEqual([
-        { role: 'user', content: 'tell me what the weather is like' },
         {
           role: 'assistant',
           content: null,
@@ -1413,7 +1402,6 @@ describe('resource completions', () => {
       ]);
 
       expect(listener.messages).toEqual([
-        { role: 'user', content: 'tell me what the weather is like' },
         {
           role: 'assistant',
           content: null,


### PR DESCRIPTION
Closes https://github.com/openai/openai-node/issues/994

This is techincally a breaking change but the helpers are still in beta.
