### PR TITLE
docs: document assistant stream failures

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -286,12 +286,31 @@ More information on tools can be found here [Tools](https://platform.openai.com/
 
 ```ts
 .on('error', (error: OpenAIError) => ...)
+.on('abort', (error: APIUserAbortError) => ...)
 .on('end', () => ...)
 ```
 
-The `error` event is emitted when the stream encounters an API or SDK error. The `end` event is the last SDK
-event emitted when the stream finishes, including after an error or abort. The raw `[DONE]` marker is consumed
-by the SDK rather than emitted through the `event` listener.
+The `error` event is emitted when the stream encounters an API or SDK error. The `abort` event is emitted
+when the stream is cancelled through an `AbortSignal` or `.abort()`. The `end` event is the last SDK event
+emitted when the stream finishes, including after an error or abort. The raw `[DONE]` marker is consumed by
+the SDK rather than emitted through the `event` listener.
+
+Register `error` and `abort` listeners before handing the stream to another consumer. If you call a
+promise-returning helper such as `.done()` or `.finalRun()`, await or catch that promise as well; event
+listeners do not handle a separate promise rejection.
+
+```ts
+const run = openai.beta.threads.runs
+  .stream(threadId, { assistant_id: assistantId })
+  .on('error', (error) => console.error('Run failed:', error))
+  .on('abort', (error) => console.error('Run aborted:', error));
+
+try {
+  await run.finalRun();
+} catch (error) {
+  // Handle the rejected helper promise here.
+}
+```
 
 ### Assistant Methods
 


### PR DESCRIPTION
## Summary

- document the Assistants stream `abort` event alongside `error` and `end`
- explain that cancellation through an `AbortSignal` or `.abort()` emits `abort`
- add a safe example that registers both listeners and catches the `finalRun()` promise

## Why

Issue #959 reports unhandled rejections while retrying or cancelling Assistant streams. The current helper already separates API and SDK failures from cancellations, but the Assistants event docs only showed `error` and did not explain that promise-returning helpers still need their own `await` or `catch`.

## Impact

Users now have an explicit pattern for handling stream failures before handing a stream to another consumer, including client disconnect and cancellation paths. This clarifies the existing runtime behavior without changing stream semantics.

## Validation

- `pnpm run format`
- `pnpm run lint`

Resolves #959