### PR TITLE
feat: support streaming file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,11 +232,11 @@ Request parameters that correspond to file uploads can be passed in many differe
 - `File` (or an object with the same structure)
 - a `fetch` `Response` (or an object with the same structure)
 - an `fs.ReadStream`
-- the return value of our `toFile` helper
+- the return value of our `toFile` or `toStreamingFile` helpers
 
 ```ts
 import fs from 'fs';
-import OpenAI, { toFile } from 'openai';
+import OpenAI, { toFile, toStreamingFile } from 'openai';
 
 const client = new OpenAI();
 
@@ -259,6 +259,13 @@ await client.files.create({
 });
 await client.files.create({
   file: await toFile(new Uint8Array([0, 1, 2]), 'input.jsonl'),
+  purpose: 'fine-tune',
+});
+
+// `toFile()` creates a web File, so it must buffer stream inputs before sending them.
+// Use `toStreamingFile()` to stream an arbitrary web, Node, or cloud-storage stream directly:
+await client.files.create({
+  file: toStreamingFile(myReadableStream, 'input.jsonl', { type: 'application/jsonl' }),
   purpose: 'fine-tune',
 });
 ```

--- a/src/client.ts
+++ b/src/client.ts
@@ -765,6 +765,7 @@ export class OpenAI {
     const { req, url, timeout } = await this.buildRequest(options, {
       retryCount: maxRetries - retriesRemaining,
     });
+    const hasStreamingBody = options.__metadata?.['hasStreamingBody'] === true;
 
     await this.prepareRequest(req, { url, options });
     await this._provider?.prepareRequest?.(req, { url, options });
@@ -806,7 +807,7 @@ export class OpenAI {
       const isTimeout =
         isAbortError(response) ||
         /timed? ?out/i.test(String(response) + ('cause' in response ? String(response.cause) : ''));
-      if (retriesRemaining) {
+      if (retriesRemaining && !hasStreamingBody) {
         loggerFor(this).info(
           `[${requestLogID}] connection ${isTimeout ? 'timed out' : 'failed'} - ${retryMessage}`,
         );
@@ -821,11 +822,13 @@ export class OpenAI {
         );
         return this.retryRequest(options, retriesRemaining, retryOfRequestLogID ?? requestLogID);
       }
+      const terminalMessage =
+        hasStreamingBody ? 'error; streaming body cannot be retried' : 'error; no more retries left';
       loggerFor(this).info(
-        `[${requestLogID}] connection ${isTimeout ? 'timed out' : 'failed'} - error; no more retries left`,
+        `[${requestLogID}] connection ${isTimeout ? 'timed out' : 'failed'} - ${terminalMessage}`,
       );
       loggerFor(this).debug(
-        `[${requestLogID}] connection ${isTimeout ? 'timed out' : 'failed'} (error; no more retries left)`,
+        `[${requestLogID}] connection ${isTimeout ? 'timed out' : 'failed'} (${terminalMessage})`,
         formatRequestDetails({
           retryOfRequestLogID,
           url,
@@ -878,7 +881,7 @@ export class OpenAI {
       }
 
       const shouldRetry = await this.shouldRetry(response);
-      if (retriesRemaining && shouldRetry) {
+      if (retriesRemaining && shouldRetry && !hasStreamingBody) {
         const retryMessage = `retrying, ${retriesRemaining} attempts remaining`;
 
         // We don't need the body of this response.
@@ -902,7 +905,11 @@ export class OpenAI {
         );
       }
 
-      const retryMessage = shouldRetry ? `error; no more retries left` : `error; not retryable`;
+      const retryMessage =
+        shouldRetry ?
+          hasStreamingBody ? `error; streaming body cannot be retried`
+          : `error; no more retries left`
+        : `error; not retryable`;
 
       loggerFor(this).info(`${responseInfo} - ${retryMessage}`);
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1278,6 +1278,7 @@ export class OpenAI {
   static InvalidWebhookSignatureError = Errors.InvalidWebhookSignatureError;
 
   static toFile = Uploads.toFile;
+  static toStreamingFile = Uploads.toStreamingFile;
 
   /**
    * Given a prompt, the model will return one or more predicted completions, and can also return the probabilities of alternative tokens at each position.

--- a/src/core/uploads.ts
+++ b/src/core/uploads.ts
@@ -1,2 +1,7 @@
-export { type Uploadable } from '../internal/uploads';
+export {
+  type StreamingFile,
+  type StreamingFileInput,
+  type Uploadable,
+  toStreamingFile,
+} from '../internal/uploads';
 export { toFile, type ToFileInput } from '../internal/to-file';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 
 export { OpenAI as default } from './client';
 
-export { type Uploadable, toFile } from './core/uploads';
+export { type Uploadable, toFile, toStreamingFile } from './core/uploads';
 export { APIPromise } from './core/api-promise';
 export { OpenAI, type ClientOptions } from './client';
 export { PagePromise } from './core/pagination';

--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -343,7 +343,7 @@ async function* iterateBytes(value: unknown): AsyncGenerator<Uint8Array> {
     } else {
       yield* iterateBytes(await value.blob());
     }
-  } else if (isNamedBlob(value)) {
+  } else if (value instanceof Blob) {
     if (typeof value.stream === 'function') {
       yield* iterateBytes(value.stream());
     } else {

--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -1,15 +1,60 @@
 import { type RequestOptions } from './request-options';
 import type { FilePropertyBag, Fetch } from './builtin-types';
 import type { OpenAI } from '../client';
-import { ReadableStreamFrom } from './shims';
+import { buildHeaders } from './headers';
+import { ReadableStreamFrom, ReadableStreamToAsyncIterable } from './shims';
+import type { ReadableStream } from './shim-types';
+import { encodeUTF8 } from './utils/bytes';
 
 export type BlobPart = string | ArrayBuffer | ArrayBufferView | Blob | DataView;
 type FsReadStream = AsyncIterable<Uint8Array> & { path: string | { toString(): string } };
+
+export type StreamingFileInput = AsyncIterable<BlobPart> | ReadableStream<BlobPart>;
+
+const brand_privateStreamingFile = /* @__PURE__ */ Symbol('brand.privateStreamingFile');
+
+/**
+ * A file whose contents are read lazily while the multipart request is sent.
+ * Create one with {@link toStreamingFile} when buffering an upload into a `File` is undesirable.
+ */
+export interface StreamingFile {
+  /** Brand check, prevent users from creating a StreamingFile without a filename. */
+  readonly [brand_privateStreamingFile]: true;
+  readonly data: StreamingFileInput;
+  readonly name: string;
+  readonly type?: string | undefined;
+}
+
+/**
+ * Wrap a stream as an uploadable file without reading it into memory.
+ *
+ * Unlike {@link toFile}, this helper does not create a web `File`, because the `File` constructor
+ * must consume all of its contents up front. The stream is instead encoded lazily as multipart
+ * form data when the request is sent.
+ */
+export function toStreamingFile(
+  data: StreamingFileInput,
+  name: string,
+  options?: Pick<FilePropertyBag, 'type'>,
+): StreamingFile {
+  if (!name) {
+    throw new TypeError('toStreamingFile requires a non-empty file name');
+  }
+
+  return {
+    [brand_privateStreamingFile]: true,
+    data,
+    name,
+    ...(options?.type ? { type: options.type } : {}),
+  };
+}
 
 // https://github.com/oven-sh/bun/issues/5980
 interface BunFile extends Blob {
   readonly name?: string | undefined;
 }
+
+type NamedBlob = Blob & { readonly name?: string | undefined };
 
 export const checkFileSupport = () => {
   if (typeof File === 'undefined') {
@@ -34,7 +79,15 @@ export const checkFileSupport = () => {
  * For convenience, you can also pass a fetch Response, or in Node,
  * the result of fs.createReadStream().
  */
-export type Uploadable = File | Response | FsReadStream | BunFile;
+export type Uploadable =
+  | File
+  | Response
+  | FsReadStream
+  | BunFile
+  | NamedBlob
+  | AsyncIterable<BlobPart>
+  | ReadableStream<BlobPart>
+  | StreamingFile;
 
 /**
  * Construct a `File` instance. This is used to ensure a helpful error is thrown
@@ -78,6 +131,10 @@ export const maybeMultipartFormRequestOptions = async (
 ): Promise<RequestOptions> => {
   if (!hasUploadableValue(opts.body)) return opts;
 
+  if (hasStreamingUploadableValue(opts.body)) {
+    return createStreamingFormRequestOptions(opts);
+  }
+
   return { ...opts, body: await createForm(opts.body, fetch) };
 };
 
@@ -87,6 +144,10 @@ export const multipartFormRequestOptions = async (
   opts: MultipartFormRequestOptions,
   fetch: OpenAI | Fetch,
 ): Promise<RequestOptions> => {
+  if (hasStreamingUploadableValue(opts.body)) {
+    return createStreamingFormRequestOptions(opts);
+  }
+
   return { ...opts, body: await createForm(opts.body, fetch) };
 };
 
@@ -138,12 +199,36 @@ export const createForm = async <T = Record<string, unknown>>(
 
 // We check for Blob not File because Bun.File doesn't inherit from File,
 // but they both inherit from Blob and have a `name` property at runtime.
-const isNamedBlob = (value: unknown) => value instanceof Blob && 'name' in value;
+const isNamedBlob = (value: unknown): value is NamedBlob => value instanceof Blob && 'name' in value;
+
+const isReadableStream = (value: unknown): value is ReadableStream<BlobPart> =>
+  typeof value === 'object' &&
+  value !== null &&
+  'getReader' in value &&
+  typeof value.getReader === 'function';
+
+const isStreamingFile = (value: unknown): value is StreamingFile =>
+  typeof value === 'object' && value !== null && brand_privateStreamingFile in value;
 
 const isUploadable = (value: unknown) =>
   typeof value === 'object' &&
   value !== null &&
-  (value instanceof Response || isAsyncIterable(value) || isNamedBlob(value));
+  (value instanceof Response ||
+    isAsyncIterable(value) ||
+    isReadableStream(value) ||
+    isStreamingFile(value) ||
+    isNamedBlob(value));
+
+const hasStreamingUploadableValue = (value: unknown): boolean => {
+  if (isStreamingFile(value) || isAsyncIterable(value) || isReadableStream(value)) return true;
+  if (Array.isArray(value)) return value.some(hasStreamingUploadableValue);
+  if (value && typeof value === 'object' && !isNamedBlob(value) && !(value instanceof Response)) {
+    for (const k in value) {
+      if (hasStreamingUploadableValue((value as Record<string, unknown>)[k])) return true;
+    }
+  }
+  return false;
+};
 
 const hasUploadableValue = (value: unknown): boolean => {
   if (isUploadable(value)) return true;
@@ -155,6 +240,131 @@ const hasUploadableValue = (value: unknown): boolean => {
   }
   return false;
 };
+
+type FormEntry = { key: string; value: unknown };
+
+const createStreamingFormRequestOptions = (opts: RequestOptions): RequestOptions => {
+  const boundary = `openai-${Math.random().toString(36).slice(2)}`;
+  const body = ReadableStreamFrom(iterateMultipartBody(opts.body, boundary));
+
+  return {
+    ...opts,
+    body,
+    headers: buildHeaders([{ 'content-type': `multipart/form-data; boundary=${boundary}` }, opts.headers]),
+  };
+};
+
+async function* iterateMultipartBody(body: unknown, boundary: string): AsyncGenerator<Uint8Array> {
+  for await (const { key, value } of iterateFormEntries(body)) {
+    yield encodeUTF8(`--${boundary}\r\n`);
+    if (isUploadable(value)) {
+      const filename = getStreamingFileName(value);
+      const type = getStreamingFileType(value);
+      yield encodeUTF8(
+        `Content-Disposition: form-data; name="${escapeHeaderValue(key)}"; filename="${escapeHeaderValue(
+          filename,
+        )}"\r\n` + `Content-Type: ${type}\r\n\r\n`,
+      );
+      yield* iterateBytes(getStreamingFileData(value));
+    } else {
+      yield encodeUTF8(
+        `Content-Disposition: form-data; name="${escapeHeaderValue(key)}"\r\n\r\n${String(value)}`,
+      );
+    }
+    yield encodeUTF8('\r\n');
+  }
+  yield encodeUTF8(`--${boundary}--\r\n`);
+}
+
+async function* iterateFormEntries(body: unknown): AsyncGenerator<FormEntry> {
+  if (!body || typeof body !== 'object') return;
+
+  for (const [key, value] of Object.entries(body)) {
+    yield* iterateFormValue(key, value);
+  }
+}
+
+async function* iterateFormValue(key: string, value: unknown): AsyncGenerator<FormEntry> {
+  if (value === undefined) return;
+  if (value == null) {
+    throw new TypeError(
+      `Received null for "${key}"; to pass null in FormData, you must use the string 'null'`,
+    );
+  }
+
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    isUploadable(value)
+  ) {
+    yield { key, value };
+  } else if (Array.isArray(value)) {
+    for (const entry of value) {
+      yield* iterateFormValue(key + '[]', entry);
+    }
+  } else if (typeof value === 'object') {
+    for (const [name, prop] of Object.entries(value)) {
+      yield* iterateFormValue(`${key}[${name}]`, prop);
+    }
+  } else {
+    throw new TypeError(
+      `Invalid value given to form, expected a string, number, boolean, object, Array, File or Blob but got ${value} instead`,
+    );
+  }
+}
+
+function getStreamingFileName(value: Uploadable): string {
+  return isStreamingFile(value) ? value.name : getName(value) ?? 'unknown_file';
+}
+
+function getStreamingFileType(value: Uploadable): string {
+  if (isStreamingFile(value)) return value.type || 'application/octet-stream';
+  if (isNamedBlob(value) && value.type) return value.type;
+  if (value instanceof Response) return value.headers.get('content-type') || 'application/octet-stream';
+  return 'application/octet-stream';
+}
+
+function getStreamingFileData(value: Uploadable): unknown {
+  if (isStreamingFile(value)) return value.data;
+  return value;
+}
+
+async function* iterateBytes(value: unknown): AsyncGenerator<Uint8Array> {
+  if (typeof value === 'string') {
+    yield encodeUTF8(value);
+  } else if (ArrayBuffer.isView(value)) {
+    yield new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  } else if (value instanceof ArrayBuffer) {
+    yield new Uint8Array(value);
+  } else if (value instanceof Response) {
+    if (value.body) {
+      yield* iterateBytes(value.body);
+    } else {
+      yield* iterateBytes(await value.blob());
+    }
+  } else if (isNamedBlob(value)) {
+    if (typeof value.stream === 'function') {
+      yield* iterateBytes(value.stream());
+    } else {
+      yield new Uint8Array(await value.arrayBuffer());
+    }
+  } else if (isReadableStream(value)) {
+    for await (const chunk of ReadableStreamToAsyncIterable<unknown>(value)) {
+      yield* iterateBytes(chunk);
+    }
+  } else if (isAsyncIterable(value)) {
+    for await (const chunk of value) {
+      yield* iterateBytes(chunk);
+    }
+  } else {
+    throw new TypeError(`Invalid streaming file chunk: ${String(value)}`);
+  }
+}
+
+function escapeHeaderValue(value: string): string {
+  return value.replace(/["\\\r\n]/g, (character) => encodeURIComponent(character));
+}
 
 const addFormValue = async (form: FormData, key: string, value: unknown): Promise<void> => {
   if (value === undefined) return;

--- a/tests/form.test.ts
+++ b/tests/form.test.ts
@@ -121,4 +121,22 @@ describe('form data validation', () => {
     expect(encoded).toContain('streamed-content-1streamed-content-2streamed-content-3');
     expect(encoded).toContain('name="model"\r\n\r\nwhisper-1');
   });
+
+  test('streams plain Blob chunks', async () => {
+    async function* chunks() {
+      yield new Blob(['blob-content']);
+    }
+
+    const options = await multipartFormRequestOptions(
+      {
+        body: {
+          file: toStreamingFile(chunks(), 'audio.webm'),
+        },
+      },
+      fetch,
+    );
+
+    const encoded = await new Response(options.body as ReadableStream).text();
+    expect(encoded).toContain('blob-content');
+  });
 });

--- a/tests/form.test.ts
+++ b/tests/form.test.ts
@@ -1,4 +1,5 @@
-import { multipartFormRequestOptions, createForm } from 'openai/internal/uploads';
+import { multipartFormRequestOptions, createForm, toStreamingFile } from 'openai/internal/uploads';
+import { buildHeaders } from 'openai/internal/headers';
 import { toFile } from 'openai/core/uploads';
 
 describe('form data validation', () => {
@@ -81,5 +82,43 @@ describe('form data validation', () => {
       fetch,
     );
     expect(Array.from(form2.entries())).toEqual([['bar[]', 'foo']]);
+  });
+
+  test('streams multipart file content lazily', async () => {
+    let pulls = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1;
+        if (pulls <= 3) {
+          controller.enqueue(new TextEncoder().encode(`streamed-content-${pulls}`));
+        } else {
+          controller.close();
+        }
+      },
+    });
+
+    const options = await multipartFormRequestOptions(
+      {
+        body: {
+          file: toStreamingFile(stream, 'audio.webm', { type: 'audio/webm' }),
+          model: 'whisper-1',
+        },
+      },
+      fetch,
+    );
+
+    expect(pulls).toBeLessThan(4);
+    expect(options.body).toBeInstanceOf(ReadableStream);
+
+    const headers = buildHeaders([options.headers]).values;
+    const contentType = headers.get('content-type');
+    expect(contentType).toMatch(/^multipart\/form-data; boundary=openai-/);
+
+    const encoded = await new Response(options.body as ReadableStream).text();
+    expect(pulls).toBe(4);
+    expect(encoded).toContain('name="file"; filename="audio.webm"');
+    expect(encoded).toContain('Content-Type: audio/webm');
+    expect(encoded).toContain('streamed-content-1streamed-content-2streamed-content-3');
+    expect(encoded).toContain('name="model"\r\n\r\nwhisper-1');
   });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -709,6 +709,35 @@ describe('retries', () => {
     expect(count).toEqual(3);
   });
 
+  test('does not retry streaming request bodies', async () => {
+    let count = 0;
+    const testFetch = async (url: string | URL | Request, { body }: RequestInit = {}): Promise<Response> => {
+      count++;
+      expect(body).toBeInstanceOf(ReadableStream);
+      await new Response(body).text();
+      return new Response(undefined, { status: 429 });
+    };
+
+    const client = new OpenAI({
+      apiKey: 'My API Key',
+      adminAPIKey: 'My Admin API Key',
+      fetch: testFetch,
+      maxRetries: 2,
+    });
+
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('streamed-content'));
+        controller.close();
+      },
+    });
+
+    await expect(client.request({ path: '/foo', method: 'post', body })).rejects.toMatchObject({
+      status: 429,
+    });
+    expect(count).toEqual(1);
+  });
+
   test('retry count header', async () => {
     let count = 0;
     let capturedRequest: RequestInit | undefined;


### PR DESCRIPTION
## Summary

- add a public `toStreamingFile()` helper for web, Node, and cloud-storage streams
- lazily encode multipart request bodies whenever a streaming upload is present
- keep the existing `toFile()` behavior unchanged for callers that need a real web `File`
- document the streaming upload path and add regression coverage

## Root cause

`toFile()` creates a web `File`, and the `File` constructor has to consume stream contents up front. The existing multipart path also converted async streams into a `Blob` before sending, so large uploads were fully buffered in memory.

## Impact

Callers can now provide a filename and optional MIME type without buffering the source stream:

```ts
import { toStreamingFile } from 'openai';

await client.audio.transcriptions.create({
  file: toStreamingFile(myReadableStream, 'audio.webm', { type: 'audio/webm' }),
  model: 'whisper-1',
});
```

The SDK emits a bounded, lazy `ReadableStream` multipart body and preserves the existing `FormData` path for non-streaming uploads.

## Validation

- `pnpm run format`
- `pnpm exec tsc --noEmit`
- `pnpm exec jest tests/form.test.ts tests/uploads.test.ts --runInBand`

Resolves #418
Resolves #1052