### PR TITLE
test: Use CI environment for OpenAI API key workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
     name: examples
     runs-on: ${{ github.repository == 'stainless-sdks/openai-typescript' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.repository == 'openai/openai-node'
+    environment: ci
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -119,6 +120,7 @@ jobs:
     name: ecosystem tests (v${{ matrix.node-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    environment: ci
     strategy:
       fail-fast: false
       matrix:

--- a/ecosystem-tests/browser-direct-import/public/index.js
+++ b/ecosystem-tests/browser-direct-import/public/index.js
@@ -124,7 +124,7 @@ it(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
       model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'Say this is a test' }],
+      messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     })
     .asResponse();
 
@@ -157,7 +157,7 @@ it(`raw response`, async function () {
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     stream: true,
   });
   const chunks = [];

--- a/ecosystem-tests/browser-direct-import/public/index.js
+++ b/ecosystem-tests/browser-direct-import/public/index.js
@@ -123,7 +123,7 @@ async function typeTests() {
 it(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
-      model: 'gpt-4',
+      model: 'gpt-4o-mini',
       messages: [{ role: 'user', content: 'Say this is a test' }],
     })
     .asResponse();
@@ -156,7 +156,7 @@ it(`raw response`, async function () {
 
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
     stream: true,
   });

--- a/ecosystem-tests/bun/openai.test.ts
+++ b/ecosystem-tests/bun/openai.test.ts
@@ -38,7 +38,7 @@ function expectSimilar(received: any, comparedTo: string, expectedDistance: numb
 test(`basic request works`, async function () {
   const completion = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
   });
   expectSimilar(completion.choices[0]?.message?.content, 'This is a test', 10);
 });
@@ -52,7 +52,7 @@ test(`proxied request works`, async function () {
   
   const completion = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
   });
   expectSimilar(completion.choices[0]?.message?.content, 'This is a test', 10);
 });
@@ -61,7 +61,7 @@ test(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
       model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'Say this is a test' }],
+      messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     })
     .asResponse();
 
@@ -93,7 +93,7 @@ test(`raw response`, async function () {
 test(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     stream: true,
   });
   const chunks = [];

--- a/ecosystem-tests/bun/openai.test.ts
+++ b/ecosystem-tests/bun/openai.test.ts
@@ -37,7 +37,7 @@ function expectSimilar(received: any, comparedTo: string, expectedDistance: numb
 
 test(`basic request works`, async function () {
   const completion = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
   });
   expectSimilar(completion.choices[0]?.message?.content, 'This is a test', 10);
@@ -51,7 +51,7 @@ test(`proxied request works`, async function () {
   });
   
   const completion = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
   });
   expectSimilar(completion.choices[0]?.message?.content, 'This is a test', 10);
@@ -60,7 +60,7 @@ test(`proxied request works`, async function () {
 test(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
-      model: 'gpt-4',
+      model: 'gpt-4o-mini',
       messages: [{ role: 'user', content: 'Say this is a test' }],
     })
     .asResponse();
@@ -92,7 +92,7 @@ test(`raw response`, async function () {
 
 test(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
     stream: true,
   });

--- a/ecosystem-tests/cloudflare-worker/src/uploadWebApiTestCases.ts
+++ b/ecosystem-tests/cloudflare-worker/src/uploadWebApiTestCases.ts
@@ -50,7 +50,7 @@ export function uploadWebApiTestCases({
 		const response = await client.chat.completions
 			.create({
 				model: 'gpt-4o-mini',
-				messages: [{ role: 'user', content: 'Say this is a test' }],
+				messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
 			})
 			.asResponse();
 
@@ -82,7 +82,7 @@ export function uploadWebApiTestCases({
 	it(`streaming works`, async function () {
 		const stream = await client.chat.completions.create({
 			model: 'gpt-4o-mini',
-			messages: [{ role: 'user', content: 'Say this is a test' }],
+			messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
 			stream: true,
 		});
 		const chunks = [];

--- a/ecosystem-tests/cloudflare-worker/src/uploadWebApiTestCases.ts
+++ b/ecosystem-tests/cloudflare-worker/src/uploadWebApiTestCases.ts
@@ -49,7 +49,7 @@ export function uploadWebApiTestCases({
 	it(`raw response`, async function () {
 		const response = await client.chat.completions
 			.create({
-				model: 'gpt-4',
+				model: 'gpt-4o-mini',
 				messages: [{ role: 'user', content: 'Say this is a test' }],
 			})
 			.asResponse();
@@ -81,7 +81,7 @@ export function uploadWebApiTestCases({
 
 	it(`streaming works`, async function () {
 		const stream = await client.chat.completions.create({
-			model: 'gpt-4',
+			model: 'gpt-4o-mini',
 			messages: [{ role: 'user', content: 'Say this is a test' }],
 			stream: true,
 		});

--- a/ecosystem-tests/deno/main_test.ts
+++ b/ecosystem-tests/deno/main_test.ts
@@ -39,7 +39,7 @@ function assertSimilar(received: string, expected: string, maxDistance: number) 
 Deno.test(async function rawResponse() {
   const response = await client.chat.completions
     .create({
-      model: 'gpt-4',
+      model: 'gpt-4o-mini',
       messages: [{ role: 'user', content: 'Say this is a test' }],
     })
     .asResponse();
@@ -71,7 +71,7 @@ Deno.test(async function rawResponse() {
 
 Deno.test(async function streamingWorks() {
   const stream = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
     stream: true,
   });

--- a/ecosystem-tests/deno/main_test.ts
+++ b/ecosystem-tests/deno/main_test.ts
@@ -40,7 +40,7 @@ Deno.test(async function rawResponse() {
   const response = await client.chat.completions
     .create({
       model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'Say this is a test' }],
+      messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     })
     .asResponse();
 
@@ -72,7 +72,7 @@ Deno.test(async function rawResponse() {
 Deno.test(async function streamingWorks() {
   const stream = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     stream: true,
   });
   const chunks = [];

--- a/ecosystem-tests/node-ts-cjs-auto/tests/test.ts
+++ b/ecosystem-tests/node-ts-cjs-auto/tests/test.ts
@@ -57,7 +57,7 @@ expect.extend({
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     stream: true,
   });
   const chunks = [];
@@ -79,7 +79,7 @@ it(`ChatCompletionStream works`, async function () {
   const stream = client.chat.completions
     .stream({
       model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'Say this is a test' }],
+      messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     })
     .on('chunk', (chunk) => chunks.push(chunk))
     .on('content', (delta, snapshot) => contents.push([delta, snapshot]))
@@ -124,7 +124,7 @@ it(`aborting ChatCompletionStream works`, async function () {
     .stream(
       {
         model: 'gpt-4o-mini',
-        messages: [{ role: 'user', content: 'Say this is a test' }],
+        messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
       },
       { signal: controller.signal },
     )

--- a/ecosystem-tests/node-ts-cjs-auto/tests/test.ts
+++ b/ecosystem-tests/node-ts-cjs-auto/tests/test.ts
@@ -56,7 +56,7 @@ expect.extend({
 
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
     stream: true,
   });
@@ -78,7 +78,7 @@ it(`ChatCompletionStream works`, async function () {
 
   const stream = client.chat.completions
     .stream({
-      model: 'gpt-4',
+      model: 'gpt-4o-mini',
       messages: [{ role: 'user', content: 'Say this is a test' }],
     })
     .on('chunk', (chunk) => chunks.push(chunk))
@@ -123,7 +123,7 @@ it(`aborting ChatCompletionStream works`, async function () {
   const stream = client.chat.completions
     .stream(
       {
-        model: 'gpt-4',
+        model: 'gpt-4o-mini',
         messages: [{ role: 'user', content: 'Say this is a test' }],
       },
       { signal: controller.signal },

--- a/ecosystem-tests/node-ts-cjs-web/tests/test-jsdom.ts
+++ b/ecosystem-tests/node-ts-cjs-web/tests/test-jsdom.ts
@@ -57,7 +57,7 @@ expect.extend({
 
 test(`basic request works`, async function () {
   const completion = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
   });
   expect(completion.choices[0]?.message?.content).toBeSimilarTo('This is a test', 10);
@@ -67,7 +67,7 @@ test(`basic request works`, async function () {
 it.skip(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
-      model: 'gpt-4',
+      model: 'gpt-4o-mini',
       messages: [{ role: 'user', content: 'Say this is a test' }],
     })
     .asResponse();
@@ -100,7 +100,7 @@ it.skip(`raw response`, async function () {
 // response bodies aren't working with the chosen polyfills
 it.skip(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
     stream: true,
   });

--- a/ecosystem-tests/node-ts-cjs-web/tests/test-jsdom.ts
+++ b/ecosystem-tests/node-ts-cjs-web/tests/test-jsdom.ts
@@ -58,7 +58,7 @@ expect.extend({
 test(`basic request works`, async function () {
   const completion = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
   });
   expect(completion.choices[0]?.message?.content).toBeSimilarTo('This is a test', 10);
 });
@@ -68,7 +68,7 @@ it.skip(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
       model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'Say this is a test' }],
+      messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     })
     .asResponse();
 
@@ -101,7 +101,7 @@ it.skip(`raw response`, async function () {
 it.skip(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     stream: true,
   });
   const chunks = [];

--- a/ecosystem-tests/node-ts-cjs-web/tests/test-node.ts
+++ b/ecosystem-tests/node-ts-cjs-web/tests/test-node.ts
@@ -56,7 +56,7 @@ it(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
       model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'Say this is a test' }],
+      messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     })
     .asResponse();
 
@@ -88,7 +88,7 @@ it(`raw response`, async function () {
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     stream: true,
   });
   const chunks = [];

--- a/ecosystem-tests/node-ts-cjs-web/tests/test-node.ts
+++ b/ecosystem-tests/node-ts-cjs-web/tests/test-node.ts
@@ -55,7 +55,7 @@ expect.extend({
 it(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
-      model: 'gpt-4',
+      model: 'gpt-4o-mini',
       messages: [{ role: 'user', content: 'Say this is a test' }],
     })
     .asResponse();
@@ -87,7 +87,7 @@ it(`raw response`, async function () {
 
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
     stream: true,
   });

--- a/ecosystem-tests/node-ts-cjs/tests/test-jsdom.ts
+++ b/ecosystem-tests/node-ts-cjs/tests/test-jsdom.ts
@@ -60,7 +60,7 @@ expect.extend({
 test(`basic request works`, async function () {
   const completion = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
   });
   expect(completion.choices[0]?.message?.content).toBeSimilarTo('This is a test', 10);
 });
@@ -68,7 +68,7 @@ test(`basic request works`, async function () {
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     stream: true,
   });
   const chunks = [];

--- a/ecosystem-tests/node-ts-cjs/tests/test-jsdom.ts
+++ b/ecosystem-tests/node-ts-cjs/tests/test-jsdom.ts
@@ -59,7 +59,7 @@ expect.extend({
 
 test(`basic request works`, async function () {
   const completion = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
   });
   expect(completion.choices[0]?.message?.content).toBeSimilarTo('This is a test', 10);
@@ -67,7 +67,7 @@ test(`basic request works`, async function () {
 
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
     stream: true,
   });

--- a/ecosystem-tests/node-ts-cjs/tests/test-node.ts
+++ b/ecosystem-tests/node-ts-cjs/tests/test-node.ts
@@ -59,7 +59,7 @@ expect.extend({
 it(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
-      model: 'gpt-4',
+      model: 'gpt-4o-mini',
       messages: [{ role: 'user', content: 'Say this is a test' }],
     })
     .asResponse();
@@ -76,7 +76,7 @@ it(`raw response`, async function () {
 
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
     stream: true,
   });
@@ -96,7 +96,7 @@ test.skip(`proxied request`, async function () {
     },
   });
   const completion = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
   });
   expect(completion.choices[0]?.message?.content).toBeSimilarTo('This is a test', 10);

--- a/ecosystem-tests/node-ts-cjs/tests/test-node.ts
+++ b/ecosystem-tests/node-ts-cjs/tests/test-node.ts
@@ -60,7 +60,7 @@ it(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
       model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'Say this is a test' }],
+      messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     })
     .asResponse();
 
@@ -77,7 +77,7 @@ it(`raw response`, async function () {
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     stream: true,
   });
   const chunks = [];
@@ -97,7 +97,7 @@ test.skip(`proxied request`, async function () {
   });
   const completion = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
   });
   expect(completion.choices[0]?.message?.content).toBeSimilarTo('This is a test', 10);
 });

--- a/ecosystem-tests/node-ts-esm-auto/tests/test.ts
+++ b/ecosystem-tests/node-ts-esm-auto/tests/test.ts
@@ -58,7 +58,7 @@ expect.extend({
 it(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
-      model: 'gpt-4',
+      model: 'gpt-4o-mini',
       messages: [{ role: 'user', content: 'Say this is a test' }],
     })
     .asResponse();
@@ -75,7 +75,7 @@ it(`raw response`, async function () {
 
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
     stream: true,
   });

--- a/ecosystem-tests/node-ts-esm-auto/tests/test.ts
+++ b/ecosystem-tests/node-ts-esm-auto/tests/test.ts
@@ -59,7 +59,7 @@ it(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
       model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'Say this is a test' }],
+      messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     })
     .asResponse();
 
@@ -76,7 +76,7 @@ it(`raw response`, async function () {
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     stream: true,
   });
   const chunks = [];

--- a/ecosystem-tests/node-ts-esm-web/tests/test.ts
+++ b/ecosystem-tests/node-ts-esm-web/tests/test.ts
@@ -56,7 +56,7 @@ it(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
       model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'Say this is a test' }],
+      messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     })
     .asResponse();
 
@@ -88,7 +88,7 @@ it(`raw response`, async function () {
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     stream: true,
   });
   const chunks = [];

--- a/ecosystem-tests/node-ts-esm-web/tests/test.ts
+++ b/ecosystem-tests/node-ts-esm-web/tests/test.ts
@@ -55,7 +55,7 @@ expect.extend({
 it(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
-      model: 'gpt-4',
+      model: 'gpt-4o-mini',
       messages: [{ role: 'user', content: 'Say this is a test' }],
     })
     .asResponse();
@@ -87,7 +87,7 @@ it(`raw response`, async function () {
 
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
     stream: true,
   });

--- a/ecosystem-tests/node-ts-esm/tests/test-esnext.ts
+++ b/ecosystem-tests/node-ts-esm/tests/test-esnext.ts
@@ -46,7 +46,7 @@ expect.extend({
 it(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
-      model: 'gpt-4',
+      model: 'gpt-4o-mini',
       messages: [{ role: 'user', content: 'Say this is a test' }],
     })
     .asResponse();

--- a/ecosystem-tests/node-ts-esm/tests/test-esnext.ts
+++ b/ecosystem-tests/node-ts-esm/tests/test-esnext.ts
@@ -47,7 +47,7 @@ it(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
       model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'Say this is a test' }],
+      messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     })
     .asResponse();
 

--- a/ecosystem-tests/node-ts-esm/tests/test.ts
+++ b/ecosystem-tests/node-ts-esm/tests/test.ts
@@ -57,7 +57,7 @@ expect.extend({
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     stream: true,
   });
   const chunks = [];

--- a/ecosystem-tests/node-ts-esm/tests/test.ts
+++ b/ecosystem-tests/node-ts-esm/tests/test.ts
@@ -56,7 +56,7 @@ expect.extend({
 
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
     stream: true,
   });

--- a/ecosystem-tests/node-ts4.5-jest28/tests/test.ts
+++ b/ecosystem-tests/node-ts4.5-jest28/tests/test.ts
@@ -58,7 +58,7 @@ expect.extend({
 it(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
-      model: 'gpt-4',
+      model: 'gpt-4o-mini',
       messages: [{ role: 'user', content: 'Say this is a test' }],
     })
     .asResponse();
@@ -75,7 +75,7 @@ it(`raw response`, async function () {
 
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
     stream: true,
   });

--- a/ecosystem-tests/node-ts4.5-jest28/tests/test.ts
+++ b/ecosystem-tests/node-ts4.5-jest28/tests/test.ts
@@ -59,7 +59,7 @@ it(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
       model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'Say this is a test' }],
+      messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     })
     .asResponse();
 
@@ -76,7 +76,7 @@ it(`raw response`, async function () {
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     stream: true,
   });
   const chunks = [];

--- a/ecosystem-tests/ts-browser-webpack/src/index.ts
+++ b/ecosystem-tests/ts-browser-webpack/src/index.ts
@@ -109,7 +109,7 @@ it(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
       model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'Say this is a test' }],
+      messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     })
     .asResponse();
 
@@ -141,7 +141,7 @@ it(`raw response`, async function () {
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     stream: true,
   });
   const chunks = [];

--- a/ecosystem-tests/ts-browser-webpack/src/index.ts
+++ b/ecosystem-tests/ts-browser-webpack/src/index.ts
@@ -108,7 +108,7 @@ async function typeTests() {
 it(`raw response`, async function () {
   const response = await client.chat.completions
     .create({
-      model: 'gpt-4',
+      model: 'gpt-4o-mini',
       messages: [{ role: 'user', content: 'Say this is a test' }],
     })
     .asResponse();
@@ -140,7 +140,7 @@ it(`raw response`, async function () {
 
 it(`streaming works`, async function () {
   const stream = await client.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
     stream: true,
   });

--- a/ecosystem-tests/vercel-edge/src/pages/api/response.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/response.ts
@@ -15,7 +15,7 @@ export default async (request: NextRequest) => {
   const openai = new OpenAI();
 
   const result = await openai.completions.create({
-    prompt: 'Say this is a test',
+    prompt: 'Reply with exactly this text and nothing else: This is a test',
     model: 'gpt-3.5-turbo-instruct',
   });
   return NextResponse.json(result);

--- a/ecosystem-tests/vercel-edge/src/pages/api/streaming.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/streaming.ts
@@ -17,7 +17,7 @@ export default async (request: NextRequest) => {
   const text: string[] = [];
 
   const stream = await openai.completions.create({
-    prompt: 'Say this is a test',
+    prompt: 'Reply with exactly this text and nothing else: This is a test',
     model: 'gpt-3.5-turbo-instruct',
     stream: true,
   });

--- a/ecosystem-tests/vercel-edge/src/uploadWebApiTestCases.ts
+++ b/ecosystem-tests/vercel-edge/src/uploadWebApiTestCases.ts
@@ -52,7 +52,7 @@ export function uploadWebApiTestCases({
     it(`raw response`, async function () {
       const response = await client.chat.completions
         .create({
-          model: 'gpt-4',
+          model: 'gpt-4o-mini',
           messages: [{ role: 'user', content: 'Say this is a test' }],
         })
         .asResponse();
@@ -76,7 +76,7 @@ export function uploadWebApiTestCases({
     it(`raw response`, async function () {
       const response = await client.chat.completions
         .create({
-          model: 'gpt-4',
+          model: 'gpt-4o-mini',
           messages: [{ role: 'user', content: 'Say this is a test' }],
         })
         .asResponse();
@@ -109,7 +109,7 @@ export function uploadWebApiTestCases({
 
   it(`streaming works`, async function () {
     const stream = await client.chat.completions.create({
-      model: 'gpt-4',
+      model: 'gpt-4o-mini',
       messages: [{ role: 'user', content: 'Say this is a test' }],
       stream: true,
     });

--- a/ecosystem-tests/vercel-edge/src/uploadWebApiTestCases.ts
+++ b/ecosystem-tests/vercel-edge/src/uploadWebApiTestCases.ts
@@ -53,7 +53,7 @@ export function uploadWebApiTestCases({
       const response = await client.chat.completions
         .create({
           model: 'gpt-4o-mini',
-          messages: [{ role: 'user', content: 'Say this is a test' }],
+          messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
         })
         .asResponse();
 
@@ -77,7 +77,7 @@ export function uploadWebApiTestCases({
       const response = await client.chat.completions
         .create({
           model: 'gpt-4o-mini',
-          messages: [{ role: 'user', content: 'Say this is a test' }],
+          messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
         })
         .asResponse();
 
@@ -110,7 +110,7 @@ export function uploadWebApiTestCases({
   it(`streaming works`, async function () {
     const stream = await client.chat.completions.create({
       model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'Say this is a test' }],
+      messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
       stream: true,
     });
     const chunks = [];

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -8,14 +8,14 @@ const openai = new OpenAI();
 async function main() {
   // Non-streaming:
   const completion = await openai.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
   });
   console.log(completion.choices[0]?.message?.content);
 
   // Streaming:
   const stream = await openai.chat.completions.create({
-    model: 'gpt-4',
+    model: 'gpt-4o-mini',
     messages: [{ role: 'user', content: 'Say this is a test' }],
     stream: true,
   });

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -9,14 +9,14 @@ async function main() {
   // Non-streaming:
   const completion = await openai.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
   });
   console.log(completion.choices[0]?.message?.content);
 
   // Streaming:
   const stream = await openai.chat.completions.create({
     model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'Say this is a test' }],
+    messages: [{ role: 'user', content: 'Reply with exactly this text and nothing else: This is a test' }],
     stream: true,
   });
   for await (const part of stream) {


### PR DESCRIPTION
## Summary

- Add the `ci` GitHub Environment to the CI jobs that read `secrets.OPENAI_API_KEY`.
- Limit the environment change to the `examples` and `ecosystem_tests` jobs, which are the workflow jobs currently using that secret.
- Update live example/ecosystem chat-completions smoke tests from legacy `gpt-4` to `gpt-4o-mini`, because the CI-scoped API key resolves but does not have access to `gpt-4`.
- Tighten live smoke-test prompts to request the exact expected phrase, avoiding flaky failures from extra conversational text.

## Why

`OPENAI_API_KEY` is now environment-scoped for CI, so jobs that consume it must explicitly run in the `ci` environment. Once the secret was available, the examples job reached the API and failed on model access for `gpt-4`; the live smoke tests now use a broadly available small model while preserving the test intent. Follow-up ecosystem failures showed the new chat model returned valid responses with extra assistant text, so the prompt now asks for the exact expected phrase.

## Validation

- Parsed `.github/workflows/ci.yml` with Ruby YAML loader.
- Ran `git diff --check`.
- Ran Prettier via `npx prettier --write` on the non-ignored touched example file; ecosystem test fixtures are intentionally ignored by repo Prettier config.
- Monitored PR CI and inspected failed logs; confirmed `OPENAI_API_KEY` was injected, fixed `model_not_found` for `gpt-4`, then tightened prompts after valid `gpt-4o-mini` responses contained extra text.