### PR TITLE
fix(realtime): remove beta headers

### DIFF
--- a/src/realtime/websocket.ts
+++ b/src/realtime/websocket.ts
@@ -67,7 +67,6 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     this.socket = new WebSocket(this.url.toString(), [
       'realtime',
       ...(isAzure(client) ? [] : [`openai-insecure-api-key.${client.apiKey}`]),
-      'openai-beta.realtime-v1',
     ]);
 
     this.socket.addEventListener('message', (websocketEvent: MessageEvent) => {

--- a/src/realtime/ws.ts
+++ b/src/realtime/ws.ts
@@ -33,7 +33,6 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
       headers: {
         ...props.options?.headers,
         ...(isAzure(client) && !props.__resolvedApiKey ? {} : { Authorization: `Bearer ${client.apiKey}` }),
-        'OpenAI-Beta': 'realtime=v1',
       },
     });
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Closes issue #1641

## Additional context & links

The [beta to GA migration guide](https://platform.openai.com/docs/guides/realtime#beta-to-ga-migration) mentions that the "OpenAI-Beta" should no longer be used for the GA version of the API. The types are up to date, but the code still adds the headers