### PR TITLE
feat(api): add gpt-5.5 model slugs

### DIFF
--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -7921,6 +7921,10 @@ export interface ResponseCompactParams {
    * available models.
    */
   model:
+    | 'gpt-5.5'
+    | 'gpt-5.5-2026-04-23'
+    | 'gpt-5.5-pro'
+    | 'gpt-5.5-pro-2026-04-23'
     | 'gpt-5.4'
     | 'gpt-5.4-mini'
     | 'gpt-5.4-nano'

--- a/src/resources/shared.ts
+++ b/src/resources/shared.ts
@@ -19,6 +19,10 @@ export type AllModels =
   | 'gpt-5.1-codex-max';
 
 export type ChatModel =
+  | 'gpt-5.5'
+  | 'gpt-5.5-2026-04-23'
+  | 'gpt-5.5-pro'
+  | 'gpt-5.5-pro-2026-04-23'
   | 'gpt-5.4'
   | 'gpt-5.4-mini'
   | 'gpt-5.4-nano'


### PR DESCRIPTION
## Changes being requested

Add the new GPT-5.5 model aliases and dated snapshots to the SDK model type unions:

- `gpt-5.5`
- `gpt-5.5-2026-04-23`
- `gpt-5.5-pro`
- `gpt-5.5-pro-2026-04-23`

This updates `ChatModel` and the Responses compact model union so users can pass the new model IDs without relying on the loose string escape hatch.

## Additional context & links

The public model docs list GPT-5.5 and GPT-5.5 pro aliases plus their dated snapshots:

- https://developers.openai.com/api/docs/models/gpt-5.5
- https://developers.openai.com/api/docs/models/gpt-5.5-pro

Because this repository is generated, this may need to land through the upstream OpenAPI/Stainless generation flow rather than being merged as a manual patch.

## Validation

- `yarn build` with Node.js 20.13.1

- [x] I understand that this repository is auto-generated and my pull request may not be merged