### PR TITLE
export runner options type

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -229,6 +229,7 @@ import {
   ChatCompletionUpdateParams,
   ChatCompletionUserMessageParam,
   ChatCompletionsPage,
+  RunnerOptions,
 } from './resources/chat/completions/completions';
 import { type Fetch } from './internal/builtin-types';
 import { isRunningInBrowser } from './internal/detect-platform';
@@ -1475,6 +1476,7 @@ export declare namespace OpenAI {
     type ChatCompletionCreateParamsStreaming as ChatCompletionCreateParamsStreaming,
     type ChatCompletionUpdateParams as ChatCompletionUpdateParams,
     type ChatCompletionListParams as ChatCompletionListParams,
+    type RunnerOptions as RunnerOptions,
   };
 
   export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { OpenAI as default } from './client';
 export { type Uploadable, toFile, toStreamingFile } from './core/uploads';
 export { APIPromise } from './core/api-promise';
 export { OpenAI, type ClientOptions } from './client';
+export { type RunnerOptions } from './resources/chat/completions';
 export { PagePromise } from './core/pagination';
 export {
   OpenAIError,

--- a/src/resources/chat/completions/completions.ts
+++ b/src/resources/chat/completions/completions.ts
@@ -314,6 +314,7 @@ export {
   type ChatCompletionStreamingToolRunnerParamsWithContext,
   type ChatCompletionStreamingToolRunnerParamsWithoutContext,
 } from '../../../lib/ChatCompletionStreamingRunner';
+export { type RunnerOptions } from '../../../lib/AbstractChatCompletionRunner';
 export { ChatCompletionStream, type ChatCompletionStreamParams } from '../../../lib/ChatCompletionStream';
 export { ChatCompletionRunner } from '../../../lib/ChatCompletionRunner';
 

--- a/src/resources/chat/completions/index.ts
+++ b/src/resources/chat/completions/index.ts
@@ -43,6 +43,7 @@ export {
   type ChatCompletionCreateParamsStreaming,
   type ChatCompletionUpdateParams,
   type ChatCompletionListParams,
+  type RunnerOptions,
   type ChatCompletionStoreMessagesPage,
   type ChatCompletionsPage,
 } from './completions';

--- a/src/resources/chat/index.ts
+++ b/src/resources/chat/index.ts
@@ -44,6 +44,7 @@ export {
   type ChatCompletionCreateParamsStreaming,
   type ChatCompletionUpdateParams,
   type ChatCompletionListParams,
+  type RunnerOptions,
   type ChatCompletionStoreMessagesPage,
   type ChatCompletionsPage,
 } from './completions/index';

--- a/tests/runner-options-exports.test.ts
+++ b/tests/runner-options-exports.test.ts
@@ -1,0 +1,14 @@
+import OpenAI, { type RunnerOptions } from 'openai';
+import type { RunnerOptions as ResourceRunnerOptions } from 'openai/resources/chat/completions';
+import { compareType, expectType } from './utils/typing';
+
+describe('RunnerOptions exports', () => {
+  test('exports runTools options from public package surfaces', () => {
+    const options: RunnerOptions = { maxChatCompletions: 1 };
+
+    expectType<OpenAI.RunnerOptions>(options);
+    compareType<RunnerOptions, ResourceRunnerOptions>(true);
+
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
summary
- export `RunnerOptions` from the public package and chat completions resource surfaces
- expose the type on the `OpenAI` namespace for parity with other chat completion types
- add a type regression covering root and resource imports

change
- `openai` now supports `import type { RunnerOptions } from "openai"`
- `openai/resources/chat/completions` now supports `import type { RunnerOptions } ...`
- `OpenAI.RunnerOptions` is available in the root namespace

why
`runTools` already accepts `RunnerOptions` internally, but users could not name the options type from public exports when configuring `maxChatCompletions`.

fixes #593

tests
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec jest tests/runner-options-exports.test.ts --runInBand`
- `pnpm lint`
