### PR TITLE
Fix docs: ResponseStreamEvent JSDoc comment

### DIFF
--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -5419,7 +5419,7 @@ export interface ResponseRefusalDoneEvent {
 export type ResponseStatus = 'completed' | 'failed' | 'in_progress' | 'cancelled' | 'queued' | 'incomplete';
 
 /**
- * Emitted when there is a partial audio response.
+ * Events emitted during response streaming.
  */
 export type ResponseStreamEvent =
   | ResponseAudioDeltaEvent


### PR DESCRIPTION
Fixes #1699. Corrects JSDoc comment for ResponseStreamEvent union type to accurately describe it as events emitted during response streaming, rather than incorrectly describing a specific audio event.