### PR TITLE
perf(embedding): default embedding creation to base64

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -1287,6 +1287,27 @@ export const toBase64 = (str: string | null | undefined): string => {
   throw new OpenAIError('Cannot generate b64 string; Expected `Buffer` or `btoa` to be defined');
 };
 
+/**
+ * Converts a Base64 encoded string to a Float32Array.
+ * @param base64Str - The Base64 encoded string.
+ * @returns An Array of numbers interpreted as Float32 values.
+ */
+export const toFloat32Array = (base64Str: string): Array<number> => {
+  if (typeof Buffer !== 'undefined') {
+    // for Node.js environment
+    return Array.from(new Float32Array(Buffer.from(base64Str, 'base64').buffer));
+  } else {
+    // for legacy web platform APIs
+    const binaryStr = atob(base64Str);
+    const len = binaryStr.length;
+    const bytes = new Uint8Array(len);
+    for (let i = 0; i < len; i++) {
+      bytes[i] = binaryStr.charCodeAt(i);
+    }
+    return Array.from(new Float32Array(bytes.buffer));
+  }
+};
+
 export function isObj(obj: unknown): obj is Record<string, unknown> {
   return obj != null && typeof obj === 'object' && !Array.isArray(obj);
 }

--- a/src/resources/embeddings.ts
+++ b/src/resources/embeddings.ts
@@ -42,7 +42,6 @@ export class Embeddings extends APIResource {
     // and we defaulted to base64 for performance reasons
     // we are sure then that the response is base64 encoded, let's decode it
     // the returned result will be a float32 array since this is OpenAI API's default encoding
-    Core.debug('response', `User requested encoding_format=${encoding_format || 'default'}`);
     Core.debug('response', 'Decoding base64 embeddings to float32 array');
 
     return (response as Core.APIPromise<CreateEmbeddingResponse>)._thenUnwrap((response) => {

--- a/src/resources/embeddings.ts
+++ b/src/resources/embeddings.ts
@@ -11,8 +11,6 @@ export class Embeddings extends APIResource {
     body: EmbeddingCreateParams,
     options?: Core.RequestOptions<EmbeddingCreateParams>,
   ): Core.APIPromise<CreateEmbeddingResponse> {
-    Core.debug('request', 'Sending request with arguments:', { body, ...options });
-
     const hasUserProvidedEncodingFormat = !!body.encoding_format;
     // No encoding_format specified, defaulting to base64 for performance reasons
     // See https://github.com/openai/openai-node/pull/1312
@@ -48,7 +46,6 @@ export class Embeddings extends APIResource {
           const embeddingBase64Str = embeddingBase64Obj.embedding as unknown as string;
           embeddingBase64Obj.embedding = Core.toFloat32Array(embeddingBase64Str);
         });
-        Core.debug('response', 'Decoded embeddings:', response.data);
       }
 
       return response;

--- a/src/resources/embeddings.ts
+++ b/src/resources/embeddings.ts
@@ -37,11 +37,8 @@ export class Embeddings extends APIResource {
       return base64Response._thenUnwrap((response) => {
         if (response && response.data) {
           response.data.forEach((embeddingBase64Obj) => {
-            console.log(embeddingBase64Obj);
             const embeddingBase64Str = embeddingBase64Obj.embedding as unknown as string;
-            embeddingBase64Obj.embedding = Array.from(
-              new Float32Array(Buffer.from(embeddingBase64Str, 'base64').buffer),
-            );
+            embeddingBase64Obj.embedding = Core.toFloat32Array(embeddingBase64Str);
           });
           Core.debug('response', 'Decoded embeddings:', response.data);
         }

--- a/src/resources/embeddings.ts
+++ b/src/resources/embeddings.ts
@@ -14,18 +14,16 @@ export class Embeddings extends APIResource {
     Core.debug('request', 'Sending request with arguments:', { body, ...options });
 
     const hasUserProvidedEncodingFormat = !!body.encoding_format;
+    // No encoding_format specified, defaulting to base64 for performance reasons
+    // See https://github.com/openai/openai-node/pull/1312
     let encoding_format: EmbeddingCreateParams['encoding_format'] =
       hasUserProvidedEncodingFormat ? body.encoding_format : 'base64';
 
     if (hasUserProvidedEncodingFormat) {
       Core.debug('Request', 'User defined encoding_format:', body.encoding_format);
-    } else {
-      // No encoding_format specified, defaulting to base64 for performance reasons
-      // See https://github.com/openai/openai-node/pull/1312
-      encoding_format = 'base64';
     }
 
-    const response = this._client.post('/embeddings', {
+    const response: Core.APIPromise<CreateEmbeddingResponse> = this._client.post('/embeddings', {
       body: {
         ...body,
         encoding_format: encoding_format as EmbeddingCreateParams['encoding_format'],
@@ -35,7 +33,7 @@ export class Embeddings extends APIResource {
 
     // if the user specified an encoding_format, return the response as-is
     if (hasUserProvidedEncodingFormat) {
-      return response as Core.APIPromise<CreateEmbeddingResponse>;
+      return response;
     }
 
     // in this stage, we are sure the user did not specify an encoding_format

--- a/tests/api-resources/embeddings.test.ts
+++ b/tests/api-resources/embeddings.test.ts
@@ -33,7 +33,7 @@ describe('resource embeddings', () => {
     });
   });
 
-  test.only('create: encoding_format=float should create float32 embeddings', async () => {
+  test('create: encoding_format=float should create float32 embeddings', async () => {
     const responsePromise = client.embeddings.create({
       input: 'The quick brown fox jumped over the lazy dog',
       model: 'text-embedding-3-small',

--- a/tests/api-resources/embeddings.test.ts
+++ b/tests/api-resources/embeddings.test.ts
@@ -55,11 +55,10 @@ describe('resource embeddings', () => {
   });
 
   test('create: encoding_format=default should create float32 embeddings', async () => {
-    const responsePromise = client.embeddings.create({
+    const response = await client.embeddings.create({
       input: 'The quick brown fox jumped over the lazy dog',
       model: 'text-embedding-3-small',
     });
-    const response = await responsePromise;
 
     expect(response.data?.at(0)?.embedding).toBeInstanceOf(Array);
     expect(Number.isFinite(response.data?.at(0)?.embedding.at(0))).toBe(true);

--- a/tests/api-resources/embeddings.test.ts
+++ b/tests/api-resources/embeddings.test.ts
@@ -34,11 +34,10 @@ describe('resource embeddings', () => {
   });
 
   test('create: encoding_format=float should create float32 embeddings', async () => {
-    const responsePromise = client.embeddings.create({
+    const response = await client.embeddings.create({
       input: 'The quick brown fox jumped over the lazy dog',
       model: 'text-embedding-3-small',
     });
-    const response = await responsePromise;
 
     expect(response.data?.at(0)?.embedding).toBeInstanceOf(Array);
     expect(Number.isFinite(response.data?.at(0)?.embedding.at(0))).toBe(true);

--- a/tests/api-resources/embeddings.test.ts
+++ b/tests/api-resources/embeddings.test.ts
@@ -33,13 +33,35 @@ describe('resource embeddings', () => {
     });
   });
 
+  test.only('create: encoding_format=float should create float32 embeddings', async () => {
+    const responsePromise = client.embeddings.create({
+      input: 'The quick brown fox jumped over the lazy dog',
+      model: 'text-embedding-3-small',
+    });
+    const response = await responsePromise;
+
+    expect(response.data?.at(0)?.embedding).toBeInstanceOf(Array);
+    expect(Number.isFinite(response.data?.at(0)?.embedding.at(0))).toBe(true);
+  });
+
+  test('create: encoding_format=base64 should create float32 embeddings', async () => {
+    const responsePromise = client.embeddings.create({
+      input: 'The quick brown fox jumped over the lazy dog',
+      model: 'text-embedding-3-small',
+      encoding_format: 'base64',
+    });
+    const response = await responsePromise;
+
+    expect(response.data?.at(0)?.embedding).toBeInstanceOf(Array);
+    expect(Number.isFinite(response.data?.at(0)?.embedding.at(0))).toBe(true);
+  });
+
   test('create: encoding_format=default should create float32 embeddings', async () => {
     const responsePromise = client.embeddings.create({
       input: 'The quick brown fox jumped over the lazy dog',
       model: 'text-embedding-3-small',
     });
     const response = await responsePromise;
-    console.log(response.data?.at(0)?.embedding);
 
     expect(response.data?.at(0)?.embedding).toBeInstanceOf(Array);
     expect(Number.isFinite(response.data?.at(0)?.embedding.at(0))).toBe(true);

--- a/tests/api-resources/embeddings.test.ts
+++ b/tests/api-resources/embeddings.test.ts
@@ -45,12 +45,11 @@ describe('resource embeddings', () => {
   });
 
   test('create: encoding_format=base64 should create float32 embeddings', async () => {
-    const responsePromise = client.embeddings.create({
+    const response = await client.embeddings.create({
       input: 'The quick brown fox jumped over the lazy dog',
       model: 'text-embedding-3-small',
       encoding_format: 'base64',
     });
-    const response = await responsePromise;
 
     expect(response.data?.at(0)?.embedding).toBeInstanceOf(Array);
     expect(Number.isFinite(response.data?.at(0)?.embedding.at(0))).toBe(true);

--- a/tests/api-resources/embeddings.test.ts
+++ b/tests/api-resources/embeddings.test.ts
@@ -32,4 +32,16 @@ describe('resource embeddings', () => {
       user: 'user-1234',
     });
   });
+
+  test('create: encoding_format=default should create float32 embeddings', async () => {
+    const responsePromise = client.embeddings.create({
+      input: 'The quick brown fox jumped over the lazy dog',
+      model: 'text-embedding-3-small',
+    });
+    const response = await responsePromise;
+    console.log(response.data?.at(0)?.embedding);
+
+    expect(response.data?.at(0)?.embedding).toBeInstanceOf(Array);
+    expect(Number.isFinite(response.data?.at(0)?.embedding.at(0))).toBe(true);
+  });
 });


### PR DESCRIPTION
Requesting base64 encoded embeddings returns smaller body sizes, on average ~60% smaller than float32 encoded. In other words, the size of the response body containing embeddings in float32 is ~2.3x bigger than base64 encoded embedding.

Closes #1310

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

We always request embedding creating encoded as base64, and then decoded them to float32 based on the user's provided encoding_format parameter.

## Additional context & links

After running a few [benchmarks](https://github.com/manekinekko/rich-bench-node), requesting base64 encoded embeddings returns smaller body sizes, on average **~60% smaller** than float32 encoded. In other words, the size of the response body containing embeddings in float32 is **~2.3x bigger** than base64 encoded embedding.

This performance improvement could translate to:
- ✅ Faster HTTP responses
- ✅ Less bandwidth used when generating multiple embeddings

This is the result of a request that creates embedding from a 10kb chunk, run 10 times (the number are the size of response body in kb):

| Benchmark        | Min (ms) | Max (ms)  | Mean (ms)  | Min (+)          | Max (+)           | Mean (+)          |
|-----------------|---------:|----------:|----------:|-----------------:|-------------------:|------------------:|
| float32 vs base64 |   41.742 | 19616.000 |  9848.819 | 40.094 (3.9%)    | 8351.000 (57.4%)  | 4206.126 (57.3%)  |

Read more #1310
