### PR TITLE
keep error message

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -499,7 +499,7 @@ export abstract class APIClient {
 
       const errText = await response.text().catch((e) => castToError(e).message);
       const errJSON = safeJSON(errText);
-      const errMessage = errJSON ? undefined : errText;
+      const errMessage = errJSON ? errJSON.message : errText;
       const retryMessage = retriesRemaining ? `(error; no more retries left)` : `(error; not retryable)`;
 
       debug(`response (error; ${retryMessage})`, response.status, url, responseHeaders, errMessage);


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

OpenAI return error, but it does not show the error message. 
```
{"code":20041,"message":"The model is not a VLM (Vision Language Model). Please use text-only prompts.","data":null}
```

I know this repo is auto-generated, but I don't konw how to fix it. So just keep this PR here.

## Changes being requested

## Additional context & links
