### PR TITLE
fix: remove abort listener after fetch settles

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -969,6 +969,7 @@ export class OpenAI {
       return await this.fetch.call(undefined, url, fetchOptions);
     } finally {
       clearTimeout(timeout);
+      if (signal) signal.removeEventListener('abort', abort);
     }
   }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -652,6 +652,29 @@ describe('retries', () => {
     expect(count).toEqual(3);
   });
 
+  test('removes caller abort listener after successful fetch', async () => {
+    const testFetch = async (): Promise<Response> => {
+      return new Response(JSON.stringify({ a: 1 }), { headers: { 'Content-Type': 'application/json' } });
+    };
+
+    const client = new OpenAI({
+      apiKey: 'My API Key',
+      adminAPIKey: 'My Admin API Key',
+      fetch: testFetch,
+    });
+    const controller = new AbortController();
+    const addEventListenerSpy = jest.spyOn(controller.signal, 'addEventListener');
+    const removeEventListenerSpy = jest.spyOn(controller.signal, 'removeEventListener');
+
+    expect(await client.request({ path: '/foo', method: 'get', signal: controller.signal })).toEqual({
+      a: 1,
+    });
+
+    const abortListener = addEventListenerSpy.mock.calls.find(([event]) => event === 'abort')?.[1];
+    expect(abortListener).toEqual(expect.any(Function));
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('abort', abortListener);
+  });
+
   test('retry count header', async () => {
     let count = 0;
     let capturedRequest: RequestInit | undefined;


### PR DESCRIPTION
Fixes #1811.

## Summary

- remove the forwarded caller abort listener after `fetchWithTimeout` settles
- keep the existing internal timeout cleanup behavior
- add a regression test that verifies the caller signal listener is detached after a successful request

## Verification

- `yarn test tests/index.test.ts --runInBand`
- `npx -p node@20 -c './node_modules/.bin/prettier --check src/client.ts tests/index.test.ts && ./node_modules/.bin/eslint src/client.ts tests/index.test.ts'`
- `npx -p node@20 -c './scripts/build'`

Note: full `yarn lint` proceeds through Prettier, ESLint, and build under Node 20, then local type-checking fails because optional example dependencies are not installed in this checkout: `@azure/identity`, `express`, and `next`.
