### PR TITLE
ci: remove Agents SDK downstream check

### DIFF
--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -1,6 +1,5 @@
-# Compares pull requests with their base revision and tests the Agents SDK
-# against the proposed package. This catches exported API breaks and downstream
-# incompatibilities that ordinary unit tests can miss.
+# Compares pull requests with their base revision to catch exported API breaks
+# that ordinary unit tests can miss.
 name: CI
 on:
   pull_request:
@@ -45,67 +44,3 @@ jobs:
           # we still detect breaking changes when entire files and their tests are removed.
           git checkout "${{ github.event.pull_request.base.sha }}" -- ./scripts/detect-breaking-changes 2>/dev/null || true
           DETECT_BREAKING_CHANGES_COMPAT=1 ./scripts/detect-breaking-changes ${{ github.event.pull_request.base.sha }}
-  agents_sdk:
-    runs-on: 'ubuntu-latest'
-    name: Detect Agents SDK regressions
-    if: github.repository == 'openai/openai-node'
-    permissions:
-      contents: read
-    steps:
-      # Setup this sdk
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          path: openai-node
-
-      - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version-file: 'openai-node/.nvmrc'
-
-      # openai-agents-js is a pnpm workspace, so this downstream check intentionally
-      # uses the pnpm version pinned by this repository while consuming the local SDK.
-      - name: Install pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
-        with:
-          package_json_file: openai-node/package.json
-
-      - name: Bootstrap
-        working-directory: openai-node
-        run: ./scripts/bootstrap
-
-      - name: Build
-        working-directory: openai-node
-        run: ./scripts/build
-
-      # Setup the agents packages
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          repository: openai/openai-agents-js
-          ref: main
-          path: openai-agents-js
-
-      - name: Configure pnpm
-        working-directory: openai-agents-js
-        run: |
-          echo "resolution-mode=highest" >> .npmrc
-          perl -0pi -e 's/minimumReleaseAge: 10080/minimumReleaseAge: 0/' pnpm-workspace.yaml
-
-      - name: Link agents packages to local SDKs
-        working-directory: openai-agents-js
-        run: pnpm --filter @openai/agents-core --filter @openai/agents-openai --filter @openai/agents add file:../../../openai-node/dist
-
-      - name: Install dependencies
-        working-directory: openai-agents-js
-        run: pnpm install
-
-      - name: Build all packages
-        working-directory: openai-agents-js
-        run: pnpm build
-
-      - name: Run linter
-        working-directory: openai-agents-js
-        run: pnpm lint
-
-      - name: Type-check docs scripts
-        working-directory: openai-agents-js
-        run: pnpm docs:scripts:check


### PR DESCRIPTION
## Summary

- remove the `Detect Agents SDK regressions` downstream compatibility job
- keep the exported API breaking-change check unchanged
- update the workflow header to describe the remaining coverage

## Why

The required downstream check tests a proposed openai-node package against the current `openai-agents-js@main` branch. For intentional type changes, this creates a merge deadlock: Agents cannot adopt the new types until openai-node is merged or published, while openai-node cannot merge because the current Agents branch fails to compile.

The check is still useful as an advisory or post-merge signal, but it should not block pre-merge SDK evolution.

Linear: https://linear.app/openai/issue/SDK-208/evaluate-removing-the-openai-agents-js-downstream-compatibility-check

## Validation

- `yq eval '.' .github/workflows/detect-breaking-changes.yml`
- `git diff --check -- .github/workflows/detect-breaking-changes.yml`

## Merge prerequisite

The `main` repository ruleset currently requires the `Detect Agents SDK regressions` status context. A repository admin must remove that required context before this PR can merge.