### PR TITLE
Preserve nested filenames for skill uploads

### DIFF
--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -75,10 +75,11 @@ export const isAsyncIterable = (value: any): value is AsyncIterable<any> =>
 export const maybeMultipartFormRequestOptions = async (
   opts: RequestOptions,
   fetch: OpenAI | Fetch,
+  { stripFilenames = true }: { stripFilenames?: boolean } = {},
 ): Promise<RequestOptions> => {
   if (!hasUploadableValue(opts.body)) return opts;
 
-  return { ...opts, body: await createForm(opts.body, fetch) };
+  return { ...opts, body: await createForm(opts.body, fetch, { stripFilenames }) };
 };
 
 type MultipartFormRequestOptions = Omit<RequestOptions, 'body'> & { body: unknown };
@@ -86,8 +87,9 @@ type MultipartFormRequestOptions = Omit<RequestOptions, 'body'> & { body: unknow
 export const multipartFormRequestOptions = async (
   opts: MultipartFormRequestOptions,
   fetch: OpenAI | Fetch,
+  { stripFilenames = true }: { stripFilenames?: boolean } = {},
 ): Promise<RequestOptions> => {
-  return { ...opts, body: await createForm(opts.body, fetch) };
+  return { ...opts, body: await createForm(opts.body, fetch, { stripFilenames }) };
 };
 
 const supportsFormDataMap = /* @__PURE__ */ new WeakMap<Fetch, Promise<boolean>>();
@@ -125,6 +127,7 @@ function supportsFormData(fetchObject: OpenAI | Fetch): Promise<boolean> {
 export const createForm = async <T = Record<string, unknown>>(
   body: T | undefined,
   fetch: OpenAI | Fetch,
+  { stripFilenames = true }: { stripFilenames?: boolean } = {},
 ): Promise<FormData> => {
   if (!(await supportsFormData(fetch))) {
     throw new TypeError(
@@ -132,7 +135,9 @@ export const createForm = async <T = Record<string, unknown>>(
     );
   }
   const form = new FormData();
-  await Promise.all(Object.entries(body || {}).map(([key, value]) => addFormValue(form, key, value)));
+  await Promise.all(
+    Object.entries(body || {}).map(([key, value]) => addFormValue(form, key, value, { stripFilenames })),
+  );
   return form;
 };
 
@@ -156,7 +161,12 @@ const hasUploadableValue = (value: unknown): boolean => {
   return false;
 };
 
-const addFormValue = async (form: FormData, key: string, value: unknown): Promise<void> => {
+const addFormValue = async (
+  form: FormData,
+  key: string,
+  value: unknown,
+  { stripFilenames = true }: { stripFilenames?: boolean } = {},
+): Promise<void> => {
   if (value === undefined) return;
   if (value == null) {
     throw new TypeError(
@@ -172,12 +182,16 @@ const addFormValue = async (form: FormData, key: string, value: unknown): Promis
   } else if (isAsyncIterable(value)) {
     form.append(key, makeFile([await new Response(ReadableStreamFrom(value)).blob()], getName(value)));
   } else if (isNamedBlob(value)) {
-    form.append(key, value, getName(value));
+    form.append(
+      key,
+      value,
+      stripFilenames ? getName(value) : (('name' in value && value.name && String(value.name)) || getName(value)),
+    );
   } else if (Array.isArray(value)) {
-    await Promise.all(value.map((entry) => addFormValue(form, key + '[]', entry)));
+    await Promise.all(value.map((entry) => addFormValue(form, key + '[]', entry, { stripFilenames })));
   } else if (typeof value === 'object') {
     await Promise.all(
-      Object.entries(value).map(([name, prop]) => addFormValue(form, `${key}[${name}]`, prop)),
+      Object.entries(value).map(([name, prop]) => addFormValue(form, `${key}[${name}]`, prop, { stripFilenames })),
     );
   } else {
     throw new TypeError(

--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -5935,7 +5935,7 @@ export interface ResponseRefusalDoneEvent {
 export type ResponseStatus = 'completed' | 'failed' | 'in_progress' | 'cancelled' | 'queued' | 'incomplete';
 
 /**
- * Emitted when there is a partial audio response.
+ * A streamed event emitted by the Responses API.
  */
 export type ResponseStreamEvent =
   | ResponseAudioDeltaEvent

--- a/src/resources/skills/skills.ts
+++ b/src/resources/skills/skills.ts
@@ -30,7 +30,10 @@ export class Skills extends APIResource {
    * Create a new skill.
    */
   create(body: SkillCreateParams | null | undefined = {}, options?: RequestOptions): APIPromise<Skill> {
-    return this._client.post('/skills', maybeMultipartFormRequestOptions({ body, ...options }, this._client));
+    return this._client.post(
+      '/skills',
+      maybeMultipartFormRequestOptions({ body, ...options }, this._client, { stripFilenames: false }),
+    );
   }
 
   /**

--- a/src/resources/skills/versions/versions.ts
+++ b/src/resources/skills/versions/versions.ts
@@ -23,7 +23,7 @@ export class Versions extends APIResource {
   ): APIPromise<SkillVersion> {
     return this._client.post(
       path`/skills/${skillID}/versions`,
-      maybeMultipartFormRequestOptions({ body, ...options }, this._client),
+      maybeMultipartFormRequestOptions({ body, ...options }, this._client, { stripFilenames: false }),
     );
   }
 

--- a/tests/api-resources/skills/skills.test.ts
+++ b/tests/api-resources/skills/skills.test.ts
@@ -1,6 +1,8 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import OpenAI, { toFile } from 'openai';
+import { mockFetch } from '../../utils/mock-fetch';
+import { File } from 'node:buffer';
 
 const client = new OpenAI({
   apiKey: 'My API Key',
@@ -27,6 +29,25 @@ describe('resource skills', () => {
         { path: '/_stainless_unknown_path' },
       ),
     ).rejects.toThrow(OpenAI.NotFoundError);
+  });
+
+  test('create: preserves nested skill file paths', async () => {
+    const { fetch, handleRequest } = mockFetch();
+    const client = new OpenAI({ apiKey: 'My API Key', fetch });
+
+    handleRequest(async (_, init) => {
+      const files = (init!.body as FormData).getAll('files[]');
+      expect(files).toHaveLength(1);
+      expect(files[0]).toBeInstanceOf(File);
+      expect((files[0] as File).name).toEqual('my-skill/SKILL.md');
+
+      return new Response(JSON.stringify({ id: 'skill_123', created_at: 0, default_version: '1', description: '', latest_version: '1', name: 'my-skill', object: 'skill' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    await client.skills.create({ files: [new File(['# skill'], 'my-skill/SKILL.md')] });
   });
 
   test('retrieve', async () => {

--- a/tests/api-resources/skills/versions/versions.test.ts
+++ b/tests/api-resources/skills/versions/versions.test.ts
@@ -1,6 +1,8 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import OpenAI, { toFile } from 'openai';
+import { mockFetch } from '../../../utils/mock-fetch';
+import { File } from 'node:buffer';
 
 const client = new OpenAI({
   apiKey: 'My API Key',
@@ -28,6 +30,36 @@ describe('resource versions', () => {
         { path: '/_stainless_unknown_path' },
       ),
     ).rejects.toThrow(OpenAI.NotFoundError);
+  });
+
+  test('create: preserves nested skill file paths', async () => {
+    const { fetch, handleRequest } = mockFetch();
+    const client = new OpenAI({ apiKey: 'My API Key', fetch });
+
+    handleRequest(async (_, init) => {
+      const files = (init!.body as FormData).getAll('files[]');
+      expect(files).toHaveLength(1);
+      expect(files[0]).toBeInstanceOf(File);
+      expect((files[0] as File).name).toEqual('my-skill/SKILL.md');
+
+      return new Response(
+        JSON.stringify({
+          id: 'skillver_123',
+          created_at: 0,
+          description: '',
+          name: 'my-skill',
+          object: 'skill.version',
+          skill_id: 'skill_123',
+          version: '1',
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    });
+
+    await client.skills.versions.create('skill_123', { files: [new File(['# skill'], 'my-skill/SKILL.md')] });
   });
 
   test('retrieve: only required params', async () => {


### PR DESCRIPTION
## Summary
- preserve nested file names for `skills.create()` and `skills.versions.create()` multipart uploads
- keep the existing filename stripping behavior for other upload endpoints
- add regression tests that assert `my-skill/SKILL.md` is preserved in the multipart body

## Testing
- not run locally: `yarn` is not installed in this environment
