### PR TITLE
feat(speech-voice-types): add SpeechVoice and SpeechResponseFormat types

### DIFF
--- a/src/resources/audio/speech.ts
+++ b/src/resources/audio/speech.ts
@@ -20,6 +20,10 @@ export class Speech extends APIResource {
 
 export type SpeechModel = 'tts-1' | 'tts-1-hd';
 
+export type SpeechVoice = 'alloy' | 'ash' | 'coral' | 'echo' | 'fable' | 'onyx' | 'nova' | 'sage' | 'shimmer';
+
+export type SpeechResponseFormat = 'mp3' | 'opus' | 'aac' | 'flac' | 'wav' | 'pcm';
+
 export interface SpeechCreateParams {
   /**
    * The text to generate audio for. The maximum length is 4096 characters.
@@ -38,13 +42,13 @@ export interface SpeechCreateParams {
    * voices are available in the
    * [Text to speech guide](https://platform.openai.com/docs/guides/text-to-speech#voice-options).
    */
-  voice: 'alloy' | 'ash' | 'coral' | 'echo' | 'fable' | 'onyx' | 'nova' | 'sage' | 'shimmer';
+  voice: (string & {}) | SpeechVoice;
 
   /**
    * The format to audio in. Supported formats are `mp3`, `opus`, `aac`, `flac`,
    * `wav`, and `pcm`.
    */
-  response_format?: 'mp3' | 'opus' | 'aac' | 'flac' | 'wav' | 'pcm';
+  response_format?: (string & {}) | SpeechResponseFormat;
 
   /**
    * The speed of the generated audio. Select a value from `0.25` to `4.0`. `1.0` is
@@ -54,5 +58,10 @@ export interface SpeechCreateParams {
 }
 
 export declare namespace Speech {
-  export { type SpeechModel as SpeechModel, type SpeechCreateParams as SpeechCreateParams };
+  export {
+    type SpeechModel as SpeechModel,
+    type SpeechCreateParams as SpeechCreateParams,
+    type SpeechVoice as SpeechVoice,
+    type SpeechResponseFormat as SpeechResponseFormat,
+  };
 }


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

If we could make SpeechVoice and SpeechResponseFormat types consistent with SpeechModel they can be referenced in consuming libraries. Due to them being hardcoded you can't use it as a type in consuming libraries.

Adding the (string & {}) flexibility for these types also makes it possible to use OpenAI compatible APIs.