### PR TITLE
fix(realtime): call .toString() on WebSocket url

### DIFF
--- a/src/beta/realtime/websocket.ts
+++ b/src/beta/realtime/websocket.ts
@@ -53,7 +53,7 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     props.onURL?.(this.url);
 
     // @ts-ignore
-    this.socket = new WebSocket(this.url, [
+    this.socket = new WebSocket(this.url.toString(), [
       'realtime',
       ...(isAzure(client) ? [] : [`openai-insecure-api-key.${client.apiKey}`]),
       'openai-beta.realtime-v1',


### PR DESCRIPTION
The [WebSocket spec at WHATWG](https://websockets.spec.whatwg.org/#ref-for-dom-websocket-websocket%E2%91%A0) indicates that the `url` parameter of the WebSocket constructor is a string. Some implementations (like Chrome) will accept a URL object, but calling .toString() should work for all cases.

Fixes #1323.

- [x] I understand that this repository is auto-generated and my pull request may not be merged
