### PR TITLE
docs: document file search result limits

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -212,6 +212,26 @@ openai.beta.threads.runs.submitToolOutputsStream();
 
 This method can be used to submit a tool output to a run waiting on the output and start a stream.
 
+### Configuring file search results
+
+`max_num_results` is a run-level `file_search` tool override. Set it at
+`tools[].file_search.max_num_results` when creating or streaming a run:
+
+```ts
+const run = openai.beta.threads.runs.stream(thread.id, {
+  assistant_id: assistant.id,
+  tools: [
+    {
+      type: 'file_search',
+      file_search: { max_num_results: 10 },
+    },
+  ],
+});
+```
+
+Message attachments only associate a file with the `file_search` tool, so their `tools` entries use
+`{ type: 'file_search' }` without a nested `file_search` configuration object.
+
 ### Assistant Events
 
 The assistant API provides events you can subscribe to for the following events.


### PR DESCRIPTION
## Summary

- add an Assistants helper example for configuring `max_num_results`
- document the exact run-level path: `tools[].file_search.max_num_results`
- clarify that message attachments only associate files with `file_search` and cannot carry tool configuration

## Why

Issue #1004 reports conflicting guidance about where `max_num_results` belongs. The generated Assistants types already expose the correct run-level shape, but the hand-maintained helper guide did not show it or contrast it with the invalid attachment placement.

## Impact

Existing Assistants users now have a copyable example for limiting file search results without changing the generated API surface or runtime behavior.

## Validation

- `pnpm run format`
- `pnpm run lint`

Resolves #1004