### PR TITLE
fix(types): add 1080p video sizes (1920x1080, 1080x1920) for sora-2-pro

### DIFF
--- a/src/resources/videos.ts
+++ b/src/resources/videos.ts
@@ -218,7 +218,13 @@ export type VideoModel =
 
 export type VideoSeconds = '4' | '8' | '12';
 
-export type VideoSize = '720x1280' | '1280x720' | '1024x1792' | '1792x1024';
+export type VideoSize =
+  | '720x1280'
+  | '1280x720'
+  | '1024x1792'
+  | '1792x1024'
+  | '1920x1080'
+  | '1080x1920';
 
 /**
  * Confirmation payload returned after deleting a video.


### PR DESCRIPTION
## Summary

Adds support for 1080p video resolutions to the VideoSize type.

The sora-2-pro model supports higher-resolution exports in 1920x1080 and 1080x1920, but these sizes were not included in the VideoSize type union.

## Changes

- Added `'1920x1080'` to VideoSize type
- Added `'1080x1920'` to VideoSize type

## Documentation Reference

From the [Video generation with Sora guide](https://platform.openai.com/docs/guides/video-generation):

> Use sora-2-pro for higher-resolution exports in 1920x1080 or 1080x1920.

## Testing

- TypeScript compilation passes
- Type change is backward compatible (union expansion)

Fixes #1789