### PR TITLE
fix(types): include prompt text and image token counts

### DIFF
--- a/src/resources/completions.ts
+++ b/src/resources/completions.ts
@@ -189,6 +189,16 @@ export namespace CompletionUsage {
      * Cached tokens present in the prompt.
      */
     cached_tokens?: number;
+
+    /**
+     * Image input tokens present in the prompt.
+     */
+    image_tokens?: number;
+
+    /**
+     * Text input tokens present in the prompt.
+     */
+    text_tokens?: number;
   }
 }
 

--- a/tests/usage-types.test.ts
+++ b/tests/usage-types.test.ts
@@ -1,0 +1,16 @@
+import OpenAI from 'openai';
+import { expectType } from './utils/typing';
+
+describe('usage types', () => {
+  test('prompt token details include modality token counts', () => {
+    const usage = {} as OpenAI.CompletionUsage;
+    const details = usage.prompt_tokens_details;
+
+    if (details) {
+      expectType<number | undefined>(details.audio_tokens);
+      expectType<number | undefined>(details.cached_tokens);
+      expectType<number | undefined>(details.image_tokens);
+      expectType<number | undefined>(details.text_tokens);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1718.

`CompletionUsage.PromptTokensDetails` already exposes `audio_tokens` and `cached_tokens`, but chat completions usage payloads for audio/image-capable models can also include `text_tokens` and `image_tokens`. This adds those optional fields to the shared completion usage type so `response.usage.prompt_tokens_details.text_tokens` and `.image_tokens` type-check for chat completions.

I also added a small type regression test that exercises the shared `OpenAI.CompletionUsage` surface.

## Tests

- `npx -y yarn@1.22.22 install --frozen-lockfile --ignore-scripts`
- `npx -y yarn@1.22.22 test tests/usage-types.test.ts`
- `npx -y yarn@1.22.22 build`
- `./node_modules/.bin/prettier --check src/resources/completions.ts tests/usage-types.test.ts`
- `./node_modules/.bin/eslint src/resources/completions.ts tests/usage-types.test.ts`
- `git diff --check`

Note: the full `npx -y yarn@1.22.22 lint` run completed prettier/eslint/build, then stopped in its repo-wide type-check step because this checkout does not have optional example dependencies (`@azure/identity`, `express`, `next`) installed. The changed files passed targeted prettier/eslint, and the package build plus type regression test passed.

Git HTTPS push repeatedly timed out to github.com:443 from this environment, so I created the fork branch via the GitHub Git Data API after local validation.
