### PR TITLE
fix(assistants): preserve readable stream deltas

### DIFF
--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -103,11 +103,12 @@ export class AssistantStream
 
     //Catch all for passing along all events
     this.on('event', (event) => {
+      const eventCopy = structuredClone(event);
       const reader = readQueue.shift();
       if (reader) {
-        reader.resolve(event);
+        reader.resolve(eventCopy);
       } else {
-        pushQueue.push(event);
+        pushQueue.push(eventCopy);
       }
     });
 

--- a/tests/streaming/assistants/assistant.test.ts
+++ b/tests/streaming/assistants/assistant.test.ts
@@ -1,5 +1,7 @@
 import OpenAI from 'openai';
+import { ReadableStreamFrom } from 'openai/internal/shims';
 import { AssistantStream } from 'openai/lib/AssistantStream';
+import { Stream } from 'openai/streaming';
 
 const openai = new OpenAI({
   apiKey: 'My API Key',
@@ -43,5 +45,55 @@ describe('assistant tests', () => {
     const atIndex2 = acc.tool_calls.filter((t: any) => t.index === 2);
     expect(atIndex2).toHaveLength(1);
     expect(atIndex2[0].function.arguments).toBe('{"x":1}');
+  });
+
+  test('toReadableStream preserves queued message deltas', async () => {
+    const encoder = new TextEncoder();
+    const events = [
+      {
+        event: 'thread.message.created',
+        data: {
+          id: 'msg_1',
+          content: [],
+        },
+      },
+      {
+        event: 'thread.message.delta',
+        data: {
+          id: 'msg_1',
+          delta: {
+            content: [{ index: 0, type: 'text', text: { value: 'E', annotations: [] } }],
+          },
+        },
+      },
+      {
+        event: 'thread.message.delta',
+        data: {
+          id: 'msg_1',
+          delta: {
+            content: [{ index: 0, type: 'text', text: { value: 'ddy' } }],
+          },
+        },
+      },
+      {
+        event: 'thread.run.completed',
+        data: { id: 'run_1' },
+      },
+    ];
+    const input = ReadableStreamFrom(events.map((event) => encoder.encode(JSON.stringify(event) + '\n')));
+    const assistantStream = AssistantStream.fromReadableStream(input);
+    const readable = assistantStream.toReadableStream();
+
+    await assistantStream.done();
+
+    const output = Stream.fromReadableStream<any>(readable, new AbortController());
+    const deltas: string[] = [];
+    for await (const event of output) {
+      if (event.event === 'thread.message.delta') {
+        deltas.push(event.data.delta.content[0].text.value);
+      }
+    }
+
+    expect(deltas).toEqual(['E', 'ddy']);
   });
 });


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #1315.

`AssistantStream.toReadableStream()` could emit a corrupted first message delta when the downstream reader was slower than the Assistants stream. The async iterator queued raw event objects by reference, while message snapshot accumulation reused and mutated the first delta's content object. By the time `toReadableStream()` serialized the queued event, the first delta could already contain later text, and those later deltas were then emitted again.

This clones each event as it crosses the `AssistantStream` async iterator boundary. Direct `for await` consumers and `toReadableStream()` now receive stable event payloads, while synchronous event listeners and the existing snapshot accumulation behavior remain unchanged.

The regression test creates an Assistant stream from queued events, waits for accumulation to finish before reading the proxied readable stream, and verifies that `E` followed by `ddy` remains two distinct deltas instead of becoming `Eddy` followed by `ddy`.

## Additional context & links

- Issue: #1315
- Validation:
  - `pnpm test --runInBand tests/streaming/assistants/assistant.test.ts`
  - `pnpm lint`
  - `pnpm test --runInBand`
