### PR TITLE
[responses] add multi-agent-aware beta output_text

### DIFF
--- a/src/lib/ResponsesParser.ts
+++ b/src/lib/ResponsesParser.ts
@@ -13,6 +13,11 @@ import {
   type ResponseFunctionToolCall,
   type Tool,
 } from '../resources/responses/responses';
+import type {
+  BetaResponse,
+  BetaResponseOutputItem,
+  BetaResponseOutputMessage,
+} from '../resources/beta/responses/responses';
 import { type AutoParseableTextFormat, isAutoParsableResponseFormat } from '../lib/parser';
 
 export type ParseableToolsParams = Array<Tool> | ChatCompletionTool | null;
@@ -261,10 +266,38 @@ function needsOutputText(
   return !Object.getOwnPropertyDescriptor(response, 'output_text') || target.output_text == null;
 }
 
-export function addOutputText(rsp: Response): void {
+function hasAgentMetadata(
+  output: Response['output'][number] | BetaResponseOutputItem,
+): output is BetaResponseOutputMessage {
+  return output.type === 'message' && 'agent' in output && output.agent != null;
+}
+
+export function addOutputText(rsp: Response | BetaResponse): void {
+  let hasMultiAgentOutput = false;
+  let finalRootMessage: BetaResponseOutputMessage | undefined;
+
+  for (const output of rsp.output) {
+    if (!hasAgentMetadata(output)) {
+      continue;
+    }
+
+    hasMultiAgentOutput = true;
+    if (output.agent?.agent_name === '/root' && output.phase === 'final_answer') {
+      finalRootMessage = output;
+    }
+  }
+
+  if (hasMultiAgentOutput && !finalRootMessage) {
+    rsp.output_text = '';
+    return;
+  }
+
   const texts: string[] = [];
   for (const output of rsp.output) {
     if (output.type !== 'message') {
+      continue;
+    }
+    if (hasMultiAgentOutput && output !== finalRootMessage) {
       continue;
     }
 

--- a/src/resources/beta/responses/responses.ts
+++ b/src/resources/beta/responses/responses.ts
@@ -12,6 +12,7 @@ import { Stream } from '../../../core/streaming';
 import { buildHeaders } from '../../../internal/headers';
 import { RequestOptions } from '../../../internal/request-options';
 import { path } from '../../../internal/utils/path';
+import { addOutputText } from '../../../lib/ResponsesParser';
 
 export class Responses extends APIResource {
   inputItems: InputItemsAPI.InputItems = new InputItemsAPI.InputItems(this._client);
@@ -49,15 +50,23 @@ export class Responses extends APIResource {
     options?: RequestOptions,
   ): APIPromise<BetaResponse> | APIPromise<Stream<BetaResponseStreamEvent>> {
     const { betas, ...body } = params;
-    return this._client.post('/responses?beta=true', {
-      body,
-      ...options,
-      headers: buildHeaders([
-        { ...(betas?.toString() != null ? { 'openai-beta': betas?.toString() } : undefined) },
-        options?.headers,
-      ]),
-      stream: params.stream ?? false,
-      __security: { bearerAuth: true },
+    return (
+      this._client.post('/responses?beta=true', {
+        body,
+        ...options,
+        headers: buildHeaders([
+          { ...(betas?.toString() != null ? { 'openai-beta': betas?.toString() } : undefined) },
+          options?.headers,
+        ]),
+        stream: params.stream ?? false,
+        __security: { bearerAuth: true },
+      }) as APIPromise<BetaResponse> | APIPromise<Stream<BetaResponseStreamEvent>>
+    )._thenUnwrap((rsp) => {
+      if ('object' in rsp && rsp.object === 'response') {
+        addOutputText(rsp as BetaResponse);
+      }
+
+      return rsp;
     }) as APIPromise<BetaResponse> | APIPromise<Stream<BetaResponseStreamEvent>>;
   }
 
@@ -92,15 +101,23 @@ export class Responses extends APIResource {
     options?: RequestOptions,
   ): APIPromise<BetaResponse> | APIPromise<Stream<BetaResponseStreamEvent>> {
     const { betas, ...query } = params ?? {};
-    return this._client.get(path`/responses/${responseID}?beta=true`, {
-      query,
-      ...options,
-      headers: buildHeaders([
-        { ...(betas?.toString() != null ? { 'openai-beta': betas?.toString() } : undefined) },
-        options?.headers,
-      ]),
-      stream: params?.stream ?? false,
-      __security: { bearerAuth: true },
+    return (
+      this._client.get(path`/responses/${responseID}?beta=true`, {
+        query,
+        ...options,
+        headers: buildHeaders([
+          { ...(betas?.toString() != null ? { 'openai-beta': betas?.toString() } : undefined) },
+          options?.headers,
+        ]),
+        stream: params?.stream ?? false,
+        __security: { bearerAuth: true },
+      }) as APIPromise<BetaResponse> | APIPromise<Stream<BetaResponseStreamEvent>>
+    )._thenUnwrap((rsp) => {
+      if ('object' in rsp && rsp.object === 'response') {
+        addOutputText(rsp as BetaResponse);
+      }
+
+      return rsp;
     }) as APIPromise<BetaResponse> | APIPromise<Stream<BetaResponseStreamEvent>>;
   }
 
@@ -148,13 +165,18 @@ export class Responses extends APIResource {
     options?: RequestOptions,
   ): APIPromise<BetaResponse> {
     const { betas } = params ?? {};
-    return this._client.post(path`/responses/${responseID}/cancel?beta=true`, {
-      ...options,
-      headers: buildHeaders([
-        { ...(betas?.toString() != null ? { 'openai-beta': betas?.toString() } : undefined) },
-        options?.headers,
-      ]),
-      __security: { bearerAuth: true },
+    return (
+      this._client.post(path`/responses/${responseID}/cancel?beta=true`, {
+        ...options,
+        headers: buildHeaders([
+          { ...(betas?.toString() != null ? { 'openai-beta': betas?.toString() } : undefined) },
+          options?.headers,
+        ]),
+        __security: { bearerAuth: true },
+      }) as APIPromise<BetaResponse>
+    )._thenUnwrap((rsp) => {
+      addOutputText(rsp);
+      return rsp;
     });
   }
 
@@ -1210,6 +1232,12 @@ export interface BetaResponse {
    *   consider using the `output_text` property where supported in SDKs.
    */
   output: Array<BetaResponseOutputItem>;
+
+  /**
+   * SDK convenience property containing the response's output text. For multi-agent
+   * responses, this contains text from the last root `final_answer` message.
+   */
+  output_text: string;
 
   /**
    * Whether to allow the model to run tool calls in parallel.

--- a/tests/api-resources/beta/responses/responses.test.ts
+++ b/tests/api-resources/beta/responses/responses.test.ts
@@ -15,6 +15,7 @@ describe('resource responses', () => {
     expect(rawResponse).toBeInstanceOf(Response);
     const response = await responsePromise;
     expect(response).not.toBeInstanceOf(Response);
+    expect(response).toHaveProperty('output_text');
     const dataAndResponse = await responsePromise.withResponse();
     expect(dataAndResponse.data).toBe(response);
     expect(dataAndResponse.response).toBe(rawResponse);
@@ -26,6 +27,7 @@ describe('resource responses', () => {
     expect(rawResponse).toBeInstanceOf(Response);
     const response = await responsePromise;
     expect(response).not.toBeInstanceOf(Response);
+    expect(response).toHaveProperty('output_text');
     const dataAndResponse = await responsePromise.withResponse();
     expect(dataAndResponse.data).toBe(response);
     expect(dataAndResponse.response).toBe(rawResponse);
@@ -76,6 +78,7 @@ describe('resource responses', () => {
     expect(rawResponse).toBeInstanceOf(Response);
     const response = await responsePromise;
     expect(response).not.toBeInstanceOf(Response);
+    expect(response).toHaveProperty('output_text');
     const dataAndResponse = await responsePromise.withResponse();
     expect(dataAndResponse.data).toBe(response);
     expect(dataAndResponse.response).toBe(rawResponse);

--- a/tests/lib/BetaResponsesParser.test.ts
+++ b/tests/lib/BetaResponsesParser.test.ts
@@ -1,0 +1,68 @@
+import { addOutputText } from '../../src/lib/ResponsesParser';
+import type {
+  BetaResponse,
+  BetaResponseOutputItem,
+  BetaResponseOutputMessage,
+} from '../../src/resources/beta/responses/responses';
+
+function message(
+  texts: string[],
+  agentName?: string,
+  phase?: BetaResponseOutputMessage['phase'],
+): BetaResponseOutputMessage {
+  return {
+    id: 'msg_123',
+    type: 'message',
+    role: 'assistant',
+    status: 'completed',
+    content: texts.map((text) => ({
+      type: 'output_text',
+      annotations: [],
+      logprobs: [],
+      text,
+    })),
+    ...(agentName ? { agent: { agent_name: agentName } } : {}),
+    ...(phase ? { phase } : {}),
+  };
+}
+
+function response(output: BetaResponseOutputItem[]): BetaResponse {
+  return {
+    object: 'response',
+    output,
+  } as BetaResponse;
+}
+
+describe('BetaResponsesParser', () => {
+  it('uses the last root final message for multi-agent output', () => {
+    const rsp = response([
+      message(['old answer'], '/root', 'final_answer'),
+      message(['child answer'], '/root/reviewer', 'final_answer'),
+      message(['root commentary'], '/root', 'commentary'),
+      message(['final ', 'answer'], '/root', 'final_answer'),
+    ]);
+
+    addOutputText(rsp);
+
+    expect(rsp.output_text).toBe('final answer');
+  });
+
+  it('returns an empty string without a root final message for multi-agent output', () => {
+    const rsp = response([
+      message(['child answer'], '/root/reviewer', 'final_answer'),
+      message(['root commentary'], '/root', 'commentary'),
+    ]);
+
+    addOutputText(rsp);
+
+    expect(rsp.output_text).toBe('');
+  });
+
+  it('aggregates non-multi-agent output', () => {
+    const rsp = response([message(['first ']), message(['second'])]);
+
+    addOutputText(rsp);
+
+    expect(rsp.output_text).toBe('first second');
+  });
+});


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Add and populate `BetaResponse.output_text` for beta Responses create, retrieve, and cancel calls. When output contains multi-agent metadata, the helper selects the last `/root` `final_answer` message instead of concatenating root commentary, child-agent output, and earlier root answers. Responses without agent metadata preserve the existing response-wide aggregation behavior.

Tests cover last-root selection, missing terminal root output, the non-multi-agent fallback, and response-resource wiring.

## Additional context & links

Companion docs PR: https://github.com/openai/developers-website/pull/2094

Validation:
- `pnpm lint`
- Full Jest suite: 1,217 passed, 1 skipped
