### PR TITLE
fix: expose metadata in chat completions response

### DIFF
--- a/src/resources/chat/completions/completions.ts
+++ b/src/resources/chat/completions/completions.ts
@@ -331,6 +331,16 @@ export interface ChatCompletion {
   system_fingerprint?: string;
 
   /**
+   * Set of 16 key-value pairs that can be attached to an object. This can be useful
+   * for storing additional information about the object in a structured format, and
+   * querying for objects via API or the dashboard.
+   *
+   * Keys are strings with a maximum length of 64 characters. Values are strings with
+   * a maximum length of 512 characters.
+   */
+  metadata?: Shared.Metadata | null;
+
+  /**
    * Usage statistics for the completion request.
    */
   usage?: CompletionsAPI.CompletionUsage;


### PR DESCRIPTION
Exposes metadata from Chat Completions API in the SDK response.

Fixes #1818