### PR TITLE
fix(types): support sizes for new image model

### DIFF
--- a/src/resources/images.ts
+++ b/src/resources/images.ts
@@ -215,7 +215,7 @@ export interface ImageEditParams {
    * (landscape), `1024x1536` (portrait), or `auto` (default value) for
    * `gpt-image-1`, and one of `256x256`, `512x512`, or `1024x1024` for `dall-e-2`.
    */
-  size?: '256x256' | '512x512' | '1024x1024' | null;
+  size?: '256x256' | '512x512' | '1024x1024' | '1024x1536' | '1536x1024' | 'auto' | null;
 
   /**
    * A unique identifier representing your end-user, which can help OpenAI to monitor


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
- Support `gpt-image-1` sizes in `ImageEditParams`

## Additional context & links
#1480 