### PR TITLE
fix: Update usage type to match documented behavior

### DIFF
--- a/src/resources/chat/completions/completions.ts
+++ b/src/resources/chat/completions/completions.ts
@@ -1,16 +1,15 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-import { APIResource } from '../../../resource';
-import { isRequestOptions } from '../../../core';
-import { APIPromise } from '../../../core';
 import * as Core from '../../../core';
-import * as CompletionsCompletionsAPI from './completions';
+import { APIPromise, isRequestOptions } from '../../../core';
+import { CursorPage, type CursorPageParams } from '../../../pagination';
+import { APIResource } from '../../../resource';
+import { Stream } from '../../../streaming';
 import * as CompletionsAPI from '../../completions';
 import * as Shared from '../../shared';
+import * as CompletionsCompletionsAPI from './completions';
 import * as MessagesAPI from './messages';
 import { MessageListParams, Messages } from './messages';
-import { CursorPage, type CursorPageParams } from '../../../pagination';
-import { Stream } from '../../../streaming';
 
 export class Completions extends APIResource {
   messages: MessagesAPI.Messages = new MessagesAPI.Messages(this._client);
@@ -383,7 +382,7 @@ export interface ChatCompletionChunk {
    * **NOTE:** If the stream is interrupted or cancelled, you may not receive the
    * final usage chunk which contains the total token usage for the request.
    */
-  usage?: CompletionsAPI.CompletionUsage;
+  usage?: CompletionsAPI.CompletionUsage | null;
 }
 
 export namespace ChatCompletionChunk {


### PR DESCRIPTION

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested  
The TypeScript type definition for the `usage` field does not match the documented behavior.  
According to the documentation, `usage` can be `null` for all chunks except the last one, but the current type definition does not allow `null`.  
This change updates the type to correctly reflect the API response.  

## Additional context & links  
- Documentation states that `usage` is `null` except for the last chunk.  
- Suggested fix:  
  ```ts
  usage?: CompletionsAPI.CompletionUsage | null;
  ```
- Related discussion: [[GitHub Issue #1402](https://github.com/openai/openai-node/issues/1402)](https://github.com/openai/openai-node/issues/1402)
