### PR TITLE
docs: document custom CA configuration for Node fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,41 @@ const client = new OpenAI({
 });
 ```
 
+#### Using custom CA certificates in Node
+
+If your Node runtime does not pick up `NODE_EXTRA_CA_CERTS` for `fetch`, you can create an `undici.Agent`
+with a combined CA bundle and pass it through `fetchOptions`.
+
+```ts
+import fs from 'fs';
+import tls from 'tls';
+import OpenAI from 'openai';
+import * as undici from 'undici';
+
+const extraCAPath = process.env.NODE_EXTRA_CA_CERTS;
+const extraCA = extraCAPath ? fs.readFileSync(extraCAPath, 'utf8') : undefined;
+const ca = extraCA ? [...tls.rootCertificates, extraCA] : tls.rootCertificates;
+
+const dispatcher = new undici.Agent({ connect: { ca } });
+const client = new OpenAI({
+  fetchOptions: {
+    dispatcher,
+  },
+});
+```
+
+Frameworks that patch `globalThis.fetch` may drop `dispatcher`. In those environments, pass a custom
+`fetch` implementation that calls `undici.fetch` directly:
+
+```ts
+const client = new OpenAI({
+  fetch: (url, init) => undici.fetch(url, { ...init, dispatcher }),
+});
+```
+
+Passing `ca` replaces the default trust store, so include `tls.rootCertificates` along with your
+private CA chain.
+
 ## Frequently Asked Questions
 
 ## Semantic versioning

--- a/src/client.ts
+++ b/src/client.ts
@@ -814,8 +814,9 @@ export class OpenAI {
     }
 
     try {
+      const requestFetch = Shims.getRequestFetch(this.fetch, fetchOptions);
       // use undefined this binding; fetch errors if bound to something else in browser/cloudflare
-      return await this.fetch.call(undefined, url, fetchOptions);
+      return await requestFetch.call(undefined, url, fetchOptions);
     } finally {
       clearTimeout(timeout);
     }

--- a/src/internal/shims.ts
+++ b/src/internal/shims.ts
@@ -20,6 +20,28 @@ export function getDefaultFetch(): Fetch {
   );
 }
 
+type NextPatchedFetch = Fetch & {
+  __nextPatched?: true;
+  _nextOriginalFetch?: Fetch;
+};
+
+export function getRequestFetch(fetch: Fetch, init?: RequestInit): Fetch {
+  if (!hasNodeDispatcher(init)) return fetch;
+
+  const nextPatchedFetch = fetch as NextPatchedFetch;
+  // Next.js stores the underlying Node fetch on `_nextOriginalFetch`; use it
+  // when dispatcher-based undici options would otherwise be stripped.
+  if (nextPatchedFetch.__nextPatched && typeof nextPatchedFetch._nextOriginalFetch === 'function') {
+    return nextPatchedFetch._nextOriginalFetch;
+  }
+
+  return fetch;
+}
+
+function hasNodeDispatcher(init?: RequestInit): boolean {
+  return Boolean(init && typeof init === 'object' && 'dispatcher' in (init as Record<string, unknown>));
+}
+
 type ReadableStreamArgs = ConstructorParameters<typeof ReadableStream>;
 
 export function makeReadableStream(...args: ReadableStreamArgs): ReadableStream {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -241,6 +241,95 @@ describe('instantiate client', () => {
     expect(response).toEqual({ url: 'http://localhost:5000/foo', custom: true });
   });
 
+  test('keeps Next.js patched fetch for standard requests', async () => {
+    const originalFetch = jest.fn(async () => {
+      return new Response(JSON.stringify({ source: 'original' }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    const patchedFetch = Object.assign(
+      jest.fn(async () => {
+        return new Response(JSON.stringify({ source: 'patched' }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }),
+      {
+        __nextPatched: true as const,
+        _nextOriginalFetch: originalFetch,
+      },
+    );
+
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = patchedFetch as typeof fetch;
+
+    try {
+      const client = new OpenAI({
+        baseURL: 'http://localhost:5000/',
+        apiKey: 'My API Key',
+      });
+
+      const response = await client.get('/foo');
+      expect(response).toEqual({ source: 'patched' });
+      expect(patchedFetch).toHaveBeenCalledTimes(1);
+      expect(originalFetch).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  test('uses Next.js original fetch when dispatcher is set', async () => {
+    const dispatcher = { type: 'dispatcher' };
+    const originalFetch = jest.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      return new Response(
+        JSON.stringify({
+          source: 'original',
+          hasDispatcher: Boolean(init && 'dispatcher' in (init as Record<string, unknown>)),
+        }),
+        {
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    });
+    const patchedFetch = Object.assign(
+      jest.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+        const { dispatcher: _dispatcher, ...nextInit } = ((init as Record<string, unknown> | undefined) ??
+          {}) as Record<string, unknown>;
+        return new Response(
+          JSON.stringify({
+            source: 'patched',
+            hasDispatcher: 'dispatcher' in nextInit,
+          }),
+          {
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+      }),
+      {
+        __nextPatched: true as const,
+        _nextOriginalFetch: originalFetch,
+      },
+    );
+
+    const previousFetch = globalThis.fetch;
+    globalThis.fetch = patchedFetch as typeof fetch;
+
+    try {
+      const client = new OpenAI({
+        baseURL: 'http://localhost:5000/',
+        apiKey: 'My API Key',
+        fetchOptions: { dispatcher } as any,
+      });
+
+      const response = await client.get('/foo');
+      expect(response).toEqual({ source: 'original', hasDispatcher: true });
+      expect(patchedFetch).not.toHaveBeenCalled();
+      expect(originalFetch).toHaveBeenCalledTimes(1);
+      expect((originalFetch.mock.calls[0]?.[1] as Record<string, unknown>)['dispatcher']).toBe(dispatcher);
+    } finally {
+      globalThis.fetch = previousFetch;
+    }
+  });
+
   test('explicit global fetch', async () => {
     // make sure the global fetch type is assignable to our Fetch type
     const client = new OpenAI({


### PR DESCRIPTION
## Summary
- document a Node custom-CA setup that combines 	ls.rootCertificates with a private CA bundle
- show the etchOptions.dispatcher path for plain Node runtimes
- document the custom etch fallback for frameworks that patch globalThis.fetch and drop dispatcher

Closes #1758.