### PR TITLE
fix: Improve undici dispatcher mismatch guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,15 +710,20 @@ options to requests:
 
 ```ts
 import OpenAI from 'openai';
-import * as undici from 'undici';
+import { fetch, ProxyAgent } from 'undici';
 
-const proxyAgent = new undici.ProxyAgent('http://localhost:8888');
+const proxyAgent = new ProxyAgent('http://localhost:8888');
 const client = new OpenAI({
+  fetch,
   fetchOptions: {
     dispatcher: proxyAgent,
   },
 });
 ```
+
+Undici-specific options like `dispatcher` must be paired with the matching `fetch` implementation.
+Using Node's built-in `fetch` with a `dispatcher` from another Undici version can cause errors such
+as `UND_ERR_INVALID_ARG: invalid onRequestStart method`.
 
 <img src="https://raw.githubusercontent.com/stainless-api/sdk-assets/refs/heads/main/bun.svg" align="top" width="18" height="21"> **Bun** <sup>[[docs](https://bun.sh/guides/http/proxy)]</sup>
 

--- a/README.md
+++ b/README.md
@@ -722,8 +722,6 @@ const client = new OpenAI({
 ```
 
 Undici-specific options like `dispatcher` must be paired with the matching `fetch` implementation.
-Using Node's built-in `fetch` with a `dispatcher` from another Undici version can cause errors such
-as `UND_ERR_INVALID_ARG: invalid onRequestStart method`.
 
 <img src="https://raw.githubusercontent.com/stainless-api/sdk-assets/refs/heads/main/bun.svg" align="top" width="18" height="21"> **Bun** <sup>[[docs](https://bun.sh/guides/http/proxy)]</sup>
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -789,7 +789,10 @@ export class OpenAI {
       if (isTimeout) {
         throw new Errors.APIConnectionTimeoutError();
       }
-      throw new Errors.APIConnectionError({ cause: response });
+      throw new Errors.APIConnectionError({
+        message: getConnectionErrorMessage(response),
+        cause: response,
+      });
     }
 
     const specialHeaders = [...response.headers.entries()]
@@ -1292,6 +1295,38 @@ OpenAI.Evals = Evals;
 OpenAI.Containers = Containers;
 OpenAI.Skills = Skills;
 OpenAI.Videos = Videos;
+
+function getConnectionErrorMessage(error: Error): string | undefined {
+  if (isUndiciDispatcherVersionMismatchError(error)) {
+    return [
+      'Connection error.',
+      'This may be caused by passing an undici dispatcher, such as ProxyAgent, that is incompatible with the fetch implementation.',
+      "If you are using undici's ProxyAgent, pass the fetch implementation from the same undici package:",
+      "import { fetch, ProxyAgent } from 'undici'; new OpenAI({ fetch, fetchOptions: { dispatcher: new ProxyAgent(...) } });",
+    ].join(' ');
+  }
+
+  return undefined;
+}
+
+function isUndiciDispatcherVersionMismatchError(error: unknown): boolean {
+  let current = error;
+
+  for (let i = 0; i < 8 && current && typeof current === 'object'; i++) {
+    const err = current as { code?: unknown; message?: unknown; cause?: unknown };
+    if (
+      err.code === 'UND_ERR_INVALID_ARG' &&
+      typeof err.message === 'string' &&
+      err.message.includes('invalid onRequestStart method')
+    ) {
+      return true;
+    }
+
+    current = err.cause;
+  }
+
+  return false;
+}
 
 export declare namespace OpenAI {
   export type RequestOptions = Opts.RequestOptions;

--- a/src/client.ts
+++ b/src/client.ts
@@ -1298,22 +1298,23 @@ OpenAI.Videos = Videos;
 
 function getConnectionErrorMessage(error: Error): string | undefined {
   if (isUndiciDispatcherVersionMismatchError(error)) {
-    return [
-      'Connection error.',
-      'This may be caused by passing an undici dispatcher, such as ProxyAgent, that is incompatible with the fetch implementation.',
-      "If you are using undici's ProxyAgent, pass the fetch implementation from the same undici package:",
-      "import { fetch, ProxyAgent } from 'undici'; new OpenAI({ fetch, fetchOptions: { dispatcher: new ProxyAgent(...) } });",
-    ].join(' ');
+    return `Connection error. This may be caused by passing an undici dispatcher, such as ProxyAgent, that is incompatible with the fetch implementation. If you are using undici's ProxyAgent, pass the fetch implementation from the same undici package: import { fetch, ProxyAgent } from 'undici'; new OpenAI({ fetch, fetchOptions: { dispatcher: new ProxyAgent(...) } });`;
   }
 
   return undefined;
 }
 
+type ErrorLikeWithCause = {
+  code?: unknown;
+  message?: unknown;
+  cause?: unknown;
+};
+
 function isUndiciDispatcherVersionMismatchError(error: unknown): boolean {
   let current = error;
 
   for (let i = 0; i < 8 && current && typeof current === 'object'; i++) {
-    const err = current as { code?: unknown; message?: unknown; cause?: unknown };
+    const err = current as ErrorLikeWithCause;
     if (
       err.code === 'UND_ERR_INVALID_ARG' &&
       typeof err.message === 'string' &&

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -341,6 +341,39 @@ describe('instantiate client', () => {
     expect(capturedRequest?.method).toEqual('PATCH');
   });
 
+  test('explains undici dispatcher and fetch version mismatch', async () => {
+    const undiciError = Object.assign(new Error('invalid onRequestStart method'), {
+      name: 'InvalidArgumentError',
+      code: 'UND_ERR_INVALID_ARG',
+    });
+    const fetchError = new TypeError('fetch failed');
+    (fetchError as any).cause = undiciError;
+
+    const client = new OpenAI({
+      baseURL: 'http://localhost:5000/',
+      apiKey: 'My API Key',
+      adminAPIKey: 'My Admin API Key',
+      maxRetries: 0,
+      fetch: async () => {
+        throw fetchError;
+      },
+      fetchOptions: {
+        dispatcher: { dispatch() {} },
+      } as any,
+    });
+
+    await expect(client.get('/foo')).rejects.toThrow(
+      "If you are using undici's ProxyAgent, pass the fetch implementation from the same undici package",
+    );
+
+    try {
+      await client.get('/foo');
+      throw new Error('expected request to fail');
+    } catch (error) {
+      expect((error as any).cause).toBe(fetchError);
+    }
+  });
+
   describe('baseUrl', () => {
     test('trailing slash', () => {
       const client = new OpenAI({


### PR DESCRIPTION
## Summary

Closes #1886.

This PR takes the docs + diagnostic path for the `fetchOptions.dispatcher` / `undici@8` proxy failure:

- updates the Node proxy docs to pass `fetch` from `undici` whenever using `ProxyAgent`
- adds a targeted `APIConnectionError` message when the nested cause chain contains `UND_ERR_INVALID_ARG: invalid onRequestStart method`
- preserves the original fetch error as `cause` so existing programmatic inspection keeps working
- adds a regression test for the diagnostic

## Investigation

I reproduced the user report from #1886 in a standalone project under `~/code/openai-node-issue-1886-repro` using `openai@6.38.0` and `undici@8.3.0`.

The important finding is that the SDK is already forwarding `fetchOptions` into the configured fetch call. The failure happens below the SDK boundary:

1. If users pass `fetchOptions.dispatcher: new ProxyAgent(...)` without also passing `fetch`, the SDK calls Node's built-in `globalThis.fetch`.
2. Node's built-in fetch is backed by Node's bundled Undici version.
3. `ProxyAgent` from external `undici@8` expects the newer dispatcher handler lifecycle, including `onRequestStart`.
4. Node's bundled fetch supplies an older handler shape.
5. `undici@8` rejects that handler with `UND_ERR_INVALID_ARG: invalid onRequestStart method`, which fetch wraps as `TypeError: fetch failed`, which the SDK wraps as `APIConnectionError`.

I also validated the intended fix with real OpenAI calls using the local proxy environment:

```ts
import { fetch, ProxyAgent } from 'undici';

const client = new OpenAI({
  fetch,
  fetchOptions: {
    dispatcher: new ProxyAgent(proxyUrl),
  },
});
```

With `fetch` and `ProxyAgent` both coming from `undici@8.3.0`, the mismatch disappears. A real `models.list` request succeeded through the same proxy, and a real chat completions request with `gpt-4o-mini` returned the expected response.

## Decision

We considered a few options:

- building an SDK compatibility adapter between Undici dispatcher handler versions
- forcing one Undici handler shape/version
- requiring `fetch` whenever `fetchOptions` is provided
- keeping `fetchOptions` as an opaque escape hatch, but making the implementation-specific contract clear

This PR chooses the last option.

The SDK's abstraction is custom `fetch`; `fetchOptions` are intentionally passed through to that fetch implementation. Runtime-specific options like Undici's `dispatcher` are not portable independent of the fetch implementation that consumes them. So the least surprising contract is: if you use implementation-specific fetch options, bring the matching fetch implementation too.

## Relationship to #1894

This should close out / supersede #1894.

#1894 takes the compatibility-layer approach: wrapping dispatcher calls and adapting the older fetch handler callbacks to the newer Undici lifecycle callbacks. That is clever and directly addresses the observed failure, but it means the SDK owns a bridge across Undici's internal dispatcher handler protocols.

We decided not to do that because the handler object is below the public `fetchOptions` contract and varies across Node's bundled Undici and external Undici versions. Rather than chasing those internals, this PR keeps transport ownership with the provided fetch implementation and improves the docs/error message so users can fix the mismatch directly.

## Validation

- `env npm_config_cache=/tmp/openai-node-1886-npm-cache ./scripts/test tests/index.test.ts`
- `./scripts/format`
- `./scripts/build`
- smoke-tested the patched build against the standalone `undici@8.3.0` repro:
  - without passing `fetch`, the SDK now emits the new diagnostic while preserving the original cause
  - with `fetch` from `undici`, the `invalid onRequestStart method` mismatch is avoided