### PR TITLE
feat(helpers/zod): add zodRealtimeFunction for Realtime API tool definitions

### DIFF
--- a/src/helpers/zod.ts
+++ b/src/helpers/zod.ts
@@ -12,6 +12,7 @@ import {
 import { zodToJsonSchema as _zodToJsonSchema } from '../_vendor/zod-to-json-schema';
 import { AutoParseableResponseTool, makeParseableResponseTool } from '../lib/ResponsesParser';
 import { type ResponseFormatTextJSONSchemaConfig } from '../resources/responses/responses';
+import { type RealtimeFunctionTool } from '../resources/realtime/realtime';
 import { toStrictJsonSchema } from '../lib/transform';
 import { JSONSchema } from '../lib/jsonschema';
 
@@ -177,4 +178,48 @@ export function zodResponsesFunction<Parameters extends z3.ZodType | z4.ZodType>
       parser: (args) => options.parameters.parse(JSON.parse(args)),
     },
   );
+}
+
+/**
+ * Creates a Realtime API `function` tool definition from the given Zod schema.
+ *
+ * Unlike {@link zodResponsesFunction}, this helper does **not** set `strict: true`
+ * because the Realtime API's `RealtimeFunctionTool` interface does not include
+ * that field.
+ *
+ * ```ts
+ * const session = await client.beta.realtime.sessions.create({
+ *   model: 'gpt-4o-realtime-preview',
+ *   tools: [
+ *     zodRealtimeFunction({
+ *       name: 'get_weather',
+ *       description: 'Get the current weather for a location',
+ *       parameters: z.object({
+ *         location: z.string().describe('City and state, e.g. "San Francisco, CA"'),
+ *       }),
+ *     }),
+ *   ],
+ * });
+ * ```
+ *
+ * When the model invokes the tool, parse the arguments yourself:
+ *
+ * ```ts
+ * const args = GetWeatherParams.parse(JSON.parse(event.arguments));
+ * ```
+ */
+export function zodRealtimeFunction<Parameters extends z3.ZodType | z4.ZodType>(options: {
+  name: string;
+  parameters: Parameters;
+  description?: string | undefined;
+}): RealtimeFunctionTool {
+  return {
+    type: 'function',
+    name: options.name,
+    parameters:
+      isZodV4(options.parameters) ?
+        zodV4ToJsonSchema(options.parameters)
+      : zodV3ToJsonSchema(options.parameters, { name: options.name }),
+    ...(options.description ? { description: options.description } : undefined),
+  };
 }

--- a/tests/helpers/zod.test.ts
+++ b/tests/helpers/zod.test.ts
@@ -1,4 +1,4 @@
-import { zodResponseFormat } from 'openai/helpers/zod';
+import { zodResponseFormat, zodRealtimeFunction } from 'openai/helpers/zod';
 import { z as zv3 } from 'zod/v3';
 import { z as zv4 } from 'zod/v4';
 
@@ -358,5 +358,44 @@ describe.each([
     );
 
     expect(consoleSpy).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe.each([
+  { version: 'v3', z: zv3 },
+  { version: 'v4', z: zv4 as any as typeof zv3 },
+])('zodRealtimeFunction (Zod $version)', ({ z }) => {
+  it('builds a RealtimeFunctionTool without strict', () => {
+    const tool = zodRealtimeFunction({
+      name: 'get_weather',
+      description: 'Get the current weather',
+      parameters: z.object({
+        location: z.string(),
+        unit: z.enum(['c', 'f']),
+      }),
+    });
+
+    expect(tool.type).toBe('function');
+    expect(tool.name).toBe('get_weather');
+    expect(tool.description).toBe('Get the current weather');
+    expect(tool).not.toHaveProperty('strict');
+    expect(tool.parameters).toMatchObject({
+      type: 'object',
+      properties: {
+        location: { type: 'string' },
+        unit: { enum: ['c', 'f'], type: 'string' },
+      },
+      required: ['location', 'unit'],
+    });
+  });
+
+  it('omits description when not provided', () => {
+    const tool = zodRealtimeFunction({
+      name: 'ping',
+      parameters: z.object({ message: z.string() }),
+    });
+
+    expect(tool).not.toHaveProperty('description');
+    expect(tool.name).toBe('ping');
   });
 });


### PR DESCRIPTION
## Summary

The Realtime API's `RealtimeFunctionTool` interface does not include a `strict` field, unlike the Responses API's function tool type. As a result, `zodResponsesFunction` cannot be used to build Realtime API tool definitions — it emits `strict: true`, which is an unrecognized field for that API endpoint and silently breaks schema validation.

This PR adds `zodRealtimeFunction`, a new exported helper in `src/helpers/zod.ts` that mirrors `zodResponsesFunction` but targets `RealtimeFunctionTool`. It converts a Zod v3 or v4 schema into the correct tool shape (with `type`, `name`, `parameters`, and an optional `description`) and omits `strict`. Callers pass the Zod object for type safety during tool definition; they parse the arguments themselves when the model calls the tool (e.g., `MyParams.parse(JSON.parse(event.arguments))`).

## Issue

Fixes #1809

## Local verification

Installed deps with `yarn install --frozen-lockfile --ignore-scripts` (skipping the git-swap postinstall), ran typecheck and the targeted test suite:

```
$ npx tsc --noEmit --project tsconfig.json 2>&1 | grep -v '^examples/'
(no output — zero src/ or tests/ errors)

$ npx jest tests/helpers/zod.test.ts --no-coverage
PASS tests/helpers/zod.test.ts
  zodResponseFormat (Zod v3)
    ✓ does the thing (5 ms)
    ✓ automatically adds optional properties to `required` (2 ms)
    ✓ automatically adds properties with defaults to `required` (1 ms)
    ✓ allows description field to be passed in (1 ms)
    ✓ kitchen sink types (2 ms)
    ✓ throws error on optional fields (1 ms)
    ✓ throws error on nested optional fields (1 ms)
    ✓ does not warn on union nullable fields (1 ms)
  zodResponseFormat (Zod v4)
    ✓ does the thing (3 ms)
    ✓ automatically adds optional properties to `required` (1 ms)
    ✓ automatically adds properties with defaults to `required` (2 ms)
    ✓ allows description field to be passed in
    ✓ kitchen sink types (2 ms)
    ✓ throws error on optional fields (1 ms)
    ✓ throws error on nested optional fields (1 ms)
    ✓ does not warn on union nullable fields (1 ms)
  zodRealtimeFunction (Zod v3)
    ✓ builds a RealtimeFunctionTool without strict (1 ms)
    ✓ omits description when not provided (1 ms)
  zodRealtimeFunction (Zod v4)
    ✓ builds a RealtimeFunctionTool without strict (1 ms)
    ✓ omits description when not provided

Tests: 20 passed, 20 total
=== LOCAL_TEST_PASSED ===
```

## Risk

The change is additive — no existing function is modified. `zodRealtimeFunction` is a new export in `src/helpers/zod.ts`, which the generator is documented to never overwrite. Tests for existing helpers pass unchanged.
