### PR TITLE
feat: add env to disable debug log

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -877,7 +877,7 @@ const getPlatformProperties = (): PlatformProperties => {
       'X-Stainless-Arch': normalizeArch(Deno.build.arch),
       'X-Stainless-Runtime': 'deno',
       'X-Stainless-Runtime-Version':
-        typeof Deno.version === 'string' ? Deno.version : Deno.version?.deno ?? 'unknown',
+        typeof Deno.version === 'string' ? Deno.version : (Deno.version?.deno ?? 'unknown'),
     };
   }
   if (typeof EdgeRuntime !== 'undefined') {
@@ -1139,7 +1139,11 @@ function applyHeadersMut(targetHeaders: Headers, newHeaders: Headers): void {
 }
 
 export function debug(action: string, ...args: any[]) {
-  if (typeof process !== 'undefined' && process?.env?.['DEBUG'] === 'true') {
+  if (
+    typeof process !== 'undefined' &&
+    typeof process?.env?.['OPENAI_DISABLE_DEBUG'] !== 'string' &&
+    process?.env?.['DEBUG'] === 'true'
+  ) {
     console.log(`OpenAI:DEBUG:${action}`, ...args);
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Adds the ability to completely disable debug logging.

This is a stopgap, if I was requesting an actual fix it would be to implement an inversion of control, and enable the user of this sdk to specify the logger, that way this flag becomes unnecessary. This simple workaround is more than enough for my needs.

## Additional context & links

#302 
