### PR TITLE
chore: exclude Brewfile from language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Homebrew configuration is not application Ruby source.
+Brewfile -linguist-detectable


### PR DESCRIPTION
## Summary

- mark `Brewfile` as non-detectable in GitHub Linguist
- prevent CodeQL default setup from treating this JavaScript/TypeScript repository as Ruby

## Context

GitHub Linguist classifies the Homebrew `Brewfile` as 12 bytes of Ruby. When CodeQL default setup was enabled, that language signal caused an `Analyze (ruby)` job to run. The job failed because there is no analyzable Ruby source, leaving the overall CodeQL setup page red with “No Ruby code found” and “No code scanning results.”

The stale failed Ruby analysis has been removed from Code Scanning separately. This repository change prevents the same false language detection from recreating that configuration error.

Original failed job: https://github.com/openai/openai-node/actions/runs/28062787148/job/83080604090

## Impact

No runtime or package behavior changes. GitHub language statistics and language-driven tooling will ignore `Brewfile`, while the file remains available for Homebrew setup.

## Validation

- `git check-attr linguist-detectable -- Brewfile` reports `unset`
- `git diff origin/main...HEAD --check` passes