### PR TITLE
update zod imports to reduce esbuild bundle size by 260kb

### DIFF
--- a/src/helpers/zod.ts
+++ b/src/helpers/zod.ts
@@ -1,6 +1,6 @@
 import { ResponseFormatJSONSchema } from '../resources/index';
-import { z as z3 } from 'zod/v3';
-import { z as z4 } from 'zod/v4';
+import * as z3 from 'zod/v3';
+import * as z4 from 'zod/v4';
 import {
   AutoParseableResponseFormat,
   AutoParseableTextFormat,


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
Adjust Zod imports to avoid bundling locale files and reduce the esbuild bundle size by ~260kb.

## Additional context & links
With the current import { z } from 'zod', the Zod locales end up included in the bundle, which unnecessarily increases the output size.


