### PR TITLE
feat: add warning for .optional() usage in OpenAI API schemas

### DIFF
--- a/src/_vendor/zod-to-json-schema/parsers/optional.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/optional.ts
@@ -7,8 +7,8 @@ export const parseOptionalDef = (def: ZodOptionalDef, refs: Refs): JsonSchema7Ty
     const fieldName = refs.propertyPath?.slice(-1)[0] || 'unknown';
     console.warn(
       `Warning: Field "${fieldName}" uses .optional() which is not supported by OpenAI API Structured Outputs. ` +
-      `Please use .nullable() instead. ` +
-      `See: https://platform.openai.com/docs/guides/structured-outputs#all-fields-must-be-required`
+        `Please use .nullable() instead. ` +
+        `See: https://platform.openai.com/docs/guides/structured-outputs#all-fields-must-be-required`,
     );
   }
 

--- a/src/_vendor/zod-to-json-schema/parsers/optional.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/optional.ts
@@ -3,6 +3,15 @@ import { JsonSchema7Type, parseDef } from '../parseDef';
 import { Refs } from '../Refs';
 
 export const parseOptionalDef = (def: ZodOptionalDef, refs: Refs): JsonSchema7Type | undefined => {
+  if (refs.openaiStrictMode) {
+    const fieldName = refs.propertyPath?.slice(-1)[0] || 'unknown';
+    console.warn(
+      `Warning: Field "${fieldName}" uses .optional() which is not supported by OpenAI API Structured Outputs. ` +
+      `Please use .nullable() instead. ` +
+      `See: https://platform.openai.com/docs/guides/structured-outputs#all-fields-must-be-required`
+    );
+  }
+
   if (refs.currentPath.toString() === refs.propertyPath?.toString()) {
     return parseDef(def.innerType._def, refs);
   }

--- a/tests/helpers/zod.test.ts
+++ b/tests/helpers/zod.test.ts
@@ -88,6 +88,24 @@ describe('zodResponseFormat', () => {
     `);
   });
 
+  it('warns when using optional fields with OpenAI API', () => {
+    const consoleSpy = jest.spyOn(console, 'warn');
+
+    zodResponseFormat(
+      z.object({
+        required: z.string(),
+        optional: z.string().optional(),
+      }),
+      'test',
+    );
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('uses .optional() which is not supported by OpenAI API Structured Outputs')
+    );
+
+    consoleSpy.mockRestore();
+  });
+
   it('automatically adds properties with defaults to `required`', () => {
     expect(
       zodResponseFormat(

--- a/tests/helpers/zod.test.ts
+++ b/tests/helpers/zod.test.ts
@@ -100,7 +100,7 @@ describe('zodResponseFormat', () => {
     );
 
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('uses .optional() which is not supported by OpenAI API Structured Outputs')
+      expect.stringContaining('uses .optional() which is not supported by OpenAI API Structured Outputs'),
     );
 
     consoleSpy.mockRestore();


### PR DESCRIPTION
# Add warning for .optional() usage in OpenAI API schemas

This PR adds a warning when `.optional()` is used in schemas for OpenAI API Structured Outputs, recommending the use of `.nullable()` instead since optional fields are not currently supported.

## Changes
- Added warning in `optional.ts` that triggers when `openaiStrictMode` is true
- Warning includes explanation and link to documentation
- Added test to verify warning behavior

## Testing
✅ All tests passing (411 total)
- Added new test case to verify warning is emitted
- Verified warning message contains correct information
- Ran full test suite to ensure no regressions

## Implementation Details
The warning is implemented in the optional field parser and only triggers when generating schemas specifically for OpenAI API usage (when `openaiStrictMode` is true). This ensures developers get immediate feedback about unsupported optional fields while keeping the warning relevant only to OpenAI API usage.

Created with help from Devin: https://preview.devin.ai/devin/13e97f93e3b1445c91e60da01b88febd

Fixes openai/openai-node#1180