### PR TITLE
fix(zod): avoid adding redundant `not` to optional schemas

### DIFF
--- a/src/_vendor/zod-to-json-schema/parsers/optional.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/optional.ts
@@ -3,8 +3,11 @@ import { JsonSchema7Type, parseDef } from '../parseDef';
 import { Refs } from '../Refs';
 
 export const parseOptionalDef = (def: ZodOptionalDef, refs: Refs): JsonSchema7Type | undefined => {
-  if (refs.currentPath.toString() === refs.propertyPath?.toString()) {
-    return parseDef(def.innerType._def, refs);
+  if (
+    refs.propertyPath &&
+    refs.currentPath.slice(0, refs.propertyPath.length).toString() === refs.propertyPath.toString()
+  ) {
+    return parseDef(def.innerType._def, { ...refs, currentPath: refs.currentPath });
   }
 
   const innerSchema = parseDef(def.innerType._def, {

--- a/tests/helpers/zod.test.ts
+++ b/tests/helpers/zod.test.ts
@@ -71,18 +71,11 @@ describe('zodResponseFormat', () => {
             "units": {
               "anyOf": [
                 {
-                  "anyOf": [
-                    {
-                      "not": {},
-                    },
-                    {
-                      "enum": [
-                        "c",
-                        "f",
-                      ],
-                      "type": "string",
-                    },
+                  "enum": [
+                    "c",
+                    "f",
                   ],
+                  "type": "string",
                 },
                 {
                   "type": "null",


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Adjusted optional field handling so that JSON Schema generation no longer emits redundant “not” constraints when an optional property is nested inside an object. The parser now checks that the current path begins with the property path before omitting the “not” clause

- Updated the test snapshot to match the corrected schema output, where optional nullable enums only include the union of the enum type and null without the extra “not” block

## Additional context & links

Fixes #1365