### PR TITLE
fix(types): include optional metadata on ChatCompletion responses (#1818)

### DIFF
--- a/src/resources/chat/completions/completions.ts
+++ b/src/resources/chat/completions/completions.ts
@@ -279,6 +279,14 @@ export interface ChatCompletion {
   object: 'chat.completion';
 
   /**
+   * Developer-defined metadata attached to the completion.
+   *
+   * This is commonly present on stored completions (e.g. via `retrieve`/`list`) and
+   * may be omitted in immediate `create` responses.
+   */
+  metadata?: Shared.Metadata | null;
+
+  /**
    * Specifies the processing type used for serving the request.
    *
    * - If set to 'auto', then the request will be processed with the service tier


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

This PR addresses #1818 (`Chat Completions is not returning the metadata`).

### Root cause
`metadata` is accepted in `chat.completions.create` params and supported in stored completion flows (`retrieve`, `update`, `list`), but the `ChatCompletion` response type did not include a `metadata` field.  
This caused a contract/type mismatch in the SDK even when the API returns metadata for stored objects.

### What changed
- Added `metadata?: Shared.Metadata | null` to `ChatCompletion` in:
  - `src/resources/chat/completions/completions.ts`
- Added contextual docs indicating metadata is commonly present on stored completions and may be absent in immediate `create` responses.

### Scope
- Type/docs-only change.
- No runtime request/response parsing logic changed.


