### PR TITLE
Enhancing OpenAI-Node Tests

### DIFF
--- a/tests/lib/ChatCompletionStream.test.ts
+++ b/tests/lib/ChatCompletionStream.test.ts
@@ -45,7 +45,7 @@ describe('.stream()', () => {
   });
 
   it('emits content logprobs events', async () => {
-    var capturedLogProbs: ChatCompletionTokenLogprob[] | undefined;
+    let capturedLogProbs: ChatCompletionTokenLogprob[] | undefined;
 
     const stream = (
       await makeStreamSnapshotRequest((openai) =>
@@ -200,11 +200,11 @@ describe('.stream()', () => {
         },
       }
     `);
-    expect(capturedLogProbs?.length).toEqual(choice?.logprobs?.content?.length);
+    expect(capturedLogProbs?.length).toBe(choice?.logprobs?.content?.length);
   });
 
   it('emits refusal logprobs events', async () => {
-    var capturedLogProbs: ChatCompletionTokenLogprob[] | undefined;
+    let capturedLogProbs: ChatCompletionTokenLogprob[] | undefined;
 
     const stream = (
       await makeStreamSnapshotRequest((openai) =>
@@ -387,6 +387,6 @@ describe('.stream()', () => {
         },
       }
     `);
-    expect(capturedLogProbs?.length).toEqual(choice?.logprobs?.refusal?.length);
+    expect(capturedLogProbs?.length).toBe(choice?.logprobs?.refusal?.length);
   });
 });

--- a/tests/responses.test.ts
+++ b/tests/responses.test.ts
@@ -7,12 +7,16 @@ import { compareType } from './utils/typing';
 describe('response parsing', () => {
   // TODO: test unicode characters
   test('headers are case agnostic', async () => {
-    const headers = createResponseHeaders(new Headers({ 'Content-Type': 'foo', Accept: 'text/plain' }));
-    expect(headers['content-type']).toEqual('foo');
-    expect(headers['Content-type']).toEqual('foo');
-    expect(headers['Content-Type']).toEqual('foo');
-    expect(headers['accept']).toEqual('text/plain');
-    expect(headers['Accept']).toEqual('text/plain');
+    const contentTypeValue = 'foo';
+    const acceptValue = 'text/plain';
+
+    const headers = createResponseHeaders(new Headers({ 'Content-Type': contentTypeValue, Accept: acceptValue }));
+
+    expect(headers['content-type']).toBe(contentTypeValue);
+    expect(headers['Content-type']).toBe(contentTypeValue);
+    expect(headers['Content-Type']).toBe(contentTypeValue);
+    expect(headers['accept']).toBe(acceptValue);
+    expect(headers['Accept']).toBe(acceptValue);
     expect(headers['Hello-World']).toBeUndefined();
   });
 

--- a/tests/streaming.test.ts
+++ b/tests/streaming.test.ts
@@ -20,7 +20,7 @@ describe('streaming decoding', () => {
     expect(JSON.parse(event.value.data)).toEqual({ foo: true });
 
     event = await stream.next();
-    expect(event.done).toBeTruthy();
+    expect(event.done).toBe(true);
   });
 
   test('data without event', async () => {
@@ -39,7 +39,7 @@ describe('streaming decoding', () => {
     expect(JSON.parse(event.value.data)).toEqual({ foo: true });
 
     event = await stream.next();
-    expect(event.done).toBeTruthy();
+    expect(event.done).toBe(true);
   });
 
   test('event without data', async () => {
@@ -54,11 +54,11 @@ describe('streaming decoding', () => {
 
     let event = await stream.next();
     assert(event.value);
-    expect(event.value.event).toEqual('foo');
-    expect(event.value.data).toEqual('');
+    expect(event.value.event).toBe('foo');
+    expect(event.value.data).toBe('');
 
     event = await stream.next();
-    expect(event.done).toBeTruthy();
+    expect(event.done).toBe(true);
   });
 
   test('multiple events', async () => {
@@ -75,16 +75,16 @@ describe('streaming decoding', () => {
 
     let event = await stream.next();
     assert(event.value);
-    expect(event.value.event).toEqual('foo');
-    expect(event.value.data).toEqual('');
+    expect(event.value.event).toBe('foo');
+    expect(event.value.data).toBe('');
 
     event = await stream.next();
     assert(event.value);
-    expect(event.value.event).toEqual('ping');
-    expect(event.value.data).toEqual('');
+    expect(event.value.event).toBe('ping');
+    expect(event.value.data).toBe('');
 
     event = await stream.next();
-    expect(event.done).toBeTruthy();
+    expect(event.done).toBe(true);
   });
 
   test('multiple events with data', async () => {
@@ -103,16 +103,16 @@ describe('streaming decoding', () => {
 
     let event = await stream.next();
     assert(event.value);
-    expect(event.value.event).toEqual('foo');
+    expect(event.value.event).toBe('foo');
     expect(JSON.parse(event.value.data)).toEqual({ foo: true });
 
     event = await stream.next();
     assert(event.value);
-    expect(event.value.event).toEqual('ping');
+    expect(event.value.event).toBe('ping');
     expect(JSON.parse(event.value.data)).toEqual({ bar: false });
 
     event = await stream.next();
-    expect(event.done).toBeTruthy();
+    expect(event.done).toBe(true);
   });
 
   test('multiple data lines with empty line', async () => {
@@ -132,12 +132,12 @@ describe('streaming decoding', () => {
 
     let event = await stream.next();
     assert(event.value);
-    expect(event.value.event).toEqual('ping');
+    expect(event.value.event).toBe('ping');
     expect(JSON.parse(event.value.data)).toEqual({ foo: true });
-    expect(event.value.data).toEqual('{\n"foo":\n\n\ntrue}');
+    expect(event.value.data).toBe('{\n"foo":\n\n\ntrue}');
 
     event = await stream.next();
-    expect(event.done).toBeTruthy();
+    expect(event.done).toBe(true);
   });
 
   test('data json escaped double new line', async () => {
@@ -153,11 +153,11 @@ describe('streaming decoding', () => {
 
     let event = await stream.next();
     assert(event.value);
-    expect(event.value.event).toEqual('ping');
+    expect(event.value.event).toBe('ping');
     expect(JSON.parse(event.value.data)).toEqual({ foo: 'my long\n\ncontent' });
 
     event = await stream.next();
-    expect(event.done).toBeTruthy();
+    expect(event.done).toBe(true);
   });
 
   test('special new line characters', async () => {
@@ -189,7 +189,7 @@ describe('streaming decoding', () => {
     expect(JSON.parse(event.value.data)).toEqual({ content: 'foo' });
 
     event = await stream.next();
-    expect(event.done).toBeTruthy();
+    expect(event.done).toBe(true);
   });
 
   test('multi-byte characters across chunks', async () => {
@@ -215,7 +215,7 @@ describe('streaming decoding', () => {
     expect(JSON.parse(event.value.data)).toEqual({ content: 'известни' });
 
     event = await stream.next();
-    expect(event.done).toBeTruthy();
+    expect(event.done).toBe(true);
   });
 });
 

--- a/tests/uploads.test.ts
+++ b/tests/uploads.test.ts
@@ -34,32 +34,32 @@ describe('toFile', () => {
     // @ts-expect-error we intentionally do not type support for `string`
     // to help people avoid passing a file path
     const file = await toFile('contents');
-    expect(file.text()).resolves.toEqual('contents');
+    expect(file.text()).resolves.toBe('contents');
   });
 
   it('extracts a file name from a Response', async () => {
     const response = mockResponse({ url: 'https://example.com/my/audio.mp3' });
     const file = await toFile(response);
-    expect(file.name).toEqual('audio.mp3');
+    expect(file.name).toBe('audio.mp3');
   });
 
   it('extracts a file name from a File', async () => {
     const input = new File(['foo'], 'input.jsonl');
     const file = await toFile(input);
-    expect(file.name).toEqual('input.jsonl');
+    expect(file.name).toBe('input.jsonl');
   });
 
   it('extracts a file name from a ReadStream', async () => {
     const input = fs.createReadStream('tests/uploads.test.ts');
     const file = await toFile(input);
-    expect(file.name).toEqual('uploads.test.ts');
+    expect(file.name).toBe('uploads.test.ts');
   });
 
   it('does not copy File objects', async () => {
     const input = new File(['foo'], 'input.jsonl', { type: 'jsonl' });
     const file = await toFile(input);
     expect(file).toBe(input);
-    expect(file.name).toEqual('input.jsonl');
+    expect(file.name).toBe('input.jsonl');
     expect(file.type).toBe('jsonl');
   });
 });


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->
This PR improves the OpenAI-Node test suite.

`toBe` is more precise to compare primitive values. 
https://jestjs.io/docs/expect#tobevalue

`toBeTruthy` allows any truthy value, but toBe(true) ensures the value is strictly true, preventing unintended matches.
https://jestjs.io/docs/expect#tobetruthy

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

## Additional context & links
