### PR TITLE
export stream types from root

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -15,6 +15,8 @@ import { stringifyQuery } from './internal/utils/query';
 import { VERSION } from './version';
 import * as Errors from './core/error';
 import * as Pagination from './core/pagination';
+import * as Streaming from './streaming';
+import * as ChatCompletionStreams from './lib/ChatCompletionStream';
 import type { WorkloadIdentity } from './auth/types';
 import { WorkloadIdentityAuth } from './auth/workload-identity-auth';
 import { OAuthError, SubjectTokenProviderError } from './core/error';
@@ -1393,6 +1395,9 @@ function isUndiciDispatcherVersionMismatchError(error: unknown): boolean {
 
 export declare namespace OpenAI {
   export type RequestOptions = Opts.RequestOptions;
+
+  export import Stream = Streaming.Stream;
+  export import ChatCompletionStream = ChatCompletionStreams.ChatCompletionStream;
 
   export import Page = Pagination.Page;
   export { type PageResponse as PageResponse };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ export { OpenAI as default } from './client';
 export { type Uploadable, toFile } from './core/uploads';
 export { APIPromise } from './core/api-promise';
 export { OpenAI, type ClientOptions } from './client';
+export { Stream } from './streaming';
+export { ChatCompletionStream } from './lib/ChatCompletionStream';
 export { PagePromise } from './core/pagination';
 export {
   OpenAIError,

--- a/tests/stream-exports.test.ts
+++ b/tests/stream-exports.test.ts
@@ -1,0 +1,24 @@
+import OpenAI, { ChatCompletionStream, Stream } from '../src';
+import type { ChatCompletionChunk } from '../src/resources/chat/completions';
+
+const expectType = <T>(_value: T): void => {};
+
+describe('stream exports', () => {
+  test('exports Stream and ChatCompletionStream from the top level', () => {
+    expectType<typeof Stream>(Stream);
+    expectType<typeof ChatCompletionStream>(ChatCompletionStream);
+
+    expect(Stream).toBeDefined();
+    expect(ChatCompletionStream).toBeDefined();
+  });
+
+  test('exposes stream types on the OpenAI namespace', () => {
+    type ChatStream = OpenAI.Stream<ChatCompletionChunk>;
+    type ChatRunner = OpenAI.ChatCompletionStream;
+
+    expectType<ChatStream | null>(null);
+    expectType<ChatRunner | null>(null);
+
+    expect(true).toBe(true);
+  });
+});

--- a/tests/stream-exports.test.ts
+++ b/tests/stream-exports.test.ts
@@ -1,5 +1,5 @@
-import OpenAI, { ChatCompletionStream, Stream } from '../src';
-import type { ChatCompletionChunk } from '../src/resources/chat/completions';
+import OpenAI, { ChatCompletionStream, Stream } from 'openai';
+import type { ChatCompletionChunk } from 'openai/resources/chat/completions';
 
 const expectType = <T>(_value: T): void => {};
 


### PR DESCRIPTION
summary
- exports Stream and ChatCompletionStream from the root package entrypoint
- exposes the same stream types through the OpenAI namespace
- adds a regression test covering root imports and namespace type access

why
- fixes #558
- users can access these stream classes internally, but cannot import the types directly from openai without reaching into internal paths

validation
- pnpm exec jest tests/stream-exports.test.ts --runInBand
- pnpm exec tsc --noEmit --pretty false
- pnpm lint
- git diff --check
