### PR TITLE
Adds Nova to the ChatCompletionAudioParam.voice options

### DIFF
--- a/src/resources/chat/completions.ts
+++ b/src/resources/chat/completions.ts
@@ -263,7 +263,7 @@ export interface ChatCompletionAudioParam {
    * `coral`, `sage`, and `verse` (also supported but not recommended are `alloy`,
    * `echo`, and `shimmer`; these voices are less expressive).
    */
-  voice: 'alloy' | 'ash' | 'ballad' | 'coral' | 'echo' | 'sage' | 'shimmer' | 'verse';
+  voice: 'alloy' | 'ash' | 'ballad' | 'coral' | 'echo' | 'nova' | 'sage' | 'shimmer' | 'verse';
 }
 
 /**


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Adds Nova to the ChatCompletionAudioParam.voice options

## Additional context & links

Maybe I'm jumping the gun, since voice output models are still in preview. Although Nova voice isn't explicitly mentioned as supported in the API docs, it is available via the API playground and is currently supported by the API, and I would like to use it in my project :)
