### PR TITLE
fix streaming accept header

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1157,7 +1157,7 @@ export class OpenAI {
     const headers = buildHeaders([
       idempotencyHeaders,
       {
-        Accept: 'application/json',
+        Accept: options.stream ? 'text/event-stream' : 'application/json',
         'User-Agent': this.getUserAgent(),
         'X-Stainless-Retry-Count': String(retryCount),
         ...(options.timeout ? { 'X-Stainless-Timeout': String(Math.trunc(options.timeout / 1000)) } : {}),

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -27,6 +27,26 @@ describe('instantiate client', () => {
       adminAPIKey: 'My Admin API Key',
     });
 
+    test('uses an event-stream accept header for streaming requests', async () => {
+      const { req } = await client.buildRequest({ path: '/foo', method: 'post', stream: true });
+      expect(req.headers.get('accept')).toEqual('text/event-stream');
+    });
+
+    test('uses a JSON accept header for non-streaming requests', async () => {
+      const { req } = await client.buildRequest({ path: '/foo', method: 'post', stream: false });
+      expect(req.headers.get('accept')).toEqual('application/json');
+    });
+
+    test('preserves an explicit accept header for streaming requests', async () => {
+      const { req } = await client.buildRequest({
+        path: '/foo',
+        method: 'post',
+        stream: true,
+        headers: { Accept: 'application/x-ndjson' },
+      });
+      expect(req.headers.get('accept')).toEqual('application/x-ndjson');
+    });
+
     test('they are used in the request', async () => {
       const { req } = await client.buildRequest({ path: '/foo', method: 'post' });
       expect(req.headers.get('x-my-default-header')).toEqual('2');


### PR DESCRIPTION
summary
- set the default `Accept` header to `text/event-stream` when request options enable streaming
- keep `application/json` for non-streaming requests
- preserve caller-provided `Accept` headers for custom streaming transports

why
- closes #375
- streaming responses are returned as `text/event-stream`, and some OpenAI-compatible gateways validate the request `Accept` header before returning an SSE response
- callers can already work around this with a manual header override; this makes the default client behavior match the expected response type

validation
- `pnpm exec jest tests/index.test.ts -t 'accept header' --runInBand`
- `pnpm exec jest tests/index.test.ts --runInBand`
- `pnpm exec tsc --noEmit --pretty false`
- `git diff --check`
- `pnpm lint`
- `pnpm test`
