### PR TITLE
ci: add stable Node test matrix gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,17 +127,8 @@ jobs:
         run: ./scripts/test
 
   test_matrix:
-    name: >-
-      ${{
-        (github.event_name == 'push' || github.event.pull_request.head.repo.fork)
-        && 'test matrix'
-        || 'test matrix (not run)'
-      }}
-    if: >-
-      ${{
-        always() &&
-        (github.event_name == 'push' || github.event.pull_request.head.repo.fork)
-      }}
+    name: ${{ (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && 'test matrix' || 'test matrix (not run)' }}
+    if: ${{ always() && (github.event_name == 'push' || github.event.pull_request.head.repo.fork) }}
     needs: test
     runs-on: ubuntu-latest
     permissions: {}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,31 @@ jobs:
       - name: Run tests
         run: ./scripts/test
 
+  test_matrix:
+    name: >-
+      ${{
+        (github.event_name == 'push' || github.event.pull_request.head.repo.fork)
+        && 'test matrix'
+        || 'test matrix (not run)'
+      }}
+    if: >-
+      ${{
+        always() &&
+        (github.event_name == 'push' || github.event.pull_request.head.repo.fork)
+      }}
+    needs: test
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Verify Node.js test matrix
+        env:
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          if [ "$TEST_RESULT" != "success" ]; then
+            echo "::error::Node.js test matrix result: $TEST_RESULT"
+            exit 1
+          fi
+
   examples:
     timeout-minutes: 10
     name: examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - name: Verify Node.js test matrix
+      - name: Tests (all)
         env:
           TEST_RESULT: ${{ needs.test.result }}
         run: |


### PR DESCRIPTION
## Summary

- add a stable `test matrix` check that depends on every Node.js matrix variant
- fail the summary unless the complete matrix succeeds
- give the intentionally skipped internal-PR instance a distinct name so it cannot satisfy branch protection

This lets the `main` ruleset replace version-specific checks such as `test (20)` and `test (26.2.0)` with one stable context after this change lands.

## Validation

- `git diff --check`
- YAML syntax parse
- `actionlint` v1.7.12

## Rollout

Keep the current version-specific required checks until this PR merges and `test matrix` has run successfully on the default workflow. Then replace the four Node-version contexts in the ruleset with `test matrix`.