### PR TITLE
fix(zod): convert oneOf unions to anyOf

### DIFF
--- a/src/lib/transform.ts
+++ b/src/lib/transform.ts
@@ -103,8 +103,15 @@ function ensureStrictJsonSchema(
   // OpenAI strict schemas only support anyOf.
   const oneOf = jsonSchema.oneOf;
   if (Array.isArray(oneOf)) {
-    jsonSchema.anyOf = [...(jsonSchema.anyOf ?? []), ...oneOf];
+    const existingAnyOf = jsonSchema.anyOf;
     delete jsonSchema.oneOf;
+
+    if (Array.isArray(existingAnyOf)) {
+      jsonSchema.allOf = [...(jsonSchema.allOf ?? []), { anyOf: existingAnyOf }, { anyOf: oneOf }];
+      delete jsonSchema.anyOf;
+    } else {
+      jsonSchema.anyOf = oneOf;
+    }
   }
 
   const anyOf = jsonSchema.anyOf;

--- a/src/lib/transform.ts
+++ b/src/lib/transform.ts
@@ -99,7 +99,14 @@ function ensureStrictJsonSchema(
     jsonSchema.items = ensureStrictJsonSchema(items, [...path, 'items'], root);
   }
 
-  // Handle unions (anyOf)
+  // Handle unions (anyOf). Zod v4 emits oneOf for discriminated unions, but
+  // OpenAI strict schemas only support anyOf.
+  const oneOf = jsonSchema.oneOf;
+  if (Array.isArray(oneOf)) {
+    jsonSchema.anyOf = [...(jsonSchema.anyOf ?? []), ...oneOf];
+    delete jsonSchema.oneOf;
+  }
+
   const anyOf = jsonSchema.anyOf;
   if (Array.isArray(anyOf)) {
     jsonSchema.anyOf = anyOf.map((variant, i) =>

--- a/tests/helpers/zod.test.ts
+++ b/tests/helpers/zod.test.ts
@@ -143,6 +143,22 @@ describe.each([
     `);
   });
 
+  it('converts Zod discriminated unions to strict anyOf schemas', () => {
+    const ResponseSchema = z.object({
+      data: z.discriminatedUnion('type', [
+        z.object({ type: z.literal('a') }),
+        z.object({ type: z.literal('b') }),
+      ]),
+    });
+
+    const schema = zodResponseFormat(ResponseSchema, 'choice').json_schema.schema as Record<string, any>;
+    const dataSchema = schema['properties']['data'];
+
+    expect(dataSchema.oneOf).toBeUndefined();
+    expect(dataSchema.anyOf).toHaveLength(2);
+    expect(JSON.stringify(schema)).not.toContain('"oneOf"');
+  });
+
   it('allows description field to be passed in', () => {
     expect(
       zodResponseFormat(

--- a/tests/lib/transform.test.ts
+++ b/tests/lib/transform.test.ts
@@ -271,6 +271,73 @@ describe('toStrictJsonSchema', () => {
         }
       `);
     });
+
+    test('keeps existing anyOf separate when converting oneOf', () => {
+      const schema: JSONSchema = {
+        type: 'object',
+        properties: {
+          value: {
+            anyOf: [
+              {
+                type: 'object',
+                properties: { str: { type: 'string' } },
+                required: ['str'],
+              },
+            ],
+            oneOf: [
+              {
+                type: 'object',
+                properties: { num: { type: 'number' } },
+                required: ['num'],
+              },
+            ],
+          },
+        },
+        required: ['value'],
+      };
+
+      const strict = toStrictJsonSchema(schema);
+      const valueSchema = strict.properties?.['value'] as JSONSchema;
+
+      expect(valueSchema.oneOf).toBeUndefined();
+      expect(valueSchema.anyOf).toBeUndefined();
+      expect(valueSchema.allOf).toMatchInlineSnapshot(`
+        [
+          {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "str": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "str",
+                ],
+                "type": "object",
+              },
+            ],
+          },
+          {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "properties": {
+                  "num": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "num",
+                ],
+                "type": "object",
+              },
+            ],
+          },
+        ]
+      `);
+    });
   });
 
   describe('allOf Handling', () => {


### PR DESCRIPTION
## Summary

Fixes #1709.

Zod v4 emits `oneOf` for discriminated unions, but OpenAI strict JSON schemas do not allow `oneOf`. The Zod v4 helper path already runs schemas through `toStrictJsonSchema`, so this converts `oneOf` unions into strict-compatible `anyOf` unions during that normalization pass.

The regression test covers a Zod discriminated union through `zodResponseFormat` and asserts the final schema no longer contains `oneOf`.

## Tests

- `npx --yes yarn@1.22.22 test tests/helpers/zod.test.ts --runInBand`
- `npx --yes prettier@3.6.2 --check src/lib/transform.ts tests/helpers/zod.test.ts`
- `./node_modules/.bin/eslint src/lib/transform.ts tests/helpers/zod.test.ts`
- `git diff --check`

Note: I also ran `./node_modules/typescript/bin/tsc --noEmit`; it surfaced missing optional example dependencies in this checkout (`@azure/identity`, `express`, `next`). The only PR-local type issue it reported was fixed before the checks above were rerun.
