### PR TITLE
fix: export AzureClientOptions type from index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,4 +23,4 @@ export {
   InvalidWebhookSignatureError,
 } from './core/error';
 
-export { AzureOpenAI } from './azure';
+export { AzureOpenAI, type AzureClientOptions } from './azure';


### PR DESCRIPTION
## Summary

Fixes #1735 - The `AzureClientOptions` type was defined in `src/azure.ts` but was not exported from `src/index.ts`, making it unavailable for importers using `import { type AzureClientOptions } from 'openai'`.

## Changes

- Added `type AzureClientOptions` to the export statement in `src/index.ts`

## Testing

- Verified that `AzureClientOptions` is defined in `src/azure.ts` as an exported interface
- Confirmed the change follows the existing export pattern used for other types (e.g., `ClientOptions`)

Fixes #1735