### PR TITLE
fixed bug of image_tokens and text_tokens not being defined

### DIFF
--- a/src/resources/completions.ts
+++ b/src/resources/completions.ts
@@ -180,6 +180,16 @@ export namespace CompletionUsage {
      * Cached tokens present in the prompt.
      */
     cached_tokens?: number;
+
+    /**
+     * Image input tokens present in the prompt.
+     */
+    image_tokens?: number;
+
+    /**
+     * Text input tokens present in the prompt.
+     */
+    text_tokens?: number;
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
#### In your IDE without definition:

details = response.usage.prompt_tokens_details
details.text_ # ← No autocomplete!
details.text_tokens # ← Type checker error!

#### In your IDE with definition:
details = response.usage.prompt_tokens_details
details.text_ # ← IDE autocompletes to "text_tokens"! ✅
details.text_tokens # ← Type checker OK! ✅

## Additional context & links
To test this, need to use [gpt-4o-audio model (gpt-4o-audio-preview)](https://platform.openai.com/docs/models/gpt-4o-audio-preview) with [kaggle audio dataset](https://www.kaggle.com/datasets/crischir/sample-wav-audio-files) to make mini audio_to_text.py to be able to output 'text_tokens' and 'image_tokens' inside 'prompt_tokens_details'

## Next Step
Updating [in one of the example documentations](https://platform.openai.com/docs/api-reference/chat-streaming/streaming) here to include `text_tokens` and `image_token` inside `usage` > `prompt_tokens_details`

<img width="1228" height="924" alt="image" src="https://github.com/user-attachments/assets/85026722-4761-4a74-bad7-840b0c95ba39" />


Fixed #1718 
