### PR TITLE
docs(vector-stores): clarify files.delete required param in api.md

### DIFF
--- a/api.md
+++ b/api.md
@@ -350,7 +350,7 @@ Methods:
 - <code title="get /vector_stores/{vector_store_id}/files/{file_id}">client.vectorStores.files.<a href="./src/resources/vector-stores/files.ts">retrieve</a>(fileID, { ...params }) -> VectorStoreFile</code>
 - <code title="post /vector_stores/{vector_store_id}/files/{file_id}">client.vectorStores.files.<a href="./src/resources/vector-stores/files.ts">update</a>(fileID, { ...params }) -> VectorStoreFile</code>
 - <code title="get /vector_stores/{vector_store_id}/files">client.vectorStores.files.<a href="./src/resources/vector-stores/files.ts">list</a>(vectorStoreID, { ...params }) -> VectorStoreFilesPage</code>
-- <code title="delete /vector_stores/{vector_store_id}/files/{file_id}">client.vectorStores.files.<a href="./src/resources/vector-stores/files.ts">delete</a>(fileID, { ...params }) -> VectorStoreFileDeleted</code>
+- <code title="delete /vector_stores/{vector_store_id}/files/{file_id}">client.vectorStores.files.<a href="./src/resources/vector-stores/files.ts">delete</a>(fileID, { vector_store_id }) -> VectorStoreFileDeleted</code>
 - <code title="get /vector_stores/{vector_store_id}/files/{file_id}/content">client.vectorStores.files.<a href="./src/resources/vector-stores/files.ts">content</a>(fileID, { ...params }) -> FileContentResponsesPage</code>
 - <code>client.vectorStores.files.<a href="./src/resources/vector-stores/files.ts">createAndPoll</a>(vectorStoreId, body, options?) -> Promise&lt;VectorStoreFile&gt;</code>
 - <code>client.vectorStores.files.<a href="./src/resources/vector-stores/files.ts">poll</a>(vectorStoreId, fileId, options?) -> Promise&lt;VectorStoreFile&gt;</code>


### PR DESCRIPTION
## Summary

Fixes #1729

The `api.md` entry for `vectorStores.files.delete` used `{ ...params }` as a placeholder, which doesn't tell callers what field is actually required. The TypeScript implementation takes `FileDeleteParams` where `vector_store_id` is the only required field.

**Before:**
```
client.vectorStores.files.delete(fileID, { ...params }) -> VectorStoreFileDeleted
```

**After:**
```
client.vectorStores.files.delete(fileID, { vector_store_id }) -> VectorStoreFileDeleted
```

This matches the actual implementation in `src/resources/vector-stores/files.ts` where `const { vector_store_id } = params` is destructured and used to build the request path.