### PR TITLE
test: serialize Steady-backed Jest runs

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -25,6 +25,18 @@ function is_overriding_api_base_url() {
   [ -n "$TEST_API_BASE_URL" ]
 }
 
+function has_jest_worker_flag() {
+  for arg in "$@"; do
+    case "$arg" in
+      --runInBand|--runInBand=*|--maxWorkers|--maxWorkers=*|-i|-w)
+        return 0
+        ;;
+    esac
+  done
+
+  return 1
+}
+
 if ! is_overriding_api_base_url && ! steady_is_running ; then
   # When we exit this script, make sure to kill the background mock server process
   trap 'kill_server_on_port 4010' EXIT
@@ -53,4 +65,13 @@ else
 fi
 
 echo "==> Running tests"
-./node_modules/.bin/jest "$@"
+jest_args=("$@")
+
+if ! is_overriding_api_base_url && ! has_jest_worker_flag "$@"; then
+  # The local Steady mock server is occasionally flaky under Jest's parallel
+  # workers, especially for multipart requests. Keep the default harness stable
+  # while allowing callers to opt into explicit worker settings.
+  jest_args=(--runInBand "${jest_args[@]}")
+fi
+
+./node_modules/.bin/jest "${jest_args[@]}"

--- a/scripts/test
+++ b/scripts/test
@@ -28,7 +28,10 @@ function is_overriding_api_base_url() {
 function has_jest_worker_flag() {
   for arg in "$@"; do
     case "$arg" in
-      --runInBand|--runInBand=*|--maxWorkers|--maxWorkers=*|-i|-w)
+      --runInBand|--runInBand=*|--run-in-band|--run-in-band=*|-i)
+        return 0
+        ;;
+      --maxWorkers|--maxWorkers=*|--max-workers|--max-workers=*|-w|-w?*)
         return 0
         ;;
     esac

--- a/tests/test-script.test.ts
+++ b/tests/test-script.test.ts
@@ -1,0 +1,88 @@
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const testScriptPath = join(process.cwd(), 'scripts/test');
+
+describe('scripts/test', () => {
+  let fixtureDir: string;
+
+  beforeEach(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), 'openai-node-test-script-'));
+
+    mkdirSync(join(fixtureDir, 'scripts'), { recursive: true });
+    mkdirSync(join(fixtureDir, 'node_modules/.bin'), { recursive: true });
+    mkdirSync(join(fixtureDir, 'bin'), { recursive: true });
+
+    copyFileSync(testScriptPath, join(fixtureDir, 'scripts/test'));
+    chmodSync(join(fixtureDir, 'scripts/test'), 0o755);
+
+    writeExecutable(
+      join(fixtureDir, 'bin/curl'),
+      `#!/usr/bin/env bash
+exit 0
+`,
+    );
+    writeExecutable(
+      join(fixtureDir, 'node_modules/.bin/jest'),
+      `#!/usr/bin/env bash
+printf '%s\\0' "$@" > "$JEST_ARGS_FILE"
+`,
+    );
+  });
+
+  afterEach(() => {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  });
+
+  function writeExecutable(path: string, contents: string) {
+    writeFileSync(path, contents);
+    chmodSync(path, 0o755);
+  }
+
+  function runTestScript(...args: string[]): string[] {
+    const jestArgsFile = join(fixtureDir, 'jest-args');
+    const result = spawnSync(join(fixtureDir, 'scripts/test'), args, {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        JEST_ARGS_FILE: jestArgsFile,
+        PATH: `${join(fixtureDir, 'bin')}:${process.env.PATH}`,
+      },
+    });
+
+    if (result.status !== 0) {
+      throw new Error(
+        `scripts/test exited with ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+      );
+    }
+
+    return readFileSync(jestArgsFile, 'utf8').split('\0').slice(0, -1);
+  }
+
+  test('defaults to serial Jest execution with the local Steady server', () => {
+    expect(runTestScript('--showConfig')).toEqual(['--runInBand', '--showConfig']);
+  });
+
+  test.each([
+    { label: '--maxWorkers value', args: ['--maxWorkers', '2'] },
+    { label: '--maxWorkers=value', args: ['--maxWorkers=2'] },
+    { label: '--max-workers value', args: ['--max-workers', '2'] },
+    { label: '--max-workers=value', args: ['--max-workers=2'] },
+    { label: '-w value', args: ['-w', '2'] },
+    { label: '-w=value', args: ['-w=2'] },
+    { label: '-wvalue', args: ['-w2'] },
+    { label: '--run-in-band', args: ['--run-in-band'] },
+  ])('preserves explicit worker arguments: $label', ({ args }) => {
+    expect(runTestScript('--showConfig', ...args)).toEqual(['--showConfig', ...args]);
+  });
+});

--- a/tests/test-script.test.ts
+++ b/tests/test-script.test.ts
@@ -56,7 +56,7 @@ printf '%s\\0' "$@" > "$JEST_ARGS_FILE"
       env: {
         ...process.env,
         JEST_ARGS_FILE: jestArgsFile,
-        PATH: `${join(fixtureDir, 'bin')}:${process.env.PATH}`,
+        PATH: `${join(fixtureDir, 'bin')}:${process.env['PATH']}`,
       },
     });
 


### PR DESCRIPTION
## Summary

- Default the local Steady-backed test harness to run Jest with `--runInBand`.
- Preserve explicit Jest worker settings such as `--maxWorkers` or `--runInBand` when callers provide them.
- Leave generated API resource tests and SDK resource code untouched.

## Root Cause

Two unrelated PRs saw a single multipart skills request fail with `APIConnectionError: Connection error.` while expecting Steady to return a 404 for `/_stainless_unknown_path`. The failures happened under Jest's parallel worker mode while many tests shared one local Steady process on port 4010, and reruns passed. The rest of each job continued to communicate with Steady, which points to intermittent mock-server request handling under concurrency rather than product code.

## Impact

The default `./scripts/test` path is now more stable in CI and local runs that use the built-in Steady server. Developers can still opt into parallel workers explicitly when they are testing against another server or want to stress the harness.

## Validation

- `bash -n scripts/test`
- `./scripts/test tests/api-resources/skills/skills.test.ts tests/api-resources/skills/versions/versions.test.ts`
- `./scripts/test`
- `./scripts/test tests/api-resources/skills/skills.test.ts --maxWorkers=2`
- `npx pnpm@11.5.1 run lint`