### PR TITLE
docs: fix reusing wording in client docstring

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -433,7 +433,7 @@ export class OpenAI {
   }
 
   /**
-   * Create a new client instance re-using the same options given to the current client with optional overriding.
+   * Create a new client instance reusing the same options given to the current client with optional overriding.
    */
   withOptions(options: Partial<ClientOptions>): this {
     const client = new (this.constructor as any as new (props: ClientOptions) => typeof this)({


### PR DESCRIPTION
## Summary

Fix the client docstring by changing `re-using` to `reusing`.

## Related issue

N/A, trivial docstring wording fix.

## Guideline alignment

Single-file, non-behavioral wording change kept narrowly scoped.

## Validation/testing note

Not run; docstring-only change.