### PR TITLE
v5 chore: fully remove deprecated function call types from the tool runner

### DIFF
--- a/src/lib/chatCompletionUtils.ts
+++ b/src/lib/chatCompletionUtils.ts
@@ -1,6 +1,5 @@
 import {
   type ChatCompletionAssistantMessageParam,
-  type ChatCompletionFunctionMessageParam,
   type ChatCompletionMessageParam,
   type ChatCompletionToolMessageParam,
 } from '../resources';
@@ -9,12 +8,6 @@ export const isAssistantMessage = (
   message: ChatCompletionMessageParam | null | undefined,
 ): message is ChatCompletionAssistantMessageParam => {
   return message?.role === 'assistant';
-};
-
-export const isFunctionMessage = (
-  message: ChatCompletionMessageParam | null | undefined,
-): message is ChatCompletionFunctionMessageParam => {
-  return message?.role === 'function';
 };
 
 export const isToolMessage = (

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -130,12 +130,12 @@ class RunnerListener {
   readonly contents: string[] = [];
   readonly messages: ChatCompletionMessageParam[] = [];
   readonly chatCompletions: OpenAI.Chat.ChatCompletion[] = [];
-  readonly functionCalls: OpenAI.Chat.ChatCompletionMessage.FunctionCall[] = [];
+  readonly functionCalls: OpenAI.Chat.ChatCompletionMessageToolCall.Function[] = [];
   readonly functionCallResults: string[] = [];
   finalContent: string | null = null;
   finalMessage: ChatCompletionMessageParam | undefined;
   finalChatCompletion: OpenAI.Chat.ChatCompletion | undefined;
-  finalFunctionCall: OpenAI.Chat.ChatCompletionMessage.FunctionCall | undefined;
+  finalFunctionCall: OpenAI.Chat.ChatCompletionMessageToolCall.Function | undefined;
   finalFunctionCallResult: string | undefined;
   totalUsage: OpenAI.CompletionUsage | undefined;
   error: OpenAIError | undefined;
@@ -247,13 +247,13 @@ class StreamingRunnerListener {
   readonly eventContents: [string, string][] = [];
   readonly eventMessages: ChatCompletionMessageParam[] = [];
   readonly eventChatCompletions: OpenAI.Chat.ChatCompletion[] = [];
-  readonly eventFunctionCalls: OpenAI.Chat.ChatCompletionMessage.FunctionCall[] = [];
+  readonly eventFunctionCalls: OpenAI.Chat.ChatCompletionMessageToolCall.Function[] = [];
   readonly eventFunctionCallResults: string[] = [];
 
   finalContent: string | null = null;
   finalMessage: ChatCompletionMessageParam | undefined;
   finalChatCompletion: OpenAI.Chat.ChatCompletion | undefined;
-  finalFunctionCall: OpenAI.Chat.ChatCompletionMessage.FunctionCall | undefined;
+  finalFunctionCall: OpenAI.Chat.ChatCompletionMessageToolCall.Function | undefined;
   finalFunctionCallResult: string | undefined;
   error: OpenAIError | undefined;
   gotConnect = false;

--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -134,7 +134,7 @@ describe('instantiate azure client', () => {
 
     const spy = jest.spyOn(client, 'request');
 
-    await expect(client.get('/foo', { signal: controller.signal })).rejects.toThrowError(APIUserAbortError);
+    await expect(client.get('/foo', { signal: controller.signal })).rejects.toThrow(APIUserAbortError);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
runFunctions was already removed, this cleans up the last usage of the deprecated function calling types in the tool runner