### PR TITLE
fix(client): keep request timeout armed across body-read phase

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -243,6 +243,62 @@ import { isEmptyObj } from './internal/utils/values';
 
 const WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER = 'workload-identity-auth';
 
+/**
+ * Wrap a `Response` so that the given `clearRequestTimeout` callback runs
+ * exactly once, when the body is either fully read, cancelled, or errors.
+ * Responses without a body have the timeout cleared synchronously.
+ *
+ * This lets the request-timeout timer stay armed across the body-read phase
+ * (e.g. `await response.json()`), which native `await fetch()` does not cover.
+ */
+function wrapResponseForRequestTimeout(response: Response, clearRequestTimeout: () => void): Response {
+  if (!response.body) {
+    clearRequestTimeout();
+    return response;
+  }
+
+  let cleared = false;
+  const clearOnce = () => {
+    if (cleared) return;
+    cleared = true;
+    clearRequestTimeout();
+  };
+
+  const originalBody = response.body;
+  const wrappedBody = new ReadableStream({
+    async start(controller) {
+      const reader = originalBody.getReader();
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          controller.enqueue(value);
+        }
+        controller.close();
+      } catch (err) {
+        controller.error(err);
+      } finally {
+        clearOnce();
+        try {
+          reader.releaseLock();
+        } catch {
+          // reader may already be released
+        }
+      }
+    },
+    cancel(reason) {
+      clearOnce();
+      return originalBody.cancel(reason);
+    },
+  });
+
+  return new Response(wrappedBody, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
 export type ApiKeySetter = () => Promise<string>;
 
 export interface ClientOptions {
@@ -887,12 +943,22 @@ export class OpenAI {
       fetchOptions.method = method.toUpperCase();
     }
 
+    let response: Response;
     try {
       // use undefined this binding; fetch errors if bound to something else in browser/cloudflare
-      return await this.fetch.call(undefined, url, fetchOptions);
-    } finally {
+      response = await this.fetch.call(undefined, url, fetchOptions);
+    } catch (err) {
       clearTimeout(timeout);
+      throw err;
     }
+
+    // Keep the timer armed until the body is fully read, cancelled, or errored.
+    // The `await fetch()` above resolves as soon as response *headers* arrive, so
+    // clearing the timeout here would leave subsequent body readers — e.g.
+    // `await response.json()` in `internal/parse.ts` — without any timeout.
+    // Servers that flush 200 headers fast and then stall mid-body would cause
+    // the SDK to hang indefinitely. See openai/openai-node#1825.
+    return wrapResponseForRequestTimeout(response, () => clearTimeout(timeout));
   }
 
   private async shouldRetry(response: Response): Promise<boolean> {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -544,6 +544,56 @@ describe('default encoder', () => {
   });
 });
 
+describe('timeout covers body read phase', () => {
+  // Regression for https://github.com/openai/openai-node/issues/1825
+  // The SDK must abort the request if the server sends headers fast but
+  // stalls while streaming the body. Previously the internal timer was
+  // cleared as soon as `await fetch()` resolved (at headers arrival),
+  // leaving `response.json()` unguarded and able to hang forever.
+  test('rejects when the body read stalls past the configured timeout', async () => {
+    const CONFIGURED_TIMEOUT_MS = 50;
+    const BODY_STALL_MS = 2000;
+
+    const testFetch = async (
+      _url: string | URL | Request,
+      { signal }: RequestInit = {},
+    ): Promise<Response> => {
+      // Server-style body: headers are returned instantly, but the body
+      // stream never produces any chunks. We honour the AbortSignal so the
+      // SDK's retry/timeout path can still short-circuit it.
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          signal?.addEventListener('abort', () => controller.error(new Error('aborted')), { once: true });
+          // Safety net so the test never actually hangs longer than
+          // BODY_STALL_MS, regardless of whether the fix is in place.
+          setTimeout(() => {
+            controller.close();
+          }, BODY_STALL_MS).unref?.();
+        },
+      });
+
+      return new Response(body, {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+
+    const client = new OpenAI({
+      apiKey: 'My API Key',
+      timeout: CONFIGURED_TIMEOUT_MS,
+      maxRetries: 0,
+      fetch: testFetch,
+    });
+
+    const started = Date.now();
+    await expect(client.request({ path: '/foo', method: 'get' })).rejects.toThrow();
+    const elapsed = Date.now() - started;
+
+    // Must reject well before the body stall would naturally complete.
+    expect(elapsed).toBeLessThan(BODY_STALL_MS);
+  });
+});
+
 describe('retries', () => {
   test('retry on timeout', async () => {
     let count = 0;


### PR DESCRIPTION
Closes #1825.

## Problem

`fetchWithTimeout` clears the request timer in a `finally` block immediately after `await fetch()` resolves. But native `fetch` resolves when **response headers** arrive — not when the body has been fully read. The body is consumed later via `await response.json()` (etc.) in `internal/parse.ts`, **with no timer attached**.

So if a server sends a fast `200 OK` and then stalls while streaming the body, the SDK hangs indefinitely. We observed a 37-minute hang against an OpenAI-compatible provider before the caller had to be killed; the user-configured `timeout: 10 minutes` never fired and no retry kicked in.

Verified the bug is still present on `master` (and on every published version going back to v4.x) — the `try/finally` in `fetchWithTimeout` has not changed in any meaningful way.

## Fix

Wrap the response body in a `ReadableStream` whose `start` / `cancel` paths run the original `clearTimeout` callback exactly once: when the body is fully read, cancelled, or errored. Responses without a body (e.g. `HEAD`, `204`) have the timer cleared synchronously — preserving the previous behaviour. The wrapped `Response` keeps the original `status`, `statusText`, and `headers`.

The minimal contract change is: `fetchWithTimeout` no longer guarantees the timer is cleared by the time it returns. It is cleared once the consumer is done with the response (or errors out, or the timer fires and aborts the request).

## Bug-case test

Added `'timeout covers body read phase'` in `tests/index.test.ts`. The test fakes a server that returns 200 headers immediately and never enqueues body chunks, configures the client with a 50ms timeout and `maxRetries: 0`, and asserts the request rejects well before the body stall would naturally complete.

Verified locally on Node 24:
- **Without the fix** (master): the test fails — elapsed reaches `BODY_STALL_MS` (~2000 ms) before the assertion runs.
- **With the fix**: the test passes — request rejects in ~60 ms.

Other timeout-related tests still pass (`retry on timeout` for example), and `tests/streaming.test.ts` is unaffected.

## Why this matters

Many OpenAI-compatible providers (proxies, reasoning-heavy models, gateway tiers under load) routinely flush response headers fast and then stream the body slowly. Any stall in that body window currently translates into an unbounded hang in the SDK, with no error and no retry — the calling application has no way to detect the failure short of layering its own `AbortSignal` on every request. After this fix the SDK's documented `timeout` option means what users expect: a hard upper bound on the entire request including body read.

## Notes for maintainers

`src/client.ts` is generated, so this patch will need to be reflected upstream in the Stainless spec / generator config to survive future regenerations. Happy to follow whatever process you'd like — wanted to send a self-contained PR with a regression test so the failure mode is captured no matter how the fix lands.