### PR TITLE
feat: pass context to runTools callbacks

### DIFF
--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -294,7 +294,8 @@ export class AbstractChatCompletionRunner<
     options?: RunnerOptions,
   ) {
     const role = 'tool' as const;
-    const { tool_choice = 'auto', stream, toolContext, ...restParams } = params;
+    const { tool_choice = 'auto', stream, toolContext: inputToolContext, ...restParams } = params;
+    const toolContext = inputToolContext as ToolContext;
     const singleFunctionToCall =
       typeof tool_choice !== 'string' && tool_choice.type === 'function' && tool_choice?.function?.name;
     const { maxChatCompletions = DEFAULT_MAX_CHAT_COMPLETIONS, afterCompletion } = options || {};

--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -15,10 +15,15 @@ import type {
   ParsedChatCompletion,
 } from '../resources/chat/completions';
 import type { CompletionUsage } from '../resources/completions';
-import type { ChatCompletionRunner, ChatCompletionToolRunnerParams } from './ChatCompletionRunner';
+import type {
+  ChatCompletionRunner,
+  ChatCompletionToolRunnerParamsWithContext,
+  ChatCompletionToolRunnerParamsWithoutContext,
+} from './ChatCompletionRunner';
 import type {
   ChatCompletionStreamingRunner,
-  ChatCompletionStreamingToolRunnerParams,
+  ChatCompletionStreamingToolRunnerParamsWithContext,
+  ChatCompletionStreamingToolRunnerParamsWithoutContext,
 } from './ChatCompletionStreamingRunner';
 import { isAssistantMessage, isToolMessage } from './chatCompletionUtils';
 import { BaseEvents, EventStream } from './EventStream';
@@ -288,8 +293,10 @@ export class AbstractChatCompletionRunner<
   protected async _runTools<FunctionsArgs extends BaseFunctionsArgs, ToolContext>(
     client: OpenAI,
     params:
-      | ChatCompletionToolRunnerParams<FunctionsArgs, ToolContext>
-      | ChatCompletionStreamingToolRunnerParams<FunctionsArgs, ToolContext>,
+      | ChatCompletionToolRunnerParamsWithContext<FunctionsArgs, ToolContext>
+      | ChatCompletionToolRunnerParamsWithoutContext<FunctionsArgs>
+      | ChatCompletionStreamingToolRunnerParamsWithContext<FunctionsArgs, ToolContext>
+      | ChatCompletionStreamingToolRunnerParamsWithoutContext<FunctionsArgs>,
     runner: ChatCompletionRunner<any> | ChatCompletionStreamingRunner<any>,
     options?: RunnerOptions,
   ) {

--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -285,16 +285,16 @@ export class AbstractChatCompletionRunner<
     return await this._createChatCompletion(client, params, options);
   }
 
-  protected async _runTools<FunctionsArgs extends BaseFunctionsArgs>(
+  protected async _runTools<FunctionsArgs extends BaseFunctionsArgs, ToolContext>(
     client: OpenAI,
     params:
-      | ChatCompletionToolRunnerParams<FunctionsArgs>
-      | ChatCompletionStreamingToolRunnerParams<FunctionsArgs>,
+      | ChatCompletionToolRunnerParams<FunctionsArgs, ToolContext>
+      | ChatCompletionStreamingToolRunnerParams<FunctionsArgs, ToolContext>,
     runner: ChatCompletionRunner<any> | ChatCompletionStreamingRunner<any>,
     options?: RunnerOptions,
   ) {
     const role = 'tool' as const;
-    const { tool_choice = 'auto', stream, ...restParams } = params;
+    const { tool_choice = 'auto', stream, toolContext, ...restParams } = params;
     const singleFunctionToCall =
       typeof tool_choice !== 'string' && tool_choice.type === 'function' && tool_choice?.function?.name;
     const { maxChatCompletions = DEFAULT_MAX_CHAT_COMPLETIONS, afterCompletion } = options || {};
@@ -322,7 +322,7 @@ export class AbstractChatCompletionRunner<
       return tool as any as RunnableToolFunction<any>;
     });
 
-    const functionsByName: Record<string, RunnableFunction<any>> = {};
+    const functionsByName: Record<string, RunnableFunction<any, ToolContext>> = {};
     for (const f of inputTools) {
       if (f.type === 'function') {
         functionsByName[f.function.name || f.function.function.name] = f.function;
@@ -389,9 +389,9 @@ export class AbstractChatCompletionRunner<
           const content = error instanceof Error ? error.message : String(error);
           return { message: { role, tool_call_id, content }, functionCalled: false };
         }
-        rawContent = await fn.function(parsed, runner);
+        rawContent = await fn.function(parsed, runner, toolContext);
       } else {
-        rawContent = await fn.function(args, runner);
+        rawContent = await fn.function(args, runner, toolContext);
       }
 
       const content = this.#stringifyFunctionCallResult(rawContent);

--- a/src/lib/ChatCompletionRunner.ts
+++ b/src/lib/ChatCompletionRunner.ts
@@ -16,16 +16,40 @@ export interface ChatCompletionRunnerEvents extends AbstractChatCompletionRunner
   content: (content: string) => void;
 }
 
-export type ChatCompletionToolRunnerParams<
+type ChatCompletionToolRunnerParamsBase = Omit<ChatCompletionCreateParamsNonStreaming, 'tools'>;
+
+/**
+ * Parameters for tools that do not require a context value.
+ */
+export type ChatCompletionToolRunnerParamsWithoutContext<FunctionsArgs extends BaseFunctionsArgs> =
+  ChatCompletionToolRunnerParamsBase & {
+    tools: RunnableTools<FunctionsArgs> | AutoParseableTool<any, true>[];
+    toolContext?: never;
+  };
+
+/**
+ * Parameters for tools that require a context value.
+ */
+export type ChatCompletionToolRunnerParamsWithContext<
   FunctionsArgs extends BaseFunctionsArgs,
-  ToolContext = unknown,
-> = Omit<ChatCompletionCreateParamsNonStreaming, 'tools'> & {
+  ToolContext,
+> = ChatCompletionToolRunnerParamsBase & {
   tools: RunnableTools<FunctionsArgs, ToolContext> | AutoParseableTool<any, true>[];
   /**
    * Context to pass to each tool callback during this run.
    */
-  toolContext?: ToolContext;
+  toolContext: ToolContext;
 };
+
+/**
+ * Parameters for running tools. Supplying a context type makes `toolContext`
+ * required; omitting it preserves the existing no-context form.
+ */
+export type ChatCompletionToolRunnerParams<FunctionsArgs extends BaseFunctionsArgs, ToolContext = never> = [
+  ToolContext,
+] extends [never] ?
+  ChatCompletionToolRunnerParamsWithoutContext<FunctionsArgs>
+: ChatCompletionToolRunnerParamsWithContext<FunctionsArgs, ToolContext>;
 
 export class ChatCompletionRunner<ParsedT = null> extends AbstractChatCompletionRunner<
   ChatCompletionRunnerEvents,
@@ -33,7 +57,19 @@ export class ChatCompletionRunner<ParsedT = null> extends AbstractChatCompletion
 > {
   static runTools<ParsedT, ToolContext = unknown>(
     client: OpenAI,
-    params: ChatCompletionToolRunnerParams<any[], ToolContext>,
+    params: ChatCompletionToolRunnerParamsWithContext<any[], ToolContext>,
+    options?: RunnerOptions,
+  ): ChatCompletionRunner<ParsedT>;
+  static runTools<ParsedT>(
+    client: OpenAI,
+    params: ChatCompletionToolRunnerParamsWithoutContext<any[]>,
+    options?: RunnerOptions,
+  ): ChatCompletionRunner<ParsedT>;
+  static runTools<ParsedT, ToolContext = unknown>(
+    client: OpenAI,
+    params:
+      | ChatCompletionToolRunnerParamsWithContext<any[], ToolContext>
+      | ChatCompletionToolRunnerParamsWithoutContext<any[]>,
     options?: RunnerOptions,
   ): ChatCompletionRunner<ParsedT> {
     const runner = new ChatCompletionRunner<ParsedT>();

--- a/src/lib/ChatCompletionRunner.ts
+++ b/src/lib/ChatCompletionRunner.ts
@@ -16,20 +16,24 @@ export interface ChatCompletionRunnerEvents extends AbstractChatCompletionRunner
   content: (content: string) => void;
 }
 
-export type ChatCompletionToolRunnerParams<FunctionsArgs extends BaseFunctionsArgs> = Omit<
-  ChatCompletionCreateParamsNonStreaming,
-  'tools'
-> & {
-  tools: RunnableTools<FunctionsArgs> | AutoParseableTool<any, true>[];
+export type ChatCompletionToolRunnerParams<
+  FunctionsArgs extends BaseFunctionsArgs,
+  ToolContext = unknown,
+> = Omit<ChatCompletionCreateParamsNonStreaming, 'tools'> & {
+  tools: RunnableTools<FunctionsArgs, ToolContext> | AutoParseableTool<any, true>[];
+  /**
+   * Context to pass to each tool callback during this run.
+   */
+  toolContext?: ToolContext;
 };
 
 export class ChatCompletionRunner<ParsedT = null> extends AbstractChatCompletionRunner<
   ChatCompletionRunnerEvents,
   ParsedT
 > {
-  static runTools<ParsedT>(
+  static runTools<ParsedT, ToolContext = unknown>(
     client: OpenAI,
-    params: ChatCompletionToolRunnerParams<any[]>,
+    params: ChatCompletionToolRunnerParams<any[], ToolContext>,
     options?: RunnerOptions,
   ): ChatCompletionRunner<ParsedT> {
     const runner = new ChatCompletionRunner<ParsedT>();

--- a/src/lib/ChatCompletionStreamingRunner.ts
+++ b/src/lib/ChatCompletionStreamingRunner.ts
@@ -14,16 +14,40 @@ export interface ChatCompletionStreamEvents extends AbstractChatCompletionRunner
   chunk: (chunk: ChatCompletionChunk, snapshot: ChatCompletionSnapshot) => void;
 }
 
-export type ChatCompletionStreamingToolRunnerParams<
+type ChatCompletionStreamingToolRunnerParamsBase = Omit<ChatCompletionCreateParamsStreaming, 'tools'>;
+
+/**
+ * Parameters for tools that do not require a context value.
+ */
+export type ChatCompletionStreamingToolRunnerParamsWithoutContext<FunctionsArgs extends BaseFunctionsArgs> =
+  ChatCompletionStreamingToolRunnerParamsBase & {
+    tools: RunnableTools<FunctionsArgs> | AutoParseableTool<any, true>[];
+    toolContext?: never;
+  };
+
+/**
+ * Parameters for tools that require a context value.
+ */
+export type ChatCompletionStreamingToolRunnerParamsWithContext<
   FunctionsArgs extends BaseFunctionsArgs,
-  ToolContext = unknown,
-> = Omit<ChatCompletionCreateParamsStreaming, 'tools'> & {
+  ToolContext,
+> = ChatCompletionStreamingToolRunnerParamsBase & {
   tools: RunnableTools<FunctionsArgs, ToolContext> | AutoParseableTool<any, true>[];
   /**
    * Context to pass to each tool callback during this run.
    */
-  toolContext?: ToolContext;
+  toolContext: ToolContext;
 };
+
+/**
+ * Parameters for running streaming tools. Supplying a context type makes
+ * `toolContext` required; omitting it preserves the existing no-context form.
+ */
+export type ChatCompletionStreamingToolRunnerParams<
+  FunctionsArgs extends BaseFunctionsArgs,
+  ToolContext = never,
+> = [ToolContext] extends [never] ? ChatCompletionStreamingToolRunnerParamsWithoutContext<FunctionsArgs>
+: ChatCompletionStreamingToolRunnerParamsWithContext<FunctionsArgs, ToolContext>;
 
 export class ChatCompletionStreamingRunner<ParsedT = null>
   extends ChatCompletionStream<ParsedT>
@@ -37,7 +61,19 @@ export class ChatCompletionStreamingRunner<ParsedT = null>
 
   static runTools<T extends (string | object)[], ParsedT = null, ToolContext = unknown>(
     client: OpenAI,
-    params: ChatCompletionStreamingToolRunnerParams<T, ToolContext>,
+    params: ChatCompletionStreamingToolRunnerParamsWithContext<T, ToolContext>,
+    options?: RunnerOptions,
+  ): ChatCompletionStreamingRunner<ParsedT>;
+  static runTools<T extends (string | object)[], ParsedT = null>(
+    client: OpenAI,
+    params: ChatCompletionStreamingToolRunnerParamsWithoutContext<T>,
+    options?: RunnerOptions,
+  ): ChatCompletionStreamingRunner<ParsedT>;
+  static runTools<T extends (string | object)[], ParsedT = null, ToolContext = unknown>(
+    client: OpenAI,
+    params:
+      | ChatCompletionStreamingToolRunnerParamsWithContext<T, ToolContext>
+      | ChatCompletionStreamingToolRunnerParamsWithoutContext<T>,
     options?: RunnerOptions,
   ): ChatCompletionStreamingRunner<ParsedT> {
     const runner = new ChatCompletionStreamingRunner<ParsedT>(

--- a/src/lib/ChatCompletionStreamingRunner.ts
+++ b/src/lib/ChatCompletionStreamingRunner.ts
@@ -14,11 +14,15 @@ export interface ChatCompletionStreamEvents extends AbstractChatCompletionRunner
   chunk: (chunk: ChatCompletionChunk, snapshot: ChatCompletionSnapshot) => void;
 }
 
-export type ChatCompletionStreamingToolRunnerParams<FunctionsArgs extends BaseFunctionsArgs> = Omit<
-  ChatCompletionCreateParamsStreaming,
-  'tools'
-> & {
-  tools: RunnableTools<FunctionsArgs> | AutoParseableTool<any, true>[];
+export type ChatCompletionStreamingToolRunnerParams<
+  FunctionsArgs extends BaseFunctionsArgs,
+  ToolContext = unknown,
+> = Omit<ChatCompletionCreateParamsStreaming, 'tools'> & {
+  tools: RunnableTools<FunctionsArgs, ToolContext> | AutoParseableTool<any, true>[];
+  /**
+   * Context to pass to each tool callback during this run.
+   */
+  toolContext?: ToolContext;
 };
 
 export class ChatCompletionStreamingRunner<ParsedT = null>
@@ -31,9 +35,9 @@ export class ChatCompletionStreamingRunner<ParsedT = null>
     return runner;
   }
 
-  static runTools<T extends (string | object)[], ParsedT = null>(
+  static runTools<T extends (string | object)[], ParsedT = null, ToolContext = unknown>(
     client: OpenAI,
-    params: ChatCompletionStreamingToolRunnerParams<T>,
+    params: ChatCompletionStreamingToolRunnerParams<T, ToolContext>,
     options?: RunnerOptions,
   ): ChatCompletionStreamingRunner<ParsedT> {
     const runner = new ChatCompletionStreamingRunner<ParsedT>(

--- a/src/lib/RunnableFunction.ts
+++ b/src/lib/RunnableFunction.ts
@@ -4,15 +4,17 @@ import { JSONSchema } from './jsonschema';
 
 type PromiseOrValue<T> = T | Promise<T>;
 
-export type RunnableFunctionWithParse<Args extends object> = {
+export type RunnableFunctionWithParse<Args extends object, ToolContext = unknown> = {
   /**
    * @param args the return value from `parse`.
    * @param runner the runner evaluating this callback.
+   * @param toolContext the context passed to `.runTools()`.
    * @returns a string to send back to OpenAI.
    */
   function: (
     args: Args,
     runner: ChatCompletionRunner<unknown> | ChatCompletionStreamingRunner<unknown>,
+    toolContext: ToolContext,
   ) => PromiseOrValue<unknown>;
   /**
    * @param input the raw args from the OpenAI function call.
@@ -34,14 +36,17 @@ export type RunnableFunctionWithParse<Args extends object> = {
   strict?: boolean | undefined;
 };
 
-export type RunnableFunctionWithoutParse = {
+export type RunnableFunctionWithoutParse<ToolContext = unknown> = {
   /**
    * @param args the raw args from the OpenAI function call.
+   * @param runner the runner evaluating this callback.
+   * @param toolContext the context passed to `.runTools()`.
    * @returns a string to send back to OpenAI
    */
   function: (
     args: string,
     runner: ChatCompletionRunner<unknown> | ChatCompletionStreamingRunner<unknown>,
+    toolContext: ToolContext,
   ) => PromiseOrValue<unknown>;
   /**
    * The parameters the function accepts, describes as a JSON Schema object.
@@ -58,56 +63,61 @@ export type RunnableFunctionWithoutParse = {
   strict?: boolean | undefined;
 };
 
-export type RunnableFunction<Args extends object | string> =
-  Args extends string ? RunnableFunctionWithoutParse
-  : Args extends object ? RunnableFunctionWithParse<Args>
-  : never;
+export type RunnableFunction<Args extends object | string, ToolContext = unknown> = Args extends string ?
+  RunnableFunctionWithoutParse<ToolContext>
+: Args extends object ? RunnableFunctionWithParse<Args, ToolContext>
+: never;
 
-export type RunnableToolFunction<Args extends object | string> =
-  Args extends string ? RunnableToolFunctionWithoutParse
-  : Args extends object ? RunnableToolFunctionWithParse<Args>
-  : never;
+export type RunnableToolFunction<Args extends object | string, ToolContext = unknown> = Args extends string ?
+  RunnableToolFunctionWithoutParse<ToolContext>
+: Args extends object ? RunnableToolFunctionWithParse<Args, ToolContext>
+: never;
 
-export type RunnableToolFunctionWithoutParse = {
+export type RunnableToolFunctionWithoutParse<ToolContext = unknown> = {
   type: 'function';
-  function: RunnableFunctionWithoutParse;
+  function: RunnableFunctionWithoutParse<ToolContext>;
 };
-export type RunnableToolFunctionWithParse<Args extends object> = {
+export type RunnableToolFunctionWithParse<Args extends object, ToolContext = unknown> = {
   type: 'function';
-  function: RunnableFunctionWithParse<Args>;
+  function: RunnableFunctionWithParse<Args, ToolContext>;
 };
 
-export function isRunnableFunctionWithParse<Args extends object>(
+export function isRunnableFunctionWithParse<Args extends object, ToolContext = unknown>(
   fn: any,
-): fn is RunnableFunctionWithParse<Args> {
+): fn is RunnableFunctionWithParse<Args, ToolContext> {
   return typeof (fn as any).parse === 'function';
 }
 
 export type BaseFunctionsArgs = readonly (object | string)[];
 
-export type RunnableFunctions<FunctionsArgs extends BaseFunctionsArgs> =
-  [any[]] extends [FunctionsArgs] ? readonly RunnableFunction<any>[]
-  : {
-      [Index in keyof FunctionsArgs]: Index extends number ? RunnableFunction<FunctionsArgs[Index]>
-      : FunctionsArgs[Index];
-    };
+export type RunnableFunctions<FunctionsArgs extends BaseFunctionsArgs, ToolContext = unknown> = [
+  any[],
+] extends [FunctionsArgs] ?
+  readonly RunnableFunction<any, ToolContext>[]
+: {
+    [Index in keyof FunctionsArgs]: Index extends number ? RunnableFunction<FunctionsArgs[Index], ToolContext>
+    : FunctionsArgs[Index];
+  };
 
-export type RunnableTools<FunctionsArgs extends BaseFunctionsArgs> =
-  [any[]] extends [FunctionsArgs] ? readonly RunnableToolFunction<any>[]
-  : {
-      [Index in keyof FunctionsArgs]: Index extends number ? RunnableToolFunction<FunctionsArgs[Index]>
-      : FunctionsArgs[Index];
-    };
+export type RunnableTools<FunctionsArgs extends BaseFunctionsArgs, ToolContext = unknown> = [any[]] extends (
+  [FunctionsArgs]
+) ?
+  readonly RunnableToolFunction<any, ToolContext>[]
+: {
+    [Index in keyof FunctionsArgs]: Index extends number ?
+      RunnableToolFunction<FunctionsArgs[Index], ToolContext>
+    : FunctionsArgs[Index];
+  };
 
 /**
  * This is helper class for passing a `function` and `parse` where the `function`
  * argument type matches the `parse` return type.
  */
-export class ParsingToolFunction<Args extends object> {
+export class ParsingToolFunction<Args extends object, ToolContext = unknown> {
   type: 'function';
-  function: RunnableFunctionWithParse<Args>;
+  function: RunnableFunctionWithParse<Args, ToolContext>;
 
-  constructor(input: RunnableFunctionWithParse<Args>) {
+  constructor(input: RunnableFunctionWithParse<Args, ToolContext>) {
     this.type = 'function';
     this.function = input;
   }

--- a/src/lib/RunnableFunction.ts
+++ b/src/lib/RunnableFunction.ts
@@ -82,6 +82,25 @@ export type RunnableToolFunctionWithParse<Args extends object, ToolContext = unk
   function: RunnableFunctionWithParse<Args, ToolContext>;
 };
 
+/**
+ * A broad tool shape for contextually typing callbacks when the argument type is inferred.
+ */
+export type RunnableToolFunctionWithContext<ToolContext> = {
+  type: 'function';
+  function: {
+    function: (
+      args: any,
+      runner: ChatCompletionRunner<unknown> | ChatCompletionStreamingRunner<unknown>,
+      toolContext: ToolContext,
+    ) => PromiseOrValue<unknown>;
+    parse?: (input: string) => PromiseOrValue<any>;
+    parameters: JSONSchema;
+    description: string;
+    name?: string | undefined;
+    strict?: boolean | undefined;
+  };
+};
+
 export function isRunnableFunctionWithParse<Args extends object, ToolContext = unknown>(
   fn: any,
 ): fn is RunnableFunctionWithParse<Args, ToolContext> {

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -18,8 +18,8 @@ import { ResponseFormatJSONSchema } from '../resources/shared';
 
 type AnyChatCompletionCreateParams =
   | ChatCompletionCreateParams
-  | ChatCompletionToolRunnerParams<any>
-  | ChatCompletionStreamingToolRunnerParams<any>
+  | ChatCompletionToolRunnerParams<any, any>
+  | ChatCompletionStreamingToolRunnerParams<any, any>
   | ChatCompletionStreamParams;
 
 type Unpacked<T> = T extends (infer U)[] ? U : T;

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -7,8 +7,10 @@ import {
   ChatCompletionMessage,
   ChatCompletionMessageFunctionToolCall,
   ChatCompletionStreamingToolRunnerParams,
+  ChatCompletionStreamingToolRunnerParamsWithContext,
   ChatCompletionStreamParams,
   ChatCompletionToolRunnerParams,
+  ChatCompletionToolRunnerParamsWithContext,
   ParsedChatCompletion,
   ParsedChoice,
   ParsedFunctionToolCall,
@@ -18,8 +20,10 @@ import { ResponseFormatJSONSchema } from '../resources/shared';
 
 type AnyChatCompletionCreateParams =
   | ChatCompletionCreateParams
-  | ChatCompletionToolRunnerParams<any, any>
-  | ChatCompletionStreamingToolRunnerParams<any, any>
+  | ChatCompletionToolRunnerParams<any>
+  | ChatCompletionToolRunnerParamsWithContext<any, any>
+  | ChatCompletionStreamingToolRunnerParams<any>
+  | ChatCompletionStreamingToolRunnerParamsWithContext<any, any>
   | ChatCompletionStreamParams;
 
 type Unpacked<T> = T extends (infer U)[] ? U : T;

--- a/src/resources/chat/completions/completions.ts
+++ b/src/resources/chat/completions/completions.ts
@@ -17,6 +17,7 @@ import { ChatCompletionStreamingRunner } from '../../../lib/ChatCompletionStream
 import { RunnerOptions } from '../../../lib/AbstractChatCompletionRunner';
 import { ChatCompletionToolRunnerParams } from '../../../lib/ChatCompletionRunner';
 import { ChatCompletionStreamingToolRunnerParams } from '../../../lib/ChatCompletionStreamingRunner';
+import { type RunnableToolFunctionWithContext } from '../../../lib/RunnableFunction';
 import { ChatCompletionStream, type ChatCompletionStreamParams } from '../../../lib/ChatCompletionStream';
 import { ExtractParsedContentFromParams, parseChatCompletion, validateInputTools } from '../../../lib/parser';
 
@@ -187,6 +188,38 @@ export class Completions extends APIResource {
    * For more details and examples, see
    * [the docs](https://github.com/openai/openai-node#automated-function-calls)
    */
+  runTools<
+    ToolContext,
+    Params extends Omit<ChatCompletionToolRunnerParams<any, ToolContext>, 'toolContext' | 'tools'> = Omit<
+      ChatCompletionToolRunnerParams<any, ToolContext>,
+      'toolContext' | 'tools'
+    >,
+    ParsedT = ExtractParsedContentFromParams<Params & ChatCompletionToolRunnerParams<any, ToolContext>>,
+  >(
+    body: Params & {
+      toolContext: ToolContext;
+      tools: readonly RunnableToolFunctionWithContext<ToolContext>[];
+    },
+    options?: RunnerOptions,
+  ): ChatCompletionRunner<ParsedT>;
+
+  runTools<
+    ToolContext,
+    Params extends Omit<
+      ChatCompletionStreamingToolRunnerParams<any, ToolContext>,
+      'toolContext' | 'tools'
+    > = Omit<ChatCompletionStreamingToolRunnerParams<any, ToolContext>, 'toolContext' | 'tools'>,
+    ParsedT = ExtractParsedContentFromParams<
+      Params & ChatCompletionStreamingToolRunnerParams<any, ToolContext>
+    >,
+  >(
+    body: Params & {
+      toolContext: ToolContext;
+      tools: readonly RunnableToolFunctionWithContext<ToolContext>[];
+    },
+    options?: RunnerOptions,
+  ): ChatCompletionStreamingRunner<ParsedT>;
+
   runTools<
     Params extends ChatCompletionToolRunnerParams<any>,
     ParsedT = ExtractParsedContentFromParams<Params>,

--- a/src/resources/chat/completions/completions.ts
+++ b/src/resources/chat/completions/completions.ts
@@ -15,8 +15,14 @@ import { path } from '../../../internal/utils/path';
 import { ChatCompletionRunner } from '../../../lib/ChatCompletionRunner';
 import { ChatCompletionStreamingRunner } from '../../../lib/ChatCompletionStreamingRunner';
 import { RunnerOptions } from '../../../lib/AbstractChatCompletionRunner';
-import { ChatCompletionToolRunnerParams } from '../../../lib/ChatCompletionRunner';
-import { ChatCompletionStreamingToolRunnerParams } from '../../../lib/ChatCompletionStreamingRunner';
+import {
+  ChatCompletionToolRunnerParamsWithContext,
+  ChatCompletionToolRunnerParamsWithoutContext,
+} from '../../../lib/ChatCompletionRunner';
+import {
+  ChatCompletionStreamingToolRunnerParamsWithContext,
+  ChatCompletionStreamingToolRunnerParamsWithoutContext,
+} from '../../../lib/ChatCompletionStreamingRunner';
 import { type RunnableToolFunctionWithContext } from '../../../lib/RunnableFunction';
 import { ChatCompletionStream, type ChatCompletionStreamParams } from '../../../lib/ChatCompletionStream';
 import { ExtractParsedContentFromParams, parseChatCompletion, validateInputTools } from '../../../lib/parser';
@@ -190,11 +196,13 @@ export class Completions extends APIResource {
    */
   runTools<
     ToolContext,
-    Params extends Omit<ChatCompletionToolRunnerParams<any, ToolContext>, 'toolContext' | 'tools'> = Omit<
-      ChatCompletionToolRunnerParams<any, ToolContext>,
+    Params extends Omit<
+      ChatCompletionToolRunnerParamsWithContext<any, ToolContext>,
       'toolContext' | 'tools'
+    > = Omit<ChatCompletionToolRunnerParamsWithContext<any, ToolContext>, 'toolContext' | 'tools'>,
+    ParsedT = ExtractParsedContentFromParams<
+      Params & ChatCompletionToolRunnerParamsWithContext<any, ToolContext>
     >,
-    ParsedT = ExtractParsedContentFromParams<Params & ChatCompletionToolRunnerParams<any, ToolContext>>,
   >(
     body: Params & {
       toolContext: ToolContext;
@@ -206,11 +214,11 @@ export class Completions extends APIResource {
   runTools<
     ToolContext,
     Params extends Omit<
-      ChatCompletionStreamingToolRunnerParams<any, ToolContext>,
+      ChatCompletionStreamingToolRunnerParamsWithContext<any, ToolContext>,
       'toolContext' | 'tools'
-    > = Omit<ChatCompletionStreamingToolRunnerParams<any, ToolContext>, 'toolContext' | 'tools'>,
+    > = Omit<ChatCompletionStreamingToolRunnerParamsWithContext<any, ToolContext>, 'toolContext' | 'tools'>,
     ParsedT = ExtractParsedContentFromParams<
-      Params & ChatCompletionStreamingToolRunnerParams<any, ToolContext>
+      Params & ChatCompletionStreamingToolRunnerParamsWithContext<any, ToolContext>
     >,
   >(
     body: Params & {
@@ -221,17 +229,21 @@ export class Completions extends APIResource {
   ): ChatCompletionStreamingRunner<ParsedT>;
 
   runTools<
-    Params extends ChatCompletionToolRunnerParams<any>,
+    Params extends ChatCompletionToolRunnerParamsWithoutContext<any>,
     ParsedT = ExtractParsedContentFromParams<Params>,
   >(body: Params, options?: RunnerOptions): ChatCompletionRunner<ParsedT>;
 
   runTools<
-    Params extends ChatCompletionStreamingToolRunnerParams<any>,
+    Params extends ChatCompletionStreamingToolRunnerParamsWithoutContext<any>,
     ParsedT = ExtractParsedContentFromParams<Params>,
   >(body: Params, options?: RunnerOptions): ChatCompletionStreamingRunner<ParsedT>;
 
   runTools<
-    Params extends ChatCompletionToolRunnerParams<any> | ChatCompletionStreamingToolRunnerParams<any>,
+    Params extends
+      | ChatCompletionToolRunnerParamsWithoutContext<any>
+      | ChatCompletionToolRunnerParamsWithContext<any, any>
+      | ChatCompletionStreamingToolRunnerParamsWithoutContext<any>
+      | ChatCompletionStreamingToolRunnerParamsWithContext<any, any>,
     ParsedT = ExtractParsedContentFromParams<Params>,
   >(
     body: Params,
@@ -240,12 +252,16 @@ export class Completions extends APIResource {
     if (body.stream) {
       return ChatCompletionStreamingRunner.runTools(
         this._client,
-        body as ChatCompletionStreamingToolRunnerParams<any>,
+        body as ChatCompletionStreamingToolRunnerParamsWithContext<any, any>,
         options,
       );
     }
 
-    return ChatCompletionRunner.runTools(this._client, body as ChatCompletionToolRunnerParams<any>, options);
+    return ChatCompletionRunner.runTools(
+      this._client,
+      body as ChatCompletionToolRunnerParamsWithContext<any, any>,
+      options,
+    );
   }
 
   /**
@@ -288,8 +304,16 @@ export {
   type RunnableFunctionWithoutParse,
   ParsingToolFunction,
 } from '../../../lib/RunnableFunction';
-export { type ChatCompletionToolRunnerParams } from '../../../lib/ChatCompletionRunner';
-export { type ChatCompletionStreamingToolRunnerParams } from '../../../lib/ChatCompletionStreamingRunner';
+export {
+  type ChatCompletionToolRunnerParams,
+  type ChatCompletionToolRunnerParamsWithContext,
+  type ChatCompletionToolRunnerParamsWithoutContext,
+} from '../../../lib/ChatCompletionRunner';
+export {
+  type ChatCompletionStreamingToolRunnerParams,
+  type ChatCompletionStreamingToolRunnerParamsWithContext,
+  type ChatCompletionStreamingToolRunnerParamsWithoutContext,
+} from '../../../lib/ChatCompletionStreamingRunner';
 export { ChatCompletionStream, type ChatCompletionStreamParams } from '../../../lib/ChatCompletionStream';
 export { ChatCompletionRunner } from '../../../lib/ChatCompletionRunner';
 

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -3,12 +3,13 @@ import { OpenAIError, APIConnectionError } from 'openai/error';
 import { PassThrough } from 'stream';
 import {
   ParsingToolFunction,
-  type ChatCompletionRunner,
+  ChatCompletionRunner,
   type ChatCompletionToolRunnerParams,
   ChatCompletionStreamingRunner,
   type ChatCompletionStreamingToolRunnerParams,
 } from 'openai/resources/chat/completions';
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+import type { RunnableToolFunction } from 'openai/lib/RunnableFunction';
 import { isAssistantMessage } from '../../src/lib/chatCompletionUtils';
 import { mockFetch } from '../utils/mock-fetch';
 
@@ -352,6 +353,49 @@ class StreamingRunnerListener {
 
 function _typeTests() {
   const openai = new OpenAI();
+  const contextTool: RunnableToolFunction<string, { eventId: string }> = {
+    type: 'function',
+    function: {
+      function: (_args, _runner, context) => context.eventId,
+      parameters: {},
+      description: 'updates an event',
+    },
+  };
+  const contextToolParams = {
+    messages: [{ role: 'user' as const, content: 'update my event' }],
+    model: 'gpt-3.5-turbo',
+    tools: [contextTool],
+  };
+  const streamingContextToolParams = {
+    ...contextToolParams,
+    stream: true as const,
+  };
+
+  openai.chat.completions.runTools({
+    ...contextToolParams,
+    toolContext: { eventId: 'event_123' },
+  });
+  ChatCompletionRunner.runTools(openai, {
+    ...contextToolParams,
+    toolContext: { eventId: 'event_123' },
+  });
+  openai.chat.completions.runTools({
+    ...streamingContextToolParams,
+    toolContext: { eventId: 'event_123' },
+  });
+  ChatCompletionStreamingRunner.runTools(openai, {
+    ...streamingContextToolParams,
+    toolContext: { eventId: 'event_123' },
+  });
+
+  // @ts-expect-error context-bearing tools require toolContext
+  openai.chat.completions.runTools(contextToolParams);
+  // @ts-expect-error context-bearing tools require toolContext
+  ChatCompletionRunner.runTools(openai, contextToolParams);
+  // @ts-expect-error context-bearing tools require toolContext
+  openai.chat.completions.runTools(streamingContextToolParams);
+  // @ts-expect-error context-bearing tools require toolContext
+  ChatCompletionStreamingRunner.runTools(openai, streamingContextToolParams);
 
   openai.chat.completions.runTools({
     messages: [

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -395,6 +395,26 @@ function _typeTests() {
     ],
   });
   openai.chat.completions.runTools({
+    messages: [{ role: 'user', content: 'update my event' }],
+    model: 'gpt-3.5-turbo',
+    toolContext: { eventId: 'event_123' },
+    tools: [
+      {
+        type: 'function',
+        function: {
+          function: (_args, _runner, context) => {
+            const eventId: string = context.eventId;
+            // @ts-expect-error tool context only includes eventId
+            context.missing;
+            return eventId;
+          },
+          parameters: {},
+          description: 'updates an event',
+        },
+      },
+    ],
+  });
+  openai.chat.completions.runTools({
     messages: [
       { role: 'user', content: 'can you tell me how many properties are in {"a": 1, "b": 2, "c": 3}' },
     ],
@@ -662,6 +682,96 @@ describe('resource completions', () => {
       expect(listener.functionCallResults).toEqual([`it's raining`]);
       await listener.sanityCheck({ ignoredMessages: new Set([injectedMessage]) });
     });
+
+    test('passes tool context to callbacks without sending it to the API', async () => {
+      const { fetch, handleRequest } = mockChatCompletionFetch();
+
+      const openai = new OpenAI({ apiKey: 'something1234', baseURL: 'http://127.0.0.1:4010', fetch });
+      const toolContext = { eventId: 'event_123' };
+      const receivedContexts: (typeof toolContext)[] = [];
+      const runner = openai.chat.completions.runTools({
+        messages: [{ role: 'user', content: 'update my event' }],
+        model: 'gpt-3.5-turbo',
+        toolContext,
+        tools: [
+          {
+            type: 'function',
+            function: {
+              function: function updateEvent(_args, _runner, context) {
+                receivedContexts.push(context);
+                return context.eventId;
+              },
+              parameters: {},
+              description: 'updates an event',
+            },
+          },
+        ],
+      });
+
+      await handleRequest(async (request) => {
+        expect(request).not.toHaveProperty('toolContext');
+        return {
+          id: '1',
+          choices: [
+            {
+              index: 0,
+              finish_reason: 'tool_calls',
+              logprobs: null,
+              message: {
+                role: 'assistant',
+                content: null,
+                refusal: null,
+                tool_calls: [
+                  {
+                    type: 'function',
+                    id: '123',
+                    function: {
+                      arguments: '',
+                      name: 'updateEvent',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+          created: Math.floor(Date.now() / 1000),
+          model: 'gpt-3.5-turbo',
+          object: 'chat.completion',
+        };
+      });
+
+      await handleRequest(async (request) => {
+        expect(request.messages[2]).toEqual({
+          role: 'tool',
+          content: 'event_123',
+          tool_call_id: '123',
+        });
+        return {
+          id: '2',
+          choices: [
+            {
+              index: 0,
+              finish_reason: 'stop',
+              logprobs: null,
+              message: {
+                role: 'assistant',
+                content: 'updated',
+                refusal: null,
+              },
+            },
+          ],
+          created: Math.floor(Date.now() / 1000),
+          model: 'gpt-3.5-turbo',
+          object: 'chat.completion',
+        };
+      });
+
+      await runner.done();
+
+      expect(receivedContexts).toEqual([toolContext]);
+      expect(receivedContexts[0]).toBe(toolContext);
+    });
+
     test('generates unique IDs for parallel tool calls with empty IDs', async () => {
       const { fetch, handleRequest } = mockChatCompletionFetch();
 


### PR DESCRIPTION
## Summary

- add a typed `toolContext` option to both streaming and non-streaming `runTools` parameters
- pass the same context value as the third argument to raw and parsed tool callbacks
- remove `toolContext` before creating Chat Completions requests so it remains local to the runner
- add runtime and compile-time coverage for context delivery, identity preservation, request omission, and type inference

## Motivation

`runTools` users currently need closures or custom wrapper types to share per-run application state across tools defined in separate modules. This adds a first-class context channel while preserving existing callback signatures and keeping the context scoped to one runner invocation.

Resolves #597

## Validation

- `pnpm run format`
- `pnpm exec tsc --noEmit`
- `pnpm exec jest tests/lib/ChatCompletionRunFunctions.test.ts --runInBand`
- `git diff --check`