### PR TITLE
docs: fix client comment wording

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -433,7 +433,7 @@ export class OpenAI {
   }
 
   /**
-   * Create a new client instance re-using the same options given to the current client with optional overriding.
+   * Create a new client instance reusing the same options given to the current client with optional overriding.
    */
   withOptions(options: Partial<ClientOptions>): this {
     const client = new (this.constructor as any as new (props: ClientOptions) => typeof this)({


### PR DESCRIPTION
## Summary
- Update the `withOptions` comment in `src/client.ts` to use `reusing` instead of `re-using`.

## Related issue
- N/A (trivial comment wording fix)

## Guideline alignment
- Reviewed `CONTRIBUTING.md` before editing.
- Kept the diff to one hand-written source file with no behavior changes.

## Validation
- Not run (comment-only change).