### PR TITLE
Fix prompt cache retention literal

### DIFF
--- a/src/resources/chat/completions/completions.ts
+++ b/src/resources/chat/completions/completions.ts
@@ -1665,7 +1665,7 @@ export interface ChatCompletionCreateParamsBase {
    * of 24 hours.
    * [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
    */
-  prompt_cache_retention?: 'in-memory' | '24h' | null;
+  prompt_cache_retention?: 'in_memory' | '24h' | null;
 
   /**
    * Constrains effort on reasoning for

--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -1120,7 +1120,7 @@ export interface Response {
    * of 24 hours.
    * [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
    */
-  prompt_cache_retention?: 'in-memory' | '24h' | null;
+  prompt_cache_retention?: 'in_memory' | '24h' | null;
 
   /**
    * **gpt-5 and o-series models only**
@@ -6551,7 +6551,7 @@ export interface ResponsesClientEvent {
    * of 24 hours.
    * [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
    */
-  prompt_cache_retention?: 'in-memory' | '24h' | null;
+  prompt_cache_retention?: 'in_memory' | '24h' | null;
 
   /**
    * **gpt-5 and o-series models only**
@@ -7571,7 +7571,7 @@ export interface ResponseCreateParamsBase {
    * of 24 hours.
    * [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).
    */
-  prompt_cache_retention?: 'in-memory' | '24h' | null;
+  prompt_cache_retention?: 'in_memory' | '24h' | null;
 
   /**
    * **gpt-5 and o-series models only**

--- a/tests/api-resources/chat/completions/completions.test.ts
+++ b/tests/api-resources/chat/completions/completions.test.ts
@@ -53,7 +53,7 @@ describe('resource completions', () => {
       prediction: { content: 'string', type: 'content' },
       presence_penalty: -2,
       prompt_cache_key: 'prompt-cache-key-1234',
-      prompt_cache_retention: 'in-memory',
+      prompt_cache_retention: 'in_memory',
       reasoning_effort: 'none',
       response_format: { type: 'text' },
       safety_identifier: 'safety-identifier-1234',


### PR DESCRIPTION
Updates the `prompt_cache_retention` type literal from `in-memory` to `in_memory` to match the official prompt caching guide, which documents the allowed values as `in_memory` and `24h`.\n\nCloses #1756.\n\nVerification:\n- `npm test -- tests/api-resources/chat/completions/completions.test.ts`