### PR TITLE
fix: type structured MCP call errors

### DIFF
--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -71,6 +71,28 @@ export interface ParsedResponse<ParsedT> extends Response {
   output_parsed: ParsedT | null;
 }
 
+/**
+ * Structured error returned by an MCP tool call.
+ */
+export interface ResponseMcpCallError {
+  /**
+   * The error type returned by the MCP server or transport layer.
+   */
+  type: 'mcp_protocol_error' | 'protocol_error' | 'tool_execution_error' | 'http_error' | (string & {});
+
+  /**
+   * The error message.
+   */
+  message: string;
+
+  /**
+   * Protocol or HTTP status code, when provided.
+   */
+  code?: number;
+
+  [key: string]: unknown;
+}
+
 export type ResponseParseParams = ResponseCreateParamsNonStreaming;
 
 export class Responses extends APIResource {
@@ -4878,7 +4900,7 @@ export namespace ResponseInputItem {
     /**
      * The error from the tool call, if any.
      */
-    error?: string | null;
+    error?: string | ResponseMcpCallError | null;
 
     /**
      * The output from the tool call.
@@ -5463,7 +5485,7 @@ export namespace ResponseItem {
     /**
      * The error from the tool call, if any.
      */
-    error?: string | null;
+    error?: string | ResponseMcpCallError | null;
 
     /**
      * The output from the tool call.
@@ -5987,7 +6009,7 @@ export namespace ResponseOutputItem {
     /**
      * The error from the tool call, if any.
      */
-    error?: string | null;
+    error?: string | ResponseMcpCallError | null;
 
     /**
      * The output from the tool call.
@@ -9359,6 +9381,7 @@ export declare namespace Responses {
     type ResponseInputTextContent as ResponseInputTextContent,
     type ResponseItem as ResponseItem,
     type ResponseLocalEnvironment as ResponseLocalEnvironment,
+    type ResponseMcpCallError as ResponseMcpCallError,
     type ResponseMcpCallArgumentsDeltaEvent as ResponseMcpCallArgumentsDeltaEvent,
     type ResponseMcpCallArgumentsDoneEvent as ResponseMcpCallArgumentsDoneEvent,
     type ResponseMcpCallCompletedEvent as ResponseMcpCallCompletedEvent,

--- a/tests/responsesItems.test.ts
+++ b/tests/responsesItems.test.ts
@@ -17,6 +17,25 @@ describe('responses item types', () => {
   test('response output items are compatible with input items', async () => {
     expect(true).toBe(true);
   });
+
+  test('mcp_call output items accept structured errors', () => {
+    const item: OpenAI.Responses.ResponseOutputItem.McpCall = {
+      id: 'mcp_abc',
+      type: 'mcp_call',
+      approval_request_id: null,
+      arguments: '{"query":"latest tech gadgets"}',
+      error: {
+        type: 'mcp_protocol_error',
+        code: 32600,
+        message: 'Session terminated',
+      },
+      name: 'search',
+      output: null,
+      server_label: 'my-mcp-server',
+    };
+
+    expect(item.error).toMatchObject({ message: 'Session terminated' });
+  });
 });
 
 const unused = async () => {


### PR DESCRIPTION
Fixes #1568.

Summary:
- add a Responses-specific `ResponseMcpCallError` object type for MCP tool failures
- allow `mcp_call.error` to be either the existing string value or a structured error object
- add a regression for the reported `mcp_protocol_error` payload

Verification:
- `jest tests/responsesItems.test.ts --runInBand`
- `prettier --check src/resources/responses/responses.ts tests/responsesItems.test.ts`
- `eslint src/resources/responses/responses.ts tests/responsesItems.test.ts`
- `tsc --noEmit --pretty false`
- `git diff --check`