### PR TITLE
fix: preserve non-standard error response bodies

### DIFF
--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -67,7 +67,8 @@ export class APIError<
       return new APIConnectionError({ message, cause: castToError(errorResponse) });
     }
 
-    const error = (errorResponse as Record<string, any>)?.['error'];
+    const data = errorResponse as Record<string, any> | undefined;
+    const error = data?.['error'] ?? data;
 
     if (status === 400) {
       return new BadRequestError(status, error, message, headers);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -4,7 +4,7 @@ import { APIPromise } from 'openai/core/api-promise';
 
 import util from 'node:util';
 import OpenAI from 'openai';
-import { APIUserAbortError } from 'openai';
+import { APIUserAbortError, UnprocessableEntityError } from 'openai';
 const defaultFetch = fetch;
 
 describe('instantiate client', () => {
@@ -239,6 +239,34 @@ describe('instantiate client', () => {
 
     const response = await client.get('/foo');
     expect(response).toEqual({ url: 'http://localhost:5000/foo', custom: true });
+  });
+
+  test('error message falls back to the whole response body when error field is absent', async () => {
+    const errorBody = { detail: '422: The model gpt-5-gibberish does not exist.' };
+    const client = new OpenAI({
+      baseURL: 'http://localhost:5000/',
+      apiKey: 'My API Key',
+      fetch: () => {
+        return Promise.resolve(
+          new Response(JSON.stringify(errorBody), {
+            status: 422,
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        );
+      },
+    });
+
+    try {
+      await client.get('/foo');
+      throw new Error('Expected request to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(UnprocessableEntityError);
+      expect(error).toMatchObject({
+        status: 422,
+        error: errorBody,
+        message: `422 ${JSON.stringify(errorBody)}`,
+      });
+    }
   });
 
   test('explicit global fetch', async () => {


### PR DESCRIPTION
## Summary\n\n- fall back to the full JSON error response body when a response does not include the standard `error` envelope\n- keep the existing standard OpenAI error-envelope behavior unchanged\n- add a regression test for a 422 response body that only contains `detail`\n\nFixes #1734.\n\n## Testing\n\n- `yarn test tests/index.test.ts -t "error message falls back"`\n- `yarn build`\n