### PR TITLE
fix: emit stream finalization errors

### DIFF
--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -47,10 +47,14 @@ export class EventStream<EventTypes extends BaseEvents> {
       Promise.resolve()
         .then(executor)
         .then(() => {
-          this._emitFinal();
+          try {
+            this._emitFinal();
+          } catch (error) {
+            this.#handleError(error);
+            return;
+          }
           this._emit('end');
-        })
-        .catch(this.#handleError.bind(this));
+        }, this.#handleError.bind(this));
     }, 0);
   }
 

--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -44,10 +44,13 @@ export class EventStream<EventTypes extends BaseEvents> {
     // Unfortunately if we call `executor()` immediately we get runtime errors about
     // references to `this` before the `super()` constructor call returns.
     setTimeout(() => {
-      executor().then(() => {
-        this._emitFinal();
-        this._emit('end');
-      }, this.#handleError.bind(this));
+      Promise.resolve()
+        .then(executor)
+        .then(() => {
+          this._emitFinal();
+          this._emit('end');
+        })
+        .catch(this.#handleError.bind(this));
     }, 0);
   }
 

--- a/tests/lib/ChatCompletionStream.test.ts
+++ b/tests/lib/ChatCompletionStream.test.ts
@@ -8,6 +8,51 @@ import { makeStreamSnapshotRequest } from '../utils/mock-snapshots';
 jest.setTimeout(1000 * 30);
 
 describe('.stream()', () => {
+  it('emits finalization failures as errors', async () => {
+    const chunk: OpenAI.Chat.ChatCompletionChunk = {
+      id: 'chatcmpl-test',
+      object: 'chat.completion.chunk',
+      created: 1,
+      model: 'gpt-test',
+      choices: [
+        {
+          index: 0,
+          delta: { role: 'user', content: 'hello' },
+          finish_reason: 'stop',
+          logprobs: null,
+        },
+      ],
+    };
+
+    const client = {
+      chat: {
+        completions: {
+          create: jest.fn(async () => ({
+            controller: new AbortController(),
+            async *[Symbol.asyncIterator]() {
+              yield chunk;
+            },
+          })),
+        },
+      },
+    } as unknown as OpenAI;
+
+    const stream = ChatCompletionStream.createChatCompletion(client, {
+      model: 'gpt-test',
+      messages: [{ role: 'user', content: 'Say hello' }],
+    });
+    const errors: Error[] = [];
+    stream.on('error', (error) => errors.push(error));
+
+    await expect(stream.done()).rejects.toThrow(
+      'stream ended without producing a ChatCompletionMessage with role=assistant',
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.message).toBe(
+      'stream ended without producing a ChatCompletionMessage with role=assistant',
+    );
+  });
+
   it('removes the caller abort listener after the stream finishes', async () => {
     const callerController = new AbortController();
     const addEventListenerSpy = jest.spyOn(callerController.signal, 'addEventListener');


### PR DESCRIPTION
## Summary

- route errors thrown while emitting final stream events through the normal stream error handler
- cover malformed OpenAI-compatible streams that finish without an assistant message

## Root cause

`EventStream._run()` handled executor rejections, but `_emitFinal()` ran inside a fulfilled `.then()` callback whose returned promise was ignored. If finalization threw, such as when no assistant message was produced, the rejection escaped instead of emitting the stream's `error` event.

## Impact

Consumers using `.on('error', ...)` now receive finalization failures consistently, and awaiting `done()` rejects with the same error rather than leaving an unhandled rejection that can crash the process.

## Validation

- `pnpm run format`
- `pnpm exec tsc --noEmit`
- `pnpm exec jest tests/lib/ChatCompletionStream.test.ts --runInBand`
- `git diff --check`

Resolves #553