### PR TITLE
fix: normalize endpoint URL by removing trailing slashes in AzureOpenAI

### DIFF
--- a/src/azure.ts
+++ b/src/azure.ts
@@ -103,7 +103,7 @@ export class AzureOpenAI extends OpenAI {
         );
       }
 
-      baseURL = `${endpoint}/openai`;
+      baseURL = `${endpoint.replace(/\/+$/, '')}/openai`;
     } else {
       if (endpoint) {
         throw new Errors.OpenAIError('baseURL and endpoint are mutually exclusive');


### PR DESCRIPTION
## Summary

Fixes a bug where providing an Azure endpoint with a trailing slash would result in double slashes in the constructed baseURL.

## Changes

- Modified `src/azure.ts` to remove trailing slashes from the endpoint URL before appending `/openai`

## Testing

- Verified the fix handles edge cases: no slash, single slash, multiple slashes
- TypeScript compilation passes

Fixes #1669