### PR TITLE
fix(error): fall back to full response body when `error` field is absent

### DIFF
--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -66,7 +66,7 @@ export class APIError<
       return new APIConnectionError({ message, cause: castToError(errorResponse) });
     }
 
-    const error = (errorResponse as Record<string, any>)?.['error'];
+    const error = (errorResponse as Record<string, any>)?.['error'] ?? errorResponse;
 
     if (status === 400) {
       return new BadRequestError(status, error, message, headers);


### PR DESCRIPTION
## Summary

Fixes #1734

When an OpenAI-compatible API returns an error response that does not include an `error` field (e.g. using `detail`, `message`, or other custom fields at the top level), the Node.js client produced unhelpful error messages like `422 status code (no body)`.

This is because `APIError.generate()` extracted only `body.error` and passed `undefined` to the error constructors when that field was missing — the `makeMessage` logic then had nothing to display.

## Change

In `src/core/error.ts`, update the error extraction in `APIError.generate()` to fall back to the full response body when `body.error` is not present:

```typescript
// Before
const error = (errorResponse as Record<string, any>)?.['error'];

// After
const error = (errorResponse as Record<string, any>)?.['error'] ?? errorResponse;
```

This mirrors the behavior of the Python client, which falls back to including the entire response body in the error message when no `error` field is found. The existing `makeMessage` logic already handles this correctly by calling `JSON.stringify()` on non-string error values.

## Example

With a response body like `{"detail": "422: The model gpt-5-gibberish does not exist."}`:

- **Before:** `422 status code (no body)`
- **After:** `422 {"detail":"422: The model gpt-5-gibberish does not exist."}`
