### PR TITLE
fix(examples/realtime): remove duplicate `session.update` call

### DIFF
--- a/examples/azure/realtime/ws.ts
+++ b/examples/azure/realtime/ws.ts
@@ -25,13 +25,6 @@ async function main() {
         model: 'gpt-4o-realtime-preview',
       },
     });
-    rt.send({
-      type: 'session.update',
-      session: {
-        modalities: ['text'],
-        model: 'gpt-4o-realtime-preview',
-      },
-    });
 
     rt.send({
       type: 'conversation.item.create',

--- a/examples/realtime/ws.ts
+++ b/examples/realtime/ws.ts
@@ -13,13 +13,6 @@ async function main() {
         model: 'gpt-4o-realtime-preview',
       },
     });
-    rt.send({
-      type: 'session.update',
-      session: {
-        modalities: ['text'],
-        model: 'gpt-4o-realtime-preview',
-      },
-    });
 
     rt.send({
       type: 'conversation.item.create',


### PR DESCRIPTION
Remove a duplicate send request for `session.update` event.