### PR TITLE
build: migrate release workflow to upstream release-please

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -11,6 +11,33 @@ jobs:
     name: release
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-node'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+
+    steps:
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        id: release
+        with:
+          # Use the default token until the openai-sdks App credentials are provisioned.
+          token: ${{ github.token }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          target-branch: main
+
+  publish:
+    name: publish
+    if: >-
+      ${{
+        always() &&
+        !cancelled() &&
+        needs.release.outputs.release_created == 'true'
+      }}
+    needs: release
+    runs-on: ubuntu-latest
     environment: publish
     permissions:
       contents: read
@@ -19,29 +46,18 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: stainless-api/trigger-release-please@bb6677c5a04578eec1ccfd9e1913b5b78ed64c61 # v1.4.0
-        id: release
-        with:
-          repo: ${{ github.event.repository.full_name }}
-          stainless-api-key: ${{ secrets.STAINLESS_API_KEY }}
-
       - name: Set up pnpm
-        if: ${{ steps.release.outputs.releases_created }}
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
-
       - name: Set up Node
-        if: ${{ steps.release.outputs.releases_created }}
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: '.nvmrc'
           cache: pnpm
 
       - name: Install dependencies
-        if: ${{ steps.release.outputs.releases_created }}
         run: |
           pnpm install --frozen-lockfile
 
       - name: Publish to NPM
-        if: ${{ steps.release.outputs.releases_created }}
         run: |
           bash ./bin/publish-npm

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,13 +2,14 @@
   "packages": {
     ".": {}
   },
-  "$schema": "https://raw.githubusercontent.com/stainless-api/release-please/main/schemas/config.json",
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "versioning": "prerelease",
   "prerelease": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
+  "draft-pull-request": true,
   "pull-request-header": "Automated Release PR",
   "pull-request-title-pattern": "release: ${version}",
   "changelog-sections": [


### PR DESCRIPTION
## Summary
Migrate the release workflow from `stainless-api/trigger-release-please` to the standard `googleapis/release-please-action`.

## What changed
- switched `.github/workflows/create-releases.yml` to manifest-mode `googleapis/release-please-action`
- pinned the action to the latest upstream commit SHA we verified during the migration
- split the workflow into separate `release` and `publish` jobs so broader release-please permissions are not granted during publish
- updated the publish job guard to still run when `release_created` is true even if the release job later reports failure
- updated `release-please-config.json` to point at the upstream `googleapis/release-please` schema

## Why
- removes the dependency on the Stainless-specific wrapper action
- aligns this repo with the standard upstream release-please setup
- preserves the existing release-PR model while tightening permission scope in the publish path
- avoids a partial-failure case where a GitHub release could be created but npm/JSR publish would be skipped

## Validation
- validated `.github/workflows/create-releases.yml` parses as YAML
- validated `release-please-config.json` parses as JSON
- validated the config against the upstream release-please JSON schema
- reviewed npm publish auth flow: the workflow is set up to use GitHub Actions OIDC under the hood via `id-token: write`; repo-side workflow code does not require an `NPM_TOKEN` in Actions

## Notes
- the workflow currently uses `github.token` for release-please, not a PAT
- direct pushes to `openai/openai-node` workflow files are blocked by repo/org rulesets, so this PR is opened from a fork
