### PR TITLE
fix: fall back to response body when error field is missing

### DIFF
--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -66,7 +66,7 @@ export class APIError<
       return new APIConnectionError({ message, cause: castToError(errorResponse) });
     }
 
-    const error = (errorResponse as Record<string, any>)?.['error'];
+    const error: Object | undefined = (errorResponse as Record<string, any>)?.['error'] ?? errorResponse;
 
     if (status === 400) {
       return new BadRequestError(status, error, message, headers);


### PR DESCRIPTION
## Summary

When an OpenAI-compatible API returns errors in a field other than `error` (e.g., `detail`), the Node.js client previously showed `(no body)`. This PR adds a fallback to display the entire response body, matching the Python client behavior.

## Changes

- Modified `src/core/error.ts` to fall back to the full response body when the `error` field is missing

## Testing

- Ran existing test suite
- Verified error messages display correctly for both standard and non-standard error formats

Fixes openai/openai-node#1734