### PR TITLE
Fix fetchOptions dispatcher with undici v8

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -963,6 +963,7 @@ export class OpenAI {
       // See https://github.com/nodejs/undici/issues/2294
       fetchOptions.method = method.toUpperCase();
     }
+    maybeWrapDispatcher(fetchOptions);
 
     try {
       // use undefined this binding; fetch errors if bound to something else in browser/cloudflare
@@ -971,7 +972,6 @@ export class OpenAI {
       clearTimeout(timeout);
     }
   }
-
   private async shouldRetry(response: Response): Promise<boolean> {
     // Note this is not a standard header.
     const shouldRetryHeader = response.headers.get('x-should-retry');
@@ -1292,6 +1292,134 @@ OpenAI.Evals = Evals;
 OpenAI.Containers = Containers;
 OpenAI.Skills = Skills;
 OpenAI.Videos = Videos;
+
+function maybeWrapDispatcher(init: RequestInit): void {
+  const dispatcher = (init as any).dispatcher;
+  if (
+    !dispatcher ||
+    typeof dispatcher !== 'object' ||
+    typeof dispatcher.dispatch !== 'function' ||
+    dispatcher.__openai_fetch_compat
+  ) {
+    return;
+  }
+
+  (init as any).dispatcher = new FetchDispatcherCompatibilityWrapper(dispatcher);
+}
+
+class FetchDispatcherCompatibilityWrapper {
+  __openai_fetch_compat = true;
+
+  constructor(private dispatcher: any) {}
+
+  dispatch(options: unknown, handler: unknown): unknown {
+    return this.dispatcher.dispatch(options, wrapFetchDispatchHandler(handler));
+  }
+
+  close(...args: unknown[]): unknown {
+    return this.dispatcher.close?.(...args);
+  }
+
+  destroy(...args: unknown[]): unknown {
+    return this.dispatcher.destroy?.(...args);
+  }
+}
+
+function wrapFetchDispatchHandler(handler: unknown): unknown {
+  if (!handler || typeof handler !== 'object' || typeof (handler as any).onRequestStart === 'function') {
+    return handler;
+  }
+
+  return new FetchDispatchHandlerCompatibilityWrapper(handler);
+}
+
+class FetchDispatchHandlerCompatibilityWrapper {
+  constructor(private handler: any) {}
+
+  onRequestStart(controller: any, context: unknown): void {
+    this.handler.onConnect?.((reason: unknown) => controller.abort(reason), context);
+  }
+
+  onRequestUpgrade(controller: any, statusCode: number, headers: unknown, socket: unknown): void {
+    this.handler.onUpgrade?.(statusCode, getRawHeaders(controller, headers), socket);
+  }
+
+  onResponseStart(controller: any, statusCode: number, headers: unknown, statusMessage?: string): void {
+    if (
+      this.handler.onHeaders?.(
+        statusCode,
+        getRawHeaders(controller, headers),
+        () => controller.resume(),
+        statusMessage,
+      ) === false
+    ) {
+      controller.pause();
+    }
+  }
+
+  onResponseData(controller: any, chunk: unknown): void {
+    if (this.handler.onData?.(chunk) === false) {
+      controller.pause();
+    }
+  }
+
+  onResponseEnd(controller: any, trailers: unknown): void {
+    this.handler.onComplete?.(getRawHeaders(controller, trailers, 'rawTrailers'));
+  }
+
+  onResponseError(_controller: unknown, error: unknown): void {
+    if (!this.handler.onError) {
+      throw error;
+    }
+
+    this.handler.onError?.(error);
+  }
+
+  onBodySent(chunk: unknown): void {
+    this.handler.onBodySent?.(chunk);
+  }
+
+  onRequestSent(): void {
+    this.handler.onRequestSent?.();
+  }
+
+  onResponseStarted(): void {
+    this.handler.onResponseStarted?.();
+  }
+}
+
+function getRawHeaders(
+  controller: any,
+  headers: unknown,
+  controllerKey: 'rawHeaders' | 'rawTrailers' = 'rawHeaders',
+): string[] {
+  if (Array.isArray(controller?.[controllerKey])) {
+    return controller[controllerKey].map(String);
+  }
+
+  if (Array.isArray(headers)) {
+    return headers.map(String);
+  }
+
+  if (!headers || typeof headers !== 'object') {
+    return [];
+  }
+
+  const rawHeaders: string[] = [];
+  for (const [name, value] of Object.entries(
+    headers as Record<string, string | string[] | number | undefined>,
+  )) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        rawHeaders.push(name, String(item));
+      }
+    } else if (value !== undefined) {
+      rawHeaders.push(name, String(value));
+    }
+  }
+
+  return rawHeaders;
+}
 
 export declare namespace OpenAI {
   export type RequestOptions = Opts.RequestOptions;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -341,6 +341,68 @@ describe('instantiate client', () => {
     expect(capturedRequest?.method).toEqual('PATCH');
   });
 
+  test('fetchOptions dispatcher supports newer undici handlers', async () => {
+    const dispatcher = {
+      dispatch(_options: unknown, handler: any) {
+        expect(typeof handler.onRequestStart).toBe('function');
+        expect(typeof handler.onResponseStart).toBe('function');
+        expect(typeof handler.onResponseData).toBe('function');
+        expect(typeof handler.onResponseEnd).toBe('function');
+
+        const controller = {
+          rawHeaders: ['content-type', 'application/json'],
+          rawTrailers: [],
+          abort: jest.fn(),
+          pause: jest.fn(),
+          resume: jest.fn(),
+        };
+        handler.onRequestStart(controller, undefined);
+        handler.onResponseStart(controller, 200, { 'content-type': 'application/json' });
+        handler.onResponseData(controller, Buffer.from(JSON.stringify({ ok: true })));
+        handler.onResponseEnd(controller, {});
+        return true;
+      },
+    };
+
+    const testFetch = async (_url: string | URL | Request, init: RequestInit = {}): Promise<Response> => {
+      return new Promise((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        (init as any).dispatcher.dispatch(
+          {},
+          {
+            onConnect() {},
+            onHeaders(_statusCode: number, _headers: string[], resume: () => void) {
+              resume();
+            },
+            onData(chunk: Buffer) {
+              chunks.push(chunk);
+            },
+            onComplete() {
+              resolve(
+                new Response(Buffer.concat(chunks).toString(), {
+                  headers: { 'Content-Type': 'application/json' },
+                }),
+              );
+            },
+            onError(error: Error) {
+              reject(error);
+            },
+          },
+        );
+      });
+    };
+
+    const client = new OpenAI({
+      baseURL: 'http://localhost:5000/',
+      apiKey: 'My API Key',
+      adminAPIKey: 'My Admin API Key',
+      fetch: testFetch,
+      fetchOptions: { dispatcher } as any,
+    });
+
+    expect(await client.get('/foo')).toEqual({ ok: true });
+  });
+
   describe('baseUrl', () => {
     test('trailing slash', () => {
       const client = new OpenAI({


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #1886.

Node's built-in `fetch` can pass the older undici dispatch handler shape into a user-provided dispatcher. Newer `undici@8` dispatchers reject that handler with `UND_ERR_INVALID_ARG: invalid onRequestStart method`, which breaks the documented `fetchOptions.dispatcher` proxy setup.

This wraps dispatcher calls with a compatibility adapter that forwards the older handler callbacks to the newer request lifecycle callbacks while leaving dispatchers that already receive the newer handler shape unchanged.

## Additional context & links

Tests run:
- `./scripts/test tests/index.test.ts`
- `./scripts/build`
- built-package smoke test with `undici@8.3.0` `ProxyAgent` verifying the failure changes from `invalid onRequestStart method` to a normal proxy connection error
- `./scripts/lint`
- `./scripts/test`
- `git diff --check`