### PR TITLE
fix(types): change annotation type in ResponseOutputTextAnnotationAdd

### DIFF
--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -4924,7 +4924,11 @@ export interface ResponseOutputTextAnnotationAddedEvent {
   /**
    * The annotation object being added. (See annotation schema for details.)
    */
-  annotation: unknown;
+  annotation:
+    | ResponseOutputText.FileCitation
+    | ResponseOutputText.URLCitation
+    | ResponseOutputText.ContainerFileCitation
+    | ResponseOutputText.FilePath;
 
   /**
    * The index of the annotation within the content part.


### PR DESCRIPTION

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
`annotation` field is changed in `ResponseOutputTextAnnotationAddedEvent` from   
  `unknown` to a union of the expected annotation types such as FileCitation,       
  URLCitation, ContainerFileCitation and FilePath.

## Additional context & links
#1515 
FYI: The incorrect type was already fixed on 7/10/25, however, I opened this PR to improve the annotation type.
<img width="738" height="333" alt="Selection_006" src="https://github.com/user-attachments/assets/2ef1d099-6278-477a-ad09-e01e4e2419aa" />


Proof of work
<img width="546" height="91" alt="Selection_005" src="https://github.com/user-attachments/assets/61264faa-befc-4273-ba64-11dcbb98f93f" />

