### PR TITLE
fix: export AzureClientOptions from the root package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,4 +23,4 @@ export {
   InvalidWebhookSignatureError,
 } from './core/error';
 
-export { AzureOpenAI } from './azure';
+export { AzureOpenAI, type AzureClientOptions } from './azure';

--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -1,4 +1,4 @@
-import { AzureOpenAI } from 'openai';
+import { AzureOpenAI, type AzureClientOptions } from 'openai';
 import { APIUserAbortError } from 'openai';
 import { type Response, RequestInit, RequestInfo } from 'openai/internal/builtin-types';
 
@@ -10,6 +10,16 @@ const model = 'unused model';
 
 describe('instantiate azure client', () => {
   const env = process.env;
+
+  test('exports AzureClientOptions from the root package', () => {
+    const options: AzureClientOptions = {
+      endpoint: 'https://example-resource.openai.azure.com',
+      apiKey: 'My API Key',
+      apiVersion,
+    };
+
+    expect(options.apiVersion).toEqual(apiVersion);
+  });
 
   beforeEach(() => {
     jest.resetModules();


### PR DESCRIPTION
## Summary
- re-export AzureClientOptions from the package root alongside AzureOpenAI
- add a root-package type regression in 	ests/lib/azure.test.ts

## Testing
- 
ode node_modules/typescript/bin/tsc -p tsconfig.azure-export-check.json
- 
ode node_modules/jest/bin/jest.js tests/lib/azure.test.ts --runInBand
- 
ode node_modules/prettier/bin/prettier.cjs --check src/index.ts tests/lib/azure.test.ts
- 
ode node_modules/eslint/bin/eslint.js src/index.ts tests/lib/azure.test.ts
- git diff --check

Closes #1735.