### PR TITLE
fix(client): omit User-Agent in browser requests

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1105,7 +1105,7 @@ export class OpenAI {
       idempotencyHeaders,
       {
         Accept: 'application/json',
-        'User-Agent': this.getUserAgent(),
+        ...(!isRunningInBrowser() ? { 'User-Agent': this.getUserAgent() } : undefined),
         'X-Stainless-Retry-Count': String(retryCount),
         ...(options.timeout ? { 'X-Stainless-Timeout': String(Math.trunc(options.timeout / 1000)) } : {}),
         ...getPlatformHeaders(),

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -77,6 +77,46 @@ describe('instantiate client', () => {
       expect(req.headers.get('x-env-header')).toEqual('env');
       expect(req.headers.get('x-tuple-header')).toEqual('tuple');
     });
+
+    test('omits forbidden User-Agent header in browser environments', async () => {
+      const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+      const navigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: { document: {} },
+      });
+      Object.defineProperty(globalThis, 'navigator', {
+        configurable: true,
+        value: {
+          userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+        },
+      });
+
+      try {
+        const browserClient = new OpenAI({
+          baseURL: 'http://localhost:5000/',
+          apiKey: 'My API Key',
+          dangerouslyAllowBrowser: true,
+        });
+
+        const { req } = await browserClient.buildRequest({ path: '/foo', method: 'post' });
+        expect(req.headers.has('user-agent')).toBe(false);
+      } finally {
+        if (windowDescriptor) {
+          Object.defineProperty(globalThis, 'window', windowDescriptor);
+        } else {
+          delete (globalThis as any).window;
+        }
+
+        if (navigatorDescriptor) {
+          Object.defineProperty(globalThis, 'navigator', navigatorDescriptor);
+        } else {
+          delete (globalThis as any).navigator;
+        }
+      }
+    });
   });
   describe('logging', () => {
     const env = process.env;


### PR DESCRIPTION
Fixes #1694.

## Summary
- omit the SDK-generated `User-Agent` header when the client is running in a browser-like environment
- keep the existing `User-Agent` behavior for Node, Deno, edge, and other non-browser runtimes
- add a regression test for `dangerouslyAllowBrowser` requests so browser usage does not send a forbidden header

## Tests
- `./node_modules/.bin/jest tests/index.test.ts --runInBand -t "omits forbidden User-Agent"`
- `./node_modules/.bin/prettier --check src/client.ts tests/index.test.ts`
- `./node_modules/.bin/eslint src/client.ts tests/index.test.ts`
- `PATH=/Users/ubl/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./scripts/build`