### PR TITLE
feat: add back deno runtime testing without type checks

### DIFF
--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -95,16 +95,14 @@ const projectRunners = {
       await run('bun', ['test']);
     }
   },
-  // Temporarily comment this out until we can test with JSR transformations end-to-end.
-  // deno: async () => {
-  //   // we don't need to explicitly install the package here
-  //   // because our deno setup relies on `rootDir/deno` to exist
-  //   // which is an artifact produced from our build process
-  //   await run('deno', ['task', 'install']);
-  //   await run('deno', ['task', 'check']);
+  deno: async () => {
+    // we don't need to explicitly install the package here
+    // because our deno setup relies on `rootDir/dist-deno` to exist
+    // which is an artifact produced from our build process
+    await run('deno', ['task', 'install', '--unstable-sloppy-imports']);
 
-  //   if (state.live) await run('deno', ['task', 'test']);
-  // },
+    if (state.live) await run('deno', ['task', 'test']);
+  },
 };
 
 let projectNames = Object.keys(projectRunners) as Array<keyof typeof projectRunners>;

--- a/ecosystem-tests/deno/deno.jsonc
+++ b/ecosystem-tests/deno/deno.jsonc
@@ -1,11 +1,10 @@
 {
   "tasks": {
     "install": "deno install --node-modules-dir main_test.ts -f",
-    "check": "deno lint && deno check main_test.ts",
-    "test": "deno test --allow-env --allow-net --allow-read --node-modules-dir"
+    "test": "deno test --allow-env --allow-net --allow-read --node-modules-dir --unstable-sloppy-imports --no-check"
   },
   "imports": {
-    "openai": "../../deno/mod.ts",
-    "openai/": "../../deno/"
+    "openai": "../../dist-deno/index.ts",
+    "openai/": "../../dist-deno/"
   }
 }

--- a/scripts/build-deno
+++ b/scripts/build-deno
@@ -7,13 +7,21 @@ cd "$(dirname "$0")/.."
 rm -rf dist-deno; mkdir dist-deno
 cp -rp src/* jsr.json dist-deno
 
-rm dist-deno/_shims/auto/*-node.ts
-for dir in dist-deno/_shims dist-deno/_shims/auto; do
-  rm "${dir}"/*.{d.ts,js,mjs}
-  for file in "${dir}"/*-deno.ts; do
-    mv -- "$file" "${file%-deno.ts}.ts"
-  done
+rm -rf dist-deno/shims
+
+rm dist-deno/_shims/node*.{js,mjs,ts}
+rm dist-deno/_shims/manual*.{js,mjs,ts}
+rm dist-deno/_shims/index.{d.ts,js,mjs}
+for file in dist-deno/_shims/*-deno.ts; do
+	mv -- "$file" "${file%-deno.ts}.ts"
 done
+
+rm dist-deno/_shims/auto/*-node.ts
+rm dist-deno/_shims/auto/*.{d.ts,js,mjs}
+for file in dist-deno/_shims/auto/*-deno.ts; do
+	mv -- "$file" "${file%-deno.ts}.ts"
+done
+
 for file in README.md LICENSE CHANGELOG.md; do
   if [ -e "${file}" ]; then cp "${file}" dist-deno; fi
 done


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

This adds back deno runtime tests, though type checking doesn't quite work because of [limitations in jsr](https://github.com/jsr-io/jsr/issues/179).

## Additional context & links

