### PR TITLE
fix: add gpt-5.1-codex-mini model to type definitions

### DIFF
--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -8199,7 +8199,7 @@ export interface ResponseCompactParams {
     | 'gpt-5.1'
     | 'gpt-5.1-2025-11-13'
     | 'gpt-5.1-codex'
-    | 'gpt-5.1-mini'
+    | 'gpt-5.1-codex-mini'
     | 'gpt-5.1-chat-latest'
     | 'gpt-5'
     | 'gpt-5-mini'

--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -8199,6 +8199,7 @@ export interface ResponseCompactParams {
     | 'gpt-5.1'
     | 'gpt-5.1-2025-11-13'
     | 'gpt-5.1-codex'
+    | 'gpt-5.1-mini'
     | 'gpt-5.1-codex-mini'
     | 'gpt-5.1-chat-latest'
     | 'gpt-5'

--- a/src/resources/shared.ts
+++ b/src/resources/shared.ts
@@ -33,6 +33,7 @@ export type ChatModel =
   | 'gpt-5.1'
   | 'gpt-5.1-2025-11-13'
   | 'gpt-5.1-codex'
+  | 'gpt-5.1-mini'
   | 'gpt-5.1-codex-mini'
   | 'gpt-5.1-chat-latest'
   | 'gpt-5'

--- a/src/resources/shared.ts
+++ b/src/resources/shared.ts
@@ -33,7 +33,7 @@ export type ChatModel =
   | 'gpt-5.1'
   | 'gpt-5.1-2025-11-13'
   | 'gpt-5.1-codex'
-  | 'gpt-5.1-mini'
+  | 'gpt-5.1-codex-mini'
   | 'gpt-5.1-chat-latest'
   | 'gpt-5'
   | 'gpt-5-mini'


### PR DESCRIPTION
Adds support for the gpt-5.1-codex-mini model.

Fixes #1706