### PR TITLE
fix: add text_tokens and image_tokens to PromptTokensDetails

### DIFF
--- a/src/resources/completions.ts
+++ b/src/resources/completions.ts
@@ -186,6 +186,16 @@ export namespace CompletionUsage {
      * Cached tokens present in the prompt.
      */
     cached_tokens?: number;
+
+    /**
+     * Text tokens present in the prompt.
+     */
+    text_tokens?: number;
+
+    /**
+     * Image tokens present in the prompt.
+     */
+    image_tokens?: number;
   }
 }
 


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Add `text_tokens` and `image_tokens` fields to the `PromptTokensDetails` interface in `src/resources/completions.ts`.

These fields are returned by the OpenAI API in the `prompt_tokens_details` object when using audio models like `gpt-4o-audio-preview` and `gpt-4o-mini-audio-preview`, but are currently not typed in the SDK.

Example API response:
```json
"prompt_tokens_details": {
  "cached_tokens": 0,
  "audio_tokens": 21,
  "text_tokens": 11,
  "image_tokens": 0
}
```

## Additional context & links

Fixes #1718