### PR TITLE
fix(partial json): parse unterminated strings

### DIFF
--- a/examples/tool-calls-stream.ts
+++ b/examples/tool-calls-stream.ts
@@ -27,6 +27,9 @@ import {
   ChatCompletionMessageParam,
 } from 'openai/resources/chat';
 
+// Used so that the each chunk coming in is noticable
+const CHUNK_DELAY_MS = 100;
+
 // gets API Key from environment variable OPENAI_API_KEY
 const openai = new OpenAI();
 
@@ -126,6 +129,9 @@ async function main() {
     for await (const chunk of stream) {
       message = messageReducer(message, chunk);
       writeLine(message);
+
+      // Add a small delay so that the chunks coming in are noticablej
+      await new Promise((resolve) => setTimeout(resolve, CHUNK_DELAY_MS));
     }
     console.log();
     messages.push(message);

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint": "^8.49.0",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-unused-imports": "^3.0.0",
+    "fast-check": "^3.22.0",
     "jest": "^29.4.0",
     "prettier": "^3.0.0",
     "prettier-2": "npm:prettier@^2",

--- a/src/_vendor/partial-json-parser/README.md
+++ b/src/_vendor/partial-json-parser/README.md
@@ -1,3 +1,3 @@
 # Partial JSON Parser
 
-Vendored from https://www.npmjs.com/package/partial-json-parser and updated to use TypeScript.
+Vendored from https://www.npmjs.com/package/partial-json with some modifications

--- a/tests/_vendor/partial-json-parser/partial-json-parsing.test.ts
+++ b/tests/_vendor/partial-json-parser/partial-json-parsing.test.ts
@@ -1,0 +1,58 @@
+import fc from 'fast-check';
+import { MalformedJSON, partialParse } from 'openai/_vendor/partial-json-parser/parser';
+
+describe('partial parsing', () => {
+  test('should parse complete json', () => {
+    expect(partialParse('{"__proto__": 0}')).toEqual(JSON.parse('{"__proto__": 0}'));
+
+    fc.assert(
+      fc.property(fc.json({ depthSize: 'large', noUnicodeString: false }), (jsonString) => {
+        const parsedNormal = JSON.parse(jsonString);
+        const parsedPartial = partialParse(jsonString);
+        expect(parsedPartial).toEqual(parsedNormal);
+      }),
+    );
+  });
+
+  test('should parse partial json', () => {
+    expect(partialParse('{"field')).toEqual({});
+    expect(partialParse('"')).toEqual('');
+    expect(partialParse('[2, 3, 4')).toEqual([2, 3]);
+    expect(partialParse('{"field": true, "field2')).toEqual({ field: true });
+    expect(partialParse('{"field": true, "field2":')).toEqual({ field: true });
+    expect(partialParse('{"field": true, "field2":{')).toEqual({ field: true, field2: {} });
+    expect(partialParse('{"field": true, "field2": { "obj": "somestr')).toEqual({
+      field: true,
+      field2: { obj: 'somestr' },
+    });
+    expect(partialParse('{"field": true, "field2": { "obj": "somestr",')).toEqual({
+      field: true,
+      field2: { obj: 'somestr' },
+    });
+    expect(partialParse('{"field": "va')).toEqual({ field: 'va' });
+    expect(partialParse('[ "v1", 2, "v2", 3')).toEqual(['v1', 2, 'v2']);
+    expect(partialParse('[ "v1", 2, "v2", -')).toEqual(['v1', 2, 'v2']);
+    expect(partialParse('[1, 2e')).toEqual([1]);
+  });
+
+  test('should only throw errors parsing numbers', () =>
+    fc.assert(
+      fc.property(fc.json({ depthSize: 'large', noUnicodeString: false }), (jsonString) => {
+        for (let i = 1; i < jsonString.length; i++) {
+          // speedup
+          i += Math.floor(Math.random() * 3);
+          const substring = jsonString.substring(0, i);
+
+          // since we don't allow partial parsing for numbers
+          if (
+            typeof JSON.parse(jsonString) === 'number' &&
+            'e-+.'.includes(substring[substring.length - 1]!)
+          ) {
+            expect(() => partialParse(substring)).toThrow(MalformedJSON);
+          } else {
+            partialParse(substring);
+          }
+        }
+      }),
+    ));
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,6 +1725,13 @@ expect@^29.0.0, expect@^29.7.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
+fast-check@^3.22.0:
+  version "3.22.0"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-3.22.0.tgz#1a8153e9d6fbdcc60b818f447cbb9cac1fdd8fb6"
+  integrity sha512-8HKz3qXqnHYp/VCNn2qfjHdAdcI8zcSqOyX64GOMukp7SL2bfzfeDKjSd+UyECtejccaZv3LcvZTm9YDD22iCQ==
+  dependencies:
+    pure-rand "^6.1.0"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -3036,6 +3043,11 @@ pure-rand@^6.0.0:
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.0.4.tgz#50b737f6a925468679bff00ad20eade53f37d5c7"
   integrity sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==
+
+pure-rand@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-6.1.0.tgz#d173cf23258231976ccbdb05247c9787957604f2"
+  integrity sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==
 
 qs@^6.10.3:
   version "6.13.0"


### PR DESCRIPTION
This PR refactors the partial JSON parser we use from https://www.npmjs.com/package/partial-json-parser to https://www.npmjs.com/package/partial-json so that we can parse unterminated strings.

For example:
```
content: {"steps":[{"explanation":"Identifying
parsed: { steps: [ { explanation: 'Identifying' } ] }

content: {"steps":[{"explanation":"Identifying basic
parsed: { steps: [ { explanation: 'Identifying basic' } ] }

content: {"steps":[{"explanation":"Identifying basic climate
parsed: { steps: [ { explanation: 'Identifying basic climate' } ] }
```