### PR TITLE
TranscriptionVerbose.duration is a number, not a string

### DIFF
--- a/src/resources/audio/transcriptions.ts
+++ b/src/resources/audio/transcriptions.ts
@@ -104,7 +104,7 @@ export interface TranscriptionVerbose {
   /**
    * The duration of the input audio.
    */
-  duration: string;
+  duration: number;
 
   /**
    * The language of the input audio.


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

The real API returns numbers, not strings.

[The API is also documented here](https://platform.openai.com/docs/api-reference/audio/verbose-json-object). That documentation partially makes the same mistake: it claims that `duration` is a string. However, it also shows this example: `"duration": 8.470000267028809`, in which the duration is a number.

## Additional context & links
