### PR TITLE
fix(client): apply timeout to response body reads

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -949,7 +949,28 @@ export class OpenAI {
     const abort = this._makeAbort(controller);
     if (signal) signal.addEventListener('abort', abort, { once: true });
 
-    const timeout = setTimeout(abort, ms);
+    let timeout: ReturnType<typeof setTimeout> | undefined = setTimeout(abort, ms);
+    let timeoutCleared = false;
+    // Re-arm the timer so that the timeout applies to inactivity during the
+    // body-read phase as well, not just to header arrival. A stalled body read
+    // (headers received, then the server stops sending) is aborted after `ms`
+    // of inactivity instead of hanging forever, while a steadily-streaming
+    // response keeps resetting the timer and is never cut off.
+    // See https://github.com/openai/openai-node/issues/1825
+    const rearmTimeout = () => {
+      if (timeoutCleared) return;
+      if (timeout) clearTimeout(timeout);
+      timeout = setTimeout(abort, ms);
+    };
+    const clearCurrentTimeout = () => {
+      if (timeout) clearTimeout(timeout);
+      timeout = undefined;
+    };
+    const clearTimeoutOnce = () => {
+      if (timeoutCleared) return;
+      timeoutCleared = true;
+      clearCurrentTimeout();
+    };
 
     const isReadableBody =
       ((globalThis as any).ReadableStream && options.body instanceof (globalThis as any).ReadableStream) ||
@@ -967,12 +988,65 @@ export class OpenAI {
       fetchOptions.method = method.toUpperCase();
     }
 
+    let response: Response;
     try {
       // use undefined this binding; fetch errors if bound to something else in browser/cloudflare
-      return await this.fetch.call(undefined, url, fetchOptions);
-    } finally {
-      clearTimeout(timeout);
+      response = await this.fetch.call(undefined, url, fetchOptions);
+    } catch (err) {
+      clearTimeoutOnce();
+      throw err;
     }
+
+    const ReadableStreamCtor = (globalThis as any).ReadableStream;
+    if (!response.body || !ReadableStreamCtor) {
+      clearTimeoutOnce();
+      return response;
+    }
+
+    // Headers have arrived; wait until the body is actually read before starting
+    // the body-read timeout, so callers that only inspect the Response don't
+    // leave an active timer behind.
+    clearCurrentTimeout();
+
+    const reader = response.body.getReader();
+    const releaseReader = () => {
+      try {
+        reader.releaseLock();
+      } catch {}
+    };
+    const monitoredBody = new ReadableStreamCtor({
+      async pull(streamController: ReadableStreamDefaultController) {
+        try {
+          rearmTimeout();
+          const { done, value } = await reader.read();
+          if (done) {
+            clearTimeoutOnce();
+            releaseReader();
+            streamController.close();
+            return;
+          }
+          clearCurrentTimeout();
+          streamController.enqueue(value);
+        } catch (err) {
+          clearTimeoutOnce();
+          releaseReader();
+          streamController.error(err);
+        }
+      },
+      cancel(reason: any) {
+        clearTimeoutOnce();
+        return reader.cancel(reason).finally(releaseReader);
+      },
+    });
+
+    const monitoredResponse = new Response(monitoredBody as any, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+    // `Response` does not let us pass `url` through the constructor, so preserve it.
+    Object.defineProperty(monitoredResponse, 'url', { value: response.url, configurable: true });
+    return monitoredResponse;
   }
 
   private async shouldRetry(response: Response): Promise<boolean> {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -685,6 +685,37 @@ describe('retries', () => {
     expect(count).toEqual(3);
   });
 
+  test('timeout applies to the response body read phase', async () => {
+    // Server sends headers promptly, then stalls mid-body (never finishes the
+    // body). The timeout must still fire instead of hanging forever.
+    const testFetch = async (
+      _url: string | URL | Request,
+      { signal }: RequestInit = {},
+    ): Promise<Response> => {
+      const body = new ReadableStream({
+        start(controller) {
+          signal?.addEventListener('abort', () => controller.error(new Error('aborted')));
+          // intentionally never enqueue or close: the body read stalls
+        },
+      });
+      return new Response(body, { headers: { 'Content-Type': 'application/json' } });
+    };
+
+    const client = new OpenAI({
+      apiKey: 'My API Key',
+      adminAPIKey: 'My Admin API Key',
+      timeout: 50,
+      maxRetries: 0,
+      fetch: testFetch,
+    });
+
+    const started = Date.now();
+    await expect(client.request({ path: '/foo', method: 'get' })).rejects.toThrow();
+    const elapsed = Date.now() - started;
+    // Should abort shortly after the 50ms timeout, not hang.
+    expect(elapsed).toBeLessThan(2000);
+  });
+
   test('retry count header', async () => {
     let count = 0;
     let capturedRequest: RequestInit | undefined;


### PR DESCRIPTION
Summary
- keep request timeouts active during stalled response body reads, not only until headers arrive
- start the body timeout lazily when the response body is actually consumed, so asResponse() callers do not leave active timers behind
- release the response body reader when the monitored stream closes, errors, or is cancelled
- add regression coverage for a response that sends headers and then stalls before completing the body

Tests
- ./scripts/test tests/index.test.ts
- ./node_modules/.bin/jest tests/index.test.ts --runInBand --detectOpenHandles
- ./node_modules/.bin/prettier --check src/client.ts tests/index.test.ts
- ./node_modules/.bin/tsc --noEmit --skipLibCheck --target es2020 --lib es2020,dom,dom.iterable --module commonjs --moduleResolution node --esModuleInterop --strict --exactOptionalPropertyTypes --noUncheckedIndexedAccess --noImplicitOverride --noPropertyAccessFromIndexSignature src/client.ts

Fixes #1825