### PR TITLE
[codex] Add runnable image generation and editing example

### DIFF
--- a/examples/picture.ts
+++ b/examples/picture.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env -S npm run tsn -T
+import OpenAI from 'openai';
+
+// gets API Key from environment variable OPENAI_API_KEY
+const openai = new OpenAI();
+
+async function main() {
+  // Generate an image based on the prompt
+  const response = await openai.images.generate({
+    model: 'dall-e-3',
+    prompt: 'An astronaut lounging in a tropical resort in space, pixel art',
+  });
+  console.log(response); // Log the response to the console, a URL link to image will be in the response.data[0].url
+  if (response.data && response.data[0] && response.data[0].url) {
+    console.log('Image URL:', response.data[0].url); // Log the image URL
+  } else {
+    console.log('Image URL not found in response.');
+  }
+}
+
+main().catch(console.error);

--- a/examples/picture.ts
+++ b/examples/picture.ts
@@ -1,20 +1,70 @@
 #!/usr/bin/env -S npm run tsn -T
-import OpenAI from 'openai';
+import OpenAI, { toFile } from 'openai';
+import fs from 'fs';
+/* 
+This example shows how to generate images from text prompts, as well as how to generate an image from a prompt and an input image.
+
+if you are working with solution 1 alone, you can remove {toFile} from the openai import on line 2.
+*/
 
 // gets API Key from environment variable OPENAI_API_KEY
 const openai = new OpenAI();
-
 async function main() {
-  // Generate an image based on the prompt
-  const response = await openai.images.generate({
-    model: 'dall-e-3',
+  // [1] Generate an image based on the prompt
+  await createImage();
+  // [2] Generate an image with edit based on prompt and input image
+  await createImageEdit();
+}
+/* 
+[1] The code below is used to create an image based on prompt.
+  n-is the number of images to be generated, and size is the size of the image to be generated.
+  size- can be one of the following: '256x256', '512x512', or '1024x1024'.
+  both size and n are optional parameters, if not provided, the default values will be used.
+  The generated image will be saved to a file named output.png
+ */
+async function createImage() {
+  const img = await openai.images.generate({
+    model: 'gpt-image-1', //
     prompt: 'An astronaut lounging in a tropical resort in space, pixel art',
+    n: 1,
+    size: '1024x1024',
   });
-  console.log(response); // Log the response to the console, a URL link to image will be in the response.data[0].url
-  if (response.data && response.data[0] && response.data[0].url) {
-    console.log('Image URL:', response.data[0].url); // Log the image URL
-  } else {
-    console.log('Image URL not found in response.');
+  // Save the image to a file, you can do console.log(img) to see the response structure
+  if (img.data && img.data[0] && img.data[0].b64_json) {
+    const imageBuffer = Buffer.from(img.data[0].b64_json, 'base64');
+    fs.writeFileSync('output.png', imageBuffer);
+  }
+}
+/* 
+[2] The code below is used to create an image edit based on the input images and prompt.
+ */
+// List of image files to be used for the image edit, this should be in the same directory as this script
+const imageFiles: string[] = ['bath-bomb.png', 'body-lotion.png', 'incense-kit.png', 'soap.png'];
+
+/**
+ * Processes multiple image files and converts them to File objects
+ * using OpenAI's toFile utility for API compatibility
+ */
+async function createImageEdit(): Promise<void> {
+  const images: File[] = await Promise.all(
+    imageFiles.map(
+      async (file: string): Promise<File> =>
+        await toFile(fs.createReadStream(file), null, {
+          type: 'image/png',
+        }),
+    ),
+  );
+
+  const img: OpenAI.Images.ImagesResponse = await openai.images.edit({
+    model: 'gpt-image-1',
+    image: images,
+    prompt: 'Create a lovely gift basket with these four items in it',
+  });
+
+  // Save the image to a file, you can do console.log(img) to see the response structure
+  if (img.data && img.data[0] && img.data[0].b64_json) {
+    const imageBuffer: Buffer = Buffer.from(img.data[0].b64_json, 'base64');
+    fs.writeFileSync('output2.png', imageBuffer);
   }
 }
 

--- a/examples/picture.ts
+++ b/examples/picture.ts
@@ -1,71 +1,81 @@
-#!/usr/bin/env -S npm run tsn -T
-import OpenAI, { toFile } from 'openai';
+#!/usr/bin/env -S npm run tsn -- -T
+
 import fs from 'fs';
-/* 
-This example shows how to generate images from text prompts, as well as how to generate an image from a prompt and an input image.
+import path from 'path';
+import OpenAI, { toFile } from 'openai';
 
-if you are working with solution 1 alone, you can remove {toFile} from the openai import on line 2.
-*/
-
-// gets API Key from environment variable OPENAI_API_KEY
 const openai = new OpenAI();
-async function main() {
-  // [1] Generate an image based on the prompt
-  await createImage();
-  // [2] Generate an image with edit based on prompt and input image
-  await createImageEdit();
-}
-/* 
-[1] The code below is used to create an image based on prompt.
-  n-is the number of images to be generated, and size is the size of the image to be generated.
-  size- can be one of the following: '256x256', '512x512', or '1024x1024'.
-  both size and n are optional parameters, if not provided, the default values will be used.
-  The generated image will be saved to a file named output.png
- */
-async function createImage() {
-  const img = await openai.images.generate({
-    model: 'gpt-image-1', //
-    prompt: 'An astronaut lounging in a tropical resort in space, pixel art',
-    n: 1,
-    size: '1024x1024',
-  });
-  // Save the image to a file, you can do console.log(img) to see the response structure
-  if (img.data && img.data[0] && img.data[0].b64_json) {
-    const imageBuffer = Buffer.from(img.data[0].b64_json, 'base64');
-    fs.writeFileSync('output.png', imageBuffer);
-  }
-}
-/* 
-[2] The code below is used to create an image edit based on the input images and prompt.
- */
-// List of image files to be used for the image edit, this should be in the same directory as this script
-const imageFiles: string[] = ['bath-bomb.png', 'body-lotion.png', 'incense-kit.png', 'soap.png'];
+const inputImages = process.argv.slice(2);
 
 /**
- * Processes multiple image files and converts them to File objects
- * using OpenAI's toFile utility for API compatibility
+ * Run without arguments to generate an image:
+ *
+ *   ./examples/picture.ts
+ *
+ * Pass one or more PNG, JPEG, or WebP files to create an edited image:
+ *
+ *   ./examples/picture.ts image-1.png image-2.png
  */
-async function createImageEdit(): Promise<void> {
-  const images: File[] = await Promise.all(
-    imageFiles.map(
-      async (file: string): Promise<File> =>
-        await toFile(fs.createReadStream(file), null, {
-          type: 'image/png',
-        }),
-    ),
-  );
-
-  const img: OpenAI.Images.ImagesResponse = await openai.images.edit({
-    model: 'gpt-image-1',
-    image: images,
-    prompt: 'Create a lovely gift basket with these four items in it',
-  });
-
-  // Save the image to a file, you can do console.log(img) to see the response structure
-  if (img.data && img.data[0] && img.data[0].b64_json) {
-    const imageBuffer: Buffer = Buffer.from(img.data[0].b64_json, 'base64');
-    fs.writeFileSync('output2.png', imageBuffer);
+async function main() {
+  if (inputImages.length === 0) {
+    await createImage();
+  } else {
+    await createImageEdit(inputImages);
   }
 }
 
-main().catch(console.error);
+async function createImage() {
+  const response = await openai.images.generate({
+    model: 'gpt-image-2',
+    prompt: 'An astronaut lounging in a tropical resort in space, pixel art',
+    size: '1024x1024',
+  });
+
+  await saveImage('generated.png', response.data?.[0]?.b64_json);
+}
+
+async function createImageEdit(imageFiles: string[]) {
+  const images = await Promise.all(
+    imageFiles.map(async (file) => {
+      const type = imageContentType(file);
+      return await toFile(fs.createReadStream(file), path.basename(file), { type });
+    }),
+  );
+
+  const response = await openai.images.edit({
+    model: 'gpt-image-2',
+    image: images,
+    prompt: 'Create a lovely gift basket with the items from the input images',
+  });
+
+  await saveImage('edited.png', response.data?.[0]?.b64_json);
+}
+
+function imageContentType(file: string): string {
+  switch (path.extname(file).toLowerCase()) {
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.webp':
+      return 'image/webp';
+    default:
+      throw new Error(`Unsupported image type for ${file}. Use a PNG, JPEG, or WebP file.`);
+  }
+}
+
+async function saveImage(filename: string, imageBase64: string | undefined) {
+  if (!imageBase64) {
+    throw new Error('The API response did not include image data.');
+  }
+
+  const outputPath = path.resolve(filename);
+  await fs.promises.writeFile(outputPath, Buffer.from(imageBase64, 'base64'));
+  console.log(`Saved image to ${outputPath}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- integrates the two original commits from #1569 while preserving Adekunle's authorship
- adds a runnable TypeScript example for image generation and image editing
- generates an image when run without arguments and edits user-supplied images when paths are provided
- supports PNG, JPEG, and WebP inputs and writes decoded image output to disk
- updates the example to the current GPT Image model

## Why

The original example always attempted an edit using four hardcoded image files that were not included in the repository. A clean checkout would successfully generate an image, then fail with `ENOENT`. Its size guidance also listed dimensions that were not supported by the selected GPT Image model.

Directly updating the maintainer-editable external fork was blocked by the organization's PushPatrol policy, so this OpenAI-hosted integration branch preserves the contributor commits and layers the landing fix on top.

## Usage

Generate an image:

```sh
./examples/picture.ts
```

Edit one or more source images:

```sh
./examples/picture.ts image-1.png image-2.png
```

## Verification

- `./node_modules/typescript/bin/tsc --noEmit`
- `./node_modules/.bin/eslint examples/picture.ts`
- `./node_modules/.bin/prettier --check examples/picture.ts`
- `git diff --check origin/main...HEAD`

Integrates #1569.