### PR TITLE
fix(client): allow explicit empty apiKey string

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -456,7 +456,7 @@ export class OpenAI {
       throw new Errors.OpenAIError('The `apiKey` and `workloadIdentity` options are mutually exclusive');
     }
 
-    if (!providerRuntime && !apiKey && !adminAPIKey && !workloadIdentity) {
+    if (!providerRuntime && apiKey == null && !adminAPIKey && !workloadIdentity) {
       throw new Errors.OpenAIError(
         'Missing credentials. Please pass an `apiKey`, `workloadIdentity`, `adminAPIKey`, or set the `OPENAI_API_KEY` or `OPENAI_ADMIN_KEY` environment variable.',
       );

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1089,5 +1089,13 @@ describe('retries', () => {
         ),
       );
     });
+
+    test('apiKey empty string does not throw', () => {
+      delete process.env['OPENAI_API_KEY'];
+      delete process.env['OPENAI_ADMIN_KEY'];
+
+      const client = new OpenAI({ apiKey: '' });
+      expect(client.apiKey).toBe('');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes a credential validation regression introduced when admin API key auth support added a missing-credentials guard.

The guard used `!apiKey`, which treats an explicitly provided empty string as missing. Since `apiKey` is typed as `string | ApiKeySetter | null | undefined`, this updates the check to treat only `null` and `undefined` as missing.

Fixes #1957.

## Changes

- Use `apiKey == null` in the missing-credentials guard.
- Add a regression test for `new OpenAI({ apiKey: "" })`.

## Testing

- `./node_modules/.bin/jest tests/index.test.ts -t "apiKey empty string|at least one"`
- `./scripts/format`
- `./scripts/lint`

`tests/index.test.ts`: 64/64 passing.