### PR TITLE
docs(readme): fix Realtime API example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ rt.socket.addEventListener('open', () => {
 });
 ```
 
-A full example can be found [here](https://github.com/openai/openai-node/blob/master/examples/realtime/web.ts).
+A full example can be found [here](https://github.com/openai/openai-node/blob/master/examples/realtime/websocket.ts).
 
 ### Realtime error handling
 


### PR DESCRIPTION
Correct the example link for the Realtime API to point to the appropriate websocket file.