### PR TITLE
fix: remove abort event listener on successful fetch completion

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -972,6 +972,7 @@ export class OpenAI {
       return await this.fetch.call(undefined, url, fetchOptions);
     } finally {
       clearTimeout(timeout);
+      if (signal) signal.removeEventListener('abort', abort);
     }
   }
 


### PR DESCRIPTION
Cleans up the abort event listener in fetchWithTimeout on successful completion to prevent Deno process exit hang.

## Problem

fetchWithTimeout adds an abort event listener on the caller's AbortSignal to forward abort events to the internal controller. On successful completion (response received before timeout), the timeout is cleared via clearTimeout, but the abort event listener is never removed.

In Deno, AbortSignal.timeout() refs the underlying timer when it has event listeners. The orphaned listener keeps the timer ref'd for the full timeout duration, preventing the process from exiting.

## Fix

Add signal.removeEventListener('abort', abort) in the finally block alongside the existing clearTimeout(timeout). This ensures the event listener is always cleaned up on successful completion while preserving the existing { once: true } behavior for the abort path.

## Testing

- The { once: true } option on addEventListener continues to handle the timeout-abort path (self-removal)
- The new removeEventListener call handles the success path (explicit cleanup)
- No behavior change for the error path — finally block runs regardless

Fixes #1811
