### PR TITLE
fix: keep timeouts active through response body reads

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -669,7 +669,9 @@ export class OpenAI {
     }
 
     const controller = new AbortController();
-    const response = await this.fetchWithAuth(url, req, timeout, controller).catch(castToError);
+    const response = await this.fetchWithAuth(url, req, timeout, controller, !options.stream).catch(
+      castToError,
+    );
     const headersTime = Date.now();
 
     if (response instanceof globalThis.Error) {
@@ -844,6 +846,7 @@ export class OpenAI {
     init: RequestInit,
     timeout: number,
     controller: AbortController,
+    timeoutIncludesBody: boolean = true,
   ): Promise<Response> {
     if (this._workloadIdentityAuth) {
       const headers = init.headers as Headers;
@@ -854,7 +857,7 @@ export class OpenAI {
       }
     }
 
-    const response = await this.fetchWithTimeout(url, init, timeout, controller);
+    const response = await this.fetchWithTimeout(url, init, timeout, controller, timeoutIncludesBody);
 
     return response;
   }
@@ -864,12 +867,25 @@ export class OpenAI {
     init: RequestInit | undefined,
     ms: number,
     controller: AbortController,
+    timeoutIncludesBody: boolean = true,
   ): Promise<Response> {
     const { signal, method, ...options } = init || {};
     const abort = this._makeAbort(controller);
     if (signal) signal.addEventListener('abort', abort, { once: true });
 
-    const timeout = setTimeout(abort, ms);
+    let timedOut = false;
+    let cleanedUp = false;
+    const cleanup = () => {
+      if (!cleanedUp) {
+        cleanedUp = true;
+        clearTimeout(timeout);
+        if (signal) signal.removeEventListener('abort', abort);
+      }
+    };
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      abort();
+    }, ms);
 
     const isReadableBody =
       ((globalThis as any).ReadableStream && options.body instanceof (globalThis as any).ReadableStream) ||
@@ -889,10 +905,55 @@ export class OpenAI {
 
     try {
       // use undefined this binding; fetch errors if bound to something else in browser/cloudflare
-      return await this.fetch.call(undefined, url, fetchOptions);
-    } finally {
-      clearTimeout(timeout);
+      const response = await this.fetch.call(undefined, url, fetchOptions);
+      if (!timeoutIncludesBody || !response.body) {
+        cleanup();
+        return response;
+      }
+      return this.wrapResponseBodyWithTimeout(response, cleanup, () => timedOut);
+    } catch (err) {
+      cleanup();
+      throw err;
     }
+  }
+
+  private wrapResponseBodyWithTimeout(
+    response: Response,
+    cleanup: () => void,
+    isTimeout: () => boolean,
+  ): Response {
+    const reader = response.body!.getReader();
+    const body = new ReadableStream({
+      async pull(controller) {
+        try {
+          const { done, value } = await reader.read();
+          if (done) {
+            cleanup();
+            controller.close();
+            return;
+          }
+          controller.enqueue(value);
+        } catch (err) {
+          cleanup();
+          controller.error(isTimeout() ? new Errors.APIConnectionTimeoutError() : err);
+        }
+      },
+      async cancel(reason) {
+        cleanup();
+        await reader.cancel(reason);
+      },
+    });
+    const wrapped = new Response(body, response);
+    try {
+      Object.defineProperties(wrapped, {
+        redirected: { value: response.redirected },
+        type: { value: response.type },
+        url: { value: response.url },
+      });
+    } catch {
+      // Some fetch implementations may expose non-configurable Response fields.
+    }
+    return wrapped;
   }
 
   private async shouldRetry(response: Response): Promise<boolean> {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -4,7 +4,7 @@ import { APIPromise } from 'openai/core/api-promise';
 
 import util from 'node:util';
 import OpenAI from 'openai';
-import { APIUserAbortError } from 'openai';
+import { APIConnectionTimeoutError, APIUserAbortError } from 'openai';
 const defaultFetch = fetch;
 
 describe('instantiate client', () => {
@@ -574,6 +574,100 @@ describe('retries', () => {
         .then((r) => r.text()),
     ).toEqual(JSON.stringify({ a: 1 }));
     expect(count).toEqual(3);
+  });
+
+  test('timeout covers response body reads', async () => {
+    const encoder = new TextEncoder();
+    const testFetch = async (
+      url: string | URL | Request,
+      { signal }: RequestInit = {},
+    ): Promise<Response> => {
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode('{"a":'));
+            signal?.addEventListener('abort', () => controller.error(new Error('body read aborted')), {
+              once: true,
+            });
+          },
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+    };
+
+    const client = new OpenAI({
+      apiKey: 'My API Key',
+      timeout: 10,
+      fetch: testFetch,
+      maxRetries: 0,
+    });
+
+    await expect(client.request({ path: '/foo', method: 'get' })).rejects.toBeInstanceOf(
+      APIConnectionTimeoutError,
+    );
+    await expect(
+      client
+        .request({ path: '/foo', method: 'get' })
+        .asResponse()
+        .then((r) => r.text()),
+    ).rejects.toBeInstanceOf(APIConnectionTimeoutError);
+  });
+
+  test('removes caller abort listener after response body is read', async () => {
+    const controller = new AbortController();
+    const addEventListener = jest.spyOn(controller.signal, 'addEventListener');
+    const removeEventListener = jest.spyOn(controller.signal, 'removeEventListener');
+
+    const testFetch = async (): Promise<Response> => {
+      return new Response(JSON.stringify({ a: 1 }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+
+    const client = new OpenAI({
+      apiKey: 'My API Key',
+      timeout: 10_000,
+      fetch: testFetch,
+      maxRetries: 0,
+    });
+
+    expect(await client.request({ path: '/foo', method: 'get', signal: controller.signal })).toEqual({
+      a: 1,
+    });
+
+    expect(addEventListener).toHaveBeenCalledWith('abort', expect.any(Function), { once: true });
+    expect(removeEventListener).toHaveBeenCalledTimes(1);
+    expect(removeEventListener.mock.calls[0]?.[0]).toEqual('abort');
+    expect(removeEventListener.mock.calls[0]?.[1]).toBe(addEventListener.mock.calls[0]?.[1]);
+  });
+
+  test('streaming response timeouts still stop after headers', async () => {
+    let aborted = false;
+    const testFetch = async (
+      url: string | URL | Request,
+      { signal }: RequestInit = {},
+    ): Promise<Response> => {
+      signal?.addEventListener('abort', () => {
+        aborted = true;
+      });
+      return new Response(new ReadableStream(), {
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+    };
+
+    const client = new OpenAI({
+      apiKey: 'My API Key',
+      timeout: 10,
+      fetch: testFetch,
+      maxRetries: 0,
+    });
+
+    const response = await client.request({ path: '/foo', method: 'get', stream: true }).asResponse();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(response.body).toBeInstanceOf(ReadableStream);
+    expect(aborted).toEqual(false);
+    await response.body?.cancel();
   });
 
   test('retry count header', async () => {


### PR DESCRIPTION
## Summary

- keep the request timeout armed until non-streaming response bodies are fully read, cancelled, or errored
- convert timeout-triggered body read failures into `APIConnectionTimeoutError`
- clean up the caller `AbortSignal` listener after request completion so `AbortSignal.timeout()` does not keep Deno processes alive
- preserve the existing streaming behavior: `stream: true` still treats timeout as a headers/connection timeout only

Fixes #1825.
Fixes #1811.

## Validation

- `./node_modules/.bin/jest tests/index.test.ts --runInBand -t 'timeout covers response body reads|removes caller abort listener|streaming response timeouts'`
- `./node_modules/.bin/prettier --check src/client.ts tests/index.test.ts`
- `./node_modules/.bin/eslint src/client.ts tests/index.test.ts`
- `./scripts/build`
- `./node_modules/typescript/bin/tsc --noEmit -p tsconfig.build.json`
- `git diff --check`

I also ran `./node_modules/.bin/jest tests/index.test.ts --runInBand`; all 56 tests passed, but Jest did not exit afterward and reported its generic open-handle warning. The focused regression tests above exit cleanly.

A raw `./node_modules/typescript/bin/tsc --noEmit` hits existing optional example dependency errors for packages like `@azure/identity`, `express`, and `next`, so I used the repository build-oriented TypeScript check above.
