### PR TITLE
docs: add Azure Assistants example

### DIFF
--- a/azure.md
+++ b/azure.md
@@ -39,6 +39,10 @@ For dated Azure OpenAI API versions, use the `AzureOpenAI` class instead of the 
 > The Azure API shape slightly differs from the core API shape which means that the static types for responses / params
 > won't always be correct.
 
+> [!WARNING]
+> The Azure OpenAI Assistants API is deprecated and will be retired on August 26, 2026. For existing integrations,
+> see the [Azure Assistants example](examples/azure/assistants.ts).
+
 ```ts
 import { AzureOpenAI } from 'openai';
 import { getBearerTokenProvider, DefaultAzureCredential } from '@azure/identity';

--- a/examples/azure/assistants.ts
+++ b/examples/azure/assistants.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env -S npm run tsn -- -T
+
+import { AzureOpenAI } from 'openai';
+import 'dotenv/config';
+
+/**
+ * This legacy example uses the deprecated Azure OpenAI Assistants API.
+ * The API will be retired on August 26, 2026.
+ * For new integrations, use Microsoft Foundry Agents:
+ * https://learn.microsoft.com/azure/foundry/agents/overview
+ *
+ * Unlike deployment-scoped APIs such as Chat Completions, Assistants use
+ * resource-scoped URLs. Pass the deployment as the request's `model`
+ * instead of setting the client's `deployment` option.
+ */
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing ${name}`);
+  return value;
+}
+
+const openai = new AzureOpenAI({
+  endpoint: requireEnv('AZURE_OPENAI_ENDPOINT'),
+  apiKey: requireEnv('AZURE_OPENAI_API_KEY'),
+  apiVersion: requireEnv('OPENAI_API_VERSION'),
+});
+const deployment = requireEnv('AZURE_OPENAI_DEPLOYMENT');
+
+async function main() {
+  const assistant = await openai.beta.assistants.create({
+    model: deployment,
+    name: 'Math Tutor',
+    instructions: 'You are a personal math tutor. Write and run code to answer math questions.',
+  });
+  console.log('Created Assistant with Id: ' + assistant.id);
+
+  const thread = await openai.beta.threads.create({
+    messages: [
+      {
+        role: 'user',
+        content: 'I need to solve the equation 3x + 11 = 14. Can you help me?',
+      },
+    ],
+  });
+  console.log('Created Thread with Id: ' + thread.id);
+
+  const run = await openai.beta.threads.runs.createAndPoll(thread.id, {
+    assistant_id: assistant.id,
+  });
+  console.log('Run finished with status: ' + run.status);
+
+  if (run.status === 'completed') {
+    const messages = await openai.beta.threads.messages.list(thread.id);
+    for (const message of messages.getPaginatedItems()) {
+      console.log(message);
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- add a runnable `examples/azure/assistants.ts` program for existing Azure OpenAI Assistants integrations
- configure `AzureOpenAI` with the resource endpoint and API version, while passing the Azure deployment as the request `model`
- document why the client-level `deployment` option is intentionally omitted for resource-scoped Assistants endpoints
- link the example from `azure.md` with an explicit August 26, 2026 retirement warning

## Motivation

Azure Chat Completions requests may be deployment-scoped, but Assistants requests are resource-scoped. The existing examples did not show that distinction, which led users to construct a deployment-scoped base URL that cannot reach Assistants endpoints. This provides a complete example while clearly steering new integrations toward Microsoft Foundry Agents because the legacy Assistants API is deprecated.

Resolves #701

## Validation

- `pnpm run format`
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `git diff --check`