### PR TITLE
fix(client): remove caller abort listener after successful fetch

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -892,6 +892,7 @@ export class OpenAI {
       return await this.fetch.call(undefined, url, fetchOptions);
     } finally {
       clearTimeout(timeout);
+      if (signal) signal.removeEventListener('abort', abort);
     }
   }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -276,6 +276,28 @@ describe('instantiate client', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
+  test('removes the caller abort listener after a successful request', async () => {
+    const client = new OpenAI({
+      baseURL: 'http://localhost:5000/',
+      apiKey: 'My API Key',
+      fetch: async () =>
+        new Response(JSON.stringify({ ok: true }), {
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    });
+
+    const controller = new AbortController();
+    const addSpy = jest.spyOn(controller.signal, 'addEventListener');
+    const removeSpy = jest.spyOn(controller.signal, 'removeEventListener');
+
+    await client.get('/foo', { signal: controller.signal });
+
+    expect(addSpy).toHaveBeenCalledWith('abort', expect.any(Function), { once: true });
+    const listener = addSpy.mock.calls[0]?.[1];
+    expect(listener).toBeDefined();
+    expect(removeSpy).toHaveBeenCalledWith('abort', listener);
+  });
+
   test('normalized method', async () => {
     let capturedRequest: RequestInit | undefined;
     const testFetch = async (url: string | URL | Request, init: RequestInit = {}): Promise<Response> => {


### PR DESCRIPTION
## Summary
- remove the forwarded abort listener from the caller signal once fetchWithTimeout completes
- avoid leaving an orphaned listener attached to successful requests
- add regression coverage for listener cleanup on the success path

## Testing
- npm test -- --runInBand tests/index.test.ts --testNamePattern="custom signal|removes the caller abort listener"
- npx prettier --check src/client.ts tests/index.test.ts