### PR TITLE
fix: locale-sensitive header normalization

### DIFF
--- a/src/internal/headers.ts
+++ b/src/internal/headers.ts
@@ -12,6 +12,7 @@ export type HeadersLike =
   | NullableHeaders;
 
 const brand_privateNullableHeaders = /* @__PURE__ */ Symbol('brand.privateNullableHeaders');
+const httpTokenHeaderName = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 
 /**
  * @internal
@@ -74,16 +75,19 @@ export const buildHeaders = (newHeaders: HeadersLike[]): NullableHeaders => {
   for (const headers of newHeaders) {
     const seenHeaders = new Set<string>();
     for (const [name, value] of iterateHeaders(headers)) {
+      if (!httpTokenHeaderName.test(name)) {
+        throw new TypeError(`Header name must be a valid HTTP token ["${name}"]`);
+      }
       const lowerName = name.toLowerCase();
       if (!seenHeaders.has(lowerName)) {
-        targetHeaders.delete(name);
+        targetHeaders.delete(lowerName);
         seenHeaders.add(lowerName);
       }
       if (value === null) {
-        targetHeaders.delete(name);
+        targetHeaders.delete(lowerName);
         nullHeaders.add(lowerName);
       } else {
-        targetHeaders.append(name, value);
+        targetHeaders.append(lowerName, value);
         nullHeaders.delete(lowerName);
       }
     }

--- a/tests/buildHeaders.test.ts
+++ b/tests/buildHeaders.test.ts
@@ -85,4 +85,76 @@ describe('buildHeaders', () => {
       expect(inspectNullableHeaders(buildHeaders(input))).toEqual(expected);
     });
   }
+
+  test('normalizes OpenAI headers with locale-invariant ASCII casing', () => {
+    expect('OpenAI-Organization'.toLocaleLowerCase('tr-TR')).toBe('openaı-organization');
+    expect('OpenAI-Project'.toLocaleLowerCase('tr-TR')).toBe('openaı-project');
+
+    const result = buildHeaders([
+      {
+        'OpenAI-Organization': 'org_test',
+        'OpenAI-Project': 'proj_test',
+      },
+    ]);
+
+    const keys = [...result.values.keys()];
+    expect(keys).toEqual(['openai-organization', 'openai-project']);
+    expect(keys.every((key) => /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(key))).toBe(true);
+  });
+
+  test('rejects header names that lowercase into valid ASCII tokens', () => {
+    expect('cooKie'.toLowerCase()).toBe('cookie');
+    expect(() => buildHeaders([{ cooKie: 'value' }])).toThrow(
+      'Header name must be a valid HTTP token ["cooKie"]',
+    );
+  });
+
+  test('passes normalized OpenAI header names to Headers implementations', () => {
+    const OriginalHeaders = globalThis.Headers;
+
+    class LocaleSensitiveHeaders {
+      #values = new Map<string, string>();
+
+      append(name: string, value: string) {
+        this.#values.set(normalizeHeaderName(name), value);
+      }
+
+      delete(name: string) {
+        this.#values.delete(normalizeHeaderName(name));
+      }
+
+      entries() {
+        return this.#values.entries();
+      }
+
+      keys() {
+        return this.#values.keys();
+      }
+    }
+
+    const normalizeHeaderName = (name: string) => {
+      const normalized = name.toLocaleLowerCase('tr-TR');
+      if (!/^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(normalized)) {
+        throw new TypeError(`Header name must be a valid HTTP token ["${normalized}"]`);
+      }
+      return normalized;
+    };
+
+    globalThis.Headers = LocaleSensitiveHeaders as unknown as typeof Headers;
+    try {
+      const result = buildHeaders([
+        {
+          'OpenAI-Organization': 'org_test',
+          'OpenAI-Project': 'proj_test',
+        },
+      ]);
+
+      expect([...result.values.entries()]).toEqual([
+        ['openai-organization', 'org_test'],
+        ['openai-project', 'proj_test'],
+      ]);
+    } finally {
+      globalThis.Headers = OriginalHeaders;
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #1928.

This updates `buildHeaders` to normalize header names to lowercase ASCII before passing them into `Headers.delete()` and `Headers.append()`.

## Root cause

The original issue reports `OpenAI-Organization` and `OpenAI-Project` becoming invalid header names like `openaı-organization` under a Turkish locale. Plain JavaScript `String.prototype.toLowerCase()` is not locale-sensitive in Node, so changing only the internal comparison key is not enough. The issue workaround points at the real failure mode: a bundled/runtime `Headers` implementation may normalize the mixed-case header name with Turkish locale rules when we call `delete()` or `append()` with the original name.

By handing `Headers` the SDK's already-normalized ASCII header name, we avoid depending on the runtime's header-name casing behavior.

## Validation

- `pnpm exec jest tests/buildHeaders.test.ts --runInBand`
- `env LANG=tr_TR.UTF-8 LC_ALL=tr_TR.UTF-8 pnpm exec jest tests/buildHeaders.test.ts --runInBand`
- `pnpm exec jest tests/index.test.ts tests/lib/azure.test.ts tests/log.test.ts tests/lib/workload-identity.test.ts tests/lib/bedrock.test.ts tests/api-resources/webhooks.test.ts --runInBand`
- `pnpm exec jest tests/buildHeaders.test.ts tests/api-resources/chat/completions/completions.test.ts --runInBand`
- `pnpm exec jest tests/api-resources/beta/threads/threads.test.ts tests/api-resources/videos.test.ts --runInBand`
- `pnpm exec prettier --check src/internal/headers.ts tests/buildHeaders.test.ts`
- `pnpm exec eslint src/internal/headers.ts tests/buildHeaders.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm build`