### PR TITLE
fix(types): re-export AzureClientOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,4 +23,4 @@ export {
   InvalidWebhookSignatureError,
 } from './core/error';
 
-export { AzureOpenAI } from './azure';
+export { AzureOpenAI, type AzureClientOptions } from './azure';

--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -1,4 +1,4 @@
-import { AzureOpenAI } from 'openai';
+import { AzureOpenAI, type AzureClientOptions } from 'openai';
 import { APIUserAbortError } from 'openai';
 import { type Response, RequestInit, RequestInfo } from 'openai/internal/builtin-types';
 
@@ -64,6 +64,17 @@ describe('instantiate azure client', () => {
       );
       expect(req.headers.get('x-stainless-retry-count')).toEqual('1');
     });
+  });
+
+  test('exports AzureClientOptions from the root package', () => {
+    const options: AzureClientOptions = {
+      baseURL: 'https://example.com',
+      apiKey: 'My API Key',
+      apiVersion,
+    };
+
+    const client = new AzureOpenAI(options);
+    expect(client.baseURL).toEqual('https://example.com');
   });
 
   describe('defaultQuery', () => {


### PR DESCRIPTION
## Summary
- re-export `AzureClientOptions` from the package root again
- add a regression in the Azure package-surface test so `import type { AzureClientOptions } from 'openai'` stays covered

## Testing
- `./node_modules/.bin/jest tests/lib/azure.test.ts --runInBand`
- `./scripts/build`
- `./node_modules/.bin/eslint src/index.ts tests/lib/azure.test.ts`
