### PR TITLE
Add support for '1536x1024' size in gpt-image-1 for landscape images

### DIFF
--- a/src/resources/images.ts
+++ b/src/resources/images.ts
@@ -214,8 +214,9 @@ export interface ImageEditParams {
    * The size of the generated images. Must be one of `1024x1024`, `1536x1024`
    * (landscape), `1024x1536` (portrait), or `auto` (default value) for
    * `gpt-image-1`, and one of `256x256`, `512x512`, or `1024x1024` for `dall-e-2`.
+   * Added size 1536x1024 | 1024x1536 for `gpt-image-1` to support landscape images.
    */
-  size?: '256x256' | '512x512' | '1024x1024' | null;
+  size?: '256x256' | '512x512' | '1024x1024' | '1536x1024' | '1024x1536' | 'auto' | null;
 
   /**
    * A unique identifier representing your end-user, which can help OpenAI to monitor


### PR DESCRIPTION

**Thank you for contributing to this project!**

**The code in this repository is all auto-generated, and is not meant to be edited manually.**
**We recommend opening an Issue instead, but you are still welcome to open a PR to share an improvement if you wish, just note that we are unlikely to merge it as-is.**

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
- Added support for `1536x1024` (landscape) size in the `gpt-image-1` model for image generation.

## Additional context & links
- Enables landscape image generation with the new size option `1536x1024`.