### PR TITLE
fix: make detail parameter optional in ResponseInputImage interface

### DIFF
--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -2033,7 +2033,7 @@ export interface ResponseInputImage {
    * The detail level of the image to be sent to the model. One of `high`, `low`, or
    * `auto`. Defaults to `auto`.
    */
-  detail: 'low' | 'high' | 'auto';
+  detail?: 'low' | 'high' | 'auto';
 
   /**
    * The type of the input item. Always `input_image`.


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Summary
Makes the `detail` parameter optional in the `ResponseInputImage` interface to align with the documented behavior that states it "Defaults to `auto`".

## Problem
The `detail` parameter was marked as required in the TypeScript interface despite the comment indicating it has a default value of `'auto'`. This created unnecessary friction for developers who want to rely on the default behaviour. When the detail is omitted from the code, the openai api perform as expected but IDE will always flag `detail` as required (typescript). From all the examples provided on openai documentation pages, `detail` is optional.

## Solution
Added the optional modifier (`?`) to the `detail` parameter in the `ResponseInputImage` interface.

## Changes
- Added `?` to `detail` parameter in `ResponseInputImage` interface
- [x] Aligns TypeScript interface with documented API behaviour

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Impact
This change will improve developer experience by allowing developers to omit the `detail` parameter when they want to use the default `'auto'` behaviour.

## Additional context & links
