### PR TITLE
Correctly set Accept header to text/event-stream for streaming

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -228,7 +228,7 @@ export abstract class APIClient {
    */
   protected defaultHeaders(opts: FinalRequestOptions): Headers {
     return {
-      Accept: 'application/json',
+      Accept: opts.stream ? 'text/event-stream' : 'application/json',
       'Content-Type': 'application/json',
       'User-Agent': this.getUserAgent(),
       ...getPlatformHeaders(),

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -31,6 +31,11 @@ describe('instantiate client', () => {
       expect((req.headers as Headers)['x-my-default-header']).toEqual('2');
     });
 
+    test('streaming request must have Accept header set to text/event-stream', () => {
+      const { req } = client.buildRequest({ path: '/', method: 'get', stream: true });
+      expect((req.headers as Headers)['accept']).toEqual('text/event-stream');
+    });
+
     test('can ignore `undefined` and leave the default', () => {
       const { req } = client.buildRequest({
         path: '/foo',


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Previously, the standard Accept header was set to application/json unconditionally.
However, streaming response returns content-type: text/event-stream following
the specification of server-sent-events.

This correctly sets the Accept header to it accordingly in order to comply with the
standard. The exact same problem exists in other SDKS (e.g. https://github.com/openai/openai-go/pull/94)

## Additional context & links

Fixes https://github.com/openai/openai-node/issues/375

___

Context: I am an Envoy Proxy community member and from a network proxy perspective, the discrepancy from the web standard is not a good thing. Hope this brings an attention to the problem as the fix is clearly a single line!
