### PR TITLE
feat: add Valibot support for structured outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,9 @@
     "typescript-eslint": "8.31.1",
     "ws": "^8.18.0",
     "yargs": "^17.7.2",
-    "zod": "^3.25 || ^4.0"
+    "zod": "^3.25 || ^4.0",
+    "@valibot/to-json-schema": "^1.7.0",
+    "valibot": "^1.4.1"
   },
   "overrides": {
     "minimatch": "^9.0.5"
@@ -89,7 +91,9 @@
     "@smithy/hash-node": ">=4.3.0 <5",
     "@smithy/signature-v4": ">=5.4.0 <6",
     "ws": "^8.18.0",
-    "zod": "^3.25 || ^4.0"
+    "zod": "^3.25 || ^4.0",
+    "@valibot/to-json-schema": "^1.0.0",
+    "valibot": "^1.0.0"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/credential-provider-node": {
@@ -105,6 +109,12 @@
       "optional": true
     },
     "zod": {
+      "optional": true
+    },
+    "@valibot/to-json-schema": {
+      "optional": true
+    },
+    "valibot": {
       "optional": true
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@typescript-eslint/typescript-estree':
         specifier: 8.31.1
         version: 8.31.1(typescript@5.8.3)
+      '@valibot/to-json-schema':
+        specifier: ^1.7.0
+        version: 1.7.1(valibot@1.4.2(typescript@5.8.3))
       deep-object-diff:
         specifier: ^1.1.9
         version: 1.1.9
@@ -111,6 +114,9 @@ importers:
       typescript-eslint:
         specifier: 8.31.1
         version: 8.31.1(eslint@9.39.4)(typescript@5.8.3)
+      valibot:
+        specifier: ^1.4.1
+        version: 1.4.2(typescript@5.8.3)
       ws:
         specifier: ^8.18.0
         version: 8.21.0
@@ -137,7 +143,7 @@ importers:
         version: 15.5.16(@babel/core@7.29.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openai:
         specifier: file:..
-        version: file:(@aws-sdk/credential-provider-node@3.972.47)(@smithy/hash-node@4.3.5)(@smithy/signature-v4@5.4.6)(ws@8.21.0)(zod@4.4.3)
+        version: file:(@aws-sdk/credential-provider-node@3.972.47)(@smithy/hash-node@4.3.5)(@smithy/signature-v4@5.4.6)(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@5.8.3)))(valibot@1.4.2(typescript@5.8.3))(ws@8.21.0)(zod@4.4.3)
       zod-to-json-schema:
         specifier: ^3.21.4
         version: 3.25.2(zod@4.4.3)
@@ -1175,6 +1181,11 @@ packages:
   '@typespec/ts-http-runtime@0.3.5':
     resolution: {integrity: sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==}
     engines: {node: '>=20.0.0'}
+
+  '@valibot/to-json-schema@1.7.1':
+    resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
+    peerDependencies:
+      valibot: ^1.4.0
 
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -2359,6 +2370,8 @@ packages:
       '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
       '@smithy/hash-node': '>=4.3.0 <5'
       '@smithy/signature-v4': '>=5.4.0 <6'
+      '@valibot/to-json-schema': ^1.0.0
+      valibot: ^1.0.0
       ws: ^8.18.0
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:
@@ -2367,6 +2380,10 @@ packages:
       '@smithy/hash-node':
         optional: true
       '@smithy/signature-v4':
+        optional: true
+      '@valibot/to-json-schema':
+        optional: true
+      valibot:
         optional: true
       ws:
         optional: true
@@ -2872,6 +2889,14 @@ packages:
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
+
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
@@ -4220,6 +4245,10 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
+
+  '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@5.8.3))':
+    dependencies:
+      valibot: 1.4.2(typescript@5.8.3)
 
   accepts@1.3.8:
     dependencies:
@@ -5589,11 +5618,13 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openai@file:(@aws-sdk/credential-provider-node@3.972.47)(@smithy/hash-node@4.3.5)(@smithy/signature-v4@5.4.6)(ws@8.21.0)(zod@4.4.3):
+  openai@file:(@aws-sdk/credential-provider-node@3.972.47)(@smithy/hash-node@4.3.5)(@smithy/signature-v4@5.4.6)(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@5.8.3)))(valibot@1.4.2(typescript@5.8.3))(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
       '@aws-sdk/credential-provider-node': 3.972.47
       '@smithy/hash-node': 4.3.5
       '@smithy/signature-v4': 5.4.6
+      '@valibot/to-json-schema': 1.7.1(valibot@1.4.2(typescript@5.8.3))
+      valibot: 1.4.2(typescript@5.8.3)
       ws: 8.21.0
       zod: 4.4.3
 
@@ -6083,6 +6114,10 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+
+  valibot@1.4.2(typescript@5.8.3):
+    optionalDependencies:
+      typescript: 5.8.3
 
   validate-npm-package-name@5.0.1: {}
 

--- a/src/helpers/valibot.ts
+++ b/src/helpers/valibot.ts
@@ -1,0 +1,154 @@
+import { ResponseFormatJSONSchema } from '../resources/index';
+import * as v from 'valibot';
+import {
+  AutoParseableResponseFormat,
+  AutoParseableTextFormat,
+  AutoParseableTool,
+  makeParseableResponseFormat,
+  makeParseableTextFormat,
+  makeParseableTool,
+} from '../lib/parser';
+import { toJsonSchema } from '@valibot/to-json-schema';
+import { AutoParseableResponseTool, makeParseableResponseTool } from '../lib/ResponsesParser';
+import { type ResponseFormatTextJSONSchemaConfig } from '../resources/responses/responses';
+import { toStrictJsonSchema } from '../lib/transform';
+import { JSONSchema } from '../lib/jsonschema';
+
+type ValibotSchema = v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>;
+
+function valibotToJsonSchema(schema: ValibotSchema): Record<string, unknown> {
+  return toStrictJsonSchema(
+    toJsonSchema(schema, { target: 'draft-07' }) as JSONSchema,
+  ) as Record<string, unknown>;
+}
+
+/**
+ * Creates a chat completion `JSONSchema` response format object from
+ * the given Valibot schema.
+ *
+ * If this is passed to the `.parse()`, `.stream()` or `.runTools()`
+ * chat completion methods then the response message will contain a
+ * `.parsed` property that is the result of parsing the content with
+ * the given Valibot schema.
+ *
+ * ```ts
+ * const completion = await client.chat.completions.parse({
+ *    model: 'gpt-4o-2024-08-06',
+ *    messages: [
+ *      { role: 'system', content: 'You are a helpful math tutor.' },
+ *      { role: 'user', content: 'solve 8x + 31 = 2' },
+ *    ],
+ *    response_format: valibotResponseFormat(
+ *      v.object({
+ *        steps: v.array(v.object({
+ *          explanation: v.string(),
+ *          answer: v.string(),
+ *        })),
+ *        final_answer: v.string(),
+ *      }),
+ *      'math_answer',
+ *    ),
+ *  });
+ *  const message = completion.choices[0]?.message;
+ *  if (message?.parsed) {
+ *    console.log(message.parsed);
+ *    console.log(message.parsed.final_answer);
+ * }
+ * ```
+ *
+ * This can be passed directly to the `.create()` method but will not
+ * result in any automatic parsing, you'll have to parse the response yourself.
+ */
+export function valibotResponseFormat<Schema extends ValibotSchema>(
+  schema: Schema,
+  name: string,
+  props?: Omit<ResponseFormatJSONSchema.JSONSchema, 'schema' | 'strict' | 'name'>,
+): AutoParseableResponseFormat<v.InferOutput<Schema>> {
+  return makeParseableResponseFormat(
+    {
+      type: 'json_schema',
+      json_schema: {
+        ...props,
+        name,
+        strict: true,
+        schema: valibotToJsonSchema(schema),
+      },
+    },
+    (content) => v.parse(schema, JSON.parse(content)),
+  );
+}
+
+export function valibotTextFormat<Schema extends ValibotSchema>(
+  schema: Schema,
+  name: string,
+  props?: Omit<ResponseFormatTextJSONSchemaConfig, 'schema' | 'type' | 'strict' | 'name'>,
+): AutoParseableTextFormat<v.InferOutput<Schema>> {
+  return makeParseableTextFormat(
+    {
+      type: 'json_schema',
+      ...props,
+      name,
+      strict: true,
+      schema: valibotToJsonSchema(schema),
+    },
+    (content) => v.parse(schema, JSON.parse(content)),
+  );
+}
+
+/**
+ * Creates a chat completion `function` tool that can be invoked
+ * automatically by the chat completion `.runTools()` method or automatically
+ * parsed by `.parse()` / `.stream()`.
+ */
+export function valibotFunction<Parameters extends ValibotSchema>(options: {
+  name: string;
+  parameters: Parameters;
+  function?: ((args: v.InferOutput<Parameters>) => unknown | Promise<unknown>) | undefined;
+  description?: string | undefined;
+}): AutoParseableTool<{
+  arguments: Parameters;
+  name: string;
+  function: (args: v.InferOutput<Parameters>) => unknown;
+}> {
+  // @ts-expect-error TODO
+  return makeParseableTool<any>(
+    {
+      type: 'function',
+      function: {
+        name: options.name,
+        parameters: valibotToJsonSchema(options.parameters),
+        strict: true,
+        ...(options.description ? { description: options.description } : undefined),
+      },
+    },
+    {
+      callback: options.function,
+      parser: (args) => v.parse(options.parameters, JSON.parse(args)),
+    },
+  );
+}
+
+export function valibotResponsesFunction<Parameters extends ValibotSchema>(options: {
+  name: string;
+  parameters: Parameters;
+  function?: ((args: v.InferOutput<Parameters>) => unknown | Promise<unknown>) | undefined;
+  description?: string | undefined;
+}): AutoParseableResponseTool<{
+  arguments: Parameters;
+  name: string;
+  function: (args: v.InferOutput<Parameters>) => unknown;
+}> {
+  return makeParseableResponseTool<any>(
+    {
+      type: 'function',
+      name: options.name,
+      parameters: valibotToJsonSchema(options.parameters),
+      strict: true,
+      ...(options.description ? { description: options.description } : undefined),
+    },
+    {
+      callback: options.function,
+      parser: (args) => v.parse(options.parameters, JSON.parse(args)),
+    },
+  );
+}

--- a/tests/helpers/valibot.test.ts
+++ b/tests/helpers/valibot.test.ts
@@ -1,0 +1,219 @@
+import { valibotResponseFormat } from 'openai/helpers/valibot';
+import * as v from 'valibot';
+
+const toJSON = (obj: unknown) => JSON.parse(JSON.stringify(obj));
+
+describe('valibotResponseFormat', () => {
+  it('generates a valid json_schema response format', () => {
+    const result = valibotResponseFormat(
+      v.object({
+        city: v.string(),
+        temperature: v.number(),
+        units: v.picklist(['c', 'f']),
+      }),
+      'location',
+    );
+
+    expect(result.json_schema).toEqual({
+      name: 'location',
+      strict: true,
+      schema: {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        additionalProperties: false,
+        properties: {
+          city: { type: 'string' },
+          temperature: { type: 'number' },
+          units: { enum: ['c', 'f'], type: 'string' },
+        },
+        required: ['city', 'temperature', 'units'],
+        type: 'object',
+      },
+    });
+  });
+
+  it('supports nullable optional fields', () => {
+    const result = valibotResponseFormat(
+      v.object({
+        city: v.string(),
+        temperature: v.number(),
+        units: v.optional(v.nullable(v.picklist(['c', 'f']))),
+      }),
+      'location',
+    );
+
+    expect(result.json_schema).toEqual({
+      name: 'location',
+      strict: true,
+      schema: {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        additionalProperties: false,
+        properties: {
+          city: { type: 'string' },
+          temperature: { type: 'number' },
+          units: {
+            anyOf: [
+              { enum: ['c', 'f'], type: 'string' },
+              { type: 'null' },
+            ],
+          },
+        },
+        required: ['city', 'temperature', 'units'],
+        type: 'object',
+      },
+    });
+  });
+
+  it('allows description field to be passed in', () => {
+    expect(
+      valibotResponseFormat(
+        v.object({
+          city: v.string(),
+        }),
+        'city',
+        { description: 'A city' },
+      ).json_schema,
+    ).toHaveProperty('description', 'A city');
+  });
+
+  test('complex nested schema', () => {
+    const Table = v.picklist(['orders', 'customers', 'products']);
+
+    const Column = v.picklist([
+      'id',
+      'status',
+      'expected_delivery_date',
+      'delivered_at',
+      'shipped_at',
+      'ordered_at',
+      'canceled_at',
+    ]);
+
+    const Operator = v.picklist(['=', '>', '<', '<=', '>=', '!=']);
+
+    const OrderBy = v.picklist(['asc', 'desc']);
+
+    const DynamicValue = v.object({
+      column_name: v.string(),
+    });
+
+    const Condition = v.object({
+      column: v.string(),
+      operator: Operator,
+      value: v.union([v.string(), v.number(), DynamicValue]),
+    });
+
+    const Query = v.object({
+      table_name: Table,
+      columns: v.array(Column),
+      conditions: v.array(Condition),
+      order_by: OrderBy,
+    });
+
+    const result = valibotResponseFormat(Query, 'query');
+
+    expect(result.json_schema).toEqual({
+      name: 'query',
+      strict: true,
+      schema: {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        additionalProperties: false,
+        properties: {
+          columns: {
+            items: {
+              enum: [
+                'id',
+                'status',
+                'expected_delivery_date',
+                'delivered_at',
+                'shipped_at',
+                'ordered_at',
+                'canceled_at',
+              ],
+              type: 'string',
+            },
+            type: 'array',
+          },
+          conditions: {
+            items: {
+              additionalProperties: false,
+              properties: {
+                column: { type: 'string' },
+                operator: {
+                  enum: ['=', '>', '<', '<=', '>=', '!='],
+                  type: 'string',
+                },
+                value: {
+                  anyOf: [
+                    { type: 'string' },
+                    { type: 'number' },
+                    {
+                      additionalProperties: false,
+                      properties: {
+                        column_name: { type: 'string' },
+                      },
+                      required: ['column_name'],
+                      type: 'object',
+                    },
+                  ],
+                },
+              },
+              required: ['column', 'operator', 'value'],
+              type: 'object',
+            },
+            type: 'array',
+          },
+          order_by: {
+            enum: ['asc', 'desc'],
+            type: 'string',
+          },
+          table_name: {
+            enum: ['orders', 'customers', 'products'],
+            type: 'string',
+          },
+        },
+        required: ['table_name', 'columns', 'conditions', 'order_by'],
+        type: 'object',
+      },
+    });
+  });
+
+  it('throws error on optional fields without nullable', () => {
+    expect(() =>
+      valibotResponseFormat(
+        v.object({
+          required: v.string(),
+          optional: v.optional(v.string()),
+        }),
+        'schema',
+      ),
+    ).toThrow(
+      /Zod field at `properties\/optional` uses `\.optional\(\)` without `\.nullable\(\)`/,
+    );
+  });
+
+  it('throws error on nested optional fields without nullable', () => {
+    expect(() =>
+      valibotResponseFormat(
+        v.object({
+          foo: v.object({
+            bar: v.array(v.object({ can_be_missing: v.optional(v.boolean()) })),
+          }),
+        }),
+        'schema',
+      ),
+    ).toThrow(
+      /Zod field at `properties\/foo\/properties\/bar\/items\/properties\/can_be_missing` uses `\.optional\(\)` without `\.nullable\(\)`/,
+    );
+  });
+
+  it('does not throw on nullable optional fields', () => {
+    expect(() =>
+      valibotResponseFormat(
+        v.object({
+          union: v.optional(v.nullable(v.string())),
+        }),
+        'schema',
+      ),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Adds valibotResponseFormat() for using Valibot schemas with structured outputs.

## Summary
This PR adds first-class Valibot support for structured outputs, following the same pattern as the existing Zod integration.

## Changes
- Added `src/helpers/valibot.ts` with `valibotResponseFormat()`, `valibotTextFormat()`, `valibotFunction()`, and `valibotResponsesFunction()` helpers
- Added `tests/helpers/valibot.test.ts` with comprehensive test coverage
- Added `valibot` and `@valibot/to-json-schema` as optional peer dependencies

## How it works
The implementation converts Valibot schemas to JSON Schema using `@valibot/to-json-schema` (targeting draft-07), then applies the same strict mode transformation used by the Zod helpers. The `v.parse()` function is used for response parsing.

## Usage
```ts
const completion = await client.chat.completions.parse({
  model: 'gpt-4o-2024-08-06',
  messages: [{ role: 'user', content: 'What is the weather like?' }],
  response_format: valibotResponseFormat(
    v.object({
      city: v.string(),
      temperature: v.number(),
      units: v.picklist(['c', 'f']),
    }),
    'location',
  ),
});
```

Closes #1021

