### PR TITLE
ci: declare contents:read on detect-breaking-changes workflow

### DIFF
--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -5,6 +5,9 @@ on:
       - main
       - next
 
+permissions:
+  contents: read
+
 jobs:
   detect_breaking_changes:
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
The `detect-breaking-changes.yml` workflow has two jobs (`detect_breaking_changes`, `agents_sdk`) that run scripts against the PR diff and base. Neither writes to the repo or comments on the PR -- they fail the build if a breaking change is detected.

This patch pins the workflow to `permissions: contents: read`. The style matches the per-job permission blocks already declared by `ci.yml`, `publish-jsr.yml`, and `publish-npm.yml` (typically `contents: read` + `id-token: write` for trusted publishing).

With explicit scope:

- the workflow token can't be widened by a future change to the repo default
- the SLSA / OpenSSF Scorecard `Token-Permissions` check passes for this file
- third-party action exposure (`actions/setup-node@v3`, `pnpm/action-setup@v4`) is bounded to read

No behavioural change.