### PR TITLE
fix: remove abort event listener on successful completion in fetchWithTimeout

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -892,6 +892,7 @@ export class OpenAI {
       return await this.fetch.call(undefined, url, fetchOptions);
     } finally {
       clearTimeout(timeout);
+      if (signal) signal.removeEventListener('abort', abort);
     }
   }
 


### PR DESCRIPTION
When an AbortSignal is passed to fetchWithTimeout, the method adds an event listener to forward abort events to the internal controller but never removes it on successful completion. In Deno, this refs the underlying timer of AbortSignal.timeout(), preventing the process from exiting until the full timeout duration elapses.

<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested
- Clean up signal event listener when fetch finishes

## Additional context & links

Fixes openai/openai-node#1811