### PR TITLE
fix(types): add `in`/`nin` to ComparisonFilter.type; make ResponseInputImage.detail optional

### DIFF
--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -3372,7 +3372,7 @@ export interface ResponseInputImage {
    * The detail level of the image to be sent to the model. One of `high`, `low`,
    * `auto`, or `original`. Defaults to `auto`.
    */
-  detail: 'low' | 'high' | 'auto' | 'original';
+  detail?: 'low' | 'high' | 'auto' | 'original';
 
   /**
    * The type of the input item. Always `input_image`.

--- a/src/resources/shared.ts
+++ b/src/resources/shared.ts
@@ -117,7 +117,7 @@ export interface ComparisonFilter {
    * - `in`: in
    * - `nin`: not in
    */
-  type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte';
+  type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte' | 'in' | 'nin';
 
   /**
    * The value to compare against the attribute key; supports string, number, or


### PR DESCRIPTION
## Summary

Two small type-definition fixes discovered while reviewing the vector-store
filtering and Responses API types.

### 1 – `ComparisonFilter.type` missing `'in'` and `'nin'` (closes #1682)

The JSDoc comment already lists all eight comparison operators including `in`
and `nin`, but the TypeScript union type only contained six of them:

```ts
// Before
type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte';

// After
type: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte' | 'in' | 'nin';
```

Without this fix, passing `type: 'in'` or `type: 'nin'` is a TypeScript
compile error even though the OpenAI API fully supports these operators for
file-search vector-store filtering.

### 2 – `ResponseInputImage.detail` should be optional (closes #1695)

The field's own JSDoc says *"Defaults to `auto`"*, meaning the API infers
the value when it is omitted. All code examples in the OpenAI documentation
omit it. Marking it required forced every caller to supply an explicit value
that adds no information.

```ts
// Before
detail: 'low' | 'high' | 'auto' | 'original';

// After
detail?: 'low' | 'high' | 'auto' | 'original';
```

## Testing

Both changes are pure type-level; no runtime behavior is affected.
The existing test suite continues to pass unchanged.