### PR TITLE
fix(responses): type external_web_access on web_search tools

### DIFF
--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -7199,6 +7199,12 @@ export interface WebSearchTool {
   type: 'web_search' | 'web_search_2025_08_26';
 
   /**
+   * Whether to allow the model to access web content outside the search snippets
+   * returned by the tool.
+   */
+  external_web_access?: boolean;
+
+  /**
    * Filters for the search.
    */
   filters?: WebSearchTool.Filters | null;

--- a/tests/responses.test.ts
+++ b/tests/responses.test.ts
@@ -1,6 +1,6 @@
 import { APIPromise } from 'openai/api-promise';
 import OpenAI from 'openai/index';
-import { compareType } from './utils/typing';
+import { compareType, expectType } from './utils/typing';
 
 const client = new OpenAI({ apiKey: 'example-api-key' });
 
@@ -133,5 +133,24 @@ describe('request id', () => {
     const result = await promise;
     expect(result).toBe('hello world');
     expect((result as any)._request_id).toBeUndefined();
+  });
+});
+
+describe('responses request typing', () => {
+  test('web_search tools accept external_web_access', () => {
+    const webSearchTool: OpenAI.Responses.WebSearchTool = {
+      type: 'web_search',
+      external_web_access: false,
+    };
+    expectType<boolean | undefined>(webSearchTool.external_web_access);
+
+    const request: OpenAI.Responses.ResponseCreateParamsNonStreaming = {
+      model: 'gpt-5.1',
+      input: "What is NVDA's latest stock price?",
+      tools: [webSearchTool],
+    };
+    expectType<Array<OpenAI.Responses.Tool> | undefined>(request.tools);
+
+    expect(true).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add `external_web_access?: boolean` to the `WebSearchTool` response request type
- add a compile-time regression covering `tools: [{ type: "web_search", external_web_access: false }]`

## Why
The Responses API accepts `external_web_access` on `web_search` tools at runtime, but the Node SDK type currently rejects it. This patch aligns the request type with the runtime behavior the issue reports.

## Testing
- `./node_modules/.bin/jest tests/responses.test.ts --runInBand`
- `./node_modules/.bin/eslint src/resources/responses/responses.ts tests/responses.test.ts`
- `./scripts/build`