### PR TITLE
fix: remove abort listener after fetch completion

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -791,7 +791,9 @@ export class OpenAI {
 
     const security = options.__security ?? { bearerAuth: true };
     const controller = new AbortController();
-    const response = await this.fetchWithAuth(url, req, timeout, controller, security).catch(castToError);
+    const response = await this.fetchWithAuth(url, req, timeout, controller, security, options.stream).catch(
+      castToError,
+    );
     const headersTime = Date.now();
 
     if (response instanceof globalThis.Error) {
@@ -974,6 +976,7 @@ export class OpenAI {
       bearerAuth: true,
       adminAPIKeyAuth: true,
     },
+    keepAbortListener = false,
   ): Promise<Response> {
     if (this._workloadIdentityAuth && schemes.bearerAuth) {
       const headers = init.headers as Headers;
@@ -984,7 +987,7 @@ export class OpenAI {
       }
     }
 
-    const response = await this.fetchWithTimeout(url, init, timeout, controller);
+    const response = await this.fetchWithTimeout(url, init, timeout, controller, keepAbortListener);
 
     return response;
   }
@@ -994,6 +997,7 @@ export class OpenAI {
     init: RequestInit | undefined,
     ms: number,
     controller: AbortController,
+    keepAbortListener = false,
   ): Promise<Response> {
     const { signal, method, ...options } = init || {};
     const abort = this._makeAbort(controller);
@@ -1022,7 +1026,7 @@ export class OpenAI {
       return await this.fetch.call(undefined, url, fetchOptions);
     } finally {
       clearTimeout(timeout);
-      if (signal) signal.removeEventListener('abort', abort);
+      if (signal && !keepAbortListener) signal.removeEventListener('abort', abort);
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1022,6 +1022,7 @@ export class OpenAI {
       return await this.fetch.call(undefined, url, fetchOptions);
     } finally {
       clearTimeout(timeout);
+      if (signal) signal.removeEventListener('abort', abort);
     }
   }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -677,6 +677,29 @@ describe('default encoder', () => {
 });
 
 describe('retries', () => {
+  test('removes abort listener after successful fetch', async () => {
+    const client = new OpenAI({
+      apiKey: 'My API Key',
+      adminAPIKey: 'My Admin API Key',
+      fetch: async () =>
+        new Response(JSON.stringify({ a: 1 }), { headers: { 'Content-Type': 'application/json' } }),
+    });
+
+    const externalController = new AbortController();
+    const addEventListener = jest.spyOn(externalController.signal, 'addEventListener');
+    const removeEventListener = jest.spyOn(externalController.signal, 'removeEventListener');
+
+    await client.fetchWithTimeout(
+      'http://localhost/foo',
+      { signal: externalController.signal },
+      1000,
+      new AbortController(),
+    );
+
+    expect(addEventListener).toHaveBeenCalledWith('abort', expect.any(Function), { once: true });
+    expect(removeEventListener).toHaveBeenCalledWith('abort', addEventListener.mock.calls[0][1]);
+  });
+
   test('retry on timeout', async () => {
     let count = 0;
     const testFetch = async (

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -697,7 +697,37 @@ describe('retries', () => {
     );
 
     expect(addEventListener).toHaveBeenCalledWith('abort', expect.any(Function), { once: true });
-    expect(removeEventListener).toHaveBeenCalledWith('abort', addEventListener.mock.calls[0][1]);
+    const abortListener = addEventListener.mock.calls[0]?.[1];
+    expect(abortListener).toEqual(expect.any(Function));
+    expect(removeEventListener).toHaveBeenCalledWith('abort', abortListener);
+  });
+
+  test('keeps abort listener after fetch resolves for streaming responses', async () => {
+    const client = new OpenAI({
+      apiKey: 'My API Key',
+      adminAPIKey: 'My Admin API Key',
+      fetch: async () => new Response('data: {"a":1}\n\n'),
+    });
+
+    const externalController = new AbortController();
+    const requestController = new AbortController();
+    const addEventListener = jest.spyOn(externalController.signal, 'addEventListener');
+    const removeEventListener = jest.spyOn(externalController.signal, 'removeEventListener');
+
+    await client.fetchWithTimeout(
+      'http://localhost/foo',
+      { signal: externalController.signal },
+      1000,
+      requestController,
+      true,
+    );
+
+    expect(addEventListener).toHaveBeenCalledWith('abort', expect.any(Function), { once: true });
+    expect(removeEventListener).not.toHaveBeenCalled();
+
+    externalController.abort();
+
+    expect(requestController.signal.aborted).toBe(true);
   });
 
   test('retry on timeout', async () => {


### PR DESCRIPTION
## Summary
- remove the caller signal abort listener when `fetchWithTimeout` completes
- add a regression test that verifies the listener is removed after a successful fetch

Fixes #1811.

## Tests
- `./node_modules/.bin/jest tests/index.test.ts -t "removes abort listener after successful fetch" --runInBand`
- `./node_modules/.bin/prettier --check src/client.ts tests/index.test.ts`
- `./node_modules/.bin/eslint src/client.ts tests/index.test.ts`