### PR TITLE
fix: remove abort event listener from caller signal after request completes

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -892,6 +892,7 @@ export class OpenAI {
       return await this.fetch.call(undefined, url, fetchOptions);
     } finally {
       clearTimeout(timeout);
+      if (signal) signal.removeEventListener('abort', abort);
     }
   }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -276,6 +276,24 @@ describe('instantiate client', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
+  test('removes abort listener from caller signal after successful request', async () => {
+    const testFetch = async (_url: string | URL | Request, _init: RequestInit = {}): Promise<Response> => {
+      return new Response(JSON.stringify({ ok: true }), { headers: { 'Content-Type': 'application/json' } });
+    };
+
+    const client = new OpenAI({ apiKey: 'My API Key', fetch: testFetch });
+
+    const controller = new AbortController();
+    const addSpy = jest.spyOn(controller.signal, 'addEventListener');
+    const removeSpy = jest.spyOn(controller.signal, 'removeEventListener');
+
+    await client.get('/foo', { signal: controller.signal });
+
+    expect(addSpy).toHaveBeenCalledWith('abort', expect.any(Function), { once: true });
+    expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+    expect(addSpy.mock.calls[0]![1]).toBe(removeSpy.mock.calls[0]![1]);
+  });
+
   test('normalized method', async () => {
     let capturedRequest: RequestInit | undefined;
     const testFetch = async (url: string | URL | Request, init: RequestInit = {}): Promise<Response> => {


### PR DESCRIPTION
## Summary

Fixes #1811.

When a caller passes a `signal` to `fetchWithTimeout`, an abort listener is added on that signal to forward abort events to the internal `AbortController`. With `{ once: true }`, the listener cleans itself up when the signal fires — but if the request completes successfully (without the signal aborting), the listener is never removed.

On Deno, `AbortSignal.timeout()` refs its underlying timer whenever a listener is attached. The orphaned listener keeps the timer alive for the full timeout duration (e.g. 30 s), preventing the process from exiting even after the request returned in ~500 ms.

**Fix:** call `signal.removeEventListener('abort', abort)` in the `finally` block, alongside the existing `clearTimeout(timeout)`. This mirrors the symmetric cleanup already done for the `setTimeout`.

```diff
   } finally {
     clearTimeout(timeout);
+    if (signal) signal.removeEventListener('abort', abort);
   }
```

The `abort` variable is already a named reference (created by `this._makeAbort(controller)`), so it can be passed to both `addEventListener` and `removeEventListener` without any other changes.

## Test plan

- [x] Added a unit test (`removes abort listener from caller signal after successful request`) that spies on `addEventListener`/`removeEventListener` of the caller's signal and asserts:
  - the listener was added with `{ once: true }`
  - `removeEventListener` was called with the **same function reference** after a successful fetch
- [x] All existing tests in `tests/index.test.ts` continue to pass (54/54)