### PR TITLE
fix: fall back to entire response body when 'error' field is missing

### DIFF
--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -66,7 +66,7 @@ export class APIError<
       return new APIConnectionError({ message, cause: castToError(errorResponse) });
     }
 
-    const error = (errorResponse as Record<string, any>)?.['error'];
+    const error = (errorResponse as Record<string, any>)?.['error'] ?? errorResponse;
 
     if (status === 400) {
       return new BadRequestError(status, error, message, headers);

--- a/tests/error.test.ts
+++ b/tests/error.test.ts
@@ -1,0 +1,51 @@
+import { APIError, BadRequestError, UnprocessableEntityError } from 'openai/core/error';
+
+describe('APIError.generate', () => {
+  const headers = new Headers({ 'x-request-id': 'req_123' });
+
+  test('extracts error from standard OpenAI error response', () => {
+    const err = APIError.generate(
+      422,
+      { error: { message: 'Invalid model', type: 'invalid_request_error', code: 'model_not_found' } },
+      undefined,
+      headers,
+    );
+    expect(err).toBeInstanceOf(UnprocessableEntityError);
+    expect(err.message).toContain('Invalid model');
+    expect(err.code).toBe('model_not_found');
+    expect(err.type).toBe('invalid_request_error');
+  });
+
+  test('falls back to entire response body when "error" field is missing', () => {
+    const err = APIError.generate(
+      422,
+      { detail: '422: The model gpt-5-gibberish does not exist.' },
+      undefined,
+      headers,
+    );
+    expect(err).toBeInstanceOf(UnprocessableEntityError);
+    expect(err.message).not.toContain('(no body)');
+    expect(err.message).toContain('gpt-5-gibberish');
+  });
+
+  test('falls back to response body with message field (non-standard)', () => {
+    const err = APIError.generate(
+      400,
+      { message: 'Something went wrong', code: 'bad_request' },
+      undefined,
+      headers,
+    );
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect(err.message).toContain('Something went wrong');
+  });
+
+  test('still shows "(no body)" when response is truly empty', () => {
+    const err = APIError.generate(422, undefined, undefined, headers);
+    expect(err.message).toContain('(no body)');
+  });
+
+  test('uses errMessage string fallback when JSON parsing fails', () => {
+    const err = APIError.generate(422, undefined, 'raw error text', headers);
+    expect(err.message).toContain('raw error text');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1734

When an OpenAI-compatible API returns error information in fields other than `error` (e.g. `detail` or `message`), the Node client currently reports `422 status code (no body)` instead of showing the actual error content. This differs from the Python client, which falls back to the entire response body.

## Changes

- **`src/core/error.ts`**: In `APIError.generate()`, when `errorResponse.error` is `undefined`, fall back to `errorResponse` itself (the entire parsed JSON body) instead of passing `undefined` to the error constructor. This is a one-line change: `?? errorResponse`.
- **`tests/error.test.ts`**: Added tests covering:
  - Standard OpenAI error response (with `error` field) — still works as before
  - Non-standard response with `detail` field — now shows the error content
  - Non-standard response with `message` field — now shows the error content  
  - Truly empty response — still shows `(no body)`
  - Raw text fallback — still works as before

## Before / After

**Before:** An error response like `{"detail": "422: The model gpt-5-gibberish does not exist."}` would produce:
```
UnprocessableEntityError: 422 status code (no body)
```

**After:** The same response now produces:
```
UnprocessableEntityError: 422 {"detail": "422: The model gpt-5-gibberish does not exist."}
```

This matches the Python client's behavior of falling back to the full response body when the `error` field is absent.