### PR TITLE
fix(client): cap Retry-After at 60s

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1026,9 +1026,9 @@ export class OpenAI {
       }
     }
 
-    // If the API asks us to wait a certain amount of time, just do what it
-    // says, but otherwise calculate a default
-    if (timeoutMillis === undefined) {
+    // If the API asks us to wait a certain amount of time (and it's a reasonable
+    // value), just do what it says, but otherwise calculate a default
+    if (!(timeoutMillis !== undefined && 0 <= timeoutMillis && timeoutMillis < 60 * 1000)) {
       const maxRetries = options.maxRetries ?? this.maxRetries;
       timeoutMillis = this.calculateDefaultRetryTimeoutMillis(retriesRemaining, maxRetries);
     }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -885,6 +885,39 @@ describe('retries', () => {
     expect(count).toEqual(3);
   });
 
+  test('caps retry-after above 60 seconds and falls back to backoff', async () => {
+    let count = 0;
+    const testFetch = async (
+      url: string | URL | Request,
+      { signal }: RequestInit = {},
+    ): Promise<Response> => {
+      if (count++ === 0) {
+        return new Response(undefined, {
+          status: 429,
+          headers: {
+            // 600 seconds: must NOT be honored, otherwise the request hangs for 10 minutes.
+            'Retry-After': '600',
+          },
+        });
+      }
+      return new Response(JSON.stringify({ a: 1 }), { headers: { 'Content-Type': 'application/json' } });
+    };
+
+    const client = new OpenAI({
+      apiKey: 'My API Key',
+      adminAPIKey: 'My Admin API Key',
+      fetch: testFetch,
+    });
+
+    const started = Date.now();
+    expect(await client.request({ path: '/foo', method: 'get' })).toEqual({ a: 1 });
+    const elapsed = Date.now() - started;
+    expect(count).toEqual(2);
+    // Default backoff for the first retry is well under a second; assert we did not
+    // sleep anywhere near the 600s the header asked for.
+    expect(elapsed).toBeLessThan(60 * 1000);
+  });
+
   describe('auth', () => {
     test('apiKey', async () => {
       const client = new OpenAI({


### PR DESCRIPTION
Summary
- restore the 60s cap for Retry-After / retry-after-ms delays
- fall back to the normal exponential backoff when the server asks for an unreasonable wait
- add regression coverage for a 600s Retry-After response

Tests
- ./scripts/test tests/index.test.ts
- ./node_modules/.bin/prettier --check src/client.ts tests/index.test.ts
- ./node_modules/.bin/tsc --noEmit --skipLibCheck --target es2020 --lib es2020,dom,dom.iterable --module commonjs --moduleResolution node --esModuleInterop --strict --exactOptionalPropertyTypes --noUncheckedIndexedAccess --noImplicitOverride --noPropertyAccessFromIndexSignature src/client.ts

Fixes #1840