### PR TITLE
fix: add 1080p video sizes

### DIFF
--- a/src/resources/videos.ts
+++ b/src/resources/videos.ts
@@ -229,7 +229,7 @@ export type VideoModel =
 
 export type VideoSeconds = '4' | '8' | '12';
 
-export type VideoSize = '720x1280' | '1280x720' | '1024x1792' | '1792x1024';
+export type VideoSize = '720x1280' | '1280x720' | '1024x1792' | '1792x1024' | '1920x1080' | '1080x1920';
 
 /**
  * Confirmation payload returned after deleting a video.
@@ -309,7 +309,8 @@ export interface VideoCreateParams {
 
   /**
    * Output resolution formatted as width x height (allowed values: 720x1280,
-   * 1280x720, 1024x1792, 1792x1024). Defaults to 720x1280.
+   * 1280x720, 1024x1792, 1792x1024, 1920x1080, 1080x1920). Defaults to
+   * 720x1280.
    */
   size?: VideoSize;
 }

--- a/tests/api-resources/videos.test.ts
+++ b/tests/api-resources/videos.test.ts
@@ -1,6 +1,12 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import OpenAI, { toFile } from 'openai';
+import type { VideoSize } from '../../src/resources/videos';
+
+const expectType = <T>(_value: T): void => {};
+
+expectType<VideoSize>('1920x1080');
+expectType<VideoSize>('1080x1920');
 
 const client = new OpenAI({
   apiKey: 'My API Key',


### PR DESCRIPTION
## Summary
- Add the 1080p Sora video sizes to the `VideoSize` union.
- Update the `size` parameter docs to list `1920x1080` and `1080x1920`.
- Add type-level coverage so both 1080p sizes remain assignable to `VideoSize`.

Fixes #1789

## Test plan
- `npx prettier --check src/resources/videos.ts tests/api-resources/videos.test.ts`
- `npx tsc -p /tmp/openai-node-video-only-tsconfig.json --noEmit`

Note: full repo typecheck is blocked locally by pre-existing missing optional example deps (`@azure/identity`, `express`, `next`).
