### PR TITLE
Add hosted shell response stream events

### DIFF
--- a/src/resources/responses/api.md
+++ b/src/resources/responses/api.md
@@ -123,6 +123,11 @@ Types:
 - <code><a href="./src/resources/responses/responses.ts">ResponseRefusalDeltaEvent</a></code>
 - <code><a href="./src/resources/responses/responses.ts">ResponseRefusalDoneEvent</a></code>
 - <code><a href="./src/resources/responses/responses.ts">ResponseStatus</a></code>
+- <code><a href="./src/resources/responses/responses.ts">ResponseShellCallCommandAddedEvent</a></code>
+- <code><a href="./src/resources/responses/responses.ts">ResponseShellCallCommandDeltaEvent</a></code>
+- <code><a href="./src/resources/responses/responses.ts">ResponseShellCallCommandDoneEvent</a></code>
+- <code><a href="./src/resources/responses/responses.ts">ResponseShellCallOutputContentDeltaEvent</a></code>
+- <code><a href="./src/resources/responses/responses.ts">ResponseShellCallOutputContentDoneEvent</a></code>
 - <code><a href="./src/resources/responses/responses.ts">ResponseStreamEvent</a></code>
 - <code><a href="./src/resources/responses/responses.ts">ResponseTextConfig</a></code>
 - <code><a href="./src/resources/responses/responses.ts">ResponseTextDeltaEvent</a></code>

--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -2763,6 +2763,188 @@ export interface ResponseFunctionCallArgumentsDoneEvent {
 }
 
 /**
+ * Emitted when a shell command starts streaming.
+ */
+export interface ResponseShellCallCommandAddedEvent {
+  /**
+   * The initial command text.
+   */
+  command: string;
+
+  /**
+   * The index of the command in the shell call action.
+   */
+  command_index: number;
+
+  /**
+   * The index of the shell call output item.
+   */
+  output_index: number;
+
+  /**
+   * The sequence number of this event.
+   */
+  sequence_number: number;
+
+  /**
+   * The type of the event. Always `response.shell_call_command.added`.
+   */
+  type: 'response.shell_call_command.added';
+}
+
+/**
+ * Emitted when a shell command receives a partial delta.
+ */
+export interface ResponseShellCallCommandDeltaEvent {
+  /**
+   * The index of the command in the shell call action.
+   */
+  command_index: number;
+
+  /**
+   * The command delta that was added.
+   */
+  delta: string;
+
+  /**
+   * An opaque obfuscation token for sensitive command text.
+   */
+  obfuscation: string;
+
+  /**
+   * The index of the shell call output item.
+   */
+  output_index: number;
+
+  /**
+   * The sequence number of this event.
+   */
+  sequence_number: number;
+
+  /**
+   * The type of the event. Always `response.shell_call_command.delta`.
+   */
+  type: 'response.shell_call_command.delta';
+}
+
+/**
+ * Emitted when a shell command is finalized.
+ */
+export interface ResponseShellCallCommandDoneEvent {
+  /**
+   * The fully assembled command text.
+   */
+  command: string;
+
+  /**
+   * The index of the command in the shell call action.
+   */
+  command_index: number;
+
+  /**
+   * The index of the shell call output item.
+   */
+  output_index: number;
+
+  /**
+   * The sequence number of this event.
+   */
+  sequence_number: number;
+
+  /**
+   * The type of the event. Always `response.shell_call_command.done`.
+   */
+  type: 'response.shell_call_command.done';
+}
+
+/**
+ * Emitted when a shell call output receives a partial delta.
+ */
+export interface ResponseShellCallOutputContentDeltaEvent {
+  /**
+   * The index of the command this output belongs to.
+   */
+  command_index: number;
+
+  /**
+   * The partial stdout or stderr delta.
+   */
+  delta: ResponseShellCallOutputContentDeltaEvent.Delta;
+
+  /**
+   * The ID of the shell call output item.
+   */
+  item_id: string;
+
+  /**
+   * The index of the shell call output item.
+   */
+  output_index: number;
+
+  /**
+   * The sequence number of this event.
+   */
+  sequence_number: number;
+
+  /**
+   * The type of the event. Always `response.shell_call_output_content.delta`.
+   */
+  type: 'response.shell_call_output_content.delta';
+}
+
+export namespace ResponseShellCallOutputContentDeltaEvent {
+  /**
+   * A partial shell output chunk for stdout or stderr.
+   */
+  export interface Delta {
+    /**
+     * The stderr text delta.
+     */
+    stderr?: string;
+
+    /**
+     * The stdout text delta.
+     */
+    stdout?: string;
+  }
+}
+
+/**
+ * Emitted when shell call output content is finalized.
+ */
+export interface ResponseShellCallOutputContentDoneEvent {
+  /**
+   * The index of the command this output belongs to.
+   */
+  command_index: number;
+
+  /**
+   * The ID of the shell call output item.
+   */
+  item_id: string;
+
+  /**
+   * The finalized shell call output chunks.
+   */
+  output: Array<ResponseFunctionShellCallOutputContent>;
+
+  /**
+   * The index of the shell call output item.
+   */
+  output_index: number;
+
+  /**
+   * The sequence number of this event.
+   */
+  sequence_number: number;
+
+  /**
+   * The type of the event. Always `response.shell_call_output_content.done`.
+   */
+  type: 'response.shell_call_output_content.done';
+}
+
+/**
  * A piece of message content, such as text, an image, or a file.
  */
 export type ResponseFunctionCallOutputItem =
@@ -5957,6 +6139,11 @@ export type ResponseStreamEvent =
   | ResponseFileSearchCallSearchingEvent
   | ResponseFunctionCallArgumentsDeltaEvent
   | ResponseFunctionCallArgumentsDoneEvent
+  | ResponseShellCallCommandAddedEvent
+  | ResponseShellCallCommandDeltaEvent
+  | ResponseShellCallCommandDoneEvent
+  | ResponseShellCallOutputContentDeltaEvent
+  | ResponseShellCallOutputContentDoneEvent
   | ResponseInProgressEvent
   | ResponseFailedEvent
   | ResponseIncompleteEvent
@@ -6755,6 +6942,11 @@ export type ResponsesServerEvent =
   | ResponseFileSearchCallSearchingEvent
   | ResponseFunctionCallArgumentsDeltaEvent
   | ResponseFunctionCallArgumentsDoneEvent
+  | ResponseShellCallCommandAddedEvent
+  | ResponseShellCallCommandDeltaEvent
+  | ResponseShellCallCommandDoneEvent
+  | ResponseShellCallOutputContentDeltaEvent
+  | ResponseShellCallOutputContentDoneEvent
   | ResponseInProgressEvent
   | ResponseFailedEvent
   | ResponseIncompleteEvent
@@ -8093,6 +8285,11 @@ export declare namespace Responses {
     type ResponseRefusalDeltaEvent as ResponseRefusalDeltaEvent,
     type ResponseRefusalDoneEvent as ResponseRefusalDoneEvent,
     type ResponseStatus as ResponseStatus,
+    type ResponseShellCallCommandAddedEvent as ResponseShellCallCommandAddedEvent,
+    type ResponseShellCallCommandDeltaEvent as ResponseShellCallCommandDeltaEvent,
+    type ResponseShellCallCommandDoneEvent as ResponseShellCallCommandDoneEvent,
+    type ResponseShellCallOutputContentDeltaEvent as ResponseShellCallOutputContentDeltaEvent,
+    type ResponseShellCallOutputContentDoneEvent as ResponseShellCallOutputContentDoneEvent,
     type ResponseStreamEvent as ResponseStreamEvent,
     type ResponseTextConfig as ResponseTextConfig,
     type ResponseTextDeltaEvent as ResponseTextDeltaEvent,

--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -2809,7 +2809,7 @@ export interface ResponseShellCallCommandDeltaEvent {
   /**
    * An opaque obfuscation token for sensitive command text.
    */
-  obfuscation: string;
+  obfuscation?: string;
 
   /**
    * The index of the shell call output item.

--- a/tests/lib/ResponseStream.test.ts
+++ b/tests/lib/ResponseStream.test.ts
@@ -57,4 +57,61 @@ describe('.stream()', () => {
     }
     expect(final.output_text).toBe('The answer is 42');
   });
+
+  it('hosted shell events work', async () => {
+    const commandEvents: string[] = [];
+    const outputDeltas: Array<{ stdout?: string; stderr?: string }> = [];
+    const outputDoneEvents: Array<
+      Array<{ stdout: string; stderr: string; outcome: { type: 'exit'; exit_code: number } }>
+    > = [];
+
+    const stream = (
+      await makeStreamSnapshotRequest((openai) =>
+        openai.responses.stream({
+          model: 'gpt-4.1',
+          input: 'Use the shell tool to print 55',
+          tools: [{ type: 'shell' }],
+        }),
+      )
+    )
+      .on('response.shell_call_command.added', (event) => {
+        commandEvents.push(event.command);
+      })
+      .on('response.shell_call_command.delta', (event) => {
+        expect(typeof event.obfuscation).toBe('string');
+        commandEvents.push(event.delta);
+      })
+      .on('response.shell_call_command.done', (event) => {
+        commandEvents.push(event.command);
+      })
+      .on('response.shell_call_output_content.delta', (event) => {
+        outputDeltas.push(event.delta);
+      })
+      .on('response.shell_call_output_content.done', (event) => {
+        outputDoneEvents.push(event.output as (typeof outputDoneEvents)[number]);
+      });
+
+    const final = await stream.finalResponse();
+
+    expect(commandEvents).toEqual(['', 'python ', '-c "print(55)"', 'python -c "print(55)"']);
+    expect(outputDeltas).toEqual([{ stdout: '55\\n' }]);
+    expect(outputDoneEvents).toEqual([
+      [{ stdout: '55\\n', stderr: '', outcome: { type: 'exit', exit_code: 0 } }],
+    ]);
+    expect(final.output_text).toBe('');
+
+    const shellCall = final.output[0];
+    expect(shellCall?.type).toBe('shell_call');
+    if (shellCall?.type === 'shell_call') {
+      expect(shellCall.action.commands).toEqual(['python -c "print(55)"']);
+    }
+
+    const shellOutput = final.output[1];
+    expect(shellOutput?.type).toBe('shell_call_output');
+    if (shellOutput?.type === 'shell_call_output') {
+      expect(shellOutput.output).toEqual([
+        { stdout: '55\\n', stderr: '', outcome: { type: 'exit', exit_code: 0 } },
+      ]);
+    }
+  });
 });

--- a/tests/lib/ResponseStream.test.ts
+++ b/tests/lib/ResponseStream.test.ts
@@ -1,4 +1,5 @@
 import { makeStreamSnapshotRequest } from '../utils/mock-snapshots';
+import { expectType } from '../utils/typing';
 
 jest.setTimeout(1000 * 30);
 
@@ -80,6 +81,7 @@ describe('.stream()', () => {
         commandEvents.push(event.command);
       })
       .on('response.shell_call_command.delta', (event) => {
+        expectType<string | undefined>(event.obfuscation);
         obfuscations.push(event.obfuscation);
         commandEvents.push(event.delta);
       })
@@ -87,6 +89,7 @@ describe('.stream()', () => {
         commandEvents.push(event.command);
       })
       .on('response.shell_call_output_content.delta', (event) => {
+        expectType<{ stdout?: string; stderr?: string }>(event.delta);
         outputDeltas.push(event.delta);
       })
       .on('response.shell_call_output_content.done', (event) => {
@@ -106,12 +109,14 @@ describe('.stream()', () => {
     const shellCall = final.output[0];
     expect(shellCall?.type).toBe('shell_call');
     if (shellCall?.type === 'shell_call') {
+      expectType<string[]>(shellCall.action.commands);
       expect(shellCall.action.commands).toEqual(['python -c "print(55)"']);
     }
 
     const shellOutput = final.output[1];
     expect(shellOutput?.type).toBe('shell_call_output');
     if (shellOutput?.type === 'shell_call_output') {
+      expectType<Array<{ stdout: string; stderr: string }>>(shellOutput.output);
       expect(shellOutput.output).toEqual([
         { stdout: '55\\n', stderr: '', outcome: { type: 'exit', exit_code: 0 } },
       ]);

--- a/tests/lib/ResponseStream.test.ts
+++ b/tests/lib/ResponseStream.test.ts
@@ -60,6 +60,7 @@ describe('.stream()', () => {
 
   it('hosted shell events work', async () => {
     const commandEvents: string[] = [];
+    const obfuscations: Array<string | undefined> = [];
     const outputDeltas: Array<{ stdout?: string; stderr?: string }> = [];
     const outputDoneEvents: Array<
       Array<{ stdout: string; stderr: string; outcome: { type: 'exit'; exit_code: number } }>
@@ -70,6 +71,7 @@ describe('.stream()', () => {
         openai.responses.stream({
           model: 'gpt-4.1',
           input: 'Use the shell tool to print 55',
+          stream_options: { include_obfuscation: false },
           tools: [{ type: 'shell' }],
         }),
       )
@@ -78,7 +80,7 @@ describe('.stream()', () => {
         commandEvents.push(event.command);
       })
       .on('response.shell_call_command.delta', (event) => {
-        expect(typeof event.obfuscation).toBe('string');
+        obfuscations.push(event.obfuscation);
         commandEvents.push(event.delta);
       })
       .on('response.shell_call_command.done', (event) => {
@@ -94,6 +96,7 @@ describe('.stream()', () => {
     const final = await stream.finalResponse();
 
     expect(commandEvents).toEqual(['', 'python ', '-c "print(55)"', 'python -c "print(55)"']);
+    expect(obfuscations).toEqual([undefined, undefined]);
     expect(outputDeltas).toEqual([{ stdout: '55\\n' }]);
     expect(outputDoneEvents).toEqual([
       [{ stdout: '55\\n', stderr: '', outcome: { type: 'exit', exit_code: 0 } }],

--- a/tests/lib/__snapshots__/ResponseStream.test.ts.snap
+++ b/tests/lib/__snapshots__/ResponseStream.test.ts.snap
@@ -50,3 +50,32 @@ data: [DONE]
 "
 `;
 
+exports[`.stream() hosted shell events work 1`] = `
+"data: {\"response\":{\"id\":\"resp_shell_1\",\"object\":\"response\",\"created_at\":1723031667,\"model\":\"gpt-4.1\",\"output\":[],\"output_text\":\"\",\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"metadata\":null,\"parallel_tool_calls\":false,\"temperature\":null,\"tools\":[{\"type\":\"shell\"}],\"top_p\":null,\"status\":\"in_progress\",\"usage\":{\"input_tokens\":0,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":0}},\"sequence_number\":0,\"type\":\"response.created\"}
+
+data: {\"item\":{\"id\":\"sh_1\",\"type\":\"shell_call\",\"call_id\":\"call_shell_1\",\"status\":\"in_progress\",\"environment\":null,\"action\":{\"commands\":[\"\"],\"timeout_ms\":null,\"max_output_length\":null}},\"output_index\":0,\"sequence_number\":1,\"type\":\"response.output_item.added\"}
+
+data: {\"command\":\"\",\"command_index\":0,\"output_index\":0,\"sequence_number\":2,\"type\":\"response.shell_call_command.added\"}
+
+data: {\"command_index\":0,\"delta\":\"python \",\"obfuscation\":\"\",\"output_index\":0,\"sequence_number\":3,\"type\":\"response.shell_call_command.delta\"}
+
+data: {\"command_index\":0,\"delta\":\"-c \\\"print(55)\\\"\",\"obfuscation\":\"\",\"output_index\":0,\"sequence_number\":4,\"type\":\"response.shell_call_command.delta\"}
+
+data: {\"command\":\"python -c \\\"print(55)\\\"\",\"command_index\":0,\"output_index\":0,\"sequence_number\":5,\"type\":\"response.shell_call_command.done\"}
+
+data: {\"item\":{\"id\":\"sh_1\",\"type\":\"shell_call\",\"call_id\":\"call_shell_1\",\"status\":\"completed\",\"environment\":null,\"action\":{\"commands\":[\"python -c \\\"print(55)\\\"\"],\"timeout_ms\":null,\"max_output_length\":null}},\"output_index\":0,\"sequence_number\":6,\"type\":\"response.output_item.done\"}
+
+data: {\"item\":{\"id\":\"sho_1\",\"type\":\"shell_call_output\",\"call_id\":\"call_shell_1\",\"status\":\"in_progress\",\"max_output_length\":null,\"output\":[]},\"output_index\":1,\"sequence_number\":7,\"type\":\"response.output_item.added\"}
+
+data: {\"command_index\":0,\"delta\":{\"stdout\":\"55\\\\n\"},\"item_id\":\"sho_1\",\"output_index\":1,\"sequence_number\":8,\"type\":\"response.shell_call_output_content.delta\"}
+
+data: {\"command_index\":0,\"item_id\":\"sho_1\",\"output\":[{\"stdout\":\"55\\\\n\",\"stderr\":\"\",\"outcome\":{\"type\":\"exit\",\"exit_code\":0}}],\"output_index\":1,\"sequence_number\":9,\"type\":\"response.shell_call_output_content.done\"}
+
+data: {\"item\":{\"id\":\"sho_1\",\"type\":\"shell_call_output\",\"call_id\":\"call_shell_1\",\"status\":\"completed\",\"max_output_length\":null,\"output\":[{\"stdout\":\"55\\\\n\",\"stderr\":\"\",\"outcome\":{\"type\":\"exit\",\"exit_code\":0}}]},\"output_index\":1,\"sequence_number\":10,\"type\":\"response.output_item.done\"}
+
+data: {\"response\":{\"id\":\"resp_shell_1\",\"object\":\"response\",\"created_at\":1723031667,\"model\":\"gpt-4.1\",\"output\":[{\"id\":\"sh_1\",\"type\":\"shell_call\",\"call_id\":\"call_shell_1\",\"status\":\"completed\",\"environment\":null,\"action\":{\"commands\":[\"python -c \\\"print(55)\\\"\"],\"timeout_ms\":null,\"max_output_length\":null}},{\"id\":\"sho_1\",\"type\":\"shell_call_output\",\"call_id\":\"call_shell_1\",\"status\":\"completed\",\"max_output_length\":null,\"output\":[{\"stdout\":\"55\\\\n\",\"stderr\":\"\",\"outcome\":{\"type\":\"exit\",\"exit_code\":0}}]}],\"output_text\":\"\",\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"metadata\":null,\"parallel_tool_calls\":false,\"temperature\":null,\"tools\":[{\"type\":\"shell\"}],\"top_p\":null,\"status\":\"completed\",\"usage\":{\"input_tokens\":10,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":6,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":16}},\"sequence_number\":11,\"type\":\"response.completed\"}
+
+data: [DONE]
+
+"
+`;

--- a/tests/lib/__snapshots__/ResponseStream.test.ts.snap
+++ b/tests/lib/__snapshots__/ResponseStream.test.ts.snap
@@ -57,9 +57,9 @@ data: {\"item\":{\"id\":\"sh_1\",\"type\":\"shell_call\",\"call_id\":\"call_shel
 
 data: {\"command\":\"\",\"command_index\":0,\"output_index\":0,\"sequence_number\":2,\"type\":\"response.shell_call_command.added\"}
 
-data: {\"command_index\":0,\"delta\":\"python \",\"obfuscation\":\"\",\"output_index\":0,\"sequence_number\":3,\"type\":\"response.shell_call_command.delta\"}
+data: {\"command_index\":0,\"delta\":\"python \",\"output_index\":0,\"sequence_number\":3,\"type\":\"response.shell_call_command.delta\"}
 
-data: {\"command_index\":0,\"delta\":\"-c \\\"print(55)\\\"\",\"obfuscation\":\"\",\"output_index\":0,\"sequence_number\":4,\"type\":\"response.shell_call_command.delta\"}
+data: {\"command_index\":0,\"delta\":\"-c \\\"print(55)\\\"\",\"output_index\":0,\"sequence_number\":4,\"type\":\"response.shell_call_command.delta\"}
 
 data: {\"command\":\"python -c \\\"print(55)\\\"\",\"command_index\":0,\"output_index\":0,\"sequence_number\":5,\"type\":\"response.shell_call_command.done\"}
 


### PR DESCRIPTION
## Summary
- add the missing hosted-shell Responses stream event interfaces for esponse.shell_call_command.* and esponse.shell_call_output_content.*
- include them in ResponseStreamEvent, ResponsesServerEvent, and the generated export/docs index
- add a snapshot-backed ResponseStream regression covering the hosted-shell event sequence

## Testing
- ./node_modules/.bin/jest tests/lib/ResponseStream.test.ts --runInBand
- ./node_modules/.bin/prettier --check --end-of-line lf src/resources/responses/responses.ts src/resources/responses/api.md tests/lib/ResponseStream.test.ts
- ./node_modules/.bin/eslint src/resources/responses/responses.ts tests/lib/ResponseStream.test.ts

Fixes #1750.