### PR TITLE
fix(responses): correct error message in finalResponse and safely accumulate string deltas

### DIFF
--- a/src/lib/responses/ResponseAccumulator.ts
+++ b/src/lib/responses/ResponseAccumulator.ts
@@ -90,8 +90,8 @@ export function accumulateResponse(
         if (content.type !== 'output_text') {
           throw new OpenAIError(`expected content to be 'output_text', got ${content.type}`);
         }
-        content.text += event.delta;
-        snapshot.output_text += event.delta;
+        content.text = (content.text ?? '') + event.delta;
+        snapshot.output_text = (snapshot.output_text ?? '') + event.delta;
       }
       break;
     }
@@ -127,7 +127,7 @@ export function accumulateResponse(
         if (content.type !== 'refusal') {
           throw new OpenAIError(`expected content to be 'refusal', got ${content.type}`);
         }
-        content.refusal += event.delta;
+        content.refusal = (content.refusal ?? '') + event.delta;
       }
       break;
     }
@@ -145,7 +145,7 @@ export function accumulateResponse(
     case 'response.function_call_arguments.delta': {
       const output = getOutput(snapshot, event.output_index);
       if (output.type === 'function_call') {
-        output.arguments += event.delta;
+        output.arguments = (output.arguments ?? '') + event.delta;
       }
       break;
     }
@@ -166,7 +166,7 @@ export function accumulateResponse(
         if (content.type !== 'reasoning_text') {
           throw new OpenAIError(`expected content to be 'reasoning_text', got ${content.type}`);
         }
-        content.text += event.delta;
+        content.text = (content.text ?? '') + event.delta;
       }
       break;
     }
@@ -203,7 +203,7 @@ export function accumulateResponse(
       const output = getOutput(snapshot, event.output_index);
       if (output.type === 'reasoning') {
         const part = getContent(output.summary, event.summary_index);
-        part.text += event.delta;
+        part.text = (part.text ?? '') + event.delta;
       }
       break;
     }
@@ -218,7 +218,7 @@ export function accumulateResponse(
     case 'response.custom_tool_call_input.delta': {
       const output = getOutput(snapshot, event.output_index);
       if (output.type === 'custom_tool_call') {
-        output.input += event.delta;
+        output.input = (output.input ?? '') + event.delta;
       }
       break;
     }
@@ -232,7 +232,7 @@ export function accumulateResponse(
     case 'response.mcp_call_arguments.delta': {
       const output = getOutput(snapshot, event.output_index);
       if (output.type === 'mcp_call') {
-        output.arguments += event.delta;
+        output.arguments = (output.arguments ?? '') + event.delta;
       }
       break;
     }

--- a/src/lib/responses/ResponseStream.ts
+++ b/src/lib/responses/ResponseStream.ts
@@ -289,12 +289,12 @@ export class ResponseStream<ParsedT = null>
 
   /**
    * @returns a promise that resolves with the final Response, or rejects
-   * if an error occurred or the stream ended prematurely without producing a REsponse.
+   * if an error occurred or the stream ended prematurely without producing a Response.
    */
   async finalResponse(): Promise<ParsedResponse<ParsedT>> {
     await this.done();
     const response = this.#finalResponse;
-    if (!response) throw new OpenAIError('stream ended without producing a ChatCompletion');
+    if (!response) throw new OpenAIError('stream ended without producing a Response');
     return response;
   }
 }

--- a/tests/lib/ResponseAccumulator.test.ts
+++ b/tests/lib/ResponseAccumulator.test.ts
@@ -222,7 +222,384 @@ describe('ResponseAccumulator', () => {
       content: [{ type: 'refusal', refusal: 'I cannot help with that.' }],
     });
   });
+
+  describe('string delta accumulation', () => {
+    // Every target that a `.delta` event appends to. The wire payload can leave any
+    // of them unset, in which case appending must start from an empty string rather
+    // than stringifying `undefined`.
+    const cases: Array<{
+      name: string;
+      setup: ResponseStreamEvent[];
+      clear: (snapshot: Response) => void;
+      deltas: ResponseStreamEvent[];
+      read: (snapshot: Response) => string | undefined;
+    }> = [
+      {
+        name: 'response.output_text.delta (content part text)',
+        setup: [...messageSetup(), outputTextPartAdded()],
+        clear: (snapshot) => deleteField(outputTextPart(snapshot), 'text'),
+        deltas: [outputTextDelta(3, 'foo'), outputTextDelta(4, 'bar')],
+        read: (snapshot) => outputTextPart(snapshot).text,
+      },
+      {
+        name: 'response.output_text.delta (aggregated output_text)',
+        setup: [...messageSetup(), outputTextPartAdded()],
+        clear: (snapshot) => deleteField(snapshot, 'output_text'),
+        deltas: [outputTextDelta(3, 'foo'), outputTextDelta(4, 'bar')],
+        read: (snapshot) => snapshot.output_text,
+      },
+      {
+        name: 'response.refusal.delta',
+        setup: [
+          ...messageSetup(),
+          {
+            type: 'response.content_part.added',
+            sequence_number: 2,
+            item_id: 'msg_123',
+            output_index: 0,
+            content_index: 0,
+            part: { type: 'refusal', refusal: '' },
+          },
+        ],
+        clear: (snapshot) => deleteField(refusalPart(snapshot), 'refusal'),
+        deltas: [
+          {
+            type: 'response.refusal.delta',
+            sequence_number: 3,
+            item_id: 'msg_123',
+            output_index: 0,
+            content_index: 0,
+            delta: 'foo',
+          },
+          {
+            type: 'response.refusal.delta',
+            sequence_number: 4,
+            item_id: 'msg_123',
+            output_index: 0,
+            content_index: 0,
+            delta: 'bar',
+          },
+        ],
+        read: (snapshot) => refusalPart(snapshot).refusal,
+      },
+      {
+        name: 'response.function_call_arguments.delta',
+        setup: [
+          created(),
+          {
+            type: 'response.output_item.added',
+            sequence_number: 1,
+            output_index: 0,
+            item: {
+              id: 'fc_123',
+              type: 'function_call',
+              call_id: 'call_123',
+              name: 'get_weather',
+              arguments: '',
+              status: 'in_progress',
+            },
+          },
+        ],
+        clear: (snapshot) => deleteField(outputItem(snapshot, 'function_call'), 'arguments'),
+        deltas: [
+          {
+            type: 'response.function_call_arguments.delta',
+            sequence_number: 2,
+            item_id: 'fc_123',
+            output_index: 0,
+            delta: 'foo',
+          },
+          {
+            type: 'response.function_call_arguments.delta',
+            sequence_number: 3,
+            item_id: 'fc_123',
+            output_index: 0,
+            delta: 'bar',
+          },
+        ],
+        read: (snapshot) => outputItem(snapshot, 'function_call').arguments,
+      },
+      {
+        name: 'response.reasoning_text.delta',
+        setup: [
+          ...reasoningSetup(),
+          {
+            type: 'response.content_part.added',
+            sequence_number: 2,
+            item_id: 'rs_123',
+            output_index: 0,
+            content_index: 0,
+            part: { type: 'reasoning_text', text: '' },
+          },
+        ],
+        clear: (snapshot) => deleteField(reasoningTextPart(snapshot), 'text'),
+        deltas: [
+          {
+            type: 'response.reasoning_text.delta',
+            sequence_number: 3,
+            item_id: 'rs_123',
+            output_index: 0,
+            content_index: 0,
+            delta: 'foo',
+          },
+          {
+            type: 'response.reasoning_text.delta',
+            sequence_number: 4,
+            item_id: 'rs_123',
+            output_index: 0,
+            content_index: 0,
+            delta: 'bar',
+          },
+        ],
+        read: (snapshot) => reasoningTextPart(snapshot).text,
+      },
+      {
+        name: 'response.reasoning_summary_text.delta',
+        setup: [
+          ...reasoningSetup(),
+          {
+            type: 'response.reasoning_summary_part.added',
+            sequence_number: 2,
+            item_id: 'rs_123',
+            output_index: 0,
+            summary_index: 0,
+            part: { type: 'summary_text', text: '' },
+          },
+        ],
+        clear: (snapshot) => deleteField(reasoningSummaryPart(snapshot), 'text'),
+        deltas: [
+          {
+            type: 'response.reasoning_summary_text.delta',
+            sequence_number: 3,
+            item_id: 'rs_123',
+            output_index: 0,
+            summary_index: 0,
+            delta: 'foo',
+          },
+          {
+            type: 'response.reasoning_summary_text.delta',
+            sequence_number: 4,
+            item_id: 'rs_123',
+            output_index: 0,
+            summary_index: 0,
+            delta: 'bar',
+          },
+        ],
+        read: (snapshot) => reasoningSummaryPart(snapshot).text,
+      },
+      {
+        name: 'response.custom_tool_call_input.delta',
+        setup: [
+          created(),
+          {
+            type: 'response.output_item.added',
+            sequence_number: 1,
+            output_index: 0,
+            item: {
+              id: 'ctc_123',
+              type: 'custom_tool_call',
+              call_id: 'call_123',
+              name: 'run_script',
+              input: '',
+            },
+          },
+        ],
+        clear: (snapshot) => deleteField(outputItem(snapshot, 'custom_tool_call'), 'input'),
+        deltas: [
+          {
+            type: 'response.custom_tool_call_input.delta',
+            sequence_number: 2,
+            item_id: 'ctc_123',
+            output_index: 0,
+            delta: 'foo',
+          },
+          {
+            type: 'response.custom_tool_call_input.delta',
+            sequence_number: 3,
+            item_id: 'ctc_123',
+            output_index: 0,
+            delta: 'bar',
+          },
+        ],
+        read: (snapshot) => outputItem(snapshot, 'custom_tool_call').input,
+      },
+      {
+        name: 'response.mcp_call_arguments.delta',
+        setup: [
+          created(),
+          {
+            type: 'response.output_item.added',
+            sequence_number: 1,
+            output_index: 0,
+            item: {
+              id: 'mcp_123',
+              type: 'mcp_call',
+              name: 'search',
+              server_label: 'docs',
+              arguments: '',
+            },
+          },
+        ],
+        clear: (snapshot) => deleteField(outputItem(snapshot, 'mcp_call'), 'arguments'),
+        deltas: [
+          {
+            type: 'response.mcp_call_arguments.delta',
+            sequence_number: 2,
+            item_id: 'mcp_123',
+            output_index: 0,
+            delta: 'foo',
+          },
+          {
+            type: 'response.mcp_call_arguments.delta',
+            sequence_number: 3,
+            item_id: 'mcp_123',
+            output_index: 0,
+            delta: 'bar',
+          },
+        ],
+        read: (snapshot) => outputItem(snapshot, 'mcp_call').arguments,
+      },
+    ];
+
+    it.each(cases)('appends to an initialized target for $name', ({ setup, deltas, read }) => {
+      let snapshot = accumulateEvents(setup);
+
+      for (const delta of deltas) {
+        snapshot = accumulateResponse(delta, snapshot);
+      }
+
+      expect(read(snapshot)).toBe('foobar');
+    });
+
+    it.each(cases)('appends to a missing target for $name', ({ setup, clear, deltas, read }) => {
+      let snapshot = accumulateEvents(setup);
+      clear(snapshot);
+      expect(read(snapshot)).toBeUndefined();
+
+      for (const delta of deltas) {
+        snapshot = accumulateResponse(delta, snapshot);
+      }
+
+      expect(read(snapshot)).toBe('foobar');
+    });
+  });
 });
+
+function created(): ResponseStreamEvent {
+  return { type: 'response.created', sequence_number: 0, response: makeResponse() };
+}
+
+function messageSetup(): ResponseStreamEvent[] {
+  return [
+    created(),
+    {
+      type: 'response.output_item.added',
+      sequence_number: 1,
+      output_index: 0,
+      item: {
+        id: 'msg_123',
+        type: 'message',
+        role: 'assistant',
+        status: 'in_progress',
+        content: [],
+      },
+    },
+  ];
+}
+
+function reasoningSetup(): ResponseStreamEvent[] {
+  return [
+    created(),
+    {
+      type: 'response.output_item.added',
+      sequence_number: 1,
+      output_index: 0,
+      item: { id: 'rs_123', type: 'reasoning', summary: [], content: [] },
+    },
+  ];
+}
+
+function outputTextPartAdded(): ResponseStreamEvent {
+  return {
+    type: 'response.content_part.added',
+    sequence_number: 2,
+    item_id: 'msg_123',
+    output_index: 0,
+    content_index: 0,
+    part: { type: 'output_text', annotations: [], text: '' },
+  };
+}
+
+function outputTextDelta(sequenceNumber: number, delta: string): ResponseStreamEvent {
+  return {
+    type: 'response.output_text.delta',
+    sequence_number: sequenceNumber,
+    item_id: 'msg_123',
+    output_index: 0,
+    content_index: 0,
+    delta,
+    logprobs: [],
+  };
+}
+
+/**
+ * Drops a required field the way a wire payload that omits it would, without
+ * widening the type of the object under test.
+ */
+function deleteField<T extends object, K extends keyof T>(target: T, key: K): void {
+  delete (target as Partial<T>)[key];
+}
+
+function outputItem<T extends Response['output'][number]['type']>(
+  snapshot: Response,
+  type: T,
+): Extract<Response['output'][number], { type: T }> {
+  const output = snapshot.output[0];
+  if (output?.type !== type) {
+    throw new Error(`expected output at index 0 to be '${type}', got ${output?.type}`);
+  }
+  return output as Extract<Response['output'][number], { type: T }>;
+}
+
+function messagePart(snapshot: Response) {
+  const part = outputItem(snapshot, 'message').content[0];
+  if (!part) {
+    throw new Error('expected content at index 0');
+  }
+  return part;
+}
+
+function outputTextPart(snapshot: Response) {
+  const part = messagePart(snapshot);
+  if (part.type !== 'output_text') {
+    throw new Error(`expected content to be 'output_text', got ${part.type}`);
+  }
+  return part;
+}
+
+function refusalPart(snapshot: Response) {
+  const part = messagePart(snapshot);
+  if (part.type !== 'refusal') {
+    throw new Error(`expected content to be 'refusal', got ${part.type}`);
+  }
+  return part;
+}
+
+function reasoningTextPart(snapshot: Response) {
+  const part = outputItem(snapshot, 'reasoning').content?.[0];
+  if (!part) {
+    throw new Error('expected reasoning content at index 0');
+  }
+  return part;
+}
+
+function reasoningSummaryPart(snapshot: Response) {
+  const part = outputItem(snapshot, 'reasoning').summary[0];
+  if (!part) {
+    throw new Error('expected reasoning summary at index 0');
+  }
+  return part;
+}
 
 function accumulateEvents(events: ResponseStreamEvent[]): Response {
   let snapshot: Response | undefined;

--- a/tests/lib/ResponseStream.test.ts
+++ b/tests/lib/ResponseStream.test.ts
@@ -254,6 +254,52 @@ describe('.stream()', () => {
     }
     expect(final.output_text).toBe('The answer is 42');
   });
+
+  it('rejects with Response error message when finalResponse() is called without producing a response', async () => {
+    const stream = new ResponseStream(null);
+    stream._emit('end');
+    await expect(stream.finalResponse()).rejects.toThrowError('stream ended without producing a Response');
+  });
+
+  it('safely accumulates deltas when properties are uninitialized', async () => {
+    const events: ResponseStreamEvent[] = [
+      {
+        type: 'response.created',
+        sequence_number: 0,
+        response: makeResponse(),
+      },
+      {
+        type: 'response.output_item.added',
+        sequence_number: 1,
+        output_index: 0,
+        item: {
+          id: 'call_123',
+          type: 'function_call',
+          call_id: 'call_123',
+          name: 'get_weather',
+          arguments: '',
+          status: 'in_progress',
+        },
+      },
+      {
+        type: 'response.function_call_arguments.delta',
+        sequence_number: 2,
+        item_id: 'call_123',
+        output_index: 0,
+        delta: '{"loc',
+      },
+    ];
+
+    const stream = ResponseStream.fromReadableStream(readableStreamFromEvents(events));
+    for await (const _ of stream) {
+    }
+
+    const final = await stream.finalResponse();
+    expect(final.output[0]).toMatchObject({
+      type: 'function_call',
+      arguments: '{"loc',
+    });
+  });
 });
 
 function readableStreamFromEvents(events: ResponseStreamEvent[]) {

--- a/tests/lib/ResponseStream.test.ts
+++ b/tests/lib/ResponseStream.test.ts
@@ -1,7 +1,11 @@
 import OpenAI, { APIUserAbortError } from 'openai';
 import { ReadableStreamFrom } from 'openai/internal/shims';
 import { ResponseStream } from 'openai/lib/responses/ResponseStream';
-import type { Response, ResponseStreamEvent } from 'openai/resources/responses/responses';
+import type {
+  Response,
+  ResponseFunctionToolCall,
+  ResponseStreamEvent,
+} from 'openai/resources/responses/responses';
 import { makeStreamSnapshotRequest } from '../utils/mock-snapshots';
 
 jest.setTimeout(1000 * 30);
@@ -262,6 +266,17 @@ describe('.stream()', () => {
   });
 
   it('safely accumulates deltas when properties are uninitialized', async () => {
+    const item = {
+      id: 'call_123',
+      type: 'function_call',
+      call_id: 'call_123',
+      name: 'get_weather',
+      status: 'in_progress',
+    } as ResponseFunctionToolCall;
+    // The reported payload omits `arguments` on the added item, so the first delta
+    // has no string to append to.
+    expect(item.arguments).toBeUndefined();
+
     const events: ResponseStreamEvent[] = [
       {
         type: 'response.created',
@@ -272,14 +287,7 @@ describe('.stream()', () => {
         type: 'response.output_item.added',
         sequence_number: 1,
         output_index: 0,
-        item: {
-          id: 'call_123',
-          type: 'function_call',
-          call_id: 'call_123',
-          name: 'get_weather',
-          arguments: '',
-          status: 'in_progress',
-        },
+        item,
       },
       {
         type: 'response.function_call_arguments.delta',


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Fix error message thrown by `ResponseStream.finalResponse()` when a stream ends prematurely without producing a response (`stream ended without producing a Response` instead of `stream ended without producing a ChatCompletion`).
- Fix typo in `ResponseStream.finalResponse()` docstring (`REsponse` -> `Response`).
- Safely handle nullish initial values when accumulating string deltas in `ResponseAccumulator.ts` across `output_text`, `refusal`, `function_call_arguments`, `reasoning_text`, `reasoning_summary_text`, `custom_tool_call_input`, and `mcp_call_arguments` events using `(target ?? '') + event.delta`.
- Add unit tests for `finalResponse()` error message and `ResponseAccumulator` string delta accumulation.

## Additional context & links

### Problem
1. `ResponseStream` belongs to the Responses API. When `finalResponse()` is called on a stream that ended prematurely without producing a `Response`, it previously threw `OpenAIError('stream ended without producing a ChatCompletion')`.
2. When stream delta events (`response.function_call_arguments.delta`, `response.refusal.delta`, etc.) arrive on uninitialized string properties, `+= event.delta` resulted in `"undefined"` prefixing the delta content.

### Root cause
1. Copy-paste typo from `ChatCompletionStream.ts` in `ResponseStream.ts`.
2. Missing nullish fallback `(str ?? '')` on string property delta accumulation in `ResponseAccumulator.ts`.

### Verification
- `pnpm test tests/lib/ResponseStream.test.ts` (Pass)
- `pnpm build` (Pass)
- `pnpm lint` (Pass)