### PR TITLE
fix: run chat completion tools in parallel

### DIFF
--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -334,8 +334,9 @@ export class AbstractChatCompletionRunner<
         return;
       }
 
-      for (const tool_call of message.tool_calls) {
-        if (tool_call.type !== 'function') continue;
+      const runFunctionToolCall = async (
+        tool_call: ChatCompletionMessageFunctionToolCall,
+      ): Promise<{ tool_call_id: string; content: string; didExecute: boolean }> => {
         const tool_call_id = tool_call.id;
         const { name, arguments: args } = tool_call.function;
         const fn = functionsByName[name];
@@ -347,15 +348,13 @@ export class AbstractChatCompletionRunner<
             .map((name) => JSON.stringify(name))
             .join(', ')}. Please try again`;
 
-          this._addMessage({ role, tool_call_id, content });
-          continue;
+          return { tool_call_id, content, didExecute: false };
         } else if (singleFunctionToCall && singleFunctionToCall !== name) {
           const content = `Invalid tool_call: ${JSON.stringify(name)}. ${JSON.stringify(
             singleFunctionToCall,
           )} requested. Please try again`;
 
-          this._addMessage({ role, tool_call_id, content });
-          continue;
+          return { tool_call_id, content, didExecute: false };
         }
 
         let parsed;
@@ -363,17 +362,40 @@ export class AbstractChatCompletionRunner<
           parsed = isRunnableFunctionWithParse(fn) ? await fn.parse(args) : args;
         } catch (error) {
           const content = error instanceof Error ? error.message : String(error);
-          this._addMessage({ role, tool_call_id, content });
-          continue;
+          return { tool_call_id, content, didExecute: false };
         }
 
         // @ts-expect-error it can't rule out `never` type.
         const rawContent = await fn.function(parsed, this);
         const content = this.#stringifyFunctionCallResult(rawContent);
-        this._addMessage({ role, tool_call_id, content });
+        return { tool_call_id, content, didExecute: true };
+      };
 
-        if (singleFunctionToCall) {
-          return;
+      const addToolCallResult = (result: { tool_call_id: string; content: string }) => {
+        this._addMessage({ role, tool_call_id: result.tool_call_id, content: result.content });
+      };
+
+      const functionToolCalls = message.tool_calls.filter(
+        (tool_call): tool_call is ChatCompletionMessageFunctionToolCall => tool_call.type === 'function',
+      );
+
+      if (singleFunctionToCall) {
+        for (const tool_call of functionToolCalls) {
+          const result = await runFunctionToolCall(tool_call);
+          addToolCallResult(result);
+
+          if (result.didExecute) {
+            return;
+          }
+        }
+      } else {
+        const results = await Promise.allSettled(functionToolCalls.map(runFunctionToolCall));
+        for (const result of results) {
+          if (result.status === 'rejected') {
+            throw result.reason;
+          }
+
+          addToolCallResult(result.value);
         }
       }
     }

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -633,6 +633,164 @@ describe('resource completions', () => {
       expect(listener.functionCallResults).toEqual([`it's raining`]);
       await listener.sanityCheck();
     });
+
+    test('runs multiple tool calls concurrently and preserves result order', async () => {
+      const { fetch, handleRequest } = mockChatCompletionFetch();
+
+      const openai = new OpenAI({ apiKey: 'something1234', baseURL: 'http://127.0.0.1:4010', fetch });
+
+      let activeToolCalls = 0;
+      let maxActiveToolCalls = 0;
+      const startedToolCalls: string[] = [];
+
+      const createDelayedTool = (name: string) => async () => {
+        startedToolCalls.push(name);
+        activeToolCalls += 1;
+        maxActiveToolCalls = Math.max(maxActiveToolCalls, activeToolCalls);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        activeToolCalls -= 1;
+        return `${name} result`;
+      };
+
+      const runner = openai.chat.completions.runTools({
+        messages: [{ role: 'user', content: 'look up a discount and a product' }],
+        model: 'gpt-3.5-turbo',
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'lookupDiscount',
+              function: createDelayedTool('discount'),
+              parameters: {},
+              description: 'looks up a discount',
+            },
+          },
+          {
+            type: 'function',
+            function: {
+              name: 'lookupProduct',
+              function: createDelayedTool('product'),
+              parameters: {},
+              description: 'looks up a product',
+            },
+          },
+        ],
+      });
+      const listener = new RunnerListener(runner);
+
+      await handleRequest(async (request) => {
+        expect(request.messages).toEqual([{ role: 'user', content: 'look up a discount and a product' }]);
+        return {
+          id: '1',
+          choices: [
+            {
+              index: 0,
+              finish_reason: 'tool_calls',
+              logprobs: null,
+              message: {
+                role: 'assistant',
+                content: null,
+                refusal: null,
+                parsed: null,
+                tool_calls: [
+                  {
+                    type: 'function',
+                    id: 'discount-call',
+                    function: {
+                      arguments: '',
+                      name: 'lookupDiscount',
+                    },
+                  },
+                  {
+                    type: 'function',
+                    id: 'product-call',
+                    function: {
+                      arguments: '',
+                      name: 'lookupProduct',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+          created: Math.floor(Date.now() / 1000),
+          model: 'gpt-3.5-turbo',
+          object: 'chat.completion',
+        };
+      });
+
+      await handleRequest(async (request) => {
+        expect(request.messages).toEqual([
+          {
+            role: 'user',
+            content: 'look up a discount and a product',
+          },
+          {
+            role: 'assistant',
+            content: null,
+            refusal: null,
+            parsed: null,
+            tool_calls: [
+              {
+                type: 'function',
+                id: 'discount-call',
+                function: {
+                  arguments: '',
+                  name: 'lookupDiscount',
+                  parsed_arguments: null,
+                },
+              },
+              {
+                type: 'function',
+                id: 'product-call',
+                function: {
+                  arguments: '',
+                  name: 'lookupProduct',
+                  parsed_arguments: null,
+                },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            content: 'discount result',
+            tool_call_id: 'discount-call',
+          },
+          {
+            role: 'tool',
+            content: 'product result',
+            tool_call_id: 'product-call',
+          },
+        ]);
+
+        return {
+          id: '2',
+          choices: [
+            {
+              index: 0,
+              finish_reason: 'stop',
+              logprobs: null,
+              message: {
+                role: 'assistant',
+                content: 'both lookups are done',
+                refusal: null,
+              },
+            },
+          ],
+          created: Math.floor(Date.now() / 1000),
+          model: 'gpt-3.5-turbo',
+          object: 'chat.completion',
+        };
+      });
+
+      await runner.done();
+
+      expect(startedToolCalls).toEqual(['discount', 'product']);
+      expect(maxActiveToolCalls).toBe(2);
+      expect(listener.functionCallResults).toEqual(['discount result', 'product result']);
+      await listener.sanityCheck();
+    });
+
     test('flow with abort', async () => {
       const { fetch, handleRequest } = mockChatCompletionFetch();
 


### PR DESCRIPTION
## Summary

Fixes #1131.

- Execute multiple function tool calls from one `runTools()` assistant turn concurrently when normal `auto` tool choice is in use.
- Preserve tool-result message order by appending results in the original `tool_calls` order before the next model request.
- Keep the existing specific `tool_choice` behavior serial so a single requested function still returns after the first successful execution.
- Add a regression test that observes concurrent execution while asserting ordered tool-result messages.

## Tests

- `yarn test tests/lib/ChatCompletionRunFunctions.test.ts --runInBand`
- `./node_modules/.bin/prettier --check src/lib/AbstractChatCompletionRunner.ts tests/lib/ChatCompletionRunFunctions.test.ts`
- `./node_modules/.bin/eslint src/lib/AbstractChatCompletionRunner.ts tests/lib/ChatCompletionRunFunctions.test.ts`
- `./scripts/build`
- `git diff --check`

Note: `./node_modules/typescript/bin/tsc --noEmit` is blocked in this local checkout by missing optional example dependencies: `@azure/identity`, `express`, and `next`.