### PR TITLE
fix: Use locale-invariant toLowerCase for header normalization

### DIFF
--- a/src/internal/headers.ts
+++ b/src/internal/headers.ts
@@ -74,7 +74,7 @@ export const buildHeaders = (newHeaders: HeadersLike[]): NullableHeaders => {
   for (const headers of newHeaders) {
     const seenHeaders = new Set<string>();
     for (const [name, value] of iterateHeaders(headers)) {
-      const lowerName = name.toLowerCase();
+      const lowerName = name.toLocaleLowerCase('en-US');
       if (!seenHeaders.has(lowerName)) {
         targetHeaders.delete(name);
         seenHeaders.add(lowerName);

--- a/tests/buildHeaders.test.ts
+++ b/tests/buildHeaders.test.ts
@@ -79,6 +79,25 @@ describe('buildHeaders', () => {
     ],
     [[undefined], `NullableHeaders { }`],
     [[null], `NullableHeaders { }`],
+    [
+      [
+        {
+          'OpenAI-Organization': 'org-123',
+        },
+      ],
+      `NullableHeaders { 'OpenAI-Organization': 'org-123' }`,
+    ],
+    [
+      [
+        {
+          'OpenAI-Organization': 'org-123',
+        },
+        {
+          'openai-organization': 'org-456',
+        },
+      ],
+      `NullableHeaders { 'openai-organization': 'org-456' }`,
+    ],
   ];
   for (const [input, expected] of cases) {
     test(expected, () => {


### PR DESCRIPTION
## Changes being requested

This PR fixes a critical bug where the SDK crashes on systems running with Turkish locale (tr-TR) on Windows. The root cause is in `src/internal/headers.ts` line 77, where `name.toLowerCase()` performs locale-sensitive string conversion. On Turkish locales, uppercase 'I' converts to dotless 'ı' instead of 'i', producing invalid HTTP header names like 'openaı-organization' that violate HTTP token validation in Node.js's underlying network layer (undici).

The fix replaces `name.toLowerCase()` with `name.toLocaleLowerCase('en-US')` to ensure locale-invariant header normalization that always produces ASCII-compliant header names regardless of system locale. This is a minimal one-line change that aligns with HTTP specification requirements.

I've also added test cases that verify header names containing 'I' (like 'OpenAI-Organization') are normalized correctly and that case-insensitive header merging works as expected.

## Additional context & links

This issue affects Turkish Windows users and potentially users of other locales with non-standard case mappings. The Turkish 'I' problem is a well-known locale-sensitivity issue in JavaScript string operations.

Fixes #1928
