### PR TITLE
docs: clarify ResponseStreamEvent description

### DIFF
--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -5949,7 +5949,7 @@ export interface ResponseRefusalDoneEvent {
 export type ResponseStatus = 'completed' | 'failed' | 'in_progress' | 'cancelled' | 'queued' | 'incomplete';
 
 /**
- * Emitted when there is a partial audio response.
+ * Event emitted while a response is streamed.
  */
 export type ResponseStreamEvent =
   | ResponseAudioDeltaEvent


### PR DESCRIPTION
## Summary
- replace the ResponseStreamEvent union doc comment with a general streaming-event description
- keep the existing ResponseAudioDeltaEvent-specific comment on the audio event itself

Fixes #1699.

## Tests
- git diff --check

Note: this is a comment-only documentation fix; node_modules is not installed locally in this worktree.