### PR TITLE
fix: correct prompt_cache_retention type to use underscore

### DIFF
--- a/src/resources/chat/completions/completions.ts
+++ b/src/resources/chat/completions/completions.ts
@@ -1651,7 +1651,7 @@ export interface ChatCompletionCreateParamsBase {
    * of 24 hours.
    * [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
    */
-  prompt_cache_retention?: 'in-memory' | '24h' | null;
+  prompt_cache_retention?: 'in_memory' | '24h' | null;
 
   /**
    * Constrains effort on reasoning for

--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -1085,7 +1085,7 @@ export interface Response {
    * of 24 hours.
    * [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
    */
-  prompt_cache_retention?: 'in-memory' | '24h' | null;
+  prompt_cache_retention?: 'in_memory' | '24h' | null;
 
   /**
    * **gpt-5 and o-series models only**
@@ -6376,7 +6376,7 @@ export interface ResponsesClientEvent {
    * of 24 hours.
    * [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
    */
-  prompt_cache_retention?: 'in-memory' | '24h' | null;
+  prompt_cache_retention?: 'in_memory' | '24h' | null;
 
   /**
    * **gpt-5 and o-series models only**
@@ -7396,7 +7396,7 @@ export interface ResponseCreateParamsBase {
    * of 24 hours.
    * [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
    */
-  prompt_cache_retention?: 'in-memory' | '24h' | null;
+  prompt_cache_retention?: 'in_memory' | '24h' | null;
 
   /**
    * **gpt-5 and o-series models only**

--- a/tests/api-resources/chat/completions/completions.test.ts
+++ b/tests/api-resources/chat/completions/completions.test.ts
@@ -53,7 +53,7 @@ describe('resource completions', () => {
       prediction: { content: 'string', type: 'content' },
       presence_penalty: -2,
       prompt_cache_key: 'prompt-cache-key-1234',
-      prompt_cache_retention: 'in-memory',
+      prompt_cache_retention: 'in_memory',
       reasoning_effort: 'none',
       response_format: { type: 'text' },
       safety_identifier: 'safety-identifier-1234',


### PR DESCRIPTION
## Summary

This PR fixes a type definition mismatch in the `prompt_cache_retention` parameter.

According to the [OpenAI API documentation](https://developers.openai.com/api/docs/guides/prompt-caching), the allowed values for `prompt_cache_retention` are `in_memory` and `24h` (with underscore, not hyphen).

> If you don't specify a retention policy, the default is in_memory. Allowed values are in_memory and 24h.

However, the SDK type definition was using `in-memory` (with hyphen) instead of `in_memory` (with underscore), causing TypeScript errors when developers try to use the documented value.

## Changes

- Updated `prompt_cache_retention` type from `in-memory | 24h` to `in_memory | 24h` in:
  - `src/resources/responses/responses.ts` (3 occurrences)
  - `src/resources/chat/completions/completions.ts` (1 occurrence)
- Updated test file to use correct value

## Testing

The type change allows developers to use the documented `in_memory` value without TypeScript errors.

Fixes #1756