### PR TITLE
Fix formatting of the collapsible note in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,7 @@ The following runtimes are supported:
 - Web browsers: disabled by default to avoid exposing your secret API credentials. Enable browser support by explicitly setting `dangerouslyAllowBrowser` to true'.
 <details>
   <summary>More explanation</summary>
+  
   ### Why is this dangerous?
   Enabling the `dangerouslyAllowBrowser` option can be dangerous because it exposes your secret API credentials in the client-side code. Web browsers are inherently less secure than server environments,
   any user with access to the browser can potentially inspect, extract, and misuse these credentials. This could lead to unauthorized access using your credentials and potentially compromise sensitive data or functionality.
@@ -628,6 +629,7 @@ The following runtimes are supported:
   - Internal Tools: If the application is used solely within a controlled internal environment where the users are trusted, the risk of credential exposure can be mitigated.
   - Public APIs with Limited Scope: If your API has very limited scope and the exposed credentials do not grant access to sensitive data or critical operations, the potential impact of exposure is reduced.
   - Development or debugging purpose: Enabling this feature temporarily might be acceptable, provided the credentials are short-lived, aren't also used in production environments, or are frequently rotated.
+
 </details>
 
 Note that React Native is not supported at this time.


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Without the extra empty lines around the content of the `<details>` element, the content is treated as being HTML content, not markdown content.

## Additional context & links
