### PR TITLE
fix(azure): normalize endpoint trailing slashes

### DIFF
--- a/src/azure.ts
+++ b/src/azure.ts
@@ -107,7 +107,11 @@ export class AzureOpenAI extends OpenAI {
         );
       }
 
-      baseURL = `${endpoint.replace(/\/+$/, '')}/openai`;
+      let endpointEnd = endpoint.length;
+      while (endpointEnd > 0 && endpoint[endpointEnd - 1] === '/') {
+        endpointEnd--;
+      }
+      baseURL = `${endpoint.slice(0, endpointEnd)}/openai`;
     } else {
       if (endpoint) {
         throw new Errors.OpenAIError('baseURL and endpoint are mutually exclusive');

--- a/src/azure.ts
+++ b/src/azure.ts
@@ -107,7 +107,7 @@ export class AzureOpenAI extends OpenAI {
         );
       }
 
-      baseURL = `${endpoint}/openai`;
+      baseURL = `${endpoint.replace(/\/+$/, '')}/openai`;
     } else {
       if (endpoint) {
         throw new Errors.OpenAIError('baseURL and endpoint are mutually exclusive');

--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -337,6 +337,11 @@ describe('instantiate azure client', () => {
     expect(client.baseURL).toEqual('https://example.com/openai');
   });
 
+  test('with endpoint trailing slash', () => {
+    const client = new AzureOpenAI({ endpoint: 'https://example.com/', apiKey: 'My API Key', apiVersion });
+    expect(client.baseURL).toEqual('https://example.com/openai');
+  });
+
   test('baseURL and endpoint are mutually exclusive', () => {
     expect(
       () =>

--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -337,10 +337,13 @@ describe('instantiate azure client', () => {
     expect(client.baseURL).toEqual('https://example.com/openai');
   });
 
-  test('with endpoint trailing slash', () => {
-    const client = new AzureOpenAI({ endpoint: 'https://example.com/', apiKey: 'My API Key', apiVersion });
-    expect(client.baseURL).toEqual('https://example.com/openai');
-  });
+  test.each(['https://example.com/', 'https://example.com///'])(
+    'with endpoint trailing slashes',
+    (endpoint) => {
+      const client = new AzureOpenAI({ endpoint, apiKey: 'My API Key', apiVersion });
+      expect(client.baseURL).toEqual('https://example.com/openai');
+    },
+  );
 
   test('baseURL and endpoint are mutually exclusive', () => {
     expect(


### PR DESCRIPTION
## Summary

- normalize `AzureOpenAI` endpoints before appending `/openai`
- add a focused regression test for the documented trailing-slash endpoint form

## Why

`AzureClientOptions.endpoint` is documented with a trailing slash, but the constructor appended `/openai` directly. Passing the documented form produced a base URL such as `https://example-resource.azure.openai.com//openai`, which then carried the double slash into Azure request URLs.

## Impact

`new AzureOpenAI({ endpoint: 'https://example-resource.azure.openai.com/' })` now produces `https://example-resource.azure.openai.com/openai`. Endpoints without trailing slashes and callers that provide an explicit `baseURL` keep their existing behavior.

Fixes #1669.

## Validation

- `pnpm exec jest tests/lib/azure.test.ts --runInBand`
- `pnpm exec prettier --check src/azure.ts tests/lib/azure.test.ts`
- `pnpm run lint`