### PR TITLE
Run tool calls in parallel safely

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -314,6 +314,10 @@ If you pass a `parse` function, it will automatically parse the `arguments` for 
 and returns any parsing errors to the model to attempt auto-recovery.
 Otherwise, the args will be passed to the function you provide as a string.
 
+When a completion requests multiple tool calls, `runTools` executes them concurrently by default and
+sends their results back in the same order as the tool calls. Set `parallel_tool_calls: false` to request
+one tool call at a time and execute any returned group sequentially.
+
 If you pass `tool_choice: {function: {name: …}}` instead of `auto`,
 it returns immediately after calling that function (and only loops to auto-recover parsing errors).
 

--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -356,8 +356,8 @@ export class AbstractChatCompletionRunner<
         return;
       }
 
-      for (const tool_call of message.tool_calls) {
-        if (tool_call.type !== 'function') continue;
+      await Promise.all(message.tool_calls.map(async (tool_call) => {
+        if (tool_call.type !== 'function') return;
         const tool_call_id = tool_call.id;
         const { name, arguments: args } = tool_call.function;
         const fn = functionsByName[name];
@@ -370,14 +370,14 @@ export class AbstractChatCompletionRunner<
             .join(', ')}. Please try again`;
 
           this._addMessage({ role, tool_call_id, content });
-          continue;
+          return;
         } else if (singleFunctionToCall && singleFunctionToCall !== name) {
           const content = `Invalid tool_call: ${JSON.stringify(name)}. ${JSON.stringify(
             singleFunctionToCall,
           )} requested. Please try again`;
 
           this._addMessage({ role, tool_call_id, content });
-          continue;
+          return;
         }
 
         let parsed;
@@ -386,7 +386,7 @@ export class AbstractChatCompletionRunner<
         } catch (error) {
           const content = error instanceof Error ? error.message : String(error);
           this._addMessage({ role, tool_call_id, content });
-          continue;
+          return;
         }
 
         // @ts-expect-error it can't rule out `never` type.
@@ -398,7 +398,7 @@ export class AbstractChatCompletionRunner<
           await afterCompletion?.(chatCompletion, this);
           return;
         }
-      }
+      });
 
       await afterCompletion?.(chatCompletion, this);
     }

--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -14,8 +14,11 @@ import type {
   ParsedChatCompletion,
 } from '../resources/chat/completions';
 import type { CompletionUsage } from '../resources/completions';
-import type { ChatCompletionToolRunnerParams } from './ChatCompletionRunner';
-import type { ChatCompletionStreamingToolRunnerParams } from './ChatCompletionStreamingRunner';
+import type { ChatCompletionRunner, ChatCompletionToolRunnerParams } from './ChatCompletionRunner';
+import type {
+  ChatCompletionStreamingRunner,
+  ChatCompletionStreamingToolRunnerParams,
+} from './ChatCompletionStreamingRunner';
 import { isAssistantMessage, isToolMessage } from './chatCompletionUtils';
 import { BaseEvents, EventStream } from './EventStream';
 import {
@@ -276,6 +279,7 @@ export class AbstractChatCompletionRunner<
     params:
       | ChatCompletionToolRunnerParams<FunctionsArgs>
       | ChatCompletionStreamingToolRunnerParams<FunctionsArgs>,
+    runner: ChatCompletionRunner<any> | ChatCompletionStreamingRunner<any>,
     options?: RunnerOptions,
   ) {
     const role = 'tool' as const;
@@ -365,16 +369,20 @@ export class AbstractChatCompletionRunner<
         return { message: { role, tool_call_id, content }, functionCalled: false };
       }
 
-      let parsed;
-      try {
-        parsed = isRunnableFunctionWithParse(fn) ? await fn.parse(args) : args;
-      } catch (error) {
-        const content = error instanceof Error ? error.message : String(error);
-        return { message: { role, tool_call_id, content }, functionCalled: false };
+      let rawContent: unknown;
+      if (isRunnableFunctionWithParse(fn)) {
+        let parsed;
+        try {
+          parsed = await fn.parse(args);
+        } catch (error) {
+          const content = error instanceof Error ? error.message : String(error);
+          return { message: { role, tool_call_id, content }, functionCalled: false };
+        }
+        rawContent = await fn.function(parsed, runner);
+      } else {
+        rawContent = await fn.function(args, runner);
       }
 
-      // @ts-expect-error it can't rule out `never` type.
-      const rawContent = await fn.function(parsed, this);
       const content = this.#stringifyFunctionCallResult(rawContent);
       return { message: { role, tool_call_id, content }, functionCalled: true };
     };
@@ -395,7 +403,7 @@ export class AbstractChatCompletionRunner<
         throw new OpenAIError(`missing message in ChatCompletion response`);
       }
       if (!message.tool_calls?.length) {
-        await afterCompletion?.(chatCompletion, this);
+        await afterCompletion?.(chatCompletion, runner);
         return;
       }
 
@@ -405,7 +413,7 @@ export class AbstractChatCompletionRunner<
           if (result.message) this._addMessage(result.message);
 
           if (singleFunctionToCall && result.functionCalled) {
-            await afterCompletion?.(chatCompletion, this);
+            await afterCompletion?.(chatCompletion, runner);
             return;
           }
         }
@@ -427,7 +435,7 @@ export class AbstractChatCompletionRunner<
         }
       }
 
-      await afterCompletion?.(chatCompletion, this);
+      await afterCompletion?.(chatCompletion, runner);
     }
 
     return;

--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -8,7 +8,9 @@ import type {
   ChatCompletionMessage,
   ChatCompletionMessageFunctionToolCall,
   ChatCompletionMessageParam,
+  ChatCompletionMessageToolCall,
   ChatCompletionTool,
+  ChatCompletionToolMessageParam,
   ParsedChatCompletion,
 } from '../resources/chat/completions';
 import type { CompletionUsage } from '../resources/completions';
@@ -39,10 +41,7 @@ export interface RunnerOptions extends RequestOptions {
    * request starts or before the runner ends. The runner's mutable `messages`
    * array can be used to add context for the next request.
    */
-  afterCompletion?: (
-    completion: ChatCompletion,
-    runner: ChatCompletionRunnerContext,
-  ) => void | Promise<void>;
+  afterCompletion?: (completion: ChatCompletion, runner: ChatCompletionRunnerContext) => void | Promise<void>;
 }
 
 export class AbstractChatCompletionRunner<
@@ -336,6 +335,50 @@ export class AbstractChatCompletionRunner<
       this._addMessage(message, false);
     }
 
+    type ToolCallResult = {
+      message: ChatCompletionToolMessageParam | undefined;
+      functionCalled: boolean;
+    };
+
+    const runToolCall = async (toolCall: ChatCompletionMessageToolCall): Promise<ToolCallResult> => {
+      if (toolCall.type !== 'function') return { message: undefined, functionCalled: false };
+
+      const tool_call_id = toolCall.id;
+      const { name, arguments: args } = toolCall.function;
+      const fn = functionsByName[name];
+
+      if (!fn) {
+        const content = `Invalid tool_call: ${JSON.stringify(name)}. Available options are: ${Object.keys(
+          functionsByName,
+        )
+          .map((name) => JSON.stringify(name))
+          .join(', ')}. Please try again`;
+
+        return { message: { role, tool_call_id, content }, functionCalled: false };
+      }
+
+      if (singleFunctionToCall && singleFunctionToCall !== name) {
+        const content = `Invalid tool_call: ${JSON.stringify(name)}. ${JSON.stringify(
+          singleFunctionToCall,
+        )} requested. Please try again`;
+
+        return { message: { role, tool_call_id, content }, functionCalled: false };
+      }
+
+      let parsed;
+      try {
+        parsed = isRunnableFunctionWithParse(fn) ? await fn.parse(args) : args;
+      } catch (error) {
+        const content = error instanceof Error ? error.message : String(error);
+        return { message: { role, tool_call_id, content }, functionCalled: false };
+      }
+
+      // @ts-expect-error it can't rule out `never` type.
+      const rawContent = await fn.function(parsed, this);
+      const content = this.#stringifyFunctionCallResult(rawContent);
+      return { message: { role, tool_call_id, content }, functionCalled: true };
+    };
+
     for (let i = 0; i < maxChatCompletions; ++i) {
       const chatCompletion: ChatCompletion = await this._createChatCompletion(
         client,
@@ -356,49 +399,33 @@ export class AbstractChatCompletionRunner<
         return;
       }
 
-      await Promise.all(message.tool_calls.map(async (tool_call) => {
-        if (tool_call.type !== 'function') return;
-        const tool_call_id = tool_call.id;
-        const { name, arguments: args } = tool_call.function;
-        const fn = functionsByName[name];
+      if (singleFunctionToCall || params.parallel_tool_calls === false) {
+        for (const toolCall of message.tool_calls) {
+          const result = await runToolCall(toolCall);
+          if (result.message) this._addMessage(result.message);
 
-        if (!fn) {
-          const content = `Invalid tool_call: ${JSON.stringify(name)}. Available options are: ${Object.keys(
-            functionsByName,
-          )
-            .map((name) => JSON.stringify(name))
-            .join(', ')}. Please try again`;
+          if (singleFunctionToCall && result.functionCalled) {
+            await afterCompletion?.(chatCompletion, this);
+            return;
+          }
+        }
+      } else {
+        const results = await Promise.allSettled(message.tool_calls.map(runToolCall));
 
-          this._addMessage({ role, tool_call_id, content });
-          return;
-        } else if (singleFunctionToCall && singleFunctionToCall !== name) {
-          const content = `Invalid tool_call: ${JSON.stringify(name)}. ${JSON.stringify(
-            singleFunctionToCall,
-          )} requested. Please try again`;
-
-          this._addMessage({ role, tool_call_id, content });
-          return;
+        // Wait for every concurrently running tool to settle before surfacing an
+        // error so tool side effects cannot continue after the runner has ended.
+        for (const result of results) {
+          if (result.status === 'rejected') throw result.reason;
         }
 
-        let parsed;
-        try {
-          parsed = isRunnableFunctionWithParse(fn) ? await fn.parse(args) : args;
-        } catch (error) {
-          const content = error instanceof Error ? error.message : String(error);
-          this._addMessage({ role, tool_call_id, content });
-          return;
+        // Promise.allSettled preserves input order, so the next request receives
+        // tool result messages in the same order as the assistant's tool calls.
+        for (const result of results) {
+          if (result.status === 'fulfilled' && result.value.message) {
+            this._addMessage(result.value.message);
+          }
         }
-
-        // @ts-expect-error it can't rule out `never` type.
-        const rawContent = await fn.function(parsed, this);
-        const content = this.#stringifyFunctionCallResult(rawContent);
-        this._addMessage({ role, tool_call_id, content });
-
-        if (singleFunctionToCall) {
-          await afterCompletion?.(chatCompletion, this);
-          return;
-        }
-      });
+      }
 
       await afterCompletion?.(chatCompletion, this);
     }

--- a/src/lib/ChatCompletionRunner.ts
+++ b/src/lib/ChatCompletionRunner.ts
@@ -37,7 +37,7 @@ export class ChatCompletionRunner<ParsedT = null> extends AbstractChatCompletion
       ...options,
       headers: { ...options?.headers, 'X-Stainless-Helper-Method': 'runTools' },
     };
-    runner._run(() => runner._runTools(client, params, opts));
+    runner._run(() => runner._runTools(client, params, runner, opts));
     return runner;
   }
 

--- a/src/lib/ChatCompletionStreamingRunner.ts
+++ b/src/lib/ChatCompletionStreamingRunner.ts
@@ -44,7 +44,7 @@ export class ChatCompletionStreamingRunner<ParsedT = null>
       ...options,
       headers: { ...options?.headers, 'X-Stainless-Helper-Method': 'runTools' },
     };
-    runner._run(() => runner._runTools(client, params, opts));
+    runner._run(() => runner._runTools(client, params, runner, opts));
     return runner;
   }
 }

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -220,7 +220,7 @@ class RunnerListener {
     );
     expect(await this.runner.finalFunctionToolCallResult()).toEqual(this.finalFunctionCallResult);
     expect(this.chatCompletions).toEqual(this.runner.allChatCompletions());
-    expect(this.messages).toEqual(this.runner.messages.slice(-this.messages.length));
+    expect(this.messages).toEqual(this.runner.messages.filter((message) => this.messages.includes(message)));
     if (this.chatCompletions.some((c) => c.usage)) {
       const totalUsage: OpenAI.CompletionUsage = {
         completion_tokens: 0,
@@ -324,7 +324,9 @@ class StreamingRunnerListener {
     );
     expect(await this.runner.finalFunctionToolCallResult()).toEqual(this.finalFunctionCallResult);
     expect(this.eventChatCompletions).toEqual(this.runner.allChatCompletions());
-    expect(this.eventMessages).toEqual(this.runner.messages.slice(-this.eventMessages.length));
+    expect(this.eventMessages).toEqual(
+      this.runner.messages.filter((message) => this.eventMessages.includes(message)),
+    );
     if (error) {
       expect(this.error?.message).toEqual(error);
       expect(this.runner.errored).toBe(true);
@@ -647,6 +649,116 @@ describe('resource completions', () => {
       ]);
       expect(listener.functionCallResults).toEqual([`it's raining`]);
       await listener.sanityCheck();
+    });
+    test('runs tool calls concurrently and preserves their result order', async () => {
+      const { fetch, handleRequest } = mockChatCompletionFetch();
+
+      const openai = new OpenAI({ apiKey: 'something1234', baseURL: 'http://127.0.0.1:4010', fetch });
+      const started: string[] = [];
+      let markFirstStarted!: () => void;
+      let resolveFirst!: (value: string) => void;
+      let resolveSecond!: (value: string) => void;
+      const firstStarted = new Promise<void>((resolve) => (markFirstStarted = resolve));
+      const firstResult = new Promise<string>((resolve) => (resolveFirst = resolve));
+      const secondResult = new Promise<string>((resolve) => (resolveSecond = resolve));
+
+      const runner = openai.chat.completions.runTools({
+        messages: [{ role: 'user', content: 'run both tools' }],
+        model: 'gpt-3.5-turbo',
+        tools: [
+          {
+            type: 'function',
+            function: {
+              function: function firstTool() {
+                started.push('firstTool');
+                markFirstStarted();
+                return firstResult;
+              },
+              parameters: {},
+              description: 'returns the first result',
+            },
+          },
+          {
+            type: 'function',
+            function: {
+              function: function secondTool() {
+                started.push('secondTool');
+                return secondResult;
+              },
+              parameters: {},
+              description: 'returns the second result',
+            },
+          },
+        ],
+      });
+
+      await handleRequest(async (request) => {
+        expect(request.messages).toEqual([{ role: 'user', content: 'run both tools' }]);
+        return {
+          id: '1',
+          choices: [
+            {
+              index: 0,
+              finish_reason: 'tool_calls',
+              logprobs: null,
+              message: {
+                role: 'assistant',
+                content: null,
+                refusal: null,
+                parsed: null,
+                tool_calls: [
+                  {
+                    type: 'function',
+                    id: 'first-call',
+                    function: { arguments: '', name: 'firstTool' },
+                  },
+                  {
+                    type: 'function',
+                    id: 'second-call',
+                    function: { arguments: '', name: 'secondTool' },
+                  },
+                ],
+              },
+            },
+          ],
+          created: Math.floor(Date.now() / 1000),
+          model: 'gpt-3.5-turbo',
+          object: 'chat.completion',
+        };
+      });
+
+      await firstStarted;
+      const startedBeforeFirstResolved = [...started];
+
+      const finalRequest = handleRequest(async (request) => {
+        expect(request.messages.slice(-2)).toEqual([
+          { role: 'tool', content: 'first result', tool_call_id: 'first-call' },
+          { role: 'tool', content: 'second result', tool_call_id: 'second-call' },
+        ]);
+        return {
+          id: '2',
+          choices: [
+            {
+              index: 0,
+              finish_reason: 'stop',
+              logprobs: null,
+              message: { role: 'assistant', content: 'done', refusal: null },
+            },
+          ],
+          created: Math.floor(Date.now() / 1000),
+          model: 'gpt-3.5-turbo',
+          object: 'chat.completion',
+        };
+      });
+
+      // Finish the second tool first to ensure completion timing cannot reorder
+      // the tool messages supplied to the next request.
+      resolveSecond('second result');
+      await Promise.resolve();
+      resolveFirst('first result');
+
+      await Promise.all([finalRequest, runner.done()]);
+      expect(startedBeforeFirstResolved).toEqual(['firstTool', 'secondTool']);
     });
     test('flow with abort', async () => {
       const { fetch, handleRequest } = mockChatCompletionFetch();

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -165,7 +165,13 @@ class RunnerListener {
       .once('message', () => this.onceMessageCallCount++);
   }
 
-  async sanityCheck({ error }: { error?: string } = {}) {
+  async sanityCheck({
+    error,
+    ignoredMessages = new Set(),
+  }: {
+    error?: string;
+    ignoredMessages?: ReadonlySet<ChatCompletionMessageParam>;
+  } = {}) {
     expect(this.onceMessageCallCount).toBeLessThanOrEqual(1);
     expect(this.gotAbort).toEqual(this.runner.aborted);
     if (this.runner.aborted) expect(this.runner.errored).toBe(true);
@@ -220,7 +226,8 @@ class RunnerListener {
     );
     expect(await this.runner.finalFunctionToolCallResult()).toEqual(this.finalFunctionCallResult);
     expect(this.chatCompletions).toEqual(this.runner.allChatCompletions());
-    expect(this.messages).toEqual(this.runner.messages.filter((message) => this.messages.includes(message)));
+    const runnerMessages = this.runner.messages.filter((message) => !ignoredMessages.has(message));
+    expect(this.messages).toEqual(runnerMessages.slice(-this.messages.length));
     if (this.chatCompletions.some((c) => c.usage)) {
       const totalUsage: OpenAI.CompletionUsage = {
         completion_tokens: 0,
@@ -278,7 +285,13 @@ class StreamingRunnerListener {
       .on('end', () => (this.gotEnd = true));
   }
 
-  async sanityCheck({ error }: { error?: string } = {}) {
+  async sanityCheck({
+    error,
+    ignoredMessages = new Set(),
+  }: {
+    error?: string;
+    ignoredMessages?: ReadonlySet<ChatCompletionMessageParam>;
+  } = {}) {
     if (error) {
       expect(this.error?.message).toEqual(error);
       expect(this.runner.errored).toBe(true);
@@ -324,9 +337,8 @@ class StreamingRunnerListener {
     );
     expect(await this.runner.finalFunctionToolCallResult()).toEqual(this.finalFunctionCallResult);
     expect(this.eventChatCompletions).toEqual(this.runner.allChatCompletions());
-    expect(this.eventMessages).toEqual(
-      this.runner.messages.filter((message) => this.eventMessages.includes(message)),
-    );
+    const runnerMessages = this.runner.messages.filter((message) => !ignoredMessages.has(message));
+    expect(this.eventMessages).toEqual(runnerMessages.slice(-this.eventMessages.length));
     if (error) {
       expect(this.error?.message).toEqual(error);
       expect(this.runner.errored).toBe(true);
@@ -648,7 +660,7 @@ describe('resource completions', () => {
         },
       ]);
       expect(listener.functionCallResults).toEqual([`it's raining`]);
-      await listener.sanityCheck();
+      await listener.sanityCheck({ ignoredMessages: new Set([injectedMessage]) });
     });
     test('runs tool calls concurrently and preserves their result order', async () => {
       const { fetch, handleRequest } = mockChatCompletionFetch();
@@ -759,6 +771,102 @@ describe('resource completions', () => {
 
       await Promise.all([finalRequest, runner.done()]);
       expect(startedBeforeFirstResolved).toEqual(['firstTool', 'secondTool']);
+    });
+    test('runs tool calls sequentially when parallel_tool_calls is false', async () => {
+      const { fetch, handleRequest } = mockChatCompletionFetch();
+
+      const openai = new OpenAI({ apiKey: 'something1234', baseURL: 'http://127.0.0.1:4010', fetch });
+      const started: string[] = [];
+      let markFirstStarted!: () => void;
+      let markSecondStarted!: () => void;
+      let resolveFirst!: (value: string) => void;
+      let resolveSecond!: (value: string) => void;
+      const firstStarted = new Promise<void>((resolve) => (markFirstStarted = resolve));
+      const secondStarted = new Promise<void>((resolve) => (markSecondStarted = resolve));
+      const firstResult = new Promise<string>((resolve) => (resolveFirst = resolve));
+      const secondResult = new Promise<string>((resolve) => (resolveSecond = resolve));
+
+      const runner = openai.chat.completions.runTools(
+        {
+          messages: [{ role: 'user', content: 'run both tools' }],
+          model: 'gpt-3.5-turbo',
+          parallel_tool_calls: false,
+          tools: [
+            {
+              type: 'function',
+              function: {
+                function: function firstTool() {
+                  started.push('firstTool');
+                  markFirstStarted();
+                  return firstResult;
+                },
+                parameters: {},
+                description: 'returns the first result',
+              },
+            },
+            {
+              type: 'function',
+              function: {
+                function: function secondTool() {
+                  started.push('secondTool');
+                  markSecondStarted();
+                  return secondResult;
+                },
+                parameters: {},
+                description: 'returns the second result',
+              },
+            },
+          ],
+        },
+        { maxChatCompletions: 1 },
+      );
+
+      await handleRequest(async (request) => {
+        expect(request.parallel_tool_calls).toBe(false);
+        return {
+          id: '1',
+          choices: [
+            {
+              index: 0,
+              finish_reason: 'tool_calls',
+              logprobs: null,
+              message: {
+                role: 'assistant',
+                content: null,
+                refusal: null,
+                parsed: null,
+                tool_calls: [
+                  {
+                    type: 'function',
+                    id: 'first-call',
+                    function: { arguments: '', name: 'firstTool' },
+                  },
+                  {
+                    type: 'function',
+                    id: 'second-call',
+                    function: { arguments: '', name: 'secondTool' },
+                  },
+                ],
+              },
+            },
+          ],
+          created: Math.floor(Date.now() / 1000),
+          model: 'gpt-3.5-turbo',
+          object: 'chat.completion',
+        };
+      });
+
+      await firstStarted;
+      const startedBeforeFirstResolved = [...started];
+      resolveFirst('first result');
+
+      await secondStarted;
+      const startedAfterFirstResolved = [...started];
+      resolveSecond('second result');
+
+      await runner.done();
+      expect(startedBeforeFirstResolved).toEqual(['firstTool']);
+      expect(startedAfterFirstResolved).toEqual(['firstTool', 'secondTool']);
     });
     test('flow with abort', async () => {
       const { fetch, handleRequest } = mockChatCompletionFetch();
@@ -1717,7 +1825,7 @@ describe('resource completions', () => {
         },
       ]);
       expect(listener.eventFunctionCallResults).toEqual([`it's raining`]);
-      await listener.sanityCheck();
+      await listener.sanityCheck({ ignoredMessages: new Set([injectedMessage]) });
     });
     test('flow with abort', async () => {
       const { fetch, handleRequest } = mockStreamingChatCompletionFetch();


### PR DESCRIPTION
## Summary

- preserve @jmoseley's original contribution and commit authorship from #1132
- run groups of function tool calls concurrently while preserving tool result order
- retain sequential execution when `parallel_tool_calls` is `false` or a single function is forced
- wait for all concurrent calls to settle before surfacing an error, preventing background side effects after the runner ends
- document the behavior and add a focused concurrency/order regression test

## History

#1132 was first merged into this integration branch, then current `main` was merged in and the review findings were fixed here. The branch therefore keeps Jeremy's original commit as a distinct authored commit instead of replacing it with a clean-room implementation.

## Validation

- `./scripts/test tests/lib/ChatCompletionRunFunctions.test.ts --runInBand` (17 tests)
- Prettier check on changed files
- ESLint on changed TypeScript files
- `tsc --noEmit`

Closes #1131