### PR TITLE
fix(client): serialize headers in APIError.toJSON() so rate-limit headers are visible

### DIFF
--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -36,6 +36,25 @@ export class APIError<
     this.type = data?.['type'];
   }
 
+  /**
+   * Returns a JSON-serializable representation of this error, with `headers`
+   * converted from a `Headers` instance to a plain object so that all headers
+   * (including rate-limit headers such as `x-ratelimit-reset-requests`) are
+   * visible when the error is logged or serialised with `JSON.stringify`.
+   */
+  toJSON() {
+    return {
+      status: this.status,
+      headers: this.headers ? Object.fromEntries(this.headers.entries()) : undefined,
+      error: this.error,
+      code: this.code,
+      param: this.param,
+      type: this.type,
+      requestID: this.requestID,
+      message: this.message,
+    };
+  }
+
   private static makeMessage(status: number | undefined, error: any, message: string | undefined) {
     const msg =
       error?.message ?


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

When a 429 (or any non-2xx) response is received, the SDK throws an `APIError` whose `headers` property is a native `Headers` instance. Because `Headers` has no `toJSON` method, calling `JSON.stringify(error)` produces `"headers": {}`, hiding all headers — including the `x-ratelimit-reset-requests`, `x-ratelimit-reset-tokens`, and related headers developers need for custom retry logic.

The fix adds a `toJSON()` method to `APIError` in `src/core/error.ts` that converts `this.headers` to a plain object via `Object.fromEntries(this.headers.entries())`. The `headers` instance itself is unchanged, so `error.headers.get('x-ratelimit-reset-requests')` continues to work as before; the change only affects serialisation.

## Additional context & links

Fixes #1477
