### PR TITLE
fix(zod): pass forceResolution through parseBrandedDef to prevent circular $ref

### DIFF
--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -230,7 +230,7 @@ const selectParser = (
     case ZodFirstPartyTypeKind.ZodDefault:
       return parseDefaultDef(def, refs);
     case ZodFirstPartyTypeKind.ZodBranded:
-      return parseBrandedDef(def, refs);
+      return parseBrandedDef(def, refs, forceResolution);
     case ZodFirstPartyTypeKind.ZodReadonly:
       return parseReadonlyDef(def, refs);
     case ZodFirstPartyTypeKind.ZodCatch:

--- a/src/_vendor/zod-to-json-schema/parsers/branded.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/branded.ts
@@ -2,6 +2,6 @@ import { ZodBrandedDef } from 'zod/v3';
 import { parseDef } from '../parseDef';
 import { Refs } from '../Refs';
 
-export function parseBrandedDef(_def: ZodBrandedDef<any>, refs: Refs) {
-  return parseDef(_def.type._def, refs);
+export function parseBrandedDef(_def: ZodBrandedDef<any>, refs: Refs, forceResolution: boolean) {
+  return parseDef(_def.type._def, refs, forceResolution);
 }


### PR DESCRIPTION
## Summary

`zodTextFormat` / `zodResponseFormat` produce a self-referencing `$ref` in the definitions block when a `z.string().brand<...>()` type is reused across multiple schema fields. The resulting JSON schema is unresolvable and causes a cryptic `SyntaxError: Unexpected end of JSON input` from `responses.parse()`.

## Root Cause

`parseBrandedDef` in the vendored zod-to-json-schema code does not accept or forward the `forceResolution` parameter when calling `parseDef`. On the second encounter of the branded type's inner def (already in `refs.seen`), `parseDef` returns a `$ref` pointing back to the definition currently being built — a cycle.

`parseEffectsDef` already handles this correctly by accepting and forwarding `forceResolution`.

## Fix

- Add `forceResolution: boolean` parameter to `parseBrandedDef`
- Forward it to `parseDef(_def.type._def, refs, forceResolution)`
- Update the `selectParser` call site to pass `forceResolution` through

## Test plan

- Schema with a branded type reused in multiple fields now produces valid JSON schema with inline definitions instead of self-referencing `$ref`
- No change for schemas without branded types

Closes #1739