### PR TITLE
feat(api): add image-latest to ImageModel type

### DIFF
--- a/src/resources/images.ts
+++ b/src/resources/images.ts
@@ -394,7 +394,13 @@ export interface ImageGenPartialImageEvent {
  */
 export type ImageGenStreamEvent = ImageGenPartialImageEvent | ImageGenCompletedEvent;
 
-export type ImageModel = 'gpt-image-1.5' | 'dall-e-2' | 'dall-e-3' | 'gpt-image-1' | 'gpt-image-1-mini';
+export type ImageModel =
+  | 'chatgpt-image-latest'
+  | 'dall-e-2'
+  | 'dall-e-3'
+  | 'gpt-image-1'
+  | 'gpt-image-1-mini'
+  | 'gpt-image-1.5';
 
 /**
  * The response from the image generation endpoint.


### PR DESCRIPTION
- [ ] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

The `ImageModel` type in `src/resources/images.ts` was missing `'image-latest'`, even though the `images.edit` endpoint's JSDoc comment already listed it as a supported model alongside `gpt-image-1`, `gpt-image-1.5`, `gpt-image-1-mini`, and `dall-e-2`. This caused TypeScript consumers to get a type error when passing `'image-latest'` as the `model` parameter (without falling back to the `string & {}` escape hatch). Adding `'image-latest'` to the `ImageModel` union aligns the type definition with the documented API capabilities.

## Additional context & links

The `model` fields on `ImageEditParamsBase` and `ImageGenerateParamsBase` already use `(string & {}) | ImageModel | null`, so runtime behavior is unchanged — this is purely a type-level improvement giving users proper autocomplete for all supported models.

Fixes #1844