### PR TITLE
Edit pass on Azure OpenAI section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Error codes are as followed:
 
 ## Microsoft Azure OpenAI
 
-To use this library with [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/overview), use the `AzureOpenAI`
+To use this library with [Azure OpenAI](https://learn.microsoft.com/azure/ai-services/openai/overview), use the `AzureOpenAI`
 class instead of the `OpenAI` class.
 
 > [!IMPORTANT]
@@ -376,9 +376,9 @@ import { getBearerTokenProvider, DefaultAzureCredential } from '@azure/identity'
 
 const credential = new DefaultAzureCredential();
 const scope = 'https://cognitiveservices.azure.com/.default';
-const azureADTokenProvider = getBearerTokenProvider(credential, scope);
+const tokenProvider = getBearerTokenProvider(credential, scope);
 
-const openai = new AzureOpenAI({ azureADTokenProvider });
+const openai = new AzureOpenAI({ tokenProvider });
 
 const result = await openai.chat.completions.create({
   model: 'gpt-4-1106-preview',


### PR DESCRIPTION
**Summary of changes**
- Rename Azure AD-focused variable used in code sample. The product was renamed to Microsoft Entra ID.
- Remove "en-us" locale string from Learn link. The user's preferred locale should be honored, not overridden.
