### PR TITLE
fix(types): ERROR, name shouldn't be optional for response's structured outputs

### DIFF
--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -1377,7 +1377,7 @@ export interface ResponseFormatTextJSONSchemaConfig {
    * The name of the response format. Must be a-z, A-Z, 0-9, or contain underscores
    * and dashes, with a maximum length of 64.
    */
-  name?: string;
+  name: string;
 
   /**
    * Whether to enable strict schema adherence when generating the output. If set to


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

In `src/resources/responses/responses.ts` make the `ResponseFormatTextJSONSchemaConfig` parameter not optional:

```typescript
/**
 * JSON Schema response format. Used to generate structured JSON responses. Learn
 * more about
 * [Structured Outputs](https://platform.openai.com/docs/guides/structured-outputs).
 */
export interface ResponseFormatTextJSONSchemaConfig {
...
  /**
   * The name of the response format. Must be a-z, A-Z, 0-9, or contain underscores
   * and dashes, with a maximum length of 64.
   */
  name?: string; -->  name: string;
...
}
```

Not setting this parameter generates an error.

## Additional context & links

Error example:

```
{
  status: 400,
  headers: {
    ...
  },
  error: {
    message: "Missing required parameter: 'text.format.name'.",
    type: "invalid_request_error",
    param: "text.format.name",
    code: "missing_required_parameter"
  },
  code: "missing_required_parameter",
  param: "text.format.name",
  type: "invalid_request_error",
  request_id: "req_ebdf4e9d8c4819718be076dabf1f6316"
}
```
