### PR TITLE
fix: fall back to top-level JSON error bodies

### DIFF
--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -67,7 +67,8 @@ export class APIError<
       return new APIConnectionError({ message, cause: castToError(errorResponse) });
     }
 
-    const error = (errorResponse as Record<string, any>)?.['error'];
+    const error =
+      (errorResponse as Record<string, any>)?.['error'] ?? (errorResponse as Record<string, any> | undefined);
 
     if (status === 400) {
       return new BadRequestError(status, error, message, headers);


### PR DESCRIPTION
## Summary
- keep preferring the standard top-level error field when present
- fall back to the full parsed JSON body for compatible APIs that return error details in other keys like detail

## Testing
- not run locally (fresh clone without built dist artifacts)

Closes #1734