### PR TITLE
fix(error): add toJSON to APIError so response headers serialize correctly

### DIFF
--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -36,6 +36,26 @@ export class APIError<
     this.type = data?.['type'];
   }
 
+  /**
+   * Returns a JSON-serializable representation of this error.
+   *
+   * The native `Headers` class does not serialize its entries with
+   * `JSON.stringify`, so this method converts them to a plain object so that
+   * rate-limit headers (e.g. `x-ratelimit-reset-requests`) and other response
+   * headers are visible when the error is logged or serialized.
+   */
+  toJSON() {
+    return {
+      status: this.status,
+      headers: this.headers ? Object.fromEntries(this.headers.entries()) : undefined,
+      error: this.error,
+      code: this.code,
+      param: this.param,
+      type: this.type,
+      request_id: this.requestID,
+    };
+  }
+
   private static makeMessage(status: number | undefined, error: any, message: string | undefined) {
     const msg =
       error?.message ?


### PR DESCRIPTION
- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

The native `Headers` class in Node.js does not enumerate its entries when passed to `JSON.stringify`, so calling `JSON.stringify(error)` on any `APIError` (including `RateLimitError`) produces `"headers": {}` — hiding every response header including `x-ratelimit-reset-requests`, `x-ratelimit-remaining-tokens`, and the other rate-limit headers users need for retry logic.

The fix adds a `toJSON()` method to `APIError` in `src/core/error.ts` that converts `this.headers` to a plain key/value object via `Object.fromEntries(this.headers.entries())`. `this.headers` itself still holds the native `Headers` instance so callers using `.headers.get(...)` are unaffected; the change only improves serialization.

## Additional context & links

- Node.js `Headers` does not implement `toJSON`, and `JSON.stringify` only walks own enumerable properties, so the internal slot holding headers entries is invisible to it.
- Users who already call `error.headers.get('x-ratelimit-reset-requests')` directly will see no change in behavior.

Fixes #1477
