### PR TITLE
ci: add CVE Lite dependency audit workflow

### DIFF
--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -1,0 +1,37 @@
+name: CVE Lite dependency audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly on Monday at 06:00 UTC - catches new advisories between pushes
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Scan dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Scan for vulnerabilities
+        uses: OWASP/cve-lite-cli@2eed959b8641042472d2810444393b88d5454e62 # v1
+        with:
+          fail-on: high
+          sarif: 'true'
+
+      - name: Upload SARIF to Code Scanning
+        if: always() && hashFiles('*.sarif') != ''
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          sarif_file: cve-lite-*.sarif
+          category: cve-lite


### PR DESCRIPTION
This PR adds a CVE Lite CLI dependency audit workflow to the openai-node CI pipeline.

A scan of the current `pnpm-lock.yaml` found **1 high-severity** advisory in a direct dependency:

**Direct high-severity finding:**
- `next@14.2.35` in `examples/` - authorization bypass via improper cache handling (CVE-2025-29927, GHSA-f82v-jwr5-mffw) - fix: `pnpm add --filter ./examples next@15.5.16`

The `examples/` directory is part of the published repository and runs a Next.js app that developers clone and run locally. An unpatched version of `next` in a reference implementation can propagate into downstream projects that copy the example code.

The workflow runs on push, pull request, and weekly schedule. Findings are uploaded to GitHub's Security tab as SARIF.

**Tool:** [CVE Lite CLI](https://github.com/OWASP/cve-lite-cli) is an OWASP Lab Project. It reads the lockfile locally, queries the OSV database, and surfaces direct dependency findings with actionable fix commands.
