### PR TITLE
fix(azure): route image edits by model deployment

### DIFF
--- a/src/resources/images.ts
+++ b/src/resources/images.ts
@@ -55,7 +55,13 @@ export class Images extends APIResource {
     return this._client.post(
       '/images/edits',
       multipartFormRequestOptions(
-        { body, ...options, stream: body.stream ?? false, __security: { bearerAuth: true } },
+        {
+          body,
+          ...options,
+          stream: body.stream ?? false,
+          __metadata: { model: body.model },
+          __security: { bearerAuth: true },
+        },
         this._client,
       ),
     ) as APIPromise<ImagesResponse> | APIPromise<Stream<ImageEditStreamEvent>>;

--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -585,6 +585,18 @@ describe('azure request building', () => {
         });
       });
 
+      test('handles image edits', async () => {
+        expect(
+          await client.images.edit({
+            model: deployment,
+            image: new File([], ''),
+            prompt: 'prompt',
+          }),
+        ).toMatchObject({
+          url: `https://example.com/openai/deployments/${deployment}/images/edits?api-version=${apiVersion}`,
+        });
+      });
+
       test('handles assistants', async () => {
         expect(
           await client.beta.assistants.create({


### PR DESCRIPTION
## Summary
- Pass image edit model metadata through multipart request options so Azure can route `/images/edits` requests to the matching deployment.
- Add an Azure regression test for `client.images.edit()` without a client-level deployment.

## Changes
| File | Change |
|------|--------|
| `src/resources/images.ts` | Includes `__metadata: { model: body.model }` for image edit multipart requests. |
| `tests/lib/azure.test.ts` | Covers Azure deployment URL mapping for image edits. |

## Test Plan
- [x] `npx --yes yarn@1.22.22 test tests/lib/azure.test.ts --runInBand`

Fixes #1917