### PR TITLE
feat(client): propagate AbortSignal reason to APIUserAbortError

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -559,7 +559,7 @@ export class OpenAI {
     );
 
     if (options.signal?.aborted) {
-      throw new Errors.APIUserAbortError();
+      throw new Errors.APIUserAbortError({ message: options.signal.reason });
     }
 
     const controller = new AbortController();
@@ -569,7 +569,7 @@ export class OpenAI {
     if (response instanceof Error) {
       const retryMessage = `retrying, ${retriesRemaining} attempts remaining`;
       if (options.signal?.aborted) {
-        throw new Errors.APIUserAbortError();
+        throw new Errors.APIUserAbortError({ message: options.signal.reason });
       }
       // detect native connection timeout errors
       // deno throws "TypeError: error sending request for url (https://example/): client error (Connect): tcp connect error: Operation timed out (os error 60): Operation timed out (os error 60)"

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -252,12 +252,33 @@ describe('instantiate client', () => {
     });
 
     const controller = new AbortController();
-    setTimeout(() => controller.abort(), 200);
+    setTimeout(() => controller.abort('abort test'), 200);
 
-    const spy = jest.spyOn(client, 'request');
+    const requestSpy = jest.spyOn(client, 'request');
+    const fetchWithTimeoutSpy = jest.spyOn(client, 'fetchWithTimeout');
 
-    await expect(client.get('/foo', { signal: controller.signal })).rejects.toThrowError(APIUserAbortError);
-    expect(spy).toHaveBeenCalledTimes(1);
+    const abortedRequest = client.get('/foo', { signal: controller.signal });
+    await expect(abortedRequest).rejects.toThrow(APIUserAbortError);
+    await expect(abortedRequest).rejects.toEqual(expect.objectContaining({ message: 'abort test' }));
+
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+    expect(fetchWithTimeoutSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('should not make a request if the signal is aborted', async () => {
+    const client = new OpenAI({ baseURL: 'http://localhost:5000/', apiKey: 'My API Key' });
+    const requestSpy = jest.spyOn(client, 'request');
+    const fetchWithTimeoutSpy = jest.spyOn(client, 'fetchWithTimeout');
+    const controller = new AbortController();
+    controller.abort();
+    const abortedRequest = client.get('/foo', { signal: controller.signal });
+    await expect(abortedRequest).rejects.toThrow(APIUserAbortError);
+    await expect(abortedRequest).rejects.toEqual(
+      expect.objectContaining({ message: 'AbortError: This operation was aborted' }),
+    );
+
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+    expect(fetchWithTimeoutSpy).toHaveBeenCalledTimes(0);
   });
 
   test('normalized method', async () => {


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

This PR enhances the error handling for aborted requests by propagating the abort reason from the AbortSignal to the APIUserAbortError.

### What changed:
- Modified `APIUserAbortError` instantiation to include the abort signal's reason as the error message
- Updated two locations in `client.ts` where `APIUserAbortError` is thrown to pass the abort reason
- Added comprehensive tests to verify:
  - Custom abort reasons are properly propagated to the error
  - Pre-aborted signals prevent requests from being made

### Why this is useful:
- Developers can now provide custom abort reasons (e.g., `controller.abort('user cancelled')`) and receive them in error handlers
- Improves debugging by providing context about why a request was aborted
- Maintains backward compatibility while adding useful functionality

## Additional context & links

This change addresses the common use case where applications need to distinguish between different types of request cancellations (user-initiated vs timeout vs navigation away, etc.). By propagating the abort reason, error handlers can make more informed decisions about how to respond to aborted requests.

Example usage:
```javascript
const controller = new AbortController();
// Abort with a reason
controller.abort('User navigated away');

try {
  await client.get('/foo', { signal: controller.signal });
} catch (error) {
  if (error instanceof APIUserAbortError) {
    console.log(error.message); // "User navigated away"
  }
}
```