### PR TITLE
fix(assistants): place array delta entries by index instead of appending

### DIFF
--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -686,7 +686,7 @@ export class AssistantStream
 
           const accEntry = accValue[index];
           if (accEntry == null) {
-            accValue.push(deltaEntry);
+            accValue[index] = deltaEntry;
           } else {
             accValue[index] = this.accumulateDelta(accEntry, deltaEntry);
           }

--- a/tests/streaming/assistants/assistant.test.ts
+++ b/tests/streaming/assistants/assistant.test.ts
@@ -29,4 +29,19 @@ describe('assistant tests', () => {
     expect(AssistantStream.accumulateDelta({ a: null }, { a: 'apple' })).toEqual({ a: 'apple' });
     expect(AssistantStream.accumulateDelta({ a: null }, { a: null })).toEqual({ a: null });
   });
+
+  test('array delta accumulation uses the entry index', () => {
+    const acc: any = {
+      tool_calls: [{ index: 0, id: 'call_0', type: 'function', function: { name: 'f0', arguments: '{' } }],
+    };
+    AssistantStream.accumulateDelta(acc, {
+      tool_calls: [{ index: 2, id: 'call_2', type: 'function', function: { name: 'f2', arguments: '{' } }],
+    });
+    AssistantStream.accumulateDelta(acc, {
+      tool_calls: [{ index: 2, function: { arguments: '"x":1}' } }],
+    });
+    const atIndex2 = acc.tool_calls.filter((t: any) => t.index === 2);
+    expect(atIndex2).toHaveLength(1);
+    expect(atIndex2[0].function.arguments).toBe('{"x":1}');
+  });
 });


### PR DESCRIPTION
When accumulating streamed array deltas, `AssistantStream.accumulateDelta`
reads and writes entries by their `index` field. The branch that handles a
not-yet-seen entry appended it with `push` instead of assigning it at
`accValue[index]`. These only agree when the index equals the current array
length, so any non-contiguous or out-of-order `index` lands the entry at the
wrong position.

The consequence is data corruption: because the entry is not at `accValue[index]`,
a later fragment for the same index finds an empty slot and appends again. The
same tool call (or content block) ends up as two separate array entries with
split, invalid JSON arguments in the accumulated snapshot.

This assigns the entry at its `index`, matching the sibling branch and the
Python SDK, which uses `insert(index, entry)` for the same case. The existing
contiguous path is unchanged.

Added a unit test that seeds an entry at index 0, then streams two fragments
for index 2. Before the fix the array holds two index-2 entries with split
arguments; after the fix it holds one merged entry.
