### PR TITLE
docs: document abort event handling

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -573,11 +573,13 @@ The event fired for the last message with a `role: "function"`.
 
 #### `.on('error', (error: OpenAIError) => …)`
 
-The event fired when an error is encountered outside of a `parse` function or an abort.
+The event fired when an error is encountered outside of a `parse` function or an abort. User-initiated aborts are
+not emitted as `error` events; listen for `abort` instead.
 
 #### `.on('abort', (error: APIUserAbortError) => …)`
 
-The event fired when the stream receives a signal to abort.
+The event fired when the stream receives a signal to abort. After this event, `done()` and the `final*` helpers
+reject with the same `APIUserAbortError`.
 
 #### `.on('totalUsage', (usage: CompletionUsage) => …)` (without `stream`, usage is not currently reported with `stream`)
 


### PR DESCRIPTION
## Summary

- clarify that user-initiated aborts emit `abort`, not `error`
- document that `done()` and the `final*` helpers reject with the same `APIUserAbortError`

## Root cause

The event reference described `error` and `abort` separately, but did not explicitly state that aborts are intentionally excluded from the `error` event. That made correct abort behavior look like a missing error callback.

## Impact

Users now have direct guidance to listen for `abort` and can handle the corresponding promise rejection consistently when awaiting stream helpers.

## Validation

- `pnpm run format`
- `git diff --check`

Resolves #526