### PR TITLE
Pass through fetch error messages in APIConnectionError

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -653,7 +653,7 @@ export class OpenAI {
       if (isTimeout) {
         throw new Errors.APIConnectionTimeoutError();
       }
-      throw new Errors.APIConnectionError({ cause: response });
+      throw new Errors.APIConnectionError({ message: response.message, cause: response });
     }
 
     const specialHeaders = [...response.headers.entries()]

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -2407,11 +2407,15 @@ describe('resource completions', () => {
         throw new Error('mock request error');
       }).catch(() => {});
 
-      async function runStream() {
-        await stream.done();
-      }
-
-      await expect(runStream).rejects.toThrow(APIConnectionError);
+      await expect(async () => {
+        try {
+          await stream.done();
+        } catch (err) {
+          expect(err).toBeInstanceOf(APIConnectionError);
+          expect((err as Error).message).toBe('mock request error');
+          throw err;
+        }
+      }).rejects.toThrow('mock request error');
     });
     test('handles network errors on async iterator', async () => {
       const { fetch, handleRequest } = mockFetch();


### PR DESCRIPTION
## Summary
- include the underlying fetch error message when constructing APIConnectionError
- assert the network error test surfaces the original message in addition to the error type

## Rationale
- fixes openai/openai-node#1656 so callers receive the full connection failure details instead of the generic "Connection error"

## Changes
- update the retry logic to pass the error message into APIConnectionError
- extend the streaming network error test to check the message is preserved

Fixes #1656