### PR TITLE
fix(types): correct prompt_cache_retention value from `in-memory` to `in_memory`

### DIFF
--- a/src/resources/chat/completions/completions.ts
+++ b/src/resources/chat/completions/completions.ts
@@ -1665,7 +1665,7 @@ export interface ChatCompletionCreateParamsBase {
    * of 24 hours.
    * [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
    */
-  prompt_cache_retention?: 'in-memory' | '24h' | null;
+  prompt_cache_retention?: 'in_memory' | '24h' | null;
 
   /**
    * Constrains effort on reasoning for

--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -1090,7 +1090,7 @@ export interface Response {
    * of 24 hours.
    * [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
    */
-  prompt_cache_retention?: 'in-memory' | '24h' | null;
+  prompt_cache_retention?: 'in_memory' | '24h' | null;
 
   /**
    * **gpt-5 and o-series models only**
@@ -6369,7 +6369,7 @@ export interface ResponsesClientEvent {
    * of 24 hours.
    * [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
    */
-  prompt_cache_retention?: 'in-memory' | '24h' | null;
+  prompt_cache_retention?: 'in_memory' | '24h' | null;
 
   /**
    * **gpt-5 and o-series models only**
@@ -7389,7 +7389,7 @@ export interface ResponseCreateParamsBase {
    * of 24 hours.
    * [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
    */
-  prompt_cache_retention?: 'in-memory' | '24h' | null;
+  prompt_cache_retention?: 'in_memory' | '24h' | null;
 
   /**
    * **gpt-5 and o-series models only**


### PR DESCRIPTION
## Summary

Fixes #1756

The OpenAI API documentation specifies `in_memory` (underscore) as the valid value for `prompt_cache_retention`, but the SDK type definitions were using `in-memory` (hyphen), causing a type mismatch for developers following the official docs.

## Changes

Updated the `prompt_cache_retention` type union in all four locations across two files:

- `src/resources/responses/responses.ts` (3 occurrences)
- `src/resources/chat/completions/completions.ts` (1 occurrence)

**Before:**
```typescript
prompt_cache_retention?: 'in-memory' | '24h' | null;
```

**After:**
```typescript
prompt_cache_retention?: 'in_memory' | '24h' | null;
```

This aligns the SDK types with the [official API documentation](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention) which documents `in_memory` as the correct value.
