### PR TITLE
Preserve error response body when error field is absent

### DIFF
--- a/src/core/error.ts
+++ b/src/core/error.ts
@@ -67,7 +67,7 @@ export class APIError<
       return new APIConnectionError({ message, cause: castToError(errorResponse) });
     }
 
-    const error = (errorResponse as Record<string, any>)?.['error'];
+    const error = (errorResponse as Record<string, any>)?.['error'] ?? errorResponse;
 
     if (status === 400) {
       return new BadRequestError(status, error, message, headers);

--- a/tests/error.test.ts
+++ b/tests/error.test.ts
@@ -1,0 +1,26 @@
+import { APIError, UnprocessableEntityError } from 'openai/error';
+
+describe('APIError.generate()', () => {
+  test('falls back to the full response body when the error field is absent', () => {
+    const body = { detail: '422: The model gpt-5-gibberish does not exist.' };
+    const error = APIError.generate(422, body, undefined, new Headers());
+
+    expect(error).toBeInstanceOf(UnprocessableEntityError);
+    expect(error.error).toEqual(body);
+    expect(error.message).toBe(`422 ${JSON.stringify(body)}`);
+  });
+
+  test('continues to prefer the nested error object when present', () => {
+    const nested = {
+      message: 'The model `gpt-5-gibberish` does not exist.',
+      type: 'invalid_request_error',
+      code: 'model_not_found',
+    };
+    const error = APIError.generate(422, { error: nested }, undefined, new Headers());
+
+    expect(error.error).toEqual(nested);
+    expect(error.message).toBe(`422 ${nested.message}`);
+    expect(error.type).toBe(nested.type);
+    expect(error.code).toBe(nested.code);
+  });
+});


### PR DESCRIPTION
## Summary
- fall back to the full JSON error response when a response body does not contain an `error` field
- preserve the existing behavior of preferring the nested `error` object when present
- add regression coverage for compatible APIs that return bodies like `{ detail: ... }`

Fixes #1734

## Tests
- npx -y -p jest@29.4.0 -p @swc/jest@0.2.29 -p @swc/core@1.3.102 jest tests/error.test.ts --runInBand --config '{...repo-equivalent targeted config...}'
- npx -y prettier@3.6.2 --check src/core/error.ts tests/error.test.ts

Note: `yarn install --frozen-lockfile` was blocked locally by a timeout downloading the repository's `tsc-multi` GitHub release tarball, so I ran the focused Jest test through npx with the same SWC transform/module mapping instead.