### PR TITLE
Fix response.output_text.annotation.added event type

### DIFF
--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -3480,7 +3480,7 @@ export interface ResponseOutputTextAnnotationAddedEvent {
   /**
    * The type of the event. Always 'response.output_text_annotation.added'.
    */
-  type: 'response.output_text_annotation.added';
+  type: 'response.output_text.annotation.added';
 }
 
 /**


### PR DESCRIPTION
Fixes type definition.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

The type returned by the api is `response.output_text.annotation.added` not `response.output_text_annotation.added`.

## Additional context & links

N/A
