### PR TITLE
fix(zod): warn on optional field usage

### DIFF
--- a/src/_vendor/zod-to-json-schema/parsers/object.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/object.ts
@@ -39,12 +39,20 @@ export function parseObjectDef(def: ZodObjectDef, refs: Refs) {
         [propName, propDef],
       ) => {
         if (propDef === undefined || propDef._def === undefined) return acc;
+        const propertyPath = [...refs.currentPath, 'properties', propName];
         const parsedDef = parseDef(propDef._def, {
           ...refs,
-          currentPath: [...refs.currentPath, 'properties', propName],
-          propertyPath: [...refs.currentPath, 'properties', propName],
+          currentPath: propertyPath,
+          propertyPath,
         });
         if (parsedDef === undefined) return acc;
+        if (refs.openaiStrictMode && propDef.isOptional() && !propDef.isNullable()) {
+          console.warn(
+            `Zod field at \`${propertyPath.join(
+              '/',
+            )}\` uses \`.optional()\` without \`.nullable()\` which is not supported by the API. See: https://platform.openai.com/docs/guides/structured-outputs?api-mode=responses#all-fields-must-be-required\nThis will become an error in a future version of the SDK.`,
+          );
+        }
         return {
           properties: {
             ...acc.properties,


### PR DESCRIPTION
The API doesn't support optional fields and the SDK is accidentally marking all fields as `required`, even when they've been marked with `.optional()`.

Fixing this would be a breaking change, so we're adding a warning and fixing this properly in v5. 