### PR TITLE
fix: cap retry-after retry delay

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -946,9 +946,10 @@ export class OpenAI {
       }
     }
 
-    // If the API asks us to wait a certain amount of time, just do what it
-    // says, but otherwise calculate a default
-    if (timeoutMillis === undefined) {
+    // If the API asks us to wait a reasonable amount of time, just do what it
+    // says, but otherwise calculate a default.
+    const maxRetryAfterMillis = 60 * 1000;
+    if (!(timeoutMillis && 0 <= timeoutMillis && timeoutMillis < maxRetryAfterMillis)) {
       const maxRetries = options.maxRetries ?? this.maxRetries;
       timeoutMillis = this.calculateDefaultRetryTimeoutMillis(retriesRemaining, maxRetries);
     }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -734,6 +734,42 @@ describe('retries', () => {
     expect(count).toEqual(3);
   });
 
+  test('retry on 429 with long retry-after falls back to default backoff', async () => {
+    jest.useFakeTimers();
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+    let count = 0;
+
+    const testFetch = async (
+      url: string | URL | Request,
+      { signal }: RequestInit = {},
+    ): Promise<Response> => {
+      if (count++ === 0) {
+        return new Response(undefined, {
+          status: 429,
+          headers: {
+            'Retry-After': '600',
+          },
+        });
+      }
+      return new Response(JSON.stringify({ a: 1 }), { headers: { 'Content-Type': 'application/json' } });
+    };
+
+    try {
+      const client = new OpenAI({ apiKey: 'My API Key', fetch: testFetch, maxRetries: 1 });
+      const request = client.request({ path: '/foo', method: 'get' }).then((response) => response);
+
+      await jest.advanceTimersByTimeAsync(0);
+      expect(count).toEqual(1);
+      await jest.advanceTimersByTimeAsync(500);
+      expect(count).toEqual(2);
+      await expect(request).resolves.toEqual({ a: 1 });
+    } finally {
+      await jest.runOnlyPendingTimersAsync();
+      jest.useRealTimers();
+      randomSpy.mockRestore();
+    }
+  });
+
   test('retry on 429 with retry-after-ms', async () => {
     let count = 0;
     const testFetch = async (


### PR DESCRIPTION
## Summary

- restore the prior safety cap for server-provided `Retry-After` values
- fall back to the SDK's default exponential retry backoff when `Retry-After` is missing, zero/invalid, or >= 60 seconds
- add a regression test so a large `Retry-After: 600` does not make the SDK wait ten minutes before retrying

Fixes #1840.

## Validation

- `./node_modules/.bin/jest tests/index.test.ts --runInBand -t 'retry on 429 with long retry-after falls back to default backoff|retry on 429 with retry-after|retry on 429 with retry-after-ms'`
- `./node_modules/.bin/prettier --check src/client.ts tests/index.test.ts`
- `./node_modules/.bin/eslint src/client.ts tests/index.test.ts`
- `./scripts/build`
- `./node_modules/typescript/bin/tsc --noEmit -p tsconfig.build.json`
- `git diff --check`
