### PR TITLE
fix: forward forceResolution through parseBrandedDef to prevent circular $ref

### DIFF
--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -230,7 +230,7 @@ const selectParser = (
     case ZodFirstPartyTypeKind.ZodDefault:
       return parseDefaultDef(def, refs);
     case ZodFirstPartyTypeKind.ZodBranded:
-      return parseBrandedDef(def, refs);
+      return parseBrandedDef(def, refs, forceResolution);
     case ZodFirstPartyTypeKind.ZodReadonly:
       return parseReadonlyDef(def, refs);
     case ZodFirstPartyTypeKind.ZodCatch:

--- a/src/_vendor/zod-to-json-schema/parsers/branded.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/branded.ts
@@ -2,6 +2,6 @@ import { ZodBrandedDef } from 'zod/v3';
 import { parseDef } from '../parseDef';
 import { Refs } from '../Refs';
 
-export function parseBrandedDef(_def: ZodBrandedDef<any>, refs: Refs) {
-  return parseDef(_def.type._def, refs);
+export function parseBrandedDef(_def: ZodBrandedDef<any>, refs: Refs, forceResolution: boolean = false) {
+  return parseDef(_def.type._def, refs, forceResolution);
 }


### PR DESCRIPTION
When a branded Zod type (e.g. `z.string().brand<"SlideId">()`) is used in multiple places in a schema, `parseDef` registers the inner type's def in `refs.seen` on first encounter. On second encounter, because `parseBrandedDef` did not forward the `forceResolution` parameter, `parseDef` returns a `$ref` instead of re-resolving. With the `extract-to-root` strategy this creates a definition entry that is just `{ $ref: '#/definitions/..._same_name' }` — a self-referencing circular `$ref`.

The fix passes `forceResolution` through `parseBrandedDef` so the inner type is always fully resolved when required.

**Changes:**
- `src/_vendor/zod-to-json-schema/parsers/branded.ts`: Accept and forward `forceResolution` parameter
- `src/_vendor/zod-to-json-schema/parseDef.ts`: Pass `forceResolution` to `parseBrandedDef` at call site

Fixes #1739