### PR TITLE
test: cover transcription duration usage seconds

### DIFF
--- a/tests/api-resources/audio/transcriptions.test.ts
+++ b/tests/api-resources/audio/transcriptions.test.ts
@@ -1,6 +1,9 @@
 // File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 import OpenAI, { toFile } from 'openai';
+import type { Transcription, TranscriptionDiarized } from 'openai/resources/audio/transcriptions';
+
+import { expectType } from '../../utils/typing';
 
 const client = new OpenAI({
   apiKey: 'My API Key',
@@ -9,6 +12,18 @@ const client = new OpenAI({
 });
 
 describe('resource transcriptions', () => {
+  test('create response duration usage exposes seconds', () => {
+    const transcriptionUsage: Transcription.Duration = { type: 'duration', seconds: 4 };
+    expectType<number>(transcriptionUsage.seconds);
+    // @ts-expect-error duration usage objects expose seconds, not duration
+    expectType<number>(transcriptionUsage.duration);
+
+    const diarizedUsage: TranscriptionDiarized.Duration = { type: 'duration', seconds: 4 };
+    expectType<number>(diarizedUsage.seconds);
+    // @ts-expect-error duration usage objects expose seconds, not duration
+    expectType<number>(diarizedUsage.duration);
+  });
+
   test('create: only required params', async () => {
     const responsePromise = client.audio.transcriptions.create({
       file: await toFile(Buffer.from('Example data'), 'README.md'),


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Adds regression coverage for transcription duration usage types.

The current generated SDK type already exposes `seconds` for `Transcription.Duration` and `TranscriptionDiarized.Duration`; this test locks that in and verifies the old `duration` field shape stays rejected by TypeScript.

## Additional context & links

Refs #1579

Tested with:

```sh
pnpm exec jest tests/api-resources/audio/transcriptions.test.ts --runInBand --testNamePattern 'duration usage exposes seconds'
pnpm exec prettier --check tests/api-resources/audio/transcriptions.test.ts
pnpm exec eslint tests/api-resources/audio/transcriptions.test.ts
git diff --check
pnpm build
```
