### PR TITLE
fix: remove abort listener on successful fetch to prevent Deno hang

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -892,6 +892,11 @@ export class OpenAI {
       return await this.fetch.call(undefined, url, fetchOptions);
     } finally {
       clearTimeout(timeout);
+      // Remove the forwarding listener so the caller's signal (and any
+      // underlying timer, e.g. AbortSignal.timeout()) can be GC'd
+      // immediately.  Without this, Deno keeps the timer ref'd for the
+      // full timeout duration, preventing clean process exit.  See #1811.
+      if (signal) signal.removeEventListener('abort', abort);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #1811

When `fetchWithTimeout` receives an external `signal`, it adds an `abort` event listener to forward cancellation to its internal controller. On successful completion, the listener was never removed — only the internal timeout was cleared.

On Deno, `AbortSignal.timeout()` refs its underlying timer when listeners are attached. The orphaned listener kept the timer ref'd for the full timeout duration, preventing clean process exit even though the request completed in milliseconds.

## Fix

Add `signal.removeEventListener('abort', abort)` in the existing `finally` block alongside `clearTimeout(timeout)`.

## Testing

- Node.js: no behavior change (timer stays unref'd regardless of listeners)
- Deno: process now exits immediately after successful request instead of hanging for the full signal timeout duration
- Abort mid-request: still works correctly (`{ once: true }` fires before cleanup)