### PR TITLE
fix(audio): add fallback overload types

### DIFF
--- a/src/resources/audio/audio.ts
+++ b/src/resources/audio/audio.ts
@@ -29,12 +29,20 @@ export namespace Audio {
   export import TranscriptionVerbose = TranscriptionsAPI.TranscriptionVerbose;
   export import TranscriptionWord = TranscriptionsAPI.TranscriptionWord;
   export import TranscriptionCreateResponse = TranscriptionsAPI.TranscriptionCreateResponse;
-  export import TranscriptionCreateParams = TranscriptionsAPI.TranscriptionCreateParams;
+  export type TranscriptionCreateParams<
+    ResponseFormat extends AudioAPI.AudioResponseFormat | undefined =
+      | AudioAPI.AudioResponseFormat
+      | undefined,
+  > = TranscriptionsAPI.TranscriptionCreateParams<ResponseFormat>;
   export import Translations = TranslationsAPI.Translations;
   export import Translation = TranslationsAPI.Translation;
   export import TranslationVerbose = TranslationsAPI.TranslationVerbose;
   export import TranslationCreateResponse = TranslationsAPI.TranslationCreateResponse;
-  export import TranslationCreateParams = TranslationsAPI.TranslationCreateParams;
+  export type TranslationCreateParams<
+    ResponseFormat extends AudioAPI.AudioResponseFormat | undefined =
+      | AudioAPI.AudioResponseFormat
+      | undefined,
+  > = TranslationsAPI.TranslationCreateParams<ResponseFormat>;
   export import Speech = SpeechAPI.Speech;
   export import SpeechModel = SpeechAPI.SpeechModel;
   export import SpeechCreateParams = SpeechAPI.SpeechCreateParams;

--- a/src/resources/audio/transcriptions.ts
+++ b/src/resources/audio/transcriptions.ts
@@ -21,6 +21,7 @@ export class Transcriptions extends APIResource {
     body: TranscriptionCreateParams<'srt' | 'vtt' | 'text'>,
     options?: Core.RequestOptions,
   ): Core.APIPromise<string>;
+  create(body: TranscriptionCreateParams, options?: Core.RequestOptions): Core.APIPromise<Transcription>;
   create(
     body: TranscriptionCreateParams,
     options?: Core.RequestOptions,

--- a/src/resources/audio/transcriptions.ts
+++ b/src/resources/audio/transcriptions.ts
@@ -210,5 +210,9 @@ export namespace Transcriptions {
   export import TranscriptionVerbose = TranscriptionsAPI.TranscriptionVerbose;
   export import TranscriptionWord = TranscriptionsAPI.TranscriptionWord;
   export import TranscriptionCreateResponse = TranscriptionsAPI.TranscriptionCreateResponse;
-  export import TranscriptionCreateParams = TranscriptionsAPI.TranscriptionCreateParams;
+  export type TranscriptionCreateParams<
+    ResponseFormat extends AudioAPI.AudioResponseFormat | undefined =
+      | AudioAPI.AudioResponseFormat
+      | undefined,
+  > = TranscriptionsAPI.TranscriptionCreateParams<ResponseFormat>;
 }

--- a/src/resources/audio/translations.ts
+++ b/src/resources/audio/translations.ts
@@ -101,5 +101,9 @@ export namespace Translations {
   export import Translation = TranslationsAPI.Translation;
   export import TranslationVerbose = TranslationsAPI.TranslationVerbose;
   export import TranslationCreateResponse = TranslationsAPI.TranslationCreateResponse;
-  export import TranslationCreateParams = TranslationsAPI.TranslationCreateParams;
+  export type TranslationCreateParams<
+    ResponseFormat extends AudioAPI.AudioResponseFormat | undefined =
+      | AudioAPI.AudioResponseFormat
+      | undefined,
+  > = TranslationsAPI.TranslationCreateParams<ResponseFormat>;
 }

--- a/src/resources/audio/translations.ts
+++ b/src/resources/audio/translations.ts
@@ -22,6 +22,7 @@ export class Translations extends APIResource {
     body: TranslationCreateParams<'text' | 'srt' | 'vtt'>,
     options?: Core.RequestOptions,
   ): Core.APIPromise<string>;
+  create(body: TranslationCreateParams, options?: Core.RequestOptions): Core.APIPromise<Translation>;
   create(
     body: TranslationCreateParams,
     options?: Core.RequestOptions,


### PR DESCRIPTION
v4.66.0 wasn't actually released due to a bug that wasn't found until release.

This PR:
- works around a bug in our deno build script
- adds fallback overload variants for audio transcriptions / translations