### PR TITLE
Add beta realtime cached token detail types

### DIFF
--- a/src/resources/beta/realtime/realtime.ts
+++ b/src/resources/beta/realtime/realtime.ts
@@ -1234,9 +1234,31 @@ export namespace RealtimeResponseUsage {
     cached_tokens?: number;
 
     /**
+     * Details about the cached tokens used in the Response.
+     */
+    cached_tokens_details?: InputTokenDetails.CachedTokensDetails;
+
+    /**
      * The number of text tokens used in the Response.
      */
     text_tokens?: number;
+  }
+
+  export namespace InputTokenDetails {
+    /**
+     * Details about the cached tokens used in the Response.
+     */
+    export interface CachedTokensDetails {
+      /**
+       * The number of cached audio tokens used in the Response.
+       */
+      audio_tokens?: number;
+
+      /**
+       * The number of cached text tokens used in the Response.
+       */
+      text_tokens?: number;
+    }
   }
 
   /**

--- a/tests/betaRealtimeTypes.test.ts
+++ b/tests/betaRealtimeTypes.test.ts
@@ -1,0 +1,20 @@
+import OpenAI from 'openai/index';
+import { expectType } from './utils/typing';
+
+describe('beta realtime types', () => {
+  test('response usage includes cached token details', () => {
+    const inputTokenDetails: OpenAI.Beta.Realtime.RealtimeResponseUsage.InputTokenDetails = {
+      audio_tokens: 1,
+      cached_tokens: 2,
+      cached_tokens_details: {
+        audio_tokens: 3,
+        text_tokens: 4,
+      },
+      text_tokens: 5,
+    };
+
+    expectType<number | undefined>(inputTokenDetails.cached_tokens_details?.audio_tokens);
+    expectType<number | undefined>(inputTokenDetails.cached_tokens_details?.text_tokens);
+    expect(inputTokenDetails.cached_tokens_details?.text_tokens).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
- add `cached_tokens_details` to `OpenAI.Beta.Realtime.RealtimeResponseUsage.InputTokenDetails`
- include nested cached token detail fields for text and audio tokens
- add a compile-time/runtime type assertion covering the beta realtime usage shape

Fixes #1600.

## Tests
- `yarn test tests/betaRealtimeTypes.test.ts`

## Notes
- `yarn build` could not complete locally on Node v26.0.0 because `tsc-multi`/`yargs` fails with `ReferenceError: require is not defined in ES module scope` before type-checking.
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json` is blocked by optional example dependencies missing locally (`@azure/identity`, `express`, `next`).