### PR TITLE
Document file content response handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,16 @@ await client.files.create({
 });
 ```
 
+To retrieve uploaded file contents, use `files.content()` and consume the returned
+web standard `Response`:
+
+```ts
+const response = await client.files.content('file-abc123');
+const fileContents = await response.arrayBuffer();
+```
+
+For text files, you can use `await response.text()` instead.
+
 ## Webhook Verification
 
 Verifying webhook signatures is _optional but encouraged_.

--- a/src/resources/files.ts
+++ b/src/resources/files.ts
@@ -120,7 +120,7 @@ export class Files extends APIResource {
 
 export type FileObjectsPage = CursorPage<FileObject>;
 
-export type FileContent = string;
+export type FileContent = Response;
 
 export interface FileDeleted {
   id: string;


### PR DESCRIPTION
## Summary
- document that `client.files.content()` returns a web-standard `Response` and show reading it with `.text()`
- align the exported `FileContent` alias with the actual response type

Closes #958.

## Validation
- `git diff --check`
- `npx --yes prettier@3.7.1 --check src/resources/files.ts`
- `./node_modules/.bin/tsc --noEmit --pretty false --target es2020 --lib es2020 --module commonjs --moduleResolution node --esModuleInterop --strict --skipLibCheck src/resources/files.ts`

Note: full `tsc --noEmit` still requires optional example dependencies such as `@azure/identity`, `express`, and `next`.