### PR TITLE
fix(types): incorrect value for prompt_cache_retention

### DIFF
--- a/src/resources/chat/completions/completions.ts
+++ b/src/resources/chat/completions/completions.ts
@@ -1644,7 +1644,7 @@ export interface ChatCompletionCreateParamsBase {
    * of 24 hours.
    * [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
    */
-  prompt_cache_retention?: 'in-memory' | '24h' | null;
+  prompt_cache_retention?: 'in_memory' | '24h' | null;
 
   /**
    * Constrains effort on reasoning for

--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -590,7 +590,7 @@ export interface Response {
    * of 24 hours.
    * [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
    */
-  prompt_cache_retention?: 'in-memory' | '24h' | null;
+  prompt_cache_retention?: 'in_memory' | '24h' | null;
 
   /**
    * **gpt-5 and o-series models only**
@@ -6148,7 +6148,7 @@ export interface ResponseCreateParamsBase {
    * of 24 hours.
    * [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
    */
-  prompt_cache_retention?: 'in-memory' | '24h' | null;
+  prompt_cache_retention?: 'in_memory' | '24h' | null;
 
   /**
    * **gpt-5 and o-series models only**

--- a/tests/api-resources/chat/completions/completions.test.ts
+++ b/tests/api-resources/chat/completions/completions.test.ts
@@ -41,7 +41,7 @@ describe('resource completions', () => {
       prediction: { content: 'string', type: 'content' },
       presence_penalty: -2,
       prompt_cache_key: 'prompt-cache-key-1234',
-      prompt_cache_retention: 'in-memory',
+      prompt_cache_retention: 'in_memory',
       reasoning_effort: 'none',
       response_format: { type: 'text' },
       safety_identifier: 'safety-identifier-1234',


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

When sending a request with `prompt_cache_retention: 'in-memory'`, the server responds with an error saying the only valid values are `in_memory` or `24h`. The typescript types though say that `in_memory` is not a valid value and should be `in-memory` instead. This updates  the types to reflect the server's requirements.

## Additional context & links
