### PR TITLE
fix: handle missing tool_call.id in runTools for providers

### DIFF
--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -341,8 +341,9 @@ export class AbstractChatCompletionRunner<
 
       for (const tool_call of message.tool_calls) {
         if (tool_call.type !== 'function') continue;
-        const tool_call_id = tool_call.id;
         const { name, arguments: args } = tool_call.function;
+        // Some LLM providers may not populate tool_call.id; use function name as fallback
+        const tool_call_id = tool_call.id || name;
         const fn = functionsByName[name];
 
         if (!fn) {


### PR DESCRIPTION
Some providers do not populate the `tool_call.id` field when returning tool calls, or may set it to an empty string. When the SDK's `AbstractChatCompletionRunner._runTools()` method constructs tool result messages to send back to the API, it uses this empty or missing `tool_call_id`, which causes the API to reject the request with a 400 status code.

This fix adds a defensive fallback in `AbstractChatCompletionRunner.ts` at line 346. When `tool_call.id` is missing or empty, the function name is used as the `tool_call_id` instead. This ensures that tool result messages always have a valid identifier, preventing the 400 error while maintaining compatibility with all providers.

Fixes #1528