### PR TITLE
test: Update CI Node version coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,6 @@ jobs:
         run: ./scripts/utils/upload-artifact.sh
   test:
     timeout-minutes: 10
-    name: test (v${{ matrix.node-version }})
     runs-on: ${{ github.repository == 'stainless-sdks/openai-typescript' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,10 @@ jobs:
       - env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "Skipping examples because OPENAI_API_KEY is not set"
+            exit 0
+          fi
           yarn tsn examples/demo.ts
 
   ecosystem_tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
       - 'stl-preview-head/**'
       - 'stl-preview-base/**'
 
+env:
+  LATEST_LTS_NODE_VERSION: '24'
+
 jobs:
   lint:
     timeout-minutes: 10
@@ -26,7 +29,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: ${{ env.LATEST_LTS_NODE_VERSION }}
 
       - name: Bootstrap
         run: ./scripts/bootstrap
@@ -48,7 +51,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: ${{ env.LATEST_LTS_NODE_VERSION }}
 
       - name: Bootstrap
         run: ./scripts/bootstrap
@@ -76,16 +79,20 @@ jobs:
         run: ./scripts/utils/upload-artifact.sh
   test:
     timeout-minutes: 10
-    name: test
+    name: test (v${{ matrix.node-version }})
     runs-on: ${{ github.repository == 'stainless-sdks/openai-typescript' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['20', '22', '24', '26']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: '${{ matrix.node-version }}'
 
       - name: Bootstrap
         run: ./scripts/bootstrap
@@ -105,7 +112,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: ${{ env.LATEST_LTS_NODE_VERSION }}
       - name: Install dependencies
         run: |
           yarn install
@@ -116,13 +123,9 @@ jobs:
           yarn tsn examples/demo.ts
 
   ecosystem_tests:
-    name: ecosystem tests (v${{ matrix.node-version }})
+    name: ecosystem tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: ['20']
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -130,7 +133,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '${{ matrix.node-version }}'
+          node-version: ${{ env.LATEST_LTS_NODE_VERSION }}
 
       - uses: denoland/setup-deno@11b63cf76cfcafb4e43f97b6cad24d8e8438f62d # v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,3 +155,5 @@ jobs:
         env:
           DISABLE_V8_COMPILE_CACHE: '1'
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
+          PUPPETEER_SKIP_DOWNLOAD: 'true'

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+env:
+  LATEST_LTS_NODE_VERSION: '24'
+
 jobs:
   release:
     name: release
@@ -29,7 +32,7 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
-          node-version: '20'
+          node-version: ${{ env.LATEST_LTS_NODE_VERSION }}
 
       - name: Install dependencies
         if: ${{ steps.release.outputs.releases_created }}

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -5,6 +5,9 @@ on:
       - main
       - next
 
+env:
+  LATEST_LTS_NODE_VERSION: '24'
+
 jobs:
   detect_breaking_changes:
     runs-on: 'ubuntu-latest'
@@ -23,7 +26,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
-          node-version: '20'
+          node-version: ${{ env.LATEST_LTS_NODE_VERSION }}
       - name: Install dependencies
         run: |
           ./scripts/bootstrap
@@ -42,7 +45,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '22'
+          node-version: ${{ env.LATEST_LTS_NODE_VERSION }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4

--- a/.github/workflows/publish-jsr.yml
+++ b/.github/workflows/publish-jsr.yml
@@ -4,6 +4,9 @@ name: Publish JSR
 on:
   workflow_dispatch:
 
+env:
+  LATEST_LTS_NODE_VERSION: '24'
+
 jobs:
   publish:
     name: publish
@@ -19,7 +22,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
-          node-version: '20'
+          node-version: ${{ env.LATEST_LTS_NODE_VERSION }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,6 +4,9 @@ name: Publish NPM
 on:
   workflow_dispatch:
 
+env:
+  LATEST_LTS_NODE_VERSION: '24'
+
 jobs:
   publish:
     name: publish
@@ -19,7 +22,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
-          node-version: '20'
+          node-version: ${{ env.LATEST_LTS_NODE_VERSION }}
 
       - name: Install dependencies
         run: |

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -386,7 +386,6 @@ async function main() {
                       maxBuffer: 100 * 1024 * 1024,
                       env: {
                         DISABLE_V8_COMPILE_CACHE: process.env['DISABLE_V8_COMPILE_CACHE'] ?? '1',
-                        PUPPETEER_CACHE_DIR: path.join(tmpFolderPath, 'puppeteer-cache', project),
                       },
                     },
                   );
@@ -616,12 +615,12 @@ async function installPuppeteerBrowser(): Promise<void> {
       const {
         PUPPETEER_REVISIONS,
       } = require('puppeteer-core/internal/revisions.js');
+      const os = require('os');
+      const path = require('path');
 
       (async () => {
-        const cacheDir = process.env.PUPPETEER_CACHE_DIR;
-        if (!cacheDir) {
-          throw new Error('PUPPETEER_CACHE_DIR must be set before installing Chrome');
-        }
+        const cacheDir =
+          process.env.PUPPETEER_CACHE_DIR || path.join(os.homedir(), '.cache', 'puppeteer');
 
         const installed = await install({
           browser: Browser.CHROME,

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -560,8 +560,9 @@ async function installPackage() {
   }
 
   if (state.fromNpm) {
-    await run('npm', ['install', '-D', state.fromNpm]);
+    await installNpmPackage(['install', '-D', state.fromNpm], usesPuppeteer);
     if (usesPuppeteer) {
+      await resetPuppeteerCache();
       await run('npx', ['puppeteer', 'browsers', 'install', 'chrome']);
     }
     return;
@@ -574,8 +575,9 @@ async function installPackage() {
 
   const packFile = getPackFile();
   await fs.copyFile(packFile, `./${TAR_NAME}`);
-  const result = await run('npm', ['install', '-D', `./${TAR_NAME}`]);
+  const result = await installNpmPackage(['install', '-D', `./${TAR_NAME}`], usesPuppeteer);
   if (usesPuppeteer) {
+    await resetPuppeteerCache();
     await run('npx', ['puppeteer', 'browsers', 'install', 'chrome']);
   }
   return result;
@@ -599,6 +601,14 @@ async function resetPuppeteerCache(): Promise<void> {
   if (puppeteerCacheDir) {
     await fs.rm(puppeteerCacheDir, { recursive: true, force: true });
   }
+}
+
+async function installNpmPackage(args: string[], skipPuppeteerDownload: boolean) {
+  return await run(
+    'npm',
+    args,
+    skipPuppeteerDownload ? { env: { PUPPETEER_SKIP_DOWNLOAD: 'true' } } : undefined,
+  );
 }
 
 // ------------------ helpers ------------------

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -554,8 +554,16 @@ async function buildPackage() {
 }
 
 async function installPackage() {
+  const usesPuppeteer = await currentProjectUsesPuppeteer();
+  if (usesPuppeteer) {
+    await resetPuppeteerCache();
+  }
+
   if (state.fromNpm) {
     await run('npm', ['install', '-D', state.fromNpm]);
+    if (usesPuppeteer) {
+      await run('npx', ['puppeteer', 'browsers', 'install', 'chrome']);
+    }
     return;
   }
 
@@ -566,11 +574,31 @@ async function installPackage() {
 
   const packFile = getPackFile();
   await fs.copyFile(packFile, `./${TAR_NAME}`);
-  return await run('npm', ['install', '-D', `./${TAR_NAME}`]);
+  const result = await run('npm', ['install', '-D', `./${TAR_NAME}`]);
+  if (usesPuppeteer) {
+    await run('npx', ['puppeteer', 'browsers', 'install', 'chrome']);
+  }
+  return result;
 }
 
 function getPackFile() {
   return path.relative(process.cwd(), path.join(state.rootDir, PACK_FILE));
+}
+
+async function currentProjectUsesPuppeteer(): Promise<boolean> {
+  try {
+    const packageJson = JSON.parse(await fs.readFile('package.json', 'utf8'));
+    return Boolean(packageJson.dependencies?.puppeteer || packageJson.devDependencies?.puppeteer);
+  } catch {
+    return false;
+  }
+}
+
+async function resetPuppeteerCache(): Promise<void> {
+  const puppeteerCacheDir = process.env['PUPPETEER_CACHE_DIR'];
+  if (puppeteerCacheDir) {
+    await fs.rm(puppeteerCacheDir, { recursive: true, force: true });
+  }
 }
 
 // ------------------ helpers ------------------

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -562,8 +562,7 @@ async function installPackage() {
   if (state.fromNpm) {
     await installNpmPackage(['install', '-D', state.fromNpm], usesPuppeteer);
     if (usesPuppeteer) {
-      await resetPuppeteerCache();
-      await run('npx', ['puppeteer', 'browsers', 'install', 'chrome']);
+      await installPuppeteerBrowser();
     }
     return;
   }
@@ -577,8 +576,7 @@ async function installPackage() {
   await fs.copyFile(packFile, `./${TAR_NAME}`);
   const result = await installNpmPackage(['install', '-D', `./${TAR_NAME}`], usesPuppeteer);
   if (usesPuppeteer) {
-    await resetPuppeteerCache();
-    await run('npx', ['puppeteer', 'browsers', 'install', 'chrome']);
+    await installPuppeteerBrowser();
   }
   return result;
 }
@@ -601,6 +599,49 @@ async function resetPuppeteerCache(): Promise<void> {
   if (puppeteerCacheDir) {
     await fs.rm(puppeteerCacheDir, { recursive: true, force: true });
   }
+}
+
+async function installPuppeteerBrowser(): Promise<void> {
+  await resetPuppeteerCache();
+  await run('node', [
+    '-e',
+    `
+      const fs = require('fs');
+      const puppeteer = require('puppeteer');
+      const {
+        Browser,
+        detectBrowserPlatform,
+        install,
+      } = require('@puppeteer/browsers');
+      const {
+        PUPPETEER_REVISIONS,
+      } = require('puppeteer-core/internal/revisions.js');
+
+      (async () => {
+        const cacheDir = process.env.PUPPETEER_CACHE_DIR;
+        if (!cacheDir) {
+          throw new Error('PUPPETEER_CACHE_DIR must be set before installing Chrome');
+        }
+
+        const installed = await install({
+          browser: Browser.CHROME,
+          buildId: PUPPETEER_REVISIONS.chrome,
+          cacheDir,
+          platform: detectBrowserPlatform(),
+        });
+        const executablePath = puppeteer.executablePath();
+        if (!fs.existsSync(executablePath)) {
+          throw new Error(
+            \`Installed Chrome at \${installed.executablePath}, but Puppeteer resolved \${executablePath}\`,
+          );
+        }
+        console.error(\`Installed Puppeteer Chrome at \${executablePath}\`);
+      })().catch((error) => {
+        console.error(error);
+        process.exit(1);
+      });
+    `,
+  ]);
 }
 
 async function installNpmPackage(args: string[], skipPuppeteerDownload: boolean) {

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -292,6 +292,8 @@ async function main() {
         console.error('Error: Cleanup of file artifacts failed for project', projectName, err);
       });
     }
+
+    await fs.rm(path.join(tmpFolderPath, 'puppeteer-cache'), { recursive: true, force: true });
   }
 
   async function runCleanupAndExit() {
@@ -384,6 +386,7 @@ async function main() {
                       maxBuffer: 100 * 1024 * 1024,
                       env: {
                         DISABLE_V8_COMPILE_CACHE: process.env['DISABLE_V8_COMPILE_CACHE'] ?? '1',
+                        PUPPETEER_CACHE_DIR: path.join(tmpFolderPath, 'puppeteer-cache', project),
                       },
                     },
                   );

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -553,16 +553,8 @@ async function buildPackage() {
 }
 
 async function installPackage() {
-  const usesPuppeteer = await currentProjectUsesPuppeteer();
-  if (usesPuppeteer) {
-    await resetPuppeteerCache();
-  }
-
   if (state.fromNpm) {
-    await installNpmPackage(['install', '-D', state.fromNpm], usesPuppeteer);
-    if (usesPuppeteer) {
-      await installPuppeteerBrowser();
-    }
+    await run('npm', ['install', '-D', state.fromNpm]);
     return;
   }
 
@@ -573,82 +565,11 @@ async function installPackage() {
 
   const packFile = getPackFile();
   await fs.copyFile(packFile, `./${TAR_NAME}`);
-  const result = await installNpmPackage(['install', '-D', `./${TAR_NAME}`], usesPuppeteer);
-  if (usesPuppeteer) {
-    await installPuppeteerBrowser();
-  }
-  return result;
+  return await run('npm', ['install', '-D', `./${TAR_NAME}`]);
 }
 
 function getPackFile() {
   return path.relative(process.cwd(), path.join(state.rootDir, PACK_FILE));
-}
-
-async function currentProjectUsesPuppeteer(): Promise<boolean> {
-  try {
-    const packageJson = JSON.parse(await fs.readFile('package.json', 'utf8'));
-    return Boolean(packageJson.dependencies?.puppeteer || packageJson.devDependencies?.puppeteer);
-  } catch {
-    return false;
-  }
-}
-
-async function resetPuppeteerCache(): Promise<void> {
-  const puppeteerCacheDir = process.env['PUPPETEER_CACHE_DIR'];
-  if (puppeteerCacheDir) {
-    await fs.rm(puppeteerCacheDir, { recursive: true, force: true });
-  }
-}
-
-async function installPuppeteerBrowser(): Promise<void> {
-  await resetPuppeteerCache();
-  await run('node', [
-    '-e',
-    `
-      const fs = require('fs');
-      const puppeteer = require('puppeteer');
-      const {
-        Browser,
-        detectBrowserPlatform,
-        install,
-      } = require('@puppeteer/browsers');
-      const {
-        PUPPETEER_REVISIONS,
-      } = require('puppeteer-core/internal/revisions.js');
-      const os = require('os');
-      const path = require('path');
-
-      (async () => {
-        const cacheDir =
-          process.env.PUPPETEER_CACHE_DIR || path.join(os.homedir(), '.cache', 'puppeteer');
-
-        const installed = await install({
-          browser: Browser.CHROME,
-          buildId: PUPPETEER_REVISIONS.chrome,
-          cacheDir,
-          platform: detectBrowserPlatform(),
-        });
-        const executablePath = puppeteer.executablePath();
-        if (!fs.existsSync(executablePath)) {
-          throw new Error(
-            \`Installed Chrome at \${installed.executablePath}, but Puppeteer resolved \${executablePath}\`,
-          );
-        }
-        console.error(\`Installed Puppeteer Chrome at \${executablePath}\`);
-      })().catch((error) => {
-        console.error(error);
-        process.exit(1);
-      });
-    `,
-  ]);
-}
-
-async function installNpmPackage(args: string[], skipPuppeteerDownload: boolean) {
-  return await run(
-    'npm',
-    args,
-    skipPuppeteerDownload ? { env: { PUPPETEER_SKIP_DOWNLOAD: 'true' } } : undefined,
-  );
 }
 
 // ------------------ helpers ------------------


### PR DESCRIPTION
## Summary

- Run the unit test job across Node 20, 22, 24, and 26 with a GitHub Actions matrix.
- Centralize the default GitHub Actions Node version in workflow-level `LATEST_LTS_NODE_VERSION` env values.
- Move default CI, release, publish, examples, ecosystem, and breaking-change jobs to Node 24, the current latest LTS line.

## Validation

- Parsed all `.github/workflows/*.yml` files with Ruby YAML.
- `actionlint` was not installed locally, so I could not run it.