### PR TITLE
docs: clarify strict Zod function schemas

### DIFF
--- a/helpers.md
+++ b/helpers.md
@@ -64,6 +64,10 @@ Some Zod behavior cannot be represented in the schema sent to the API:
   Custom refinements and transforms still run when the SDK parses the response, but
   some schemas that cannot be converted, including bare transforms in Zod v4, cause
   the helper to throw before a request is made.
+- `.default()` emits the unsupported `default` keyword, and string `.min()` or
+  `.max()` emit the unsupported `minLength` or `maxLength` keywords. Because
+  `zodFunction()` always creates a strict function tool, use a regular non-strict
+  tool and parse its arguments with Zod yourself when you need these behaviors.
 - TypeScript comments are not available at runtime and are not sent to the API. Use
   `.describe()` for field descriptions or the helper's `description` option for a
   top-level response format or function description.

--- a/helpers.md
+++ b/helpers.md
@@ -64,10 +64,10 @@ Some Zod behavior cannot be represented in the schema sent to the API:
   Custom refinements and transforms still run when the SDK parses the response, but
   some schemas that cannot be converted, including bare transforms in Zod v4, cause
   the helper to throw before a request is made.
-- `.default()` emits the unsupported `default` keyword, and string `.min()` or
-  `.max()` emit the unsupported `minLength` or `maxLength` keywords. Because
-  `zodFunction()` always creates a strict function tool, use a regular non-strict
-  tool and parse its arguments with Zod yourself when you need these behaviors.
+- `zodFunction()` always creates a strict function tool. `.default()` emits
+  `default`, but strict conversion still marks the property as required, so it does
+  not make model-generated tool arguments optional. String `.min()` and `.max()`
+  emit `minLength` and `maxLength`, which are not supported by fine-tuned models.
 - TypeScript comments are not available at runtime and are not sent to the API. Use
   `.describe()` for field descriptions or the helper's `description` option for a
   top-level response format or function description.


### PR DESCRIPTION
## Summary

- document that `zodFunction()` always creates a strict function tool
- call out that `.default()` and string `.min()`/`.max()` emit keywords outside the strict schema subset
- point users who need those Zod behaviors to a regular non-strict tool with local Zod parsing

## Why

The report in #1119 compared `zodFunction()` with a custom helper that appeared to work. The difference is that the custom helper sends a non-strict tool, while `zodFunction()` deliberately opts into strict Structured Outputs. In strict mode, `default`, `minLength`, and `maxLength` can be rejected by the API.

## Impact

Users now get an actionable explanation before reaching the API error and can choose the non-strict tool path when their Zod schema depends on defaults or string length constraints. This avoids silently stripping constraints from the model-facing schema while preserving the existing strict helper behavior.

## Validation

- `pnpm run format`
- `pnpm run lint`
- `git diff --check`

Resolves #1119