### PR TITLE
fix(types): export ParseableToolsParams

### DIFF
--- a/src/lib/ResponsesParser.ts
+++ b/src/lib/ResponsesParser.ts
@@ -14,7 +14,7 @@ import {
 } from '../resources/responses/responses';
 import { type AutoParseableTextFormat, isAutoParsableResponseFormat } from '../lib/parser';
 
-type ParseableToolsParams = Array<Tool> | ChatCompletionTool | null;
+export type ParseableToolsParams = Array<Tool> | ChatCompletionTool | null;
 
 export type ResponseCreateParamsWithTools = ResponseCreateParamsBase & {
   tools?: ParseableToolsParams;


### PR DESCRIPTION
Enable lib clients to use this ParseableToolsParams definition

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Expose ParseableToolsParams type

## Additional Context

Hey, I was just trying to use this definition to create a "tools" variable with type annotation, but then I noticed it's not exported by this lib. 
