### PR TITLE
fix: avoid deep Deno Zod types

### DIFF
--- a/src/helpers/zod.ts
+++ b/src/helpers/zod.ts
@@ -15,10 +15,14 @@ import { type ResponseFormatTextJSONSchemaConfig } from '../resources/responses/
 import { toStrictJsonSchema } from '../lib/transform';
 import { JSONSchema } from '../lib/jsonschema';
 
-type InferZodType<T> =
-  T extends z4.ZodType ? z4.infer<T>
-  : T extends z3.ZodType ? z3.infer<T>
-  : never;
+// The public helpers only need Zod's output type and parser. Using this small
+// structural type avoids expanding Zod's full v3/v4 type graphs in Deno.
+type ZodTypeLike = {
+  _output: unknown;
+  parse: (data: unknown) => unknown;
+};
+
+type InferZodType<T extends ZodTypeLike> = T['_output'];
 
 function zodV3ToJsonSchema(schema: z3.ZodType, options: { name: string }): Record<string, unknown> {
   return _zodToJsonSchema(schema, {
@@ -95,22 +99,24 @@ function isZodV4(zodObject: z3.ZodType | z4.ZodType): zodObject is z4.ZodType {
  * This can be passed directly to the `.create()` method but will not
  * result in any automatic parsing, you'll have to parse the response yourself.
  */
-export function zodResponseFormat<ZodInput extends z3.ZodType | z4.ZodType>(
+export function zodResponseFormat<ZodInput extends ZodTypeLike>(
   zodObject: ZodInput,
   name: string,
   props?: Omit<ResponseFormatJSONSchema.JSONSchema, 'schema' | 'strict' | 'name'>,
 ): AutoParseableResponseFormat<InferZodType<ZodInput>> {
-  return makeParseableResponseFormat(
+  const zodSchema = zodObject as unknown as z3.ZodType | z4.ZodType;
+
+  return makeParseableResponseFormat<InferZodType<ZodInput>>(
     {
       type: 'json_schema',
       json_schema: {
         ...props,
         name,
         strict: true,
-        schema: isZodV4(zodObject) ? zodV4ToJsonSchema(zodObject) : zodV3ToJsonSchema(zodObject, { name }),
+        schema: isZodV4(zodSchema) ? zodV4ToJsonSchema(zodSchema) : zodV3ToJsonSchema(zodSchema, { name }),
       },
     },
-    (content) => zodObject.parse(JSON.parse(content)),
+    (content) => zodObject.parse(JSON.parse(content)) as InferZodType<ZodInput>,
   );
 }
 

--- a/tests/helpers/zod.test.ts
+++ b/tests/helpers/zod.test.ts
@@ -57,6 +57,13 @@ it('converts Zod v4 discriminated unions to anyOf for strict schemas', () => {
   expect(schema.properties.data.anyOf).toHaveLength(2);
 });
 
+it('preserves inferred output types', () => {
+  const format = zodResponseFormat(zv4.object({ value: zv4.string() }), 'example');
+  const parsed: { value: string } = format.$parseRaw('{"value":"ok"}');
+
+  expect(parsed.value).toBe('ok');
+});
+
 describe.each([
   { version: 'v3', z: zv3 },
   { version: 'v4', z: zv4 as any as typeof zv3 },


### PR DESCRIPTION
## Summary

- narrow the public `zodResponseFormat()` generic constraint to the small Zod surface the helper actually needs
- infer parsed output directly from the schema `_output` type
- keep the existing Zod v3/v4 runtime schema conversion unchanged
- add coverage that the returned parser still preserves inferred output types

## Why

Issue #984 reports that `deno check` can fail with TS2589 or exhaust the JavaScript heap when calling `zodResponseFormat()`. The previous public signature asked Deno to structurally compare the supplied schema against the complete Zod v3 and v4 type graphs before inferring the output type.

## Impact

Deno no longer needs to expand those full Zod graphs at the call site. The helper still accepts Zod v3 and v4 schemas, produces the same JSON Schema at runtime, and preserves the inferred parsed result through `_output`.

## Validation

- reproduced the Deno 2.9.0 heap exhaustion before the change and verified the same call no longer enters the OOM path afterward
- `pnpm exec jest tests/helpers/zod.test.ts --runInBand`
- `pnpm exec tsc --noEmit`
- `pnpm run lint`

Resolves #984