### PR TITLE
fix(types): add hosted shell response stream events

### DIFF
--- a/src/lib/responses/EventTypes.ts
+++ b/src/lib/responses/EventTypes.ts
@@ -24,6 +24,11 @@ import {
   ResponseOutputItemDoneEvent,
   ResponseRefusalDeltaEvent,
   ResponseRefusalDoneEvent,
+  ResponseShellCallCommandAddedEvent,
+  ResponseShellCallCommandDeltaEvent,
+  ResponseShellCallCommandDoneEvent,
+  ResponseShellCallOutputContentDeltaEvent,
+  ResponseShellCallOutputContentDoneEvent,
   ResponseTextDeltaEvent as RawResponseTextDeltaEvent,
   ResponseTextDoneEvent,
   ResponseIncompleteEvent,
@@ -67,6 +72,11 @@ export type ParsedResponseStreamEvent =
   | ResponseOutputItemDoneEvent
   | ResponseRefusalDeltaEvent
   | ResponseRefusalDoneEvent
+  | ResponseShellCallCommandAddedEvent
+  | ResponseShellCallCommandDeltaEvent
+  | ResponseShellCallCommandDoneEvent
+  | ResponseShellCallOutputContentDeltaEvent
+  | ResponseShellCallOutputContentDoneEvent
   | ResponseTextDeltaEvent
   | ResponseTextDoneEvent
   | ResponseWebSearchCallCompletedEvent

--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -5795,6 +5795,11 @@ export type ResponseStreamEvent =
   | ResponseReasoningTextDoneEvent
   | ResponseRefusalDeltaEvent
   | ResponseRefusalDoneEvent
+  | ResponseShellCallCommandAddedEvent
+  | ResponseShellCallCommandDeltaEvent
+  | ResponseShellCallCommandDoneEvent
+  | ResponseShellCallOutputContentDeltaEvent
+  | ResponseShellCallOutputContentDoneEvent
   | ResponseTextDeltaEvent
   | ResponseTextDoneEvent
   | ResponseWebSearchCallCompletedEvent
@@ -6164,6 +6169,174 @@ export namespace ResponseUsage {
      */
     reasoning_tokens: number;
   }
+}
+
+/**
+ * Emitted when a shell call command starts streaming.
+ */
+export interface ResponseShellCallCommandAddedEvent {
+  /**
+   * The current command text.
+   */
+  command: string;
+
+  /**
+   * The index of the command in the shell call action.
+   */
+  command_index: number;
+
+  /**
+   * The index of the output item associated with this shell call.
+   */
+  output_index: number;
+
+  /**
+   * The sequence number of this event.
+   */
+  sequence_number: number;
+
+  /**
+   * The type of the event. Always `response.shell_call_command.added`.
+   */
+  type: 'response.shell_call_command.added';
+}
+
+/**
+ * Emitted when a shell call command receives a text delta.
+ */
+export interface ResponseShellCallCommandDeltaEvent {
+  /**
+   * The index of the command in the shell call action.
+   */
+  command_index: number;
+
+  /**
+   * The command text delta.
+   */
+  delta: string;
+
+  /**
+   * Opaque obfuscation metadata for this delta.
+   */
+  obfuscation: string;
+
+  /**
+   * The index of the output item associated with this shell call.
+   */
+  output_index: number;
+
+  /**
+   * The sequence number of this event.
+   */
+  sequence_number: number;
+
+  /**
+   * The type of the event. Always `response.shell_call_command.delta`.
+   */
+  type: 'response.shell_call_command.delta';
+}
+
+/**
+ * Emitted when a shell call command finishes streaming.
+ */
+export interface ResponseShellCallCommandDoneEvent {
+  /**
+   * The completed command text.
+   */
+  command: string;
+
+  /**
+   * The index of the command in the shell call action.
+   */
+  command_index: number;
+
+  /**
+   * The index of the output item associated with this shell call.
+   */
+  output_index: number;
+
+  /**
+   * The sequence number of this event.
+   */
+  sequence_number: number;
+
+  /**
+   * The type of the event. Always `response.shell_call_command.done`.
+   */
+  type: 'response.shell_call_command.done';
+}
+
+/**
+ * Emitted when streamed shell call output content receives a delta.
+ */
+export interface ResponseShellCallOutputContentDeltaEvent {
+  /**
+   * The index of the command this output belongs to.
+   */
+  command_index: number;
+
+  /**
+   * The streamed stdout/stderr delta.
+   */
+  delta: {
+    stderr?: string;
+    stdout?: string;
+  };
+
+  /**
+   * The ID of the shell call output item.
+   */
+  item_id: string;
+
+  /**
+   * The index of the output item associated with this shell call.
+   */
+  output_index: number;
+
+  /**
+   * The sequence number of this event.
+   */
+  sequence_number: number;
+
+  /**
+   * The type of the event. Always `response.shell_call_output_content.delta`.
+   */
+  type: 'response.shell_call_output_content.delta';
+}
+
+/**
+ * Emitted when streamed shell call output content is complete.
+ */
+export interface ResponseShellCallOutputContentDoneEvent {
+  /**
+   * The index of the command this output belongs to.
+   */
+  command_index: number;
+
+  /**
+   * The ID of the shell call output item.
+   */
+  item_id: string;
+
+  /**
+   * The completed shell call output content.
+   */
+  output: Array<ResponseFunctionShellCallOutputContent>;
+
+  /**
+   * The index of the output item associated with this shell call.
+   */
+  output_index: number;
+
+  /**
+   * The sequence number of this event.
+   */
+  sequence_number: number;
+
+  /**
+   * The type of the event. Always `response.shell_call_output_content.done`.
+   */
+  type: 'response.shell_call_output_content.done';
 }
 
 /**
@@ -6593,6 +6766,11 @@ export type ResponsesServerEvent =
   | ResponseReasoningTextDoneEvent
   | ResponseRefusalDeltaEvent
   | ResponseRefusalDoneEvent
+  | ResponseShellCallCommandAddedEvent
+  | ResponseShellCallCommandDeltaEvent
+  | ResponseShellCallCommandDoneEvent
+  | ResponseShellCallOutputContentDeltaEvent
+  | ResponseShellCallOutputContentDoneEvent
   | ResponseTextDeltaEvent
   | ResponseTextDoneEvent
   | ResponseWebSearchCallCompletedEvent
@@ -7911,6 +8089,11 @@ export declare namespace Responses {
     type ResponseReasoningTextDoneEvent as ResponseReasoningTextDoneEvent,
     type ResponseRefusalDeltaEvent as ResponseRefusalDeltaEvent,
     type ResponseRefusalDoneEvent as ResponseRefusalDoneEvent,
+    type ResponseShellCallCommandAddedEvent as ResponseShellCallCommandAddedEvent,
+    type ResponseShellCallCommandDeltaEvent as ResponseShellCallCommandDeltaEvent,
+    type ResponseShellCallCommandDoneEvent as ResponseShellCallCommandDoneEvent,
+    type ResponseShellCallOutputContentDeltaEvent as ResponseShellCallOutputContentDeltaEvent,
+    type ResponseShellCallOutputContentDoneEvent as ResponseShellCallOutputContentDoneEvent,
     type ResponseStatus as ResponseStatus,
     type ResponseStreamEvent as ResponseStreamEvent,
     type ResponseTextConfig as ResponseTextConfig,

--- a/tests/responses.test.ts
+++ b/tests/responses.test.ts
@@ -1,6 +1,6 @@
 import { APIPromise } from 'openai/api-promise';
 import OpenAI from 'openai/index';
-import { compareType } from './utils/typing';
+import { compareType, expectType } from './utils/typing';
 
 const client = new OpenAI({ apiKey: 'example-api-key' });
 
@@ -135,3 +135,94 @@ describe('request id', () => {
     expect((result as any)._request_id).toBeUndefined();
   });
 });
+
+describe('responses stream typing', () => {
+  test('hosted shell stream events are typed', () => {
+    const commandAdded: Extract<
+      OpenAI.Responses.ResponseStreamEvent,
+      { type: 'response.shell_call_command.added' }
+    > = {
+      type: 'response.shell_call_command.added',
+      command: '',
+      command_index: 0,
+      output_index: 0,
+      sequence_number: 1,
+    };
+    expectType<string>(commandAdded.command);
+
+    const commandDelta: Extract<
+      OpenAI.Responses.ResponseStreamEvent,
+      { type: 'response.shell_call_command.delta' }
+    > = {
+      type: 'response.shell_call_command.delta',
+      command_index: 0,
+      delta: 'python',
+      obfuscation: '',
+      output_index: 0,
+      sequence_number: 2,
+    };
+    expectType<string>(commandDelta.delta);
+
+    const commandDone: Extract<
+      OpenAI.Responses.ResponseStreamEvent,
+      { type: 'response.shell_call_command.done' }
+    > = {
+      type: 'response.shell_call_command.done',
+      command: 'python main.py',
+      command_index: 0,
+      output_index: 0,
+      sequence_number: 3,
+    };
+    expectType<string>(commandDone.command);
+
+    const outputDelta: Extract<
+      OpenAI.Responses.ResponseStreamEvent,
+      { type: 'response.shell_call_output_content.delta' }
+    > = {
+      type: 'response.shell_call_output_content.delta',
+      command_index: 0,
+      delta: { stdout: '42' },
+      item_id: 'item_1',
+      output_index: 0,
+      sequence_number: 4,
+    };
+    expectType<string | undefined>(outputDelta.delta.stdout);
+
+    const outputDone: Extract<
+      OpenAI.Responses.ResponseStreamEvent,
+      { type: 'response.shell_call_output_content.done' }
+    > = {
+      type: 'response.shell_call_output_content.done',
+      command_index: 0,
+      item_id: 'item_1',
+      output: [
+        {
+          stdout: '42',
+          stderr: '',
+          outcome: { type: 'exit', exit_code: 0 },
+        },
+      ],
+      output_index: 0,
+      sequence_number: 5,
+    };
+    expectType<Array<OpenAI.Responses.ResponseFunctionShellCallOutputContent>>(outputDone.output);
+
+    expect(true).toBe(true);
+  });
+});
+
+const unused = async () => {
+  const stream = await client.responses.stream({
+    model: 'gpt-5.1',
+    input: 'Run a shell command.',
+    tools: [{ type: 'shell' }],
+  });
+
+  stream.on('response.shell_call_command.delta', (event) => {
+    expectType<string>(event.delta);
+  });
+
+  stream.on('response.shell_call_output_content.done', (event) => {
+    expectType<Array<OpenAI.Responses.ResponseFunctionShellCallOutputContent>>(event.output);
+  });
+};


### PR DESCRIPTION
## Summary
- add the missing hosted shell stream event interfaces to the Responses API types
- include them in both `ResponseStreamEvent` and the parsed stream event union used by `responses.stream()`
- add a compile-time regression test covering the raw union and the typed `.on(...)` listener surface

Fixes #1750.

## Testing
- `./node_modules/.bin/jest tests/responses.test.ts --runInBand`
- `./scripts/build`
- `./node_modules/.bin/eslint src/lib/responses/EventTypes.ts src/resources/responses/responses.ts tests/responses.test.ts`