### PR TITLE
docs(readme): fix incorrect fileBatches.uploadAndPoll params

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ const fileList = [
   ...
 ];
 
-const batch = await openai.vectorStores.fileBatches.uploadAndPoll(vectorStore.id, fileList);
+const batch = await openai.vectorStores.fileBatches.uploadAndPoll(vectorStore.id, {files: fileList});
 ```
 
 ### Streaming Helpers


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [Y] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Fixed an incorrect param in README. 
This is the same incorrect referencing as in #1199 

## Additional context & links
The official doc [https://platform.openai.com/docs/assistants/tools/file-search#step-2-upload-files-and-add-them-to-a-vector-store](here) also heeds to be changed.