### PR TITLE
docs: clarify ResponseStreamEvent description

### DIFF
--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -5935,7 +5935,7 @@ export interface ResponseRefusalDoneEvent {
 export type ResponseStatus = 'completed' | 'failed' | 'in_progress' | 'cancelled' | 'queued' | 'incomplete';
 
 /**
- * Emitted when there is a partial audio response.
+ * A streamed event emitted by the Responses API.
  */
 export type ResponseStreamEvent =
   | ResponseAudioDeltaEvent


### PR DESCRIPTION
## Summary
- replace the misplaced partial-audio description on ResponseStreamEvent
- describe the union as a generic streamed event emitted by the Responses API

## Testing
- not run (documentation-only change)

Closes #1699