### PR TITLE
fix(zod): convert oneOf to anyOf in toStrictJsonSchema for Zod v4 compatibility

### DIFF
--- a/src/lib/transform.ts
+++ b/src/lib/transform.ts
@@ -110,11 +110,16 @@ function ensureStrictJsonSchema(
   // Handle oneOf — Zod v4 emits `oneOf` for discriminated unions (https://github.com/colinhacks/zod/pull/5453),
   // but the OpenAI strict-mode API only accepts `anyOf`.  The semantics are equivalent for the union types
   // that Zod produces here, so we convert in-place and recurse into each variant.
+  // Merge into an existing anyOf array when one is already present (schemas that legitimately
+  // declare both anyOf and oneOf would otherwise lose the anyOf constraints).
   const oneOf = (jsonSchema as any).oneOf;
   if (Array.isArray(oneOf)) {
-    jsonSchema.anyOf = oneOf.map((variant: JSONSchemaDefinition, i: number) =>
+    const convertedOneOf = oneOf.map((variant: JSONSchemaDefinition, i: number) =>
       ensureStrictJsonSchema(variant, [...path, 'oneOf', String(i)], root),
     );
+    jsonSchema.anyOf = Array.isArray(jsonSchema.anyOf)
+      ? [...jsonSchema.anyOf, ...convertedOneOf]
+      : convertedOneOf;
     delete (jsonSchema as any).oneOf;
   }
 


### PR DESCRIPTION
## Problem

Zod v4.1.13 changed discriminated unions to emit `oneOf` in JSON Schema output ([colinhacks/zod#5453](https://github.com/colinhacks/zod/pull/5453)). The OpenAI strict-mode API does not accept `oneOf` — it returns HTTP 400:

```
"Invalid schema for response_format 'choice': In context=('properties', 'data'), 'oneOf' is not permitted."
```

Any user on Zod v4.1.13+ who passes a discriminated union to `zodResponseFormat` / `zodTextFormat` / `zodTool` will hit this failure.

Reported in #1709.

## Fix

After the existing `anyOf` handling block in `ensureStrictJsonSchema`, add a `oneOf` → `anyOf` conversion step:

```ts
const oneOf = (jsonSchema as any).oneOf;
if (Array.isArray(oneOf)) {
  jsonSchema.anyOf = oneOf.map((variant, i) =>
    ensureStrictJsonSchema(variant, [...path, 'oneOf', String(i)], root),
  );
  delete (jsonSchema as any).oneOf;
}
```

Each variant still passes through `ensureStrictJsonSchema`, so nested objects get `additionalProperties: false` and required fields are set correctly. The conversion is semantically safe: Zod `oneOf` variants are mutually exclusive object schemas, and `anyOf` is the form the OpenAI API expects.

Fixes #1709