### PR TITLE
fix(parsing): remove tool_calls default empty array

### DIFF
--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -119,7 +119,15 @@ export function maybeParseChatCompletion<
       ...completion,
       choices: completion.choices.map((choice) => ({
         ...choice,
-        message: { ...choice.message, parsed: null, tool_calls: choice.message.tool_calls ?? [] },
+        message: {
+          ...choice.message,
+          parsed: null,
+          ...(choice.message.tool_calls ?
+            {
+              tool_calls: choice.message.tool_calls,
+            }
+          : undefined),
+        },
       })),
     };
   }
@@ -144,7 +152,12 @@ export function parseChatCompletion<
       ...choice,
       message: {
         ...choice.message,
-        tool_calls: choice.message.tool_calls?.map((toolCall) => parseToolCall(params, toolCall)) ?? [],
+        ...(choice.message.tool_calls ?
+          {
+            tool_calls:
+              choice.message.tool_calls?.map((toolCall) => parseToolCall(params, toolCall)) ?? undefined,
+          }
+        : undefined),
         parsed:
           choice.message.content && !choice.message.refusal ?
             parseResponseFormat(params, choice.message.content)

--- a/src/resources/beta/chat/completions.ts
+++ b/src/resources/beta/chat/completions.ts
@@ -50,7 +50,7 @@ export interface ParsedFunctionToolCall extends ChatCompletionMessageToolCall {
 
 export interface ParsedChatCompletionMessage<ParsedT> extends ChatCompletionMessage {
   parsed: ParsedT | null;
-  tool_calls: Array<ParsedFunctionToolCall>;
+  tool_calls?: Array<ParsedFunctionToolCall>;
 }
 
 export interface ParsedChoice<ParsedT> extends ChatCompletion.Choice {

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -628,7 +628,7 @@ describe('resource completions', () => {
           content: "it's raining",
           parsed: null,
           refusal: null,
-          tool_calls: [],
+          tool_calls: undefined,
         },
       ]);
       expect(listener.functionCallResults).toEqual([`it's raining`]);
@@ -876,7 +876,7 @@ describe('resource completions', () => {
           content: 'there are 3 properties in {"a": 1, "b": 2, "c": 3}',
           parsed: null,
           refusal: null,
-          tool_calls: [],
+          tool_calls: undefined,
         },
       ]);
       expect(listener.functionCallResults).toEqual(['3']);
@@ -1125,7 +1125,7 @@ describe('resource completions', () => {
           content: 'there are 3 properties in {"a": 1, "b": 2, "c": 3}',
           parsed: null,
           refusal: null,
-          tool_calls: [],
+          tool_calls: undefined,
         },
       ]);
       expect(listener.functionCallResults).toEqual([`must be an object`, '3']);
@@ -1443,7 +1443,7 @@ describe('resource completions', () => {
           content: "it's raining",
           parsed: null,
           refusal: null,
-          tool_calls: [],
+          tool_calls: undefined,
         },
       ]);
       expect(listener.functionCallResults).toEqual([
@@ -1572,7 +1572,7 @@ describe('resource completions', () => {
           content: "it's raining",
           parsed: null,
           refusal: null,
-          tool_calls: [],
+          tool_calls: undefined,
         },
       ]);
       expect(listener.eventFunctionCallResults).toEqual([`it's raining`]);
@@ -1795,7 +1795,7 @@ describe('resource completions', () => {
           content: 'there are 3 properties in {"a": 1, "b": 2, "c": 3}',
           parsed: null,
           refusal: null,
-          tool_calls: [],
+          tool_calls: undefined,
         },
       ]);
       expect(listener.eventFunctionCallResults).toEqual(['3']);
@@ -1997,7 +1997,7 @@ describe('resource completions', () => {
           content: 'there are 3 properties in {"a": 1, "b": 2, "c": 3}',
           parsed: null,
           refusal: null,
-          tool_calls: [],
+          tool_calls: undefined,
         },
       ]);
       expect(listener.eventFunctionCallResults).toEqual([`must be an object`, '3']);
@@ -2301,7 +2301,7 @@ describe('resource completions', () => {
           content: "it's raining",
           parsed: null,
           refusal: null,
-          tool_calls: [],
+          tool_calls: undefined,
         },
       ]);
       expect(listener.eventFunctionCallResults).toEqual([
@@ -2347,7 +2347,7 @@ describe('resource completions', () => {
         content: 'The weather is great today!',
         parsed: null,
         refusal: null,
-        tool_calls: [],
+        tool_calls: undefined,
       });
       await listener.sanityCheck();
     });
@@ -2386,7 +2386,7 @@ describe('resource completions', () => {
         content: 'The weather is great today!',
         parsed: null,
         refusal: null,
-        tool_calls: [],
+        tool_calls: undefined,
       });
       await listener.sanityCheck();
     });

--- a/tests/lib/ChatCompletionStream.test.ts
+++ b/tests/lib/ChatCompletionStream.test.ts
@@ -39,7 +39,6 @@ describe('.stream()', () => {
           },
           "refusal": null,
           "role": "assistant",
-          "tool_calls": [],
         },
       }
     `);
@@ -198,7 +197,6 @@ describe('.stream()', () => {
           },
           "refusal": null,
           "role": "assistant",
-          "tool_calls": [],
         },
       }
     `);
@@ -386,7 +384,6 @@ describe('.stream()', () => {
           "parsed": null,
           "refusal": "I'm very sorry, but I can't assist with that request.",
           "role": "assistant",
-          "tool_calls": [],
         },
       }
     `);

--- a/tests/lib/parser.test.ts
+++ b/tests/lib/parser.test.ts
@@ -39,7 +39,6 @@ describe('.parse()', () => {
             },
             "refusal": null,
             "role": "assistant",
-            "tool_calls": [],
           },
         }
       `);
@@ -154,7 +153,6 @@ describe('.parse()', () => {
           },
           "refusal": null,
           "role": "assistant",
-          "tool_calls": [],
         }
       `);
 
@@ -488,7 +486,6 @@ describe('.parse()', () => {
           },
           "refusal": null,
           "role": "assistant",
-          "tool_calls": [],
         }
       `);
     });
@@ -787,7 +784,6 @@ describe('.parse()', () => {
           },
           "refusal": null,
           "role": "assistant",
-          "tool_calls": [],
         }
       `);
     });
@@ -947,7 +943,6 @@ describe('.parse()', () => {
           },
           "refusal": null,
           "role": "assistant",
-          "tool_calls": [],
         }
       `);
     });
@@ -1061,7 +1056,6 @@ describe('.parse()', () => {
           },
           "refusal": null,
           "role": "assistant",
-          "tool_calls": [],
         }
       `);
     });


### PR DESCRIPTION
The current behaviour of defaulting to an empty array breaks sending the message back to the API
```
400 Invalid 'messages[1].tool_calls': empty array. Expected an array with minimum length 1, but got an empty array instead.
```