### PR TITLE
fix(error): preserve unwrapped API error bodies

### DIFF
--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -67,7 +67,10 @@ export class APIError<
       return new APIConnectionError({ message, cause: castToError(errorResponse) });
     }
 
-    const error = (errorResponse as Record<string, any>)?.['error'];
+    const error =
+      errorResponse && typeof errorResponse === 'object' && 'error' in errorResponse ?
+        (errorResponse as Record<string, any>)['error']
+      : errorResponse;
 
     if (status === 400) {
       return new BadRequestError(status, error, message, headers);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -341,6 +341,29 @@ describe('instantiate client', () => {
     expect(capturedRequest?.method).toEqual('PATCH');
   });
 
+  test('preserves JSON error bodies without an error wrapper', async () => {
+    const errorBody = { detail: 'Invalid request body', status: 400 };
+    const testFetch = async (): Promise<Response> => {
+      return new Response(JSON.stringify(errorBody), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+
+    const client = new OpenAI({
+      baseURL: 'http://localhost:5000/',
+      apiKey: 'My API Key',
+      adminAPIKey: 'My Admin API Key',
+      fetch: testFetch,
+      maxRetries: 0,
+    });
+
+    await expect(client.get('/foo')).rejects.toMatchObject({
+      status: 400,
+      error: errorBody,
+    });
+  });
+
   describe('baseUrl', () => {
     test('trailing slash', () => {
       const client = new OpenAI({


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Preserve JSON error response bodies that do not use the OpenAI { error: ... } wrapper. Today those responses produce an APIError with error === undefined even though the response body was valid JSON. This keeps the existing behavior for wrapped OpenAI errors, while falling back to the full parsed body when the error key is absent.

## Additional context & links

Fixes #1577.

Tests:
- ./node_modules/.bin/jest.cmd tests/index.test.ts
- ./node_modules/.bin/eslint.cmd src/core/error.ts tests/index.test.ts

Note: 
ode ./node_modules/typescript/bin/tsc currently fails in this local checkout because example files import optional packages that are not installed here (@azure/identity, express, 
ext).