### PR TITLE
fix: add external_web_access option to WebSearchTool type

### DIFF
--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -7208,6 +7208,12 @@ export interface WebSearchTool {
    * The approximate location of the user.
    */
   user_location?: WebSearchTool.UserLocation | null;
+
+  /**
+   * Whether to allow the model to use external web access during the search.
+   * When `false`, the model will not access external web sources.
+   */
+  external_web_access?: boolean | null;
 }
 
 export namespace WebSearchTool {


### PR DESCRIPTION
## Summary

Adds the missing `external_web_access` option to the `WebSearchTool` interface.

## Changes

- Added `external_web_access?: boolean | null` property to the `WebSearchTool` interface
- Added JSDoc documentation for the new property

## Testing

- TypeScript compilation passes (errors are only from missing example dependencies)
- The new property matches the API behavior described in the issue

Fixes #1716