### PR TITLE
Add Responses manual conversation state example

### DIFF
--- a/examples/responses/manual-conversation-state.ts
+++ b/examples/responses/manual-conversation-state.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env -S npm run tsn -T
+
+import OpenAI from 'openai';
+import type { ResponseInputItem } from 'openai/resources/responses/responses';
+
+const client = new OpenAI();
+
+async function main() {
+  const input: ResponseInputItem[] = [
+    {
+      type: 'message',
+      role: 'user',
+      content: 'Write a short Python prime checker.',
+    },
+  ];
+
+  const response = await client.responses.create({
+    model: 'gpt-5-mini',
+    input,
+    reasoning: { effort: 'low' },
+  });
+
+  console.log(response.output_text);
+
+  // If you manage conversation state manually, keep all output items together.
+  // Reasoning-capable models can return reasoning items that must stay paired
+  // with the following message item on future turns.
+  input.push(...response.output);
+  input.push({
+    type: 'message',
+    role: 'user',
+    content: 'Add type hints.',
+  });
+
+  const followup = await client.responses.create({
+    model: 'gpt-5-mini',
+    input,
+    reasoning: { effort: 'low' },
+  });
+
+  console.log(followup.output_text);
+}
+
+main();


### PR DESCRIPTION
Adds a Responses API example showing the safe manual conversation-state pattern: append the full `response.output` before the next user message so reasoning-capable models keep reasoning and message items paired across turns.\n\nAddresses #1791.\n\nVerification:\n- Not run: example calls the live API and requires `OPENAI_API_KEY`.