### PR TITLE
fix: preserve options in vector store file batch upload polling

### DIFF
--- a/src/resources/vector-stores/file-batches.ts
+++ b/src/resources/vector-stores/file-batches.ts
@@ -71,7 +71,7 @@ export class FileBatches extends APIResource {
     body: FileBatchCreateParams,
     options?: RequestOptions & { pollIntervalMs?: number },
   ): Promise<VectorStoreFileBatch> {
-    const batch = await this.create(vectorStoreId, body);
+    const batch = await this.create(vectorStoreId, body, options);
     return await this.poll(vectorStoreId, batch.id, options);
   }
 
@@ -190,9 +190,13 @@ export class FileBatches extends APIResource {
     // Wait for all processing to complete.
     await allSettledWithThrow(workers);
 
-    return await this.createAndPoll(vectorStoreId, {
-      file_ids: allFileIds,
-    });
+    return await this.createAndPoll(
+      vectorStoreId,
+      {
+        file_ids: allFileIds,
+      },
+      options,
+    );
   }
 }
 

--- a/tests/api-resources/vector-stores/file-batches.test.ts
+++ b/tests/api-resources/vector-stores/file-batches.test.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-import OpenAI from 'openai';
+import OpenAI, { toFile } from 'openai';
+import { mockFetch } from '../../utils/mock-fetch';
 
 const client = new OpenAI({
   apiKey: 'My API Key',
@@ -80,5 +81,62 @@ describe('resource fileBatches', () => {
       limit: 0,
       order: 'asc',
     });
+  });
+
+  test('uploadAndPoll returns the completed file batch', async () => {
+    const { fetch, handleRequest } = mockFetch();
+    const client = new OpenAI({ apiKey: 'My API Key', fetch });
+
+    const responsePromise = client.vectorStores.fileBatches.uploadAndPoll(
+      'vs_abc123',
+      { files: [await toFile(Buffer.from('Example data'), 'README.md')] },
+      { pollIntervalMs: 1 },
+    );
+
+    await handleRequest(async (req) => {
+      expect(req.toString()).toBe('data:,');
+      return new Response();
+    });
+
+    await handleRequest(async (req) => {
+      expect(req.toString()).toContain('/files');
+      return new Response(JSON.stringify({ id: 'file_abc123', object: 'file' }), {
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    await handleRequest(async (req) => {
+      expect(req.toString()).toContain('/vector_stores/vs_abc123/file_batches');
+      return new Response(
+        JSON.stringify({
+          id: 'vsfb_abc123',
+          object: 'vector_store.files_batch',
+          created_at: 0,
+          file_counts: { cancelled: 0, completed: 0, failed: 0, in_progress: 1, total: 1 },
+          status: 'in_progress',
+          vector_store_id: 'vs_abc123',
+        }),
+        { headers: { 'content-type': 'application/json' } },
+      );
+    });
+
+    await handleRequest(async (req) => {
+      expect(req.toString()).toContain('/vector_stores/vs_abc123/file_batches/vsfb_abc123');
+      return new Response(
+        JSON.stringify({
+          id: 'vsfb_abc123',
+          object: 'vector_store.files_batch',
+          created_at: 0,
+          file_counts: { cancelled: 0, completed: 1, failed: 0, in_progress: 0, total: 1 },
+          status: 'completed',
+          vector_store_id: 'vs_abc123',
+        }),
+        { headers: { 'content-type': 'application/json' } },
+      );
+    });
+
+    const response = await responsePromise;
+    expect(response.id).toBe('vsfb_abc123');
+    expect(response.object).toBe('vector_store.files_batch');
   });
 });


### PR DESCRIPTION
Fixes #1700.

## Summary
- pass request/poll options through vector store file batch create-and-poll helpers
- add a regression test ensuring uploadAndPoll resolves to the completed file batch (`vsfb_...`) object

## Tests
- yarn test tests/api-resources/vector-stores/file-batches.test.ts
- yarn format src/resources/vector-stores/file-batches.ts tests/api-resources/vector-stores/file-batches.test.ts
- git diff --check