### PR TITLE
docs: clarify ResponseStreamEvent JSDoc comment

### DIFF
--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -5753,7 +5753,7 @@ export interface ResponseRefusalDoneEvent {
 export type ResponseStatus = 'completed' | 'failed' | 'in_progress' | 'cancelled' | 'queued' | 'incomplete';
 
 /**
- * Emitted when there is a partial audio response.
+ * Events that can be emitted by the Responses API streaming interface.
  */
 export type ResponseStreamEvent =
   | ResponseAudioDeltaEvent


### PR DESCRIPTION
## Summary
- replace the incorrect audio-specific JSDoc on `ResponseStreamEvent`
- describe `ResponseStreamEvent` as the union of events emitted by the Responses streaming interface

Fixes #1699

## Validation
- `yarn build`
- `./node_modules/.bin/eslint src/resources/responses/responses.ts`
- `./node_modules/.bin/prettier --check src/resources/responses/responses.ts`

## Notes
- `yarn lint` currently fails in this checkout for unrelated existing issues: one warning in generated `dist/` and missing optional example dependencies such as `express`, `next`, and `@azure/identity`.