### PR TITLE
fix(client): remove abort listener on success in fetchWithTimeout

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -969,6 +969,12 @@ export class OpenAI {
       return await this.fetch.call(undefined, url, fetchOptions);
     } finally {
       clearTimeout(timeout);
+      // Remove the listener on success so we don't keep the caller's signal
+      // (and any underlying timer) ref'd for the full timeout duration.
+      // The `{ once: true }` option only self-removes when the signal actually
+      // fires, which on Deno keeps `AbortSignal.timeout()` timers ref'd and
+      // blocks process exit until the timeout elapses. See #1811.
+      if (signal) signal.removeEventListener('abort', abort);
     }
   }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -323,6 +323,39 @@ describe('instantiate client', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
+  test('removes abort listener from custom signal on success', async () => {
+    // Regression for #1811: the listener forwarding aborts from the caller's
+    // signal to our internal controller used to leak until the signal fired,
+    // which on Deno keeps `AbortSignal.timeout()` timers ref'd and blocks
+    // process exit.
+    const client = new OpenAI({
+      baseURL: 'http://localhost:5000/',
+      apiKey: 'My API Key',
+      adminAPIKey: 'My Admin API Key',
+      fetch: () =>
+        Promise.resolve(
+          new Response(JSON.stringify({ ok: true }), {
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        ),
+    });
+
+    const controller = new AbortController();
+    const addSpy = jest.spyOn(controller.signal, 'addEventListener');
+    const removeSpy = jest.spyOn(controller.signal, 'removeEventListener');
+
+    await client.get('/foo', { signal: controller.signal });
+
+    const abortAdds = addSpy.mock.calls.filter((c) => c[0] === 'abort');
+    const abortRemoves = removeSpy.mock.calls.filter((c) => c[0] === 'abort');
+    expect(abortAdds.length).toBeGreaterThan(0);
+    expect(abortRemoves.length).toBe(abortAdds.length);
+    // Same listener reference passed to both add and remove.
+    for (let i = 0; i < abortAdds.length; i++) {
+      expect(abortRemoves[i]![1]).toBe(abortAdds[i]![1]);
+    }
+  });
+
   test('normalized method', async () => {
     let capturedRequest: RequestInit | undefined;
     const testFetch = async (url: string | URL | Request, init: RequestInit = {}): Promise<Response> => {


### PR DESCRIPTION
Fixes #1811.

`fetchWithTimeout` attaches an abort listener to the caller's `signal` that forwards to its internal controller. The listener is added with `{ once: true }`, so it self-removes when the signal actually fires, but it is never removed when the request completes successfully.

On Node this is harmless because `AbortSignal.timeout()` keeps its timer unref'd regardless of listeners. On Deno, attaching a listener to a signal returned by `AbortSignal.timeout()` refs the underlying timer. The orphaned listener keeps that timer alive for the full timeout duration, so a request that completes in 500ms blocks process exit for the remainder of a caller's 30s timeout.

The fix removes the listener in the existing `finally` block alongside `clearTimeout`. The `abort` reference is already hoisted into the enclosing scope, so no other changes are needed.

### Repro (from the linked issue)

```ts
import OpenAI from "openai";

const client = new OpenAI();
const signal = AbortSignal.timeout(30000);

const response = await client.chat.completions.create(
  { model: "gpt-4o", messages: [{ role: "user", content: "Say hi" }], max_tokens: 10 },
  { signal },
);

console.log("Result:", response.choices[0].message.content);
// Before: Deno hangs ~30s after logging. After: exits immediately.
```

### Tests

Added a regression test in `tests/index.test.ts` that spies on `addEventListener` / `removeEventListener` of a caller-supplied `AbortSignal` and asserts the same listener reference is both added and removed once the request resolves. Full `tests/index.test.ts` suite (61 tests) passes against the mock server.