### PR TITLE
docs: fix tool-calls-stream comment typo

### DIFF
--- a/examples/tool-calls-stream.ts
+++ b/examples/tool-calls-stream.ts
@@ -27,7 +27,7 @@ import {
   ChatCompletionMessageParam,
 } from 'openai/resources/chat';
 
-// Used so that the each chunk coming in is noticable
+// Used so that each chunk coming in is noticeable
 const CHUNK_DELAY_MS = 100;
 
 // gets API Key from environment variable OPENAI_API_KEY


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fix a small typo in the `tool-calls-stream` example comment.

## Additional context & links

- Example-only change in `examples/`, which the contributing guide explicitly allows editing.
- Validation: `git diff --check`
