### PR TITLE
fix: prevent circular $ref in zodTextFormat for branded types

### DIFF
--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -98,8 +98,14 @@ export function parseDef(
   // For branded types, treat them as transparent and parse the underlying type directly.
   // This prevents circular $ref issues when the same branded type is used multiple times.
   // See: https://github.com/openai/openai-node/issues/1739
+  // Preserve metadata (description, etc.) from the branded wrapper by applying
+  // addMeta after parsing the underlying type.
   if ((def as any).typeName === ZodFirstPartyTypeKind.ZodBranded) {
-    return parseDef((def as any).type._def, refs, forceResolution);
+    const jsonSchema = parseDef((def as any).type._def, refs, forceResolution);
+    if (jsonSchema) {
+      addMeta(def, refs, jsonSchema);
+    }
+    return jsonSchema;
   }
 
   const newItem: Seen = { def, path: refs.currentPath, jsonSchema: undefined };

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -95,6 +95,13 @@ export function parseDef(
     }
   }
 
+  // For branded types, treat them as transparent and parse the underlying type directly.
+  // This prevents circular $ref issues when the same branded type is used multiple times.
+  // See: https://github.com/openai/openai-node/issues/1739
+  if ((def as any).typeName === ZodFirstPartyTypeKind.ZodBranded) {
+    return parseDef((def as any).type._def, refs, forceResolution);
+  }
+
   const newItem: Seen = { def, path: refs.currentPath, jsonSchema: undefined };
 
   refs.seen.set(def, newItem);


### PR DESCRIPTION
## Summary

Fixes circular `$ref` generation in `zodTextFormat` when using Zod branded types (e.g., `z.string().brand()`).

## Problem

When using a branded type like `z.string().brand("SlideId">())` and reusing it multiple times in a schema, `zodTextFormat` was generating a circular `$ref` that references itself:

```json
{
  "definitions": {
    "test_properties_a": {
      "$ref": "#/definitions/test_properties_a"
    }
  }
}
```

This circular reference is invalid and cannot be resolved.

## Root Cause

The issue was in `parseDef` function in the vendored `zod-to-json-schema` package. When parsing a branded type:
1. The branded type def was added to `refs.seen` with the current path
2. `parseBrandedDef` then parsed the underlying type, which also got added to `refs.seen` with the SAME path
3. When the branded type was encountered again, a `$ref` was created pointing to that path
4. When resolving the definition, the underlying type was found in `refs.seen` at that same path, causing a circular reference

## Solution

Modified `parseDef` to treat branded types as transparent wrappers. When a branded type is encountered, it now directly parses the underlying type without adding the branded def to `refs.seen`. This prevents the circular reference issue.

## Changes

- Modified `src/_vendor/zod-to-json-schema/parseDef.ts` to handle `ZodBranded` types specially by parsing the underlying type directly

## Testing

Verified with the reproduction case from the issue - no more circular references in the generated schema.

Fixes #1739