### PR TITLE
feat(api): Add Amazon Bedrock Responses support

### DIFF
--- a/README.md
+++ b/README.md
@@ -820,6 +820,7 @@ The following runtimes are supported:
   ### When might this not be dangerous?
 
   In certain scenarios where enabling browser support might not pose significant risks:
+
   - Internal Tools: If the application is used solely within a controlled internal environment where the users are trusted, the risk of credential exposure can be mitigated.
   - Public APIs with Limited Scope: If your API has very limited scope and the exposed credentials do not grant access to sensitive data or critical operations, the potential impact of exposure is reduced.
   - Development or debugging purpose: Enabling this feature temporarily might be acceptable, provided the credentials are short-lived, aren't also used in production environments, or are frequently rotated.

--- a/README.md
+++ b/README.md
@@ -401,6 +401,39 @@ const result = await openai.chat.completions.create({
 console.log(result.choices[0]!.message?.content);
 ```
 
+## Amazon Bedrock
+
+To use this library with [Amazon Bedrock's OpenAI-compatible API](https://docs.aws.amazon.com/bedrock/latest/userguide/models-api-compatibility.html), use the `BedrockOpenAI` class instead of the `OpenAI` class.
+
+```ts
+import { BedrockOpenAI } from 'openai';
+
+// gets the bearer token from AWS_BEARER_TOKEN_BEDROCK and the region from AWS_REGION/AWS_DEFAULT_REGION
+const client = new BedrockOpenAI();
+
+const response = await client.responses.create({
+  model: 'openai.gpt-5.4',
+  input: 'Say hello!',
+});
+
+console.log(response.output_text);
+```
+
+`BedrockOpenAI` configures AWS bearer auth and the Bedrock Mantle endpoint, then uses the normal SDK resources. AWS controls which endpoints and features are supported; unsupported calls surface the provider's normal HTTP errors through the SDK.
+
+Pass `baseURL` or set `AWS_BEDROCK_BASE_URL` to override the derived `https://bedrock-mantle.<region>.api.aws/openai/v1` endpoint. For long-running apps, pass `bedrockTokenProvider` to refresh the Bedrock bearer token before each request.
+
+Set `AWS_BEARER_TOKEN_BEDROCK` to an [Amazon Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html). To refresh tokens yourself, pass a provider instead of `apiKey`:
+
+```ts
+const client = new BedrockOpenAI({
+  awsRegion: 'us-west-2',
+  bedrockTokenProvider: async () => refreshBedrockToken(),
+});
+```
+
+For more information on support for Amazon Bedrock, see [bedrock.md](bedrock.md).
+
 ### Retries
 
 Certain errors will be automatically retried 2 times by default, with a short exponential backoff.
@@ -787,7 +820,6 @@ The following runtimes are supported:
   ### When might this not be dangerous?
 
   In certain scenarios where enabling browser support might not pose significant risks:
-
   - Internal Tools: If the application is used solely within a controlled internal environment where the users are trusted, the risk of credential exposure can be mitigated.
   - Public APIs with Limited Scope: If your API has very limited scope and the exposed credentials do not grant access to sensitive data or critical operations, the potential impact of exposure is reduced.
   - Development or debugging purpose: Enabling this feature temporarily might be acceptable, provided the credentials are short-lived, aren't also used in production environments, or are frequently rotated.

--- a/bedrock.md
+++ b/bedrock.md
@@ -1,0 +1,31 @@
+# Amazon Bedrock
+
+To use this library with [Amazon Bedrock's OpenAI-compatible API](https://docs.aws.amazon.com/bedrock/latest/userguide/models-api-compatibility.html), use the `BedrockOpenAI`
+class instead of the `OpenAI` class.
+
+```ts
+import { BedrockOpenAI } from 'openai';
+
+// gets the bearer token from AWS_BEARER_TOKEN_BEDROCK and the region from AWS_REGION/AWS_DEFAULT_REGION
+const client = new BedrockOpenAI();
+
+const response = await client.responses.create({
+  model: 'openai.gpt-5.4',
+  input: 'Say hello!',
+});
+
+console.log(response.output_text);
+```
+
+`BedrockOpenAI` configures AWS bearer auth and the Bedrock Mantle endpoint, then uses the normal SDK resources. AWS controls which endpoints and features are supported; unsupported calls surface the provider's normal HTTP errors through the SDK.
+
+Pass `baseURL` or set `AWS_BEDROCK_BASE_URL` to override the derived `https://bedrock-mantle.<region>.api.aws/openai/v1` endpoint. For long-running apps, pass `bedrockTokenProvider` to refresh the Bedrock bearer token before each request.
+
+Set `AWS_BEARER_TOKEN_BEDROCK` to an [Amazon Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html). To refresh tokens yourself, pass a provider instead of `apiKey`:
+
+```ts
+const client = new BedrockOpenAI({
+  awsRegion: 'us-west-2',
+  bedrockTokenProvider: async () => refreshBedrockToken(),
+});
+```

--- a/examples/bedrock/responses.ts
+++ b/examples/bedrock/responses.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env -S npm run tsn -T
+
+import { BedrockOpenAI } from 'openai';
+
+const client = new BedrockOpenAI();
+
+// For refreshed Bedrock bearer tokens:
+// const client = new BedrockOpenAI({ awsRegion: 'us-west-2', bedrockTokenProvider: getBedrockToken });
+
+async function main() {
+  const response = await client.responses.create({
+    model: 'openai.gpt-5.4',
+    input: 'Say hello!',
+  });
+
+  console.log(response.output_text);
+}
+
+main().catch(console.error);

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -1,0 +1,193 @@
+import * as Errors from './error';
+import { OpenAI } from './client';
+import type { ApiKeySetter, ClientOptions } from './client';
+import type { NullableHeaders } from './internal/headers';
+import { buildHeaders } from './internal/headers';
+import type { FinalRequestOptions, RequestOptions } from './internal/request-options';
+import { readEnv } from './internal/utils';
+import { addOutputText } from './lib/ResponsesParser';
+import type { ResponseStreamParams } from './lib/responses/ResponseStream';
+import * as API from './resources/index';
+import type * as ResponsesAPI from './resources/responses/responses';
+
+export interface BedrockClientOptions extends Omit<
+  ClientOptions,
+  'apiKey' | 'adminAPIKey' | 'baseURL' | 'workloadIdentity'
+> {
+  /**
+   * Bedrock bearer token used for authentication.
+   *
+   * Defaults to process.env['AWS_BEARER_TOKEN_BEDROCK'].
+   */
+  apiKey?: string | null | undefined;
+
+  /**
+   * Bedrock API root.
+   *
+   * Defaults to process.env['AWS_BEDROCK_BASE_URL'], or derives
+   * `https://bedrock-mantle.<region>.api.aws/openai/v1` from `awsRegion`,
+   * process.env['AWS_REGION'], or process.env['AWS_DEFAULT_REGION'].
+   */
+  baseURL?: string | null | undefined;
+
+  /**
+   * BedrockOpenAI only supports Bedrock bearer token authentication.
+   */
+  adminAPIKey?: never;
+
+  /**
+   * BedrockOpenAI only supports Bedrock bearer token authentication.
+   */
+  workloadIdentity?: never;
+
+  /**
+   * AWS region used to derive the default Bedrock Mantle endpoint.
+   *
+   * Defaults to process.env['AWS_REGION'] or process.env['AWS_DEFAULT_REGION'].
+   */
+  awsRegion?: string | undefined;
+
+  /**
+   * A function that returns a Bedrock bearer token and is invoked before each request.
+   */
+  bedrockTokenProvider?: ApiKeySetter | undefined;
+}
+
+/** Resolve the default Bedrock Mantle API root from the configured AWS region. */
+function deriveBedrockBaseURL(awsRegion: string | undefined): string {
+  const region = awsRegion?.trim();
+  if (!region) {
+    throw new Errors.OpenAIError(
+      'Must provide one of the `baseURL` or `awsRegion` arguments, or set the `AWS_BEDROCK_BASE_URL`, `AWS_REGION`, or `AWS_DEFAULT_REGION` environment variable.',
+    );
+  }
+
+  return `https://bedrock-mantle.${region}.api.aws/openai/v1`;
+}
+
+/** Normalize a Bedrock Responses URL variant back to the provider API root. */
+function normalizeBedrockBaseURL(baseURL: string): string {
+  const url = new URL(baseURL);
+  const responsesMatch = url.pathname.match(/\/responses(?:\/.*)?$/);
+  if (responsesMatch?.index !== undefined) {
+    url.pathname = url.pathname.slice(0, responsesMatch.index) || '/';
+  }
+
+  return url.toString().replace(/\/$/, '');
+}
+
+/** Restore the SDK convenience property when Bedrock omits it from a streamed final response. */
+function addBedrockOutputText<ResponseT extends ResponsesAPI.Response>(response: ResponseT): ResponseT {
+  if (!Object.getOwnPropertyDescriptor(response, 'output_text')) {
+    addOutputText(response);
+  }
+
+  return response;
+}
+
+/** Keep the standard Responses surface while repairing Bedrock streamed final responses. */
+function restoreBedrockStreamOutputText(responses: API.Responses): API.Responses {
+  const stream = responses.stream.bind(responses);
+
+  responses.stream = ((body: ResponseStreamParams, options?: RequestOptions) => {
+    const responseStream = stream(body, options);
+    const finalResponse = responseStream.finalResponse.bind(responseStream);
+    responseStream.finalResponse = async () => addBedrockOutputText(await finalResponse());
+
+    return responseStream;
+  }) as API.Responses['stream'];
+
+  return responses;
+}
+
+/** API Client for interfacing with Amazon Bedrock's OpenAI-compatible endpoint. */
+export class BedrockOpenAI extends OpenAI {
+  private readonly bedrockTokenProvider: ApiKeySetter | undefined;
+
+  /**
+   * API Client for interfacing with Amazon Bedrock's OpenAI-compatible endpoint.
+   *
+   * @param {string | null | undefined} [opts.apiKey=process.env['AWS_BEARER_TOKEN_BEDROCK'] ?? null]
+   * @param {string | null | undefined} [opts.baseURL=process.env['AWS_BEDROCK_BASE_URL'] ?? derived from opts.awsRegion or AWS_REGION/AWS_DEFAULT_REGION]
+   * @param {string | undefined} [opts.awsRegion=process.env['AWS_REGION'] ?? process.env['AWS_DEFAULT_REGION'] ?? undefined]
+   * @param {ApiKeySetter | undefined} opts.bedrockTokenProvider - A function that returns a Bedrock bearer token and is invoked before each request.
+   */
+  constructor({
+    baseURL = readEnv('AWS_BEDROCK_BASE_URL'),
+    apiKey,
+    awsRegion = readEnv('AWS_REGION') ?? readEnv('AWS_DEFAULT_REGION'),
+    bedrockTokenProvider,
+    adminAPIKey,
+    workloadIdentity,
+    ...opts
+  }: BedrockClientOptions = {}) {
+    if (adminAPIKey || workloadIdentity) {
+      throw new Errors.OpenAIError('BedrockOpenAI only supports Bedrock bearer token authentication.');
+    }
+
+    if (apiKey === undefined && !bedrockTokenProvider) {
+      apiKey = readEnv('AWS_BEARER_TOKEN_BEDROCK') ?? null;
+    }
+
+    if (typeof (apiKey as unknown) === 'function') {
+      throw new Errors.OpenAIError(
+        'Pass refreshable Bedrock credentials via `bedrockTokenProvider`, not `apiKey`.',
+      );
+    }
+
+    if (apiKey && bedrockTokenProvider) {
+      throw new Errors.OpenAIError(
+        'The `apiKey` and `bedrockTokenProvider` arguments are mutually exclusive; only one can be passed at a time.',
+      );
+    }
+
+    if (!apiKey && !bedrockTokenProvider) {
+      throw new Errors.OpenAIError(
+        'Missing credentials. Please pass an `apiKey` or `bedrockTokenProvider`, or set the `AWS_BEARER_TOKEN_BEDROCK` environment variable.',
+      );
+    }
+
+    const configuredBaseURL = baseURL?.trim() ? baseURL : deriveBedrockBaseURL(awsRegion);
+
+    super({
+      apiKey: bedrockTokenProvider ?? apiKey,
+      adminAPIKey: null,
+      baseURL: normalizeBedrockBaseURL(configuredBaseURL),
+      ...opts,
+    });
+
+    this.bedrockTokenProvider = bedrockTokenProvider;
+    this.responses = restoreBedrockStreamOutputText(new API.Responses(this));
+  }
+
+  protected override async prepareOptions(options: FinalRequestOptions): Promise<void> {
+    const security = options.__security ?? { bearerAuth: true };
+    if (security.adminAPIKeyAuth && !security.bearerAuth) {
+      await this._callApiKey();
+    }
+
+    await super.prepareOptions(options);
+  }
+
+  protected override async authHeaders(
+    opts: FinalRequestOptions,
+    schemes?: { bearerAuth?: boolean; adminAPIKeyAuth?: boolean },
+  ): Promise<NullableHeaders | undefined> {
+    const security = schemes ?? { bearerAuth: true, adminAPIKeyAuth: true };
+    if ((security.bearerAuth || security.adminAPIKeyAuth) && this.apiKey !== null) {
+      return buildHeaders([{ Authorization: `Bearer ${this.apiKey}` }]);
+    }
+
+    return super.authHeaders(opts, security);
+  }
+
+  override withOptions(options: Partial<BedrockClientOptions>): this {
+    const bedrockTokenProvider =
+      options.apiKey !== undefined ? undefined : (options.bedrockTokenProvider ?? this.bedrockTokenProvider);
+
+    return super.withOptions({
+      ...options,
+      ...(bedrockTokenProvider ? { apiKey: undefined, bedrockTokenProvider } : {}),
+    } as Partial<ClientOptions>);
+  }
+}

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -10,10 +10,8 @@ import type { ResponseStreamParams } from './lib/responses/ResponseStream';
 import * as API from './resources/index';
 import type * as ResponsesAPI from './resources/responses/responses';
 
-export interface BedrockClientOptions extends Omit<
-  ClientOptions,
-  'apiKey' | 'adminAPIKey' | 'baseURL' | 'workloadIdentity'
-> {
+export interface BedrockClientOptions
+  extends Omit<ClientOptions, 'apiKey' | 'adminAPIKey' | 'baseURL' | 'workloadIdentity'> {
   /**
    * Bedrock bearer token used for authentication.
    *
@@ -183,7 +181,7 @@ export class BedrockOpenAI extends OpenAI {
 
   override withOptions(options: Partial<BedrockClientOptions>): this {
     const bedrockTokenProvider =
-      options.apiKey !== undefined ? undefined : (options.bedrockTokenProvider ?? this.bedrockTokenProvider);
+      options.apiKey !== undefined ? undefined : options.bedrockTokenProvider ?? this.bedrockTokenProvider;
 
     return super.withOptions({
       ...options,

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,3 +26,4 @@ export {
 } from './core/error';
 
 export { AzureOpenAI } from './azure';
+export { BedrockOpenAI, type BedrockClientOptions } from './bedrock';

--- a/tests/lib/bedrock.test.ts
+++ b/tests/lib/bedrock.test.ts
@@ -1,0 +1,411 @@
+import { BedrockOpenAI, NotFoundError, type BedrockClientOptions } from 'openai';
+import { type RequestInfo, type RequestInit } from 'openai/internal/builtin-types';
+
+const RESPONSE_BODY = {
+  id: 'resp_123',
+  object: 'response',
+  created_at: 0,
+  status: 'completed',
+  background: false,
+  error: null,
+  incomplete_details: null,
+  instructions: null,
+  max_output_tokens: null,
+  max_tool_calls: null,
+  model: 'gpt-4o',
+  output: [],
+  parallel_tool_calls: true,
+  previous_response_id: null,
+  prompt_cache_key: null,
+  reasoning: { effort: null, summary: null },
+  safety_identifier: null,
+  service_tier: 'default',
+  store: true,
+  temperature: 1,
+  text: { format: { type: 'text' }, verbosity: 'medium' },
+  tool_choice: 'auto',
+  tools: [],
+  top_logprobs: 0,
+  top_p: 1,
+  truncation: 'disabled',
+  usage: {
+    input_tokens: 0,
+    input_tokens_details: { cached_tokens: 0 },
+    output_tokens: 0,
+    output_tokens_details: { reasoning_tokens: 0 },
+    total_tokens: 0,
+  },
+  user: null,
+  metadata: {},
+};
+const COMPACTED_RESPONSE_BODY = {
+  id: 'resp_123',
+  created_at: 0,
+  object: 'response.compaction',
+  output: [],
+  usage: RESPONSE_BODY.usage,
+};
+const INPUT_ITEMS_BODY = {
+  object: 'list',
+  data: [],
+  first_id: 'item_123',
+  last_id: 'item_123',
+  has_more: false,
+};
+const INPUT_TOKENS_BODY = {
+  object: 'response.input_tokens',
+  input_tokens: 1,
+};
+
+function responseStreamSSE(): string {
+  return [
+    `event: response.created\ndata: ${JSON.stringify({
+      type: 'response.created',
+      sequence_number: 0,
+      response: RESPONSE_BODY,
+    })}`,
+    `event: response.completed\ndata: ${JSON.stringify({
+      type: 'response.completed',
+      sequence_number: 1,
+      response: RESPONSE_BODY,
+    })}`,
+    '',
+  ].join('\n\n');
+}
+
+describe('instantiate bedrock client', () => {
+  const env = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...env };
+    process.env['AWS_BEARER_TOKEN_BEDROCK'] = undefined;
+    process.env['AWS_BEDROCK_BASE_URL'] = undefined;
+    process.env['AWS_REGION'] = undefined;
+    process.env['AWS_DEFAULT_REGION'] = undefined;
+  });
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  test('derives base URL from region', () => {
+    const options: BedrockClientOptions = { awsRegion: 'us-east-1', apiKey: 'token' };
+    const client = new BedrockOpenAI(options);
+    expect(client.baseURL).toBe('https://bedrock-mantle.us-east-1.api.aws/openai/v1');
+  });
+
+  test('uses Bedrock config precedence', () => {
+    process.env['AWS_BEDROCK_BASE_URL'] = 'https://env.example.com/openai/v1';
+    process.env['AWS_BEARER_TOKEN_BEDROCK'] = 'env token';
+    process.env['AWS_REGION'] = 'us-east-1';
+    process.env['AWS_DEFAULT_REGION'] = 'us-west-2';
+
+    const client = new BedrockOpenAI({
+      baseURL: 'https://explicit.example.com/openai/v1/responses',
+      apiKey: 'explicit token',
+    });
+    expect(client.baseURL).toBe('https://explicit.example.com/openai/v1');
+    expect(client.apiKey).toBe('explicit token');
+  });
+
+  test('uses Bedrock region precedence', () => {
+    process.env['AWS_REGION'] = 'us-east-1';
+    process.env['AWS_DEFAULT_REGION'] = 'us-west-2';
+
+    const explicitRegionClient = new BedrockOpenAI({ awsRegion: 'eu-west-1', apiKey: 'token' });
+    const awsRegionClient = new BedrockOpenAI({ apiKey: 'token' });
+    process.env['AWS_REGION'] = undefined;
+    const defaultRegionClient = new BedrockOpenAI({ apiKey: 'token' });
+
+    expect(explicitRegionClient.baseURL).toBe('https://bedrock-mantle.eu-west-1.api.aws/openai/v1');
+    expect(awsRegionClient.baseURL).toBe('https://bedrock-mantle.us-east-1.api.aws/openai/v1');
+    expect(defaultRegionClient.baseURL).toBe('https://bedrock-mantle.us-west-2.api.aws/openai/v1');
+  });
+
+  test('normalizes Responses URL', () => {
+    const client = new BedrockOpenAI({
+      baseURL: 'https://example.com/openai/v1/responses',
+      apiKey: 'token',
+    });
+    expect(client.baseURL).toBe('https://example.com/openai/v1');
+  });
+
+  test('uses Bedrock env vars', () => {
+    process.env['AWS_BEDROCK_BASE_URL'] = 'https://example.com/openai/v1';
+    process.env['AWS_BEARER_TOKEN_BEDROCK'] = 'bedrock token';
+    const client = new BedrockOpenAI();
+    expect(client.baseURL).toBe('https://example.com/openai/v1');
+    expect(client.apiKey).toBe('bedrock token');
+  });
+
+  test('does not use OPENAI_API_KEY', () => {
+    process.env['OPENAI_API_KEY'] = 'openai token';
+    process.env['AWS_REGION'] = 'us-west-2';
+    expect(() => new BedrockOpenAI()).toThrow(/AWS_BEARER_TOKEN_BEDROCK/);
+  });
+
+  test('requires endpoint configuration', () => {
+    expect(() => new BedrockOpenAI({ apiKey: 'token' })).toThrow(/baseURL/);
+  });
+
+  test('rejects static token and provider together', () => {
+    expect(
+      () =>
+        new BedrockOpenAI({
+          baseURL: 'https://example.com/openai/v1',
+          apiKey: 'token',
+          bedrockTokenProvider: async () => 'provider token',
+        }),
+    ).toThrow(/mutually exclusive/);
+  });
+
+  test('requires refreshable tokens to use provider option', () => {
+    expect(
+      () =>
+        new BedrockOpenAI({
+          baseURL: 'https://example.com/openai/v1',
+          apiKey: (async () => 'provider token') as unknown as string,
+        }),
+    ).toThrow(/bedrockTokenProvider/);
+  });
+
+  test('refreshes token provider before retries', async () => {
+    const authorizationHeaders: string[] = [];
+    const fetch = async (_url: RequestInfo, init?: RequestInit): Promise<Response> => {
+      authorizationHeaders.push(new Headers(init?.headers).get('authorization') ?? '');
+      const status = authorizationHeaders.length === 1 ? 500 : 200;
+      return new globalThis.Response(
+        JSON.stringify(status === 500 ? { error: 'server error' } : RESPONSE_BODY),
+        {
+          status,
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    };
+    const tokens = ['first', 'second'];
+    const client = new BedrockOpenAI({
+      baseURL: 'https://example.com/openai/v1',
+      bedrockTokenProvider: async () => tokens.shift()!,
+      fetch,
+      maxRetries: 1,
+    });
+
+    await client.responses.create({ model: 'gpt-4o', input: 'hello', background: true });
+
+    expect(authorizationHeaders).toEqual(['Bearer first', 'Bearer second']);
+  });
+
+  test('preserves token provider across withOptions', async () => {
+    const authorizationHeaders: string[] = [];
+    const fetch = async (_url: RequestInfo, init?: RequestInit): Promise<Response> => {
+      authorizationHeaders.push(new Headers(init?.headers).get('authorization') ?? '');
+      return new globalThis.Response(JSON.stringify(RESPONSE_BODY), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+    const client = new BedrockOpenAI({
+      baseURL: 'https://example.com/openai/v1',
+      bedrockTokenProvider: async () => 'provider token',
+      fetch,
+    });
+
+    await client.withOptions({ timeout: 1 }).responses.create({ model: 'gpt-4o', input: 'hello' });
+
+    expect(authorizationHeaders).toEqual(['Bearer provider token']);
+  });
+
+  test('passes non-Responses resources through', async () => {
+    const requests: string[] = [];
+    const fetch = async (url: RequestInfo): Promise<Response> => {
+      requests.push(new URL(url.toString()).pathname);
+      return new globalThis.Response(
+        JSON.stringify({ error: { message: 'AWS does not support chat completions here' } }),
+        {
+          status: 404,
+          headers: { 'Content-Type': 'application/json', 'x-request-id': 'req_chat' },
+        },
+      );
+    };
+    const client = new BedrockOpenAI({
+      baseURL: 'https://example.com/openai/v1',
+      apiKey: 'token',
+      fetch,
+    });
+
+    await expect(client.chat.completions.create({ model: 'gpt-4o', messages: [] })).rejects.toMatchObject({
+      message: expect.stringContaining('AWS does not support chat completions here'),
+      requestID: 'req_chat',
+    } satisfies Partial<NotFoundError>);
+    expect(requests).toEqual(['/openai/v1/chat/completions']);
+  });
+
+  test('passes Responses features through', async () => {
+    const requestBodies: unknown[] = [];
+    const fetch = async (_url: RequestInfo, init?: RequestInit): Promise<Response> => {
+      requestBodies.push(JSON.parse(init?.body?.toString() ?? '{}'));
+      return new globalThis.Response(JSON.stringify(RESPONSE_BODY), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+    const client = new BedrockOpenAI({
+      baseURL: 'https://example.com/openai/v1',
+      apiKey: 'token',
+      fetch,
+    });
+
+    await client.responses.create({
+      model: 'gpt-4o',
+      input: 'hello',
+      tools: [{ type: 'web_search_preview' }],
+    });
+
+    expect(requestBodies).toEqual([
+      expect.objectContaining({
+        tools: [{ type: 'web_search_preview' }],
+      }),
+    ]);
+  });
+
+  test('passes admin security routes through with Bedrock auth', async () => {
+    const authorizationHeaders: string[] = [];
+    const fetch = async (_url: RequestInfo, init?: RequestInit): Promise<Response> => {
+      authorizationHeaders.push(new Headers(init?.headers).get('authorization') ?? '');
+      return new globalThis.Response(
+        JSON.stringify({ error: { message: 'AWS does not support organization invites here' } }),
+        {
+          status: 404,
+          headers: { 'Content-Type': 'application/json', 'x-request-id': 'req_admin' },
+        },
+      );
+    };
+    const client = new BedrockOpenAI({
+      baseURL: 'https://example.com/openai/v1',
+      apiKey: 'token',
+      fetch,
+    });
+
+    await expect(client.admin.organization.invites.list()).rejects.toMatchObject({
+      message: expect.stringContaining('AWS does not support organization invites here'),
+      requestID: 'req_admin',
+    } satisfies Partial<NotFoundError>);
+    expect(authorizationHeaders).toEqual(['Bearer token']);
+  });
+
+  test('refreshes token provider for admin security routes', async () => {
+    const authorizationHeaders: string[] = [];
+    const fetch = async (_url: RequestInfo, init?: RequestInit): Promise<Response> => {
+      authorizationHeaders.push(new Headers(init?.headers).get('authorization') ?? '');
+      const status = authorizationHeaders.length === 1 ? 500 : 404;
+      return new globalThis.Response(
+        JSON.stringify(
+          status === 500 ?
+            { error: 'server error' }
+          : { error: { message: 'AWS does not support organization invites here' } },
+        ),
+        {
+          status,
+          headers: { 'Content-Type': 'application/json', 'x-request-id': 'req_admin' },
+        },
+      );
+    };
+    const tokens = ['first', 'second'];
+    const client = new BedrockOpenAI({
+      baseURL: 'https://example.com/openai/v1',
+      bedrockTokenProvider: async () => tokens.shift()!,
+      fetch,
+      maxRetries: 1,
+    });
+
+    await expect(client.admin.organization.invites.list()).rejects.toThrow(NotFoundError);
+    expect(authorizationHeaders).toEqual(['Bearer first', 'Bearer second']);
+  });
+
+  test('allows Responses HTTP methods and wrappers', async () => {
+    const requests: string[] = [];
+    const fetch = async (url: RequestInfo, init?: RequestInit): Promise<Response> => {
+      const requestURL = new URL(url.toString());
+      requests.push(`${init?.method} ${requestURL.pathname}`);
+
+      const body =
+        requestURL.pathname === '/openai/v1/responses/compact' ? COMPACTED_RESPONSE_BODY
+        : requestURL.pathname === '/openai/v1/responses/input_tokens' ? INPUT_TOKENS_BODY
+        : requestURL.pathname === '/openai/v1/responses/resp_123/input_items' ? INPUT_ITEMS_BODY
+        : RESPONSE_BODY;
+
+      return new globalThis.Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+    const client = new BedrockOpenAI({
+      baseURL: 'https://example.com/openai/v1',
+      apiKey: 'token',
+      fetch,
+    });
+
+    await client.responses.create({ model: 'gpt-4o', input: 'hello', background: true });
+    await client.responses.retrieve('resp_123');
+    await client.responses.retrieve('resp_123', { starting_after: 1, stream: true });
+    await client.responses.retrieve('resp_123', { stream: true });
+    await client.responses.cancel('resp_123');
+    await client.responses.compact({ model: 'gpt-4o' });
+    await client.responses.inputItems.list('resp_123');
+    await client.responses.inputTokens.count({ model: 'gpt-4o', input: 'hello' });
+
+    const rawResponse = await client.responses.create({ model: 'gpt-4o', input: 'hello' }).asResponse();
+    expect(rawResponse.status).toBe(200);
+    const { data, response } = await client.responses
+      .create({ model: 'gpt-4o', input: 'hello' })
+      .withResponse();
+    expect(data.id).toBe('resp_123');
+    expect(response.status).toBe(200);
+
+    expect(requests).toEqual([
+      'POST /openai/v1/responses',
+      'GET /openai/v1/responses/resp_123',
+      'GET /openai/v1/responses/resp_123',
+      'GET /openai/v1/responses/resp_123',
+      'POST /openai/v1/responses/resp_123/cancel',
+      'POST /openai/v1/responses/compact',
+      'GET /openai/v1/responses/resp_123/input_items',
+      'POST /openai/v1/responses/input_tokens',
+      'POST /openai/v1/responses',
+      'POST /openai/v1/responses',
+    ]);
+  });
+
+  test('allows Responses SSE and stream wrapper', async () => {
+    const fetch = async (): Promise<Response> =>
+      new globalThis.Response(responseStreamSSE(), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+    const client = new BedrockOpenAI({
+      baseURL: 'https://example.com/openai/v1',
+      apiKey: 'token',
+      fetch,
+    });
+
+    const events: string[] = [];
+    for await (const event of await client.responses.create({
+      model: 'gpt-4o',
+      input: 'hello',
+      stream: true,
+    })) {
+      events.push(event.type);
+    }
+    expect(events).toEqual(['response.created', 'response.completed']);
+
+    const finalResponse = await client.responses
+      .stream({
+        model: 'gpt-4o',
+        input: 'hello',
+      })
+      .finalResponse();
+    expect(finalResponse.id).toBe('resp_123');
+    expect(finalResponse.output_text).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- add first-class `BedrockOpenAI` provider client
- support Bedrock base URL, region, static bearer token, and refreshable token-provider config
- keep Bedrock support thin: SDK adapts auth and base URL, while AWS owns endpoint and feature validation
- add focused tests, docs, and an example

## Review Notes
- This rewrite removes the earlier SDK-side endpoint/tool/include/websocket guards. Formerly guarded calls now send requests and surface normal AWS HTTP errors through the standard SDK error pipeline.
- Bedrock does not implicitly reuse `OPENAI_API_KEY`; it reads `AWS_BEARER_TOKEN_BEDROCK` unless the caller passes `apiKey` or `bedrockTokenProvider`.
- Generated admin-security routes reuse the Bedrock bearer token so they pass through to AWS instead of failing SDK auth resolution before the request.
- Kept regional Mantle endpoint derivation for now; no global endpoint behavior is added before AWS defines it.
- Deliberately deferred a separate Bedrock auth/config struct. Inline config keeps this PR small and self-contained; a dedicated struct may age better if AWS adds more auth or endpoint modes.
- Kept one Bedrock-local compatibility repair for `responses.stream().finalResponse().output_text`; a future core cleanup could make that generic instead of Bedrock-specific.

## Testing
- focused Node Bedrock tests: `17 passed`
- Prettier write/check on touched provider docs/source/test/example files and touched `README.md`
- ESLint on touched Bedrock source/test/example files
- Node build passed
- live `us-east-2` probes with refreshed Bedrock credentials:
  - earlier same-day `openai.gpt-5.5` pass completed static bearer-token SSE and two token-provider `responses.create` calls
  - current recheck confirmed `/v1/models` returns `200` and lists `openai.gpt-5.4` / `openai.gpt-5.5`
  - current direct `/openai/v1/responses` and SDK `responses.create` probes return Bedrock `500 internal_server_error` for both `openai.gpt-5.4` and `openai.gpt-5.5`; SDKs surface normal `InternalServerError` with request ids, so no SDK workaround was added
  - `ResponsesWS` still passes through and AWS rejects the websocket handshake with HTTP `405`
