### PR TITLE
feat(structured outputs): support accessing raw responses

### DIFF
--- a/src/resources/beta/chat/completions.ts
+++ b/src/resources/beta/chat/completions.ts
@@ -59,21 +59,21 @@ export interface ParsedChatCompletion<ParsedT> extends ChatCompletion {
 export type ChatCompletionParseParams = ChatCompletionCreateParamsNonStreaming;
 
 export class Completions extends APIResource {
-  async parse<Params extends ChatCompletionParseParams, ParsedT = ExtractParsedContentFromParams<Params>>(
+  parse<Params extends ChatCompletionParseParams, ParsedT = ExtractParsedContentFromParams<Params>>(
     body: Params,
     options?: Core.RequestOptions,
-  ): Promise<ParsedChatCompletion<ParsedT>> {
+  ): Core.APIPromise<ParsedChatCompletion<ParsedT>> {
     validateInputTools(body.tools);
 
-    const completion = await this._client.chat.completions.create(body, {
-      ...options,
-      headers: {
-        ...options?.headers,
-        'X-Stainless-Helper-Method': 'beta.chat.completions.parse',
-      },
-    });
-
-    return parseChatCompletion(completion, body);
+    return this._client.chat.completions
+      .create(body, {
+        ...options,
+        headers: {
+          ...options?.headers,
+          'X-Stainless-Helper-Method': 'beta.chat.completions.parse',
+        },
+      })
+      ._thenUnwrap((completion) => parseChatCompletion(completion, body));
   }
 
   /**


### PR DESCRIPTION
closes #1057 

You can now do this:
```ts
  const { data: completion, response } = await client.beta.chat.completions
    .parse({
      model: 'gpt-4o-2024-08-06',
      messages: [
        { role: 'system', content: 'You are a helpful math tutor.' },
        { role: 'user', content: 'solve 8x + 31 = 2' },
      ],
      response_format: zodResponseFormat(MathResponse, 'math_response'),
    })
    .withResponse();
```