### PR TITLE
add: fileObject purpose type

### DIFF
--- a/src/resources/files.ts
+++ b/src/resources/files.ts
@@ -145,7 +145,7 @@ export interface FileObject {
   /**
    * The intended purpose of the file. Supported values are `assistants`,
    * `assistants_output`, `batch`, `batch_output`, `fine-tune`, `fine-tune-results`
-   * and `vision`.
+   *  , `vision` and `user_data`.
    */
   purpose:
     | 'assistants'
@@ -154,7 +154,8 @@ export interface FileObject {
     | 'batch_output'
     | 'fine-tune'
     | 'fine-tune-results'
-    | 'vision';
+    | 'vision'
+    | 'user_data';
 
   /**
    * @deprecated Deprecated. The current status of the file, which can be either


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixed missing `user_data` purpose type in the `FileObject` interface to match the official OpenAI API specification.

**Changes:**
- Added `'user_data'` to the union type definition for the `purpose` field
- Updated JSDoc comment to include `user_data` in the supported values list

## Additional context & links

According to the [OpenAI Files API documentation](https://platform.openai.com/docs/api-reference/files/create), `user_data` is a valid purpose value that can be used when uploading files. However, this option was missing from the TypeScript interface definition, causing a mismatch between the actual API capabilities and the type definitions.

The `user_data` purpose is commonly used for general file uploads (as seen in OpenAI's web dashboard) and is referenced in community discussions about file purposes, but was inadvertently omitted from this generated interface.

### Example

```curl
curl https://api.openai.com/v1/files \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -F purpose="user_data" \
  -F file="@my.pdf"
```

```json
// response
{
  "id": "file-abc123",
  "object": "file",
  "bytes": 120000,
  "created_at": 1677610602,
  "filename": "my.pdf",
  "purpose": "user_data",
}
```
