### PR TITLE
feat: add async event iterators

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -274,6 +274,17 @@ For convenience, the delta event includes both the incremental update and an acc
 
 Image files are not sent incrementally so an event is provided for when a image file is available.
 
+If you need to await work for each convenience event, use the event's async iterator:
+
+```ts
+for await (const [content, snapshot] of run.events('imageFileDone')) {
+  await moveImageFile(content.file_id, snapshot.id);
+}
+```
+
+The iterator yields every occurrence of the selected event, ends when the stream ends, and rejects if
+the stream errors or is aborted.
+
 ```ts
 .on('toolCallCreated', (toolCall: ToolCall) => ...)
 .on('toolCallDelta', (delta: RunStepDelta, snapshot: ToolCall) => ...)

--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -157,6 +157,110 @@ export class EventStream<EventTypes extends BaseEvents> {
     });
   }
 
+  /**
+   * Returns an async iterator that yields every time the event is triggered.
+   * The iterator ends when the stream ends and rejects if the stream errors
+   * or is aborted. If you request the 'error' or 'abort' event, the iterator
+   * yields that event instead of rejecting.
+   *
+   * Example:
+   *
+   *   for await (const [message] of stream.events('message')) {
+   *     await processMessage(message);
+   *   }
+   */
+  events<Event extends keyof EventTypes>(
+    event: Event,
+  ): AsyncIterableIterator<EventParameters<EventTypes, Event>> {
+    type Parameters = EventParameters<EventTypes, Event>;
+    type Result = IteratorResult<Parameters>;
+    type Reader = {
+      resolve: (result: Result) => void;
+      reject: (error: OpenAIError) => void;
+    };
+
+    const pushQueue: Parameters[] = [];
+    const readQueue: Reader[] = [];
+    let ended = this.ended;
+    let failure: OpenAIError | undefined;
+    let failureDelivered = false;
+
+    const doneResult = (): Result => ({ value: undefined as never, done: true });
+    const finishReaders = () => {
+      while (readQueue.length) {
+        readQueue.shift()!.resolve(doneResult());
+      }
+    };
+    const rejectReader = () => {
+      if (!failure || failureDelivered || !readQueue.length) return;
+      failureDelivered = true;
+      readQueue.shift()!.reject(failure);
+    };
+    const cleanup = () => {
+      this.off(event, onEvent as EventListener<EventTypes, Event>);
+      this.off('end', onEnd);
+      if (event !== 'error') this.off('error', onFailure);
+      if (event !== 'abort') this.off('abort', onFailure);
+    };
+    const onEvent = (...args: Parameters) => {
+      if (ended) return;
+      const reader = readQueue.shift();
+      if (reader) {
+        reader.resolve({ value: args, done: false });
+      } else {
+        pushQueue.push(args);
+      }
+    };
+    const onFailure = (error: OpenAIError) => {
+      failure = error;
+      if (!pushQueue.length) rejectReader();
+    };
+    const onEnd = () => {
+      ended = true;
+      cleanup();
+      if (!pushQueue.length) {
+        rejectReader();
+        finishReaders();
+      }
+    };
+
+    if (!ended) {
+      this.#catchingPromiseCreated = true;
+      this.on(event, onEvent as EventListener<EventTypes, Event>);
+      this.on('end', onEnd);
+      if (event !== 'error') this.on('error', onFailure);
+      if (event !== 'abort') this.on('abort', onFailure);
+    }
+
+    return {
+      next: () => {
+        const value = pushQueue.shift();
+        if (value) return Promise.resolve({ value, done: false });
+
+        if (failure && !failureDelivered) {
+          failureDelivered = true;
+          return Promise.reject(failure);
+        }
+
+        if (ended) return Promise.resolve(doneResult());
+
+        return new Promise<Result>((resolve, reject) => {
+          readQueue.push({ resolve, reject });
+        });
+      },
+      return: () => {
+        ended = true;
+        pushQueue.length = 0;
+        cleanup();
+        finishReaders();
+        return Promise.resolve(doneResult());
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+  }
+
   async done(): Promise<void> {
     this.#catchingPromiseCreated = true;
     await this.#endPromise;

--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -225,7 +225,6 @@ export class EventStream<EventTypes extends BaseEvents> {
     };
 
     if (!ended) {
-      this.#catchingPromiseCreated = true;
       this.on(event, onEvent as EventListener<EventTypes, Event>);
       this.on('end', onEnd);
       if (event !== 'error') this.on('error', onFailure);

--- a/tests/lib/EventStream.test.ts
+++ b/tests/lib/EventStream.test.ts
@@ -65,4 +65,22 @@ describe('EventStream.events', () => {
     await expect(iterator.next()).rejects.toBe(error);
     await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
   });
+
+  test('does not suppress errors after iterator cleanup', async () => {
+    const stream = new TestStream();
+    const iterator = stream.events('foo');
+    const reject = jest
+      .spyOn(Promise, 'reject')
+      .mockImplementation(() => Promise.resolve() as Promise<never>);
+    const error = new OpenAIError('oops');
+
+    try {
+      await iterator.return?.();
+      stream.emitError(error);
+
+      expect(reject).toHaveBeenCalledWith(error);
+    } finally {
+      reject.mockRestore();
+    }
+  });
 });

--- a/tests/lib/EventStream.test.ts
+++ b/tests/lib/EventStream.test.ts
@@ -1,0 +1,68 @@
+import { OpenAIError } from 'openai/error';
+import { type BaseEvents, EventStream } from 'openai/lib/EventStream';
+
+interface TestEvents extends BaseEvents {
+  foo: (value: string, index: number) => void;
+}
+
+class TestStream extends EventStream<TestEvents> {
+  emitFoo(value: string, index: number) {
+    this._emit('foo', value, index);
+  }
+
+  emitError(error: OpenAIError) {
+    this._emit('error', error);
+  }
+
+  end() {
+    this._emit('end');
+  }
+}
+
+describe('EventStream.events', () => {
+  test('iterates over repeated events in order', async () => {
+    const stream = new TestStream();
+    const seen: string[] = [];
+
+    const consuming = (async () => {
+      for await (const [value, index] of stream.events('foo')) {
+        seen.push('start:' + value + ':' + index);
+        await Promise.resolve();
+        seen.push('end:' + value + ':' + index);
+      }
+    })();
+
+    stream.emitFoo('first', 1);
+    stream.emitFoo('second', 2);
+    stream.end();
+
+    await consuming;
+
+    expect(seen).toEqual(['start:first:1', 'end:first:1', 'start:second:2', 'end:second:2']);
+  });
+
+  test('rejects pending reads when the stream errors', async () => {
+    const stream = new TestStream();
+    const iterator = stream.events('foo');
+    const next = iterator.next();
+    const error = new OpenAIError('oops');
+
+    stream.emitError(error);
+
+    await expect(next).rejects.toBe(error);
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  test('drains queued events before rejecting on an error', async () => {
+    const stream = new TestStream();
+    const iterator = stream.events('foo');
+    const error = new OpenAIError('oops');
+
+    stream.emitFoo('first', 1);
+    stream.emitError(error);
+
+    await expect(iterator.next()).resolves.toEqual({ value: ['first', 1], done: false });
+    await expect(iterator.next()).rejects.toBe(error);
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+  });
+});


### PR DESCRIPTION
## Summary

- add a typed `events(eventName)` async iterator to `EventStream`
- document awaiting repeated `imageFileDone` assistant helper events
- add coverage for ordering, queued events, and stream failures

## Why

Issue #879 needs async/await control for SDK convenience events such as `imageFileDone`. Existing `.on()` callbacks are synchronous, so callers cannot naturally process each repeated event sequentially.

## Behavior

`stream.events(eventName)` yields the emitted argument tuple for every occurrence. It queues events while the consumer awaits work, ends with the stream, and surfaces stream errors or aborts after previously queued events have been drained. Existing `.on()` behavior is unchanged.

## Validation

- `pnpm exec jest tests/lib/EventStream.test.ts --runInBand`
- `pnpm exec tsc --noEmit`
- `pnpm run lint`

Resolves #879