### PR TITLE
Honor NODE_EXTRA_CA_CERTS in the default fetch path

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,26 @@ const client = new OpenAI({
 });
 ```
 
+#### Configuring custom CA certificates
+
+On Node.js `22.19+` and `24.5+`, the SDK will merge certificates from `NODE_EXTRA_CA_CERTS` into Node's
+default TLS CA store before it uses the default global `fetch`. This keeps certificate verification enabled
+while allowing requests to trust your additional corporate or private root CAs.
+
+```sh
+export NODE_EXTRA_CA_CERTS=/path/to/corporate-ca-chain.pem
+```
+
+```ts
+import OpenAI from 'openai';
+
+const client = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+```
+
+If you need per-client CA behavior instead of a process-wide default, pass a custom `fetch` implementation.
+
 ## Frequently Asked Questions
 
 ## Semantic versioning

--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ const client = new OpenAI({ fetch });
 
 ### Fetch options
 
-If you want to set custom `fetch` options without overriding the `fetch` function, you can provide a `fetchOptions` object when instantiating the client or making a request. (Request-specific options override client options.)
+If you want to set custom `fetch` options without overriding the `fetch` function, you can provide a `fetchOptions` object when instantiating the client or making a request. (Request-specific options override client options.) These options are forwarded to the active `fetch` implementation unchanged, so runtime-specific fields such as Undici's `dispatcher` only work when the underlying `fetch` supports them.
 
 ```ts
 import OpenAI from 'openai';
@@ -670,7 +670,31 @@ const client = new OpenAI({
 });
 ```
 
-If you need per-client CA behavior instead of a process-wide default, pass a custom `fetch` implementation.
+If you need per-client CA behavior instead of a process-wide default, or you're running in a framework that patches `globalThis.fetch` and ignores Undici-specific options such as `dispatcher`, pass a custom `fetch` implementation:
+
+```ts
+import fs from 'node:fs';
+import tls from 'node:tls';
+import OpenAI from 'openai';
+import { Agent, fetch as undiciFetch } from 'undici';
+
+const extraCAPath = process.env.NODE_EXTRA_CA_CERTS;
+const extraCA = extraCAPath ? fs.readFileSync(extraCAPath, 'utf8') : undefined;
+
+const dispatcher =
+  extraCA ?
+    new Agent({
+      connect: {
+        // Supplying `ca` replaces the default trust store, so keep Node's roots too.
+        ca: [...tls.rootCertificates, extraCA],
+      },
+    })
+  : undefined;
+
+const client = new OpenAI({
+  fetch: dispatcher ? (url, init) => undiciFetch(url, { ...init, dispatcher }) : undefined,
+});
+```
 
 ## Frequently Asked Questions
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -373,7 +373,7 @@ export class OpenAI {
    * @param {string | null | undefined} [opts.webhookSecret=process.env['OPENAI_WEBHOOK_SECRET'] ?? null]
    * @param {string} [opts.baseURL=process.env['OPENAI_BASE_URL'] ?? https://api.openai.com/v1] - Override the default base URL for the API.
    * @param {number} [opts.timeout=10 minutes] - The maximum amount of time (in milliseconds) the client will wait for a response before timing out.
-   * @param {MergedRequestInit} [opts.fetchOptions] - Additional `RequestInit` options to be passed to `fetch` calls.
+   * @param {MergedRequestInit} [opts.fetchOptions] - Additional `RequestInit` options forwarded to the active `fetch` implementation.
    * @param {Fetch} [opts.fetch] - Specify a custom `fetch` function implementation.
    * @param {number} [opts.maxRetries=2] - The maximum number of times the client will retry a request.
    * @param {HeadersLike} opts.defaultHeaders - Default headers to include with every request to the API.

--- a/src/internal/shims.ts
+++ b/src/internal/shims.ts
@@ -9,7 +9,6 @@
 
 import type { Fetch } from './builtin-types';
 import type { ReadableStream } from './shim-types';
-import { readEnv } from './utils/env';
 
 type NodeTLSModule = {
   getCACertificates?: ((type?: 'default' | 'extra') => string[]) | undefined;
@@ -23,8 +22,6 @@ function getNodeTLSModule(): NodeTLSModule | undefined {
 }
 
 function applyNodeExtraCACertificates(): void {
-  if (!readEnv('NODE_EXTRA_CA_CERTS')) return;
-
   const tls = getNodeTLSModule();
   if (typeof tls?.getCACertificates !== 'function' || typeof tls?.setDefaultCACertificates !== 'function') {
     return;

--- a/src/internal/shims.ts
+++ b/src/internal/shims.ts
@@ -9,9 +9,36 @@
 
 import type { Fetch } from './builtin-types';
 import type { ReadableStream } from './shim-types';
+import { readEnv } from './utils/env';
+
+type NodeTLSModule = {
+  getCACertificates?: ((type?: 'default' | 'extra') => string[]) | undefined;
+  setDefaultCACertificates?: ((certificates: string[]) => void) | undefined;
+};
+
+function getNodeTLSModule(): NodeTLSModule | undefined {
+  const process = (globalThis as any).process;
+  if (typeof process?.getBuiltinModule !== 'function') return undefined;
+  return process.getBuiltinModule('node:tls') as NodeTLSModule | undefined;
+}
+
+function applyNodeExtraCACertificates(): void {
+  if (!readEnv('NODE_EXTRA_CA_CERTS')) return;
+
+  const tls = getNodeTLSModule();
+  if (typeof tls?.getCACertificates !== 'function' || typeof tls?.setDefaultCACertificates !== 'function') {
+    return;
+  }
+
+  const extraCertificates = tls.getCACertificates('extra');
+  if (!extraCertificates.length) return;
+
+  tls.setDefaultCACertificates([...tls.getCACertificates('default'), ...extraCertificates]);
+}
 
 export function getDefaultFetch(): Fetch {
   if (typeof fetch !== 'undefined') {
+    applyNodeExtraCACertificates();
     return fetch as any;
   }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -6,6 +6,7 @@ import util from 'node:util';
 import OpenAI from 'openai';
 import { APIUserAbortError } from 'openai';
 const defaultFetch = fetch;
+const defaultGetBuiltinModule = (process as typeof process & { getBuiltinModule?: unknown }).getBuiltinModule;
 
 describe('instantiate client', () => {
   const env = process.env;
@@ -17,6 +18,12 @@ describe('instantiate client', () => {
 
   afterEach(() => {
     process.env = env;
+    const processWithBuiltins = process as typeof process & { getBuiltinModule?: unknown };
+    if (defaultGetBuiltinModule === undefined) {
+      delete processWithBuiltins.getBuiltinModule;
+    } else {
+      processWithBuiltins.getBuiltinModule = defaultGetBuiltinModule;
+    }
   });
 
   describe('defaultHeaders', () => {
@@ -248,6 +255,47 @@ describe('instantiate client', () => {
       apiKey: 'My API Key',
       fetch: defaultFetch,
     });
+  });
+
+  test('merges NODE_EXTRA_CA_CERTS into the default Node CA store before using global fetch', async () => {
+    const getCACertificates = jest.fn((type?: 'default' | 'extra') =>
+      type === 'extra' ? ['extra-ca'] : ['default-ca'],
+    );
+    const setDefaultCACertificates = jest.fn();
+    const processWithBuiltins = process as typeof process & {
+      getBuiltinModule?: (id: string) => unknown;
+    };
+
+    process.env['NODE_EXTRA_CA_CERTS'] = '/tmp/corporate-ca.pem';
+    processWithBuiltins.getBuiltinModule = jest.fn((id: string) =>
+      id === 'node:tls' ? { getCACertificates, setDefaultCACertificates } : undefined,
+    );
+
+    new OpenAI({
+      baseURL: 'http://localhost:5000/',
+      apiKey: 'My API Key',
+    });
+
+    expect(getCACertificates).toHaveBeenCalledWith('extra');
+    expect(getCACertificates).toHaveBeenCalledWith('default');
+    expect(setDefaultCACertificates).toHaveBeenCalledWith(['default-ca', 'extra-ca']);
+  });
+
+  test('skips NODE_EXTRA_CA_CERTS setup when Node does not expose the CA APIs', async () => {
+    const processWithBuiltins = process as typeof process & {
+      getBuiltinModule?: (id: string) => unknown;
+    };
+
+    process.env['NODE_EXTRA_CA_CERTS'] = '/tmp/corporate-ca.pem';
+    processWithBuiltins.getBuiltinModule = jest.fn(() => ({}));
+
+    expect(
+      () =>
+        new OpenAI({
+          baseURL: 'http://localhost:5000/',
+          apiKey: 'My API Key',
+        }),
+    ).not.toThrow();
   });
 
   test('custom signal', async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -341,6 +341,36 @@ describe('instantiate client', () => {
     expect(capturedRequest?.method).toEqual('PATCH');
   });
 
+  test('passes merged fetchOptions through to custom fetch', async () => {
+    let capturedRequest: RequestInit | undefined;
+    const clientDispatcher = { scope: 'client' } as any;
+    const requestDispatcher = { scope: 'request' } as any;
+
+    const client = new OpenAI({
+      baseURL: 'http://localhost:5000/',
+      apiKey: 'My API Key',
+      fetchOptions: { cache: 'no-store', dispatcher: clientDispatcher } as any,
+      fetch: async (url: string | URL | Request, init: RequestInit = {}): Promise<Response> => {
+        capturedRequest = init;
+        return new Response(JSON.stringify({ ok: true }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    });
+
+    await client.get('/foo', {
+      fetchOptions: { dispatcher: requestDispatcher, integrity: 'request-integrity' } as any,
+    });
+
+    expect(capturedRequest).toMatchObject({
+      method: 'GET',
+      cache: 'no-store',
+      integrity: 'request-integrity',
+      dispatcher: requestDispatcher,
+    });
+    expect((capturedRequest as any)?.dispatcher).not.toBe(clientDispatcher);
+  });
+
   describe('baseUrl', () => {
     test('trailing slash', () => {
       const client = new OpenAI({ baseURL: 'http://localhost:5000/custom/path/', apiKey: 'My API Key' });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -281,6 +281,30 @@ describe('instantiate client', () => {
     expect(setDefaultCACertificates).toHaveBeenCalledWith(['default-ca', 'extra-ca']);
   });
 
+  test('merges loaded extra CA certificates even after NODE_EXTRA_CA_CERTS is scrubbed', async () => {
+    const getCACertificates = jest.fn((type?: 'default' | 'extra') =>
+      type === 'extra' ? ['extra-ca'] : ['default-ca'],
+    );
+    const setDefaultCACertificates = jest.fn();
+    const processWithBuiltins = process as typeof process & {
+      getBuiltinModule?: (id: string) => unknown;
+    };
+
+    delete process.env['NODE_EXTRA_CA_CERTS'];
+    processWithBuiltins.getBuiltinModule = jest.fn((id: string) =>
+      id === 'node:tls' ? { getCACertificates, setDefaultCACertificates } : undefined,
+    );
+
+    new OpenAI({
+      baseURL: 'http://localhost:5000/',
+      apiKey: 'My API Key',
+    });
+
+    expect(getCACertificates).toHaveBeenCalledWith('extra');
+    expect(getCACertificates).toHaveBeenCalledWith('default');
+    expect(setDefaultCACertificates).toHaveBeenCalledWith(['default-ca', 'extra-ca']);
+  });
+
   test('skips NODE_EXTRA_CA_CERTS setup when Node does not expose the CA APIs', async () => {
     const processWithBuiltins = process as typeof process & {
       getBuiltinModule?: (id: string) => unknown;


### PR DESCRIPTION
## Summary
- merge `NODE_EXTRA_CA_CERTS` into Node''s default TLS CA store before the SDK adopts the default global `fetch`
- cover the new default-fetch behavior in `tests/index.test.ts`
- document the Node custom-CA behavior in the fetch-options section of the README

Fixes #1758.

## Testing
- `node node_modules/jest/bin/jest.js tests/index.test.ts --runInBand`
- `node node_modules/prettier/bin/prettier.cjs --check README.md src/internal/shims.ts tests/index.test.ts`
- `node node_modules/eslint/bin/eslint.js src/internal/shims.ts tests/index.test.ts`