### PR TITLE
Organize SDK tests and enforce 98% source coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,19 +152,49 @@ jobs:
           OPENAI_DISABLE_DENO_BUILD=1 ./scripts/build
           node --experimental-strip-types scripts/test-packed-package.ts
 
+  coverage:
+    name: coverage
+    timeout-minutes: 20
+    runs-on: ${{ github.repository == 'stainless-sdks/openai-typescript' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - name: Bootstrap
+        run: ./scripts/bootstrap
+
+      - name: Enforce coverage thresholds
+        run: pnpm test:coverage
+
   test_matrix:
     name: ${{ (github.event_name == 'push' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review') && 'test matrix' || 'test matrix (not run)' }}
     if: ${{ always() && (github.event_name == 'push' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review') }}
-    needs: test
+    needs: [test, coverage]
     runs-on: ubuntu-latest
     permissions: {}
     steps:
       - name: Tests (all)
         env:
           TEST_RESULT: ${{ needs.test.result }}
+          COVERAGE_RESULT: ${{ needs.coverage.result }}
         run: |
           if [ "$TEST_RESULT" != "success" ]; then
             echo "::error::Node.js test matrix result: $TEST_RESULT"
+            exit 1
+          fi
+          if [ "$COVERAGE_RESULT" != "success" ]; then
+            echo "::error::Coverage result: $COVERAGE_RESULT"
             exit 1
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ codegen.log
 Brewfile.lock.json
 dist
 dist-deno
+/coverage
 /oidc
 /*.tgz
 .idea/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,15 +70,26 @@ $ pnpm link --global openai
 
 ## Running tests
 
-Most tests require you to [set up a mock server](https://github.com/dgellow/steady) against the OpenAPI spec to run the tests.
+The test suite is split between handwritten unit tests and Stainless-generated
+API-resource tests. Generated tests have a Stainless-generated comment at the
+top of the file and primarily live in `tests/api-resources/`. Handwritten tests
+live in `tests/lib/`, `tests/helpers/`, `tests/auth/`, and the remaining
+unmarked test files.
 
 ```sh
-$ ./scripts/mock
+$ pnpm test:unit       # Handwritten, isolated SDK behavior; no mock server
+$ pnpm test:generated  # Generated API-resource and client tests
+$ pnpm test            # Complete regular test suite
+$ pnpm test:coverage   # Complete suite with enforced coverage thresholds
 ```
 
-```sh
-$ pnpm test
-```
+The full, generated, and coverage suites automatically start a
+[Steady mock server](https://github.com/dgellow/steady) against the OpenAPI
+spec when one is not already running. To manage that server yourself, run
+`./scripts/mock` in a separate terminal. Coverage is collected from SDK source
+files, excluding vendored third-party code and type-only modules. CI requires
+at least 98% statement and line coverage, 90% branch coverage, and 93%
+function coverage.
 
 ## Linting and formatting
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,8 +1,47 @@
 import type { JestConfigWithTsJest } from 'ts-jest';
 
+const generatedTestPatterns = [
+  '<rootDir>/tests/api-resources/**/*.test.ts',
+  '<rootDir>/tests/backwards-compat-resource-exports.test.ts',
+  '<rootDir>/tests/index.test.ts',
+  '<rootDir>/tests/stringifyQuery.test.ts',
+];
+
+const testSuite = process.env['OPENAI_TEST_SUITE'] ?? 'all';
+
+if (!['all', 'generated', 'unit'].includes(testSuite)) {
+  throw new Error(`Unknown OPENAI_TEST_SUITE: ${testSuite}. Expected all, generated, or unit.`);
+}
+
 const config: JestConfigWithTsJest = {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
+  collectCoverageFrom: [
+    '<rootDir>/src/**/*.ts',
+    '!<rootDir>/src/**/*.d.ts',
+    '!<rootDir>/src/_vendor/**',
+    // V8 counts type-only TypeScript modules as uncovered executable files.
+    '!<rootDir>/src/auth/types.ts',
+    '!<rootDir>/src/internal/builtin-types.ts',
+    '!<rootDir>/src/internal/qs/types.ts',
+    '!<rootDir>/src/internal/shim-types.ts',
+    '!<rootDir>/src/internal/types.ts',
+    '!<rootDir>/src/lib/jsonschema.ts',
+    '!<rootDir>/src/lib/responses/EventTypes.ts',
+  ],
+  coverageDirectory: '<rootDir>/coverage',
+  coverageProvider: 'v8',
+  coverageReporters: ['text-summary', 'json-summary', 'lcov'],
+  coverageThreshold: {
+    global: {
+      // Keep source-line coverage near total while independently ratcheting complex paths.
+      branches: 90,
+      functions: 93,
+      lines: 98,
+      statements: 98,
+    },
+  },
+  testMatch: testSuite === 'generated' ? generatedTestPatterns : ['<rootDir>/tests/**/*.test.ts'],
   transform: {
     '^.+\\.(t|j)sx?$': ['@swc/jest', { sourceMaps: 'inline' }],
   },
@@ -17,7 +56,18 @@ const config: JestConfigWithTsJest = {
     '<rootDir>/deno_tests/',
     '<rootDir>/packages/',
   ],
-  testPathIgnorePatterns: ['scripts', '<rootDir>/tests/live/'],
+  testPathIgnorePatterns: [
+    'scripts',
+    '<rootDir>/tests/live/',
+    ...(testSuite === 'unit' ?
+      [
+        '<rootDir>/tests/api-resources/',
+        '<rootDir>/tests/backwards-compat-resource-exports\\.test\\.ts$',
+        '<rootDir>/tests/index\\.test\\.ts$',
+        '<rootDir>/tests/stringifyQuery\\.test\\.ts$',
+      ]
+    : []),
+  ],
   // prettierPath: require.resolve('prettier-2'),
 };
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   },
   "scripts": {
     "test": "./scripts/test",
+    "test:unit": "OPENAI_TEST_SUITE=unit jest --runInBand",
+    "test:generated": "OPENAI_TEST_SUITE=generated ./scripts/test",
+    "test:coverage": "OPENAI_TEST_SUITE=all ./scripts/test --coverage",
     "test:live:bedrock": "jest --config jest.live.config.ts --runInBand tests/live/bedrock.live.test.ts",
     "build": "./scripts/build",
     "prepublishOnly": "echo 'to publish, run pnpm build && (cd dist; npm publish)' && exit 1",

--- a/tests/client-behavior.test.ts
+++ b/tests/client-behavior.test.ts
@@ -1,0 +1,180 @@
+import OpenAI from 'openai';
+import {
+  APIConnectionError,
+  APIConnectionTimeoutError,
+  OAuthError,
+  SubjectTokenProviderError,
+} from 'openai/core/error';
+import { CursorPage } from 'openai/core/pagination';
+
+class IdempotentOpenAI extends OpenAI {
+  protected override idempotencyHeader = 'Idempotency-Key';
+
+  createIdempotencyKey() {
+    return this.defaultIdempotencyKey();
+  }
+}
+
+function jsonResponse(value: unknown = {}, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(value), {
+    ...init,
+    headers: { 'content-type': 'application/json', ...init.headers },
+  });
+}
+
+describe('OpenAI client request behavior', () => {
+  test('supports PUT requests through the public method helper', async () => {
+    const fetch = jest.fn(async () => jsonResponse({ updated: true }));
+    const client = new OpenAI({ apiKey: 'test-key', fetch });
+
+    await expect(client.put('/items/123', { body: { enabled: true } })).resolves.toEqual({ updated: true });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/items/123',
+      expect.objectContaining({ method: 'PUT', body: '{"enabled":true}' }),
+    );
+  });
+
+  test('generates unique idempotency keys and preserves explicitly supplied keys', async () => {
+    const client = new IdempotentOpenAI({ apiKey: 'test-key' });
+
+    expect(client.createIdempotencyKey()).toMatch(/^stainless-node-retry-[\da-f-]{36}$/);
+    const generated = await client.buildRequest({ method: 'post', path: '/items' });
+    const explicit = await client.buildRequest({
+      method: 'post',
+      path: '/items',
+      idempotencyKey: 'caller-provided',
+    });
+    const readOnly = await client.buildRequest({ method: 'get', path: '/items' });
+
+    expect(generated.req.headers.get('idempotency-key')).toMatch(/^stainless-node-retry-/);
+    expect(explicit.req.headers.get('idempotency-key')).toBe('caller-provided');
+    expect(readOnly.req.headers.has('idempotency-key')).toBe(false);
+  });
+
+  test('resolves asynchronous pagination request options before fetching', async () => {
+    const fetch = jest.fn(async () => jsonResponse({ data: [{ id: 'item_123' }], has_more: false }));
+    const client = new OpenAI({ apiKey: 'test-key', fetch });
+    const page = await client.getAPIList(
+      '/items',
+      CursorPage<{ id: string }>,
+      Promise.resolve({ query: { limit: 3 } }),
+    );
+
+    expect(page.data).toEqual([{ id: 'item_123' }]);
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/items?limit=3',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  test.each([
+    [408, {}, true],
+    [409, {}, true],
+    [429, {}, true],
+    [500, {}, true],
+    [400, { 'x-should-retry': 'true' }, true],
+    [500, { 'x-should-retry': 'false' }, false],
+    [400, {}, false],
+  ])(
+    'retries HTTP status %i according to explicit headers and defaults',
+    async (status, headers, retries) => {
+      const fetch = jest
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            { error: { message: 'request failed' } },
+            {
+              status,
+              headers: { ...headers, 'retry-after-ms': '0' },
+            },
+          ),
+        )
+        .mockResolvedValueOnce(jsonResponse({ recovered: true }));
+      const client = new OpenAI({ apiKey: 'test-key', maxRetries: 1, fetch });
+
+      if (retries) {
+        await expect(client.get('/items')).resolves.toEqual({ recovered: true });
+        expect(fetch).toHaveBeenCalledTimes(2);
+      } else {
+        await expect(client.get('/items')).rejects.toMatchObject({ status });
+        expect(fetch).toHaveBeenCalledTimes(1);
+      }
+    },
+  );
+
+  test('honors HTTP-date retry-after headers', async () => {
+    const parseDate = jest.spyOn(Date, 'parse').mockReturnValue(Date.now() + 5);
+    const fetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(
+          { error: { message: 'rate limited' } },
+          { status: 429, headers: { 'retry-after': new Date(0).toUTCString() } },
+        ),
+      )
+      .mockResolvedValueOnce(jsonResponse({ recovered: true }));
+    const client = new OpenAI({ apiKey: 'test-key', maxRetries: 1, fetch });
+
+    try {
+      await expect(client.get('/items')).resolves.toEqual({ recovered: true });
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(parseDate).toHaveBeenCalled();
+    } finally {
+      parseDate.mockRestore();
+    }
+  });
+
+  test.each([
+    [new Error('network unavailable'), APIConnectionError],
+    [new Error('connection timed out'), APIConnectionTimeoutError],
+    [new OAuthError(401, { error: 'invalid_client' }, new Headers()), OAuthError],
+    [new SubjectTokenProviderError('identity unavailable', 'test'), SubjectTokenProviderError],
+  ] as const)('preserves the appropriate error class when fetching fails', async (failure, ExpectedError) => {
+    const client = new OpenAI({
+      apiKey: 'test-key',
+      maxRetries: 0,
+      fetch: jest.fn(async () => {
+        throw failure;
+      }),
+    });
+
+    await expect(client.get('/items')).rejects.toBeInstanceOf(ExpectedError);
+  });
+
+  test('reports failures and invalid values returned by asynchronous API-key providers', async () => {
+    const failing = new OpenAI({
+      apiKey: async () => {
+        throw new Error('provider unavailable');
+      },
+    });
+    const invalid = new OpenAI({ apiKey: async () => '' });
+
+    await expect(failing._callApiKey()).rejects.toThrow("Failed to get token from 'apiKey' function");
+    await expect(invalid._callApiKey()).rejects.toThrow(
+      "Expected 'apiKey' function argument to return a string",
+    );
+  });
+
+  test('rejects already-aborted requests before making network calls', async () => {
+    const fetch = jest.fn();
+    const client = new OpenAI({ apiKey: 'test-key', fetch });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(client.get('/items', { signal: controller.signal })).rejects.toThrow('Request was aborted');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test('encodes URL-encoded request objects with the configured content type', async () => {
+    const client = new OpenAI({ apiKey: 'test-key' });
+    const { req } = await client.buildRequest({
+      method: 'post',
+      path: '/items',
+      body: { search: 'hello world', limit: 2 },
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    });
+
+    expect(req.headers.get('content-type')).toBe('application/x-www-form-urlencoded');
+    expect(req.body).toBe('search=hello%20world&limit=2');
+  });
+});

--- a/tests/generated-resource-helpers.test.ts
+++ b/tests/generated-resource-helpers.test.ts
@@ -1,0 +1,339 @@
+import OpenAI from 'openai';
+import { AssistantStream } from 'openai/lib/AssistantStream';
+import { sleep } from 'openai/internal/utils/sleep';
+import type { NullableHeaders } from 'openai/internal/headers';
+
+jest.mock('openai/internal/utils/sleep', () => ({
+  sleep: jest.fn(async () => {}),
+}));
+
+const mockedSleep = sleep as jest.MockedFunction<typeof sleep>;
+
+function createClient(): OpenAI {
+  return new OpenAI({ apiKey: 'test-key', baseURL: 'https://example.com/v1/' });
+}
+
+function withResponse(data: object, headers: Record<string, string> = {}) {
+  return {
+    withResponse: async () => ({ data, response: new Response(null, { headers }) }),
+  } as any;
+}
+
+beforeEach(() => {
+  mockedSleep.mockClear();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('vector store file helpers', () => {
+  test('creates a file and forwards polling options', async () => {
+    const files = createClient().vectorStores.files;
+    const created = { id: 'file_created', status: 'in_progress' };
+    const completed = { id: 'file_created', status: 'completed' };
+    const create = jest.spyOn(files, 'create').mockImplementation(() => Promise.resolve(created) as any);
+    const poll = jest.spyOn(files, 'poll').mockResolvedValue(completed as any);
+    const options = { pollIntervalMs: 12, headers: { 'X-Test': 'yes' } };
+
+    await expect(files.createAndPoll('vs_123', { file_id: 'file_123' }, options)).resolves.toBe(completed);
+    expect(create).toHaveBeenCalledWith('vs_123', { file_id: 'file_123' }, options);
+    expect(poll).toHaveBeenCalledWith('vs_123', 'file_created', options);
+  });
+
+  test.each([
+    { name: 'explicit interval', interval: 7, header: '12', expected: 7 },
+    { name: 'server-provided interval', interval: undefined, header: '12', expected: 12 },
+    { name: 'invalid server interval', interval: undefined, header: 'invalid', expected: 5000 },
+    { name: 'default interval', interval: undefined, header: undefined, expected: 5000 },
+  ])('polls an in-progress file using the $name', async ({ interval, header, expected }) => {
+    const files = createClient().vectorStores.files;
+    const completed = { id: 'file_123', status: 'completed' };
+    const retrieve = jest
+      .spyOn(files, 'retrieve')
+      .mockReturnValueOnce(
+        withResponse(
+          { id: 'file_123', status: 'in_progress' },
+          header ? { 'openai-poll-after-ms': header } : {},
+        ),
+      )
+      .mockReturnValueOnce(withResponse(completed));
+
+    await expect(
+      files.poll('vs_123', 'file_123', interval ? { pollIntervalMs: interval } : {}),
+    ).resolves.toEqual(completed);
+    expect(mockedSleep).toHaveBeenCalledWith(expected);
+
+    const headers = (retrieve.mock.calls[0]![2]?.headers as NullableHeaders).values;
+    expect(headers.get('X-Stainless-Poll-Helper')).toBe('true');
+    expect(headers.get('X-Stainless-Custom-Poll-Interval')).toBe(interval ? String(interval) : null);
+  });
+
+  test.each(['completed', 'failed'] as const)('returns a file in the %s terminal state', async (status) => {
+    const files = createClient().vectorStores.files;
+    const result = { id: 'file_123', status };
+    jest.spyOn(files, 'retrieve').mockReturnValue(withResponse(result));
+
+    await expect(files.poll('vs_123', 'file_123')).resolves.toEqual(result);
+    expect(mockedSleep).not.toHaveBeenCalled();
+  });
+
+  test('uploads a file before attaching it to the vector store', async () => {
+    const client = createClient();
+    const resource = client.vectorStores.files;
+    const file = new File(['contents'], 'sample.txt');
+    const uploaded = { id: 'file_uploaded' };
+    const attached = { id: 'file_attached', status: 'completed' };
+    const upload = jest
+      .spyOn(client.files, 'create')
+      .mockImplementation(() => Promise.resolve(uploaded) as any);
+    const create = jest.spyOn(resource, 'create').mockImplementation(() => Promise.resolve(attached) as any);
+
+    await expect(resource.upload('vs_123', file)).resolves.toBe(attached);
+    expect(upload).toHaveBeenCalledWith({ file, purpose: 'assistants' }, undefined);
+    expect(create).toHaveBeenCalledWith('vs_123', { file_id: 'file_uploaded' }, undefined);
+  });
+
+  test('uploads, attaches, and polls a vector-store file', async () => {
+    const files = createClient().vectorStores.files;
+    const file = new File(['contents'], 'sample.txt');
+    const attached = { id: 'file_attached', status: 'in_progress' };
+    const completed = { ...attached, status: 'completed' };
+    const options = { pollIntervalMs: 5 };
+    const upload = jest.spyOn(files, 'upload').mockResolvedValue(attached as any);
+    const poll = jest.spyOn(files, 'poll').mockResolvedValue(completed as any);
+
+    await expect(files.uploadAndPoll('vs_123', file, options)).resolves.toBe(completed);
+    expect(upload).toHaveBeenCalledWith('vs_123', file, options);
+    expect(poll).toHaveBeenCalledWith('vs_123', 'file_attached', options);
+  });
+});
+
+describe('vector store file batch helpers', () => {
+  test('creates a batch and polls its resulting identifier', async () => {
+    const batches = createClient().vectorStores.fileBatches;
+    const created = { id: 'batch_123', status: 'in_progress' };
+    const completed = { ...created, status: 'completed' };
+    const create = jest.spyOn(batches, 'create').mockImplementation(() => Promise.resolve(created) as any);
+    const poll = jest.spyOn(batches, 'poll').mockResolvedValue(completed as any);
+    const options = { pollIntervalMs: 5 };
+
+    await expect(batches.createAndPoll('vs_123', { file_ids: ['file_123'] }, options)).resolves.toBe(
+      completed,
+    );
+    expect(create).toHaveBeenCalledWith('vs_123', { file_ids: ['file_123'] });
+    expect(poll).toHaveBeenCalledWith('vs_123', 'batch_123', options);
+  });
+
+  test.each([
+    { name: 'explicit interval', interval: 7, header: '12', expected: 7 },
+    { name: 'server interval', interval: undefined, header: '12', expected: 12 },
+    { name: 'invalid server interval', interval: undefined, header: 'invalid', expected: 5000 },
+  ])('polls in-progress batches with the $name', async ({ interval, header, expected }) => {
+    const batches = createClient().vectorStores.fileBatches;
+    const completed = { id: 'batch_123', status: 'completed' };
+    const retrieve = jest
+      .spyOn(batches, 'retrieve')
+      .mockReturnValueOnce(
+        withResponse({ id: 'batch_123', status: 'in_progress' }, { 'openai-poll-after-ms': header }),
+      )
+      .mockReturnValueOnce(withResponse(completed));
+
+    await expect(
+      batches.poll('vs_123', 'batch_123', interval ? { pollIntervalMs: interval } : {}),
+    ).resolves.toEqual(completed);
+    expect(mockedSleep).toHaveBeenCalledWith(expected);
+    const headers = (retrieve.mock.calls[0]![2]?.headers as NullableHeaders).values;
+    expect(headers.get('X-Stainless-Poll-Helper')).toBe('true');
+  });
+
+  test.each(['completed', 'failed', 'cancelled'] as const)(
+    'returns a %s batch without waiting',
+    async (status) => {
+      const batches = createClient().vectorStores.fileBatches;
+      const result = { id: 'batch_123', status };
+      jest.spyOn(batches, 'retrieve').mockReturnValue(withResponse(result));
+
+      await expect(batches.poll('vs_123', 'batch_123')).resolves.toEqual(result);
+      expect(mockedSleep).not.toHaveBeenCalled();
+    },
+  );
+
+  test('rejects an empty batch before uploading any files', async () => {
+    const batches = createClient().vectorStores.fileBatches;
+
+    await expect(batches.uploadAndPoll('vs_123', { files: [] })).rejects.toThrow('No `files` provided');
+  });
+
+  test('uploads files concurrently and preserves previously uploaded identifiers', async () => {
+    const client = createClient();
+    const batches = client.vectorStores.fileBatches;
+    const files = [new File(['a'], 'a.txt'), new File(['b'], 'b.txt'), new File(['c'], 'c.txt')];
+    let nextIdentifier = 0;
+    const upload = jest
+      .spyOn(client.files, 'create')
+      .mockImplementation((async () => ({ id: `file_${++nextIdentifier}` })) as any);
+    const result = { id: 'batch_123', status: 'completed' };
+    const createAndPoll = jest.spyOn(batches, 'createAndPoll').mockResolvedValue(result as any);
+
+    await expect(
+      batches.uploadAndPoll('vs_123', { files, fileIds: ['existing'] }, { maxConcurrency: 2 }),
+    ).resolves.toBe(result);
+    expect(upload).toHaveBeenCalledTimes(3);
+    expect(createAndPoll).toHaveBeenCalledWith('vs_123', {
+      file_ids: expect.arrayContaining(['existing', 'file_1', 'file_2', 'file_3']),
+    });
+  });
+
+  test('propagates upload failures before creating a batch', async () => {
+    const client = createClient();
+    const batches = client.vectorStores.fileBatches;
+    jest
+      .spyOn(client.files, 'create')
+      .mockImplementation(() => Promise.reject(new Error('upload failed')) as any);
+    const createAndPoll = jest.spyOn(batches, 'createAndPoll');
+    const logError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(batches.uploadAndPoll('vs_123', { files: [new File(['a'], 'a.txt')] })).rejects.toThrow(
+      '1 promise(s) failed',
+    );
+    expect(logError).toHaveBeenCalledWith(expect.objectContaining({ message: 'upload failed' }));
+    expect(createAndPoll).not.toHaveBeenCalled();
+  });
+});
+
+describe('assistant run helpers', () => {
+  test('creates a run and polls the resulting run identifier', async () => {
+    const runs = createClient().beta.threads.runs;
+    const run = { id: 'run_123', status: 'queued' };
+    const completed = { ...run, status: 'completed' };
+    const create = jest.spyOn(runs, 'create').mockImplementation(() => Promise.resolve(run) as any);
+    const poll = jest.spyOn(runs, 'poll').mockResolvedValue(completed as any);
+    const options = { pollIntervalMs: 3 };
+
+    await expect(runs.createAndPoll('thread_123', { assistant_id: 'assistant_123' }, options)).resolves.toBe(
+      completed,
+    );
+    expect(create).toHaveBeenCalledWith('thread_123', { assistant_id: 'assistant_123' }, options);
+    expect(poll).toHaveBeenCalledWith('run_123', { thread_id: 'thread_123' }, options);
+  });
+
+  test.each(['queued', 'in_progress', 'cancelling'] as const)(
+    'waits while runs are %s and respects server-provided polling intervals',
+    async (status) => {
+      const runs = createClient().beta.threads.runs;
+      const completed = { id: 'run_123', status: 'completed' };
+      const retrieve = jest
+        .spyOn(runs, 'retrieve')
+        .mockReturnValueOnce(withResponse({ id: 'run_123', status }, { 'openai-poll-after-ms': '9' }))
+        .mockReturnValueOnce(withResponse(completed));
+
+      await expect(runs.poll('run_123', { thread_id: 'thread_123' })).resolves.toEqual(completed);
+      expect(mockedSleep).toHaveBeenCalledWith(9);
+      const headers = (retrieve.mock.calls[0]![2]?.headers as NullableHeaders).values;
+      expect(headers.get('X-Stainless-Poll-Helper')).toBe('true');
+    },
+  );
+
+  test.each(['requires_action', 'incomplete', 'cancelled', 'completed', 'failed', 'expired'] as const)(
+    'returns runs in the %s terminal state',
+    async (status) => {
+      const runs = createClient().beta.threads.runs;
+      const run = { id: 'run_123', status };
+      jest.spyOn(runs, 'retrieve').mockReturnValue(withResponse(run));
+
+      await expect(runs.poll('run_123', { thread_id: 'thread_123' })).resolves.toEqual(run);
+      expect(mockedSleep).not.toHaveBeenCalled();
+    },
+  );
+
+  test('uses explicit and fallback polling intervals', async () => {
+    const runs = createClient().beta.threads.runs;
+    const completed = { id: 'run_123', status: 'completed' };
+    const retrieve = jest.spyOn(runs, 'retrieve');
+
+    retrieve
+      .mockReturnValueOnce(
+        withResponse({ id: 'run_123', status: 'queued' }, { 'openai-poll-after-ms': '99' }),
+      )
+      .mockReturnValueOnce(withResponse(completed));
+    await runs.poll('run_123', { thread_id: 'thread_123' }, { pollIntervalMs: 4 });
+    expect(mockedSleep).toHaveBeenLastCalledWith(4);
+
+    retrieve
+      .mockReturnValueOnce(
+        withResponse({ id: 'run_123', status: 'queued' }, { 'openai-poll-after-ms': 'invalid' }),
+      )
+      .mockReturnValueOnce(withResponse(completed));
+    await runs.poll('run_123', { thread_id: 'thread_123' });
+    expect(mockedSleep).toHaveBeenLastCalledWith(5000);
+  });
+
+  test('submits tool outputs before polling the run', async () => {
+    const runs = createClient().beta.threads.runs;
+    const run = { id: 'run_123', status: 'in_progress' };
+    const completed = { ...run, status: 'completed' };
+    const params = { thread_id: 'thread_123', tool_outputs: [{ tool_call_id: 'tool_123', output: 'done' }] };
+    const submit = jest
+      .spyOn(runs, 'submitToolOutputs')
+      .mockImplementation(() => Promise.resolve(run) as any);
+    const poll = jest.spyOn(runs, 'poll').mockResolvedValue(completed as any);
+    const options = { pollIntervalMs: 3 };
+
+    await expect(runs.submitToolOutputsAndPoll('run_123', params, options)).resolves.toBe(completed);
+    expect(submit).toHaveBeenCalledWith('run_123', params, options);
+    expect(poll).toHaveBeenCalledWith('run_123', params, options);
+  });
+
+  test('routes deprecated and current run streams through the same stream helper', () => {
+    const runs = createClient().beta.threads.runs;
+    const stream = {} as AssistantStream;
+    const createStream = jest.spyOn(AssistantStream, 'createAssistantStream').mockReturnValue(stream);
+    const body = { assistant_id: 'assistant_123' };
+    const options = { headers: { 'X-Test': 'yes' } };
+
+    expect(runs.createAndStream('thread_123', body, options)).toBe(stream);
+    expect(runs.stream('thread_123', body, options)).toBe(stream);
+    expect(createStream).toHaveBeenNthCalledWith(1, 'thread_123', runs, body, options);
+    expect(createStream).toHaveBeenNthCalledWith(2, 'thread_123', runs, body, options);
+  });
+
+  test('creates a streaming tool-output runner', () => {
+    const runs = createClient().beta.threads.runs;
+    const stream = {} as AssistantStream;
+    const createStream = jest.spyOn(AssistantStream, 'createToolAssistantStream').mockReturnValue(stream);
+    const params = { thread_id: 'thread_123', tool_outputs: [{ tool_call_id: 'tool_123', output: 'done' }] };
+
+    expect(runs.submitToolOutputsStream('run_123', params)).toBe(stream);
+    expect(createStream).toHaveBeenCalledWith('run_123', runs, params, undefined);
+  });
+});
+
+describe('assistant thread helpers', () => {
+  test('creates and runs a thread before polling the returned run', async () => {
+    const threads = createClient().beta.threads;
+    const run = { id: 'run_123', thread_id: 'thread_123', status: 'queued' };
+    const completed = { ...run, status: 'completed' };
+    const createAndRun = jest
+      .spyOn(threads, 'createAndRun')
+      .mockImplementation(() => Promise.resolve(run) as any);
+    const poll = jest.spyOn(threads.runs, 'poll').mockResolvedValue(completed as any);
+    const body = { assistant_id: 'assistant_123' };
+    const options = { pollIntervalMs: 2 };
+
+    await expect(threads.createAndRunPoll(body, options)).resolves.toBe(completed);
+    expect(createAndRun).toHaveBeenCalledWith(body, options);
+    expect(poll).toHaveBeenCalledWith('run_123', { thread_id: 'thread_123' }, options);
+  });
+
+  test('creates a streamed thread and assistant run', () => {
+    const threads = createClient().beta.threads;
+    const stream = {} as AssistantStream;
+    const createStream = jest.spyOn(AssistantStream, 'createThreadAssistantStream').mockReturnValue(stream);
+    const body = { assistant_id: 'assistant_123' };
+    const options = { headers: { 'X-Test': 'yes' } };
+
+    expect(threads.createAndRunStream(body, options)).toBe(stream);
+    expect(createStream).toHaveBeenCalledWith(body, threads, options);
+  });
+});

--- a/tests/helpers/audio-recording.test.ts
+++ b/tests/helpers/audio-recording.test.ts
@@ -1,0 +1,162 @@
+jest.mock('node:child_process', () => ({ spawn: jest.fn() }));
+
+import { spawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough, Readable, Writable } from 'node:stream';
+import { playAudio, recordAudio } from 'openai/helpers/audio';
+
+const spawnMock = spawn as jest.MockedFunction<typeof spawn>;
+
+function mockFfmpeg() {
+  const ffmpeg = Object.assign(new EventEmitter(), {
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    kill: jest.fn(),
+  });
+  spawnMock.mockReturnValue(ffmpeg as any);
+  return ffmpeg;
+}
+
+function mockFfplay(exitCode = 0) {
+  const chunks: Buffer[] = [];
+  const stdin = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(Buffer.from(chunk));
+      callback();
+    },
+  });
+  const ffplay = Object.assign(new EventEmitter(), { stdin, kill: jest.fn() });
+  stdin.on('finish', () => ffplay.emit('close', exitCode));
+  spawnMock.mockReturnValue(ffplay as any);
+  return { chunks, ffplay };
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  spawnMock.mockReset();
+});
+
+describe('recordAudio', () => {
+  test('collects ffmpeg output into a WAV File', async () => {
+    const ffmpeg = mockFfmpeg();
+    const recording = recordAudio();
+
+    ffmpeg.stdout.write(Buffer.from('first'));
+    ffmpeg.stdout.write(Buffer.from(' second'));
+    ffmpeg.emit('close', 0);
+
+    const file = await recording;
+    expect(file).toBeInstanceOf(File);
+    expect(file.name).toBe('audio.wav');
+    expect(file.type).toBe('audio/wav');
+    expect(Buffer.from(await file.arrayBuffer()).toString()).toBe('first second');
+    expect(spawnMock).toHaveBeenCalledWith(
+      'ffmpeg',
+      expect.arrayContaining(['-i', ':0', '-ar', '24000', '-ac', '1', '-f', 'wav', 'pipe:1']),
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+  });
+
+  test('uses the requested audio input device', async () => {
+    const ffmpeg = mockFfmpeg();
+    const recording = recordAudio({ device: 3 });
+    ffmpeg.emit('close', 0);
+
+    await recording;
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'ffmpeg',
+      expect.arrayContaining(['-i', ':3']),
+      expect.any(Object),
+    );
+  });
+
+  test('terminates ffmpeg when its external abort signal is triggered', async () => {
+    const ffmpeg = mockFfmpeg();
+    const controller = new AbortController();
+    const recording = recordAudio({ signal: controller.signal });
+
+    controller.abort();
+    expect(ffmpeg.kill).toHaveBeenCalledWith('SIGTERM');
+
+    ffmpeg.emit('close', 0);
+    await recording;
+  });
+
+  test('terminates ffmpeg when the configured timeout expires', async () => {
+    const ffmpeg = mockFfmpeg();
+    const timeoutController = new AbortController();
+    const timeout = jest.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
+    const recording = recordAudio({ timeout: 50 });
+
+    expect(timeout).toHaveBeenCalledWith(50);
+    timeoutController.abort();
+    expect(ffmpeg.kill).toHaveBeenCalledWith('SIGTERM');
+
+    ffmpeg.emit('close', 0);
+    await recording;
+  });
+
+  test.each([0, -10])('does not install a timeout for %i milliseconds', async (timeout) => {
+    const ffmpeg = mockFfmpeg();
+    const timeoutSpy = jest.spyOn(AbortSignal, 'timeout');
+    const recording = recordAudio({ timeout });
+    ffmpeg.emit('close', 0);
+
+    await recording;
+
+    expect(timeoutSpy).not.toHaveBeenCalled();
+  });
+
+  test('reports ffmpeg process errors', async () => {
+    const ffmpeg = mockFfmpeg();
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const failure = new Error('microphone unavailable');
+    const recording = recordAudio();
+
+    ffmpeg.emit('error', failure);
+
+    await expect(recording).rejects.toBe(failure);
+    expect(consoleError).toHaveBeenCalledWith(failure);
+  });
+
+  test('reports synchronous ffmpeg startup failures', async () => {
+    spawnMock.mockImplementation(() => {
+      throw new Error('ffmpeg was not found');
+    });
+
+    await expect(recordAudio()).rejects.toThrow('ffmpeg was not found');
+  });
+});
+
+describe('playAudio input and process errors', () => {
+  test('plays File inputs through their readable stream', async () => {
+    const { chunks } = mockFfplay();
+
+    await playAudio(new File(['file audio'], 'audio.wav', { type: 'audio/wav' }));
+
+    expect(Buffer.concat(chunks).toString()).toBe('file audio');
+  });
+
+  test('plays Node readable stream inputs directly', async () => {
+    const { chunks } = mockFfplay();
+
+    await playAudio(Readable.from(['node audio']));
+
+    expect(Buffer.concat(chunks).toString()).toBe('node audio');
+  });
+
+  test('rejects unsuccessful ffplay exit codes', async () => {
+    mockFfplay(3);
+
+    await expect(playAudio(Readable.from(['audio']))).rejects.toThrow('ffplay process exited with code 3');
+  });
+
+  test('rejects synchronous ffplay startup failures', async () => {
+    spawnMock.mockImplementation(() => {
+      throw new Error('ffplay was not found');
+    });
+
+    await expect(playAudio(Readable.from(['audio']))).rejects.toThrow('ffplay was not found');
+  });
+});

--- a/tests/internal/detect-platform.test.ts
+++ b/tests/internal/detect-platform.test.ts
@@ -1,0 +1,162 @@
+type PlatformModule = typeof import('openai/internal/detect-platform');
+
+type PlatformGlobals = {
+  Deno?: unknown;
+  EdgeRuntime?: unknown;
+  navigator?: unknown;
+  process?: unknown;
+  window?: unknown;
+};
+
+function withGlobals<T>(overrides: PlatformGlobals, run: (detection: PlatformModule) => T): T {
+  let result!: T;
+
+  jest.isolateModules(() => {
+    const detection = require('openai/internal/detect-platform') as PlatformModule;
+    const descriptors = new Map<string, PropertyDescriptor | undefined>();
+
+    try {
+      for (const [name, value] of Object.entries(overrides)) {
+        descriptors.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+        if (value === undefined) {
+          delete (globalThis as Record<string, unknown>)[name];
+        } else {
+          Object.defineProperty(globalThis, name, { configurable: true, value });
+        }
+      }
+
+      result = run(detection);
+    } finally {
+      for (const [name, descriptor] of descriptors) {
+        if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+        else delete (globalThis as Record<string, unknown>)[name];
+      }
+    }
+  });
+
+  return result;
+}
+
+describe('platform detection', () => {
+  test('memoizes platform headers for repeated calls', () => {
+    withGlobals({}, ({ getPlatformHeaders }) => {
+      expect(getPlatformHeaders()).toBe(getPlatformHeaders());
+    });
+  });
+
+  test.each([
+    ['linux', 'x86_64', 'Linux', 'x64'],
+    ['darwin', 'x64', 'MacOS', 'x64'],
+    ['win32', 'x32', 'Windows', 'x32'],
+    ['ios-device', 'arm64', 'iOS', 'arm64'],
+    ['android', 'aarch64', 'Android', 'arm64'],
+    ['freebsd', 'arm', 'FreeBSD', 'arm'],
+    ['openbsd', 'riscv64', 'OpenBSD', 'other:riscv64'],
+    ['custom', 'mips', 'Other:custom', 'other:mips'],
+    ['', '', 'Unknown', 'unknown'],
+  ])('normalizes Deno operating system %s and architecture %s', (os, arch, expectedOS, expectedArch) => {
+    const headers = withGlobals(
+      { Deno: { build: { os, arch }, version: { deno: '2.0.0' } } },
+      ({ getPlatformHeaders }) => getPlatformHeaders(),
+    );
+
+    expect(headers).toMatchObject({
+      'X-Stainless-Lang': 'js',
+      'X-Stainless-OS': expectedOS,
+      'X-Stainless-Arch': expectedArch,
+      'X-Stainless-Runtime': 'deno',
+      'X-Stainless-Runtime-Version': '2.0.0',
+    });
+  });
+
+  test.each([
+    ['2.1.0', '2.1.0'],
+    [undefined, 'unknown'],
+  ])('accepts string or missing Deno runtime version metadata', (version, expected) => {
+    const headers = withGlobals(
+      { Deno: { build: { os: 'linux', arch: 'x64' }, version } },
+      ({ getPlatformHeaders }) => getPlatformHeaders(),
+    );
+
+    expect(headers['X-Stainless-Runtime-Version']).toBe(expected);
+  });
+
+  test('detects edge runtimes and retains their runtime versions', () => {
+    const headers = withGlobals({ EdgeRuntime: 'vercel' }, ({ getPlatformHeaders }) => getPlatformHeaders());
+
+    expect(headers).toMatchObject({
+      'X-Stainless-OS': 'Unknown',
+      'X-Stainless-Arch': 'other:vercel',
+      'X-Stainless-Runtime': 'edge',
+      'X-Stainless-Runtime-Version': process.version,
+    });
+  });
+
+  test('detects Node.js platforms and handles missing process metadata', () => {
+    const fakeProcess = {
+      [Symbol.toStringTag]: 'process',
+      platform: undefined,
+      arch: undefined,
+      version: undefined,
+    };
+    const headers = withGlobals({ process: fakeProcess }, ({ getPlatformHeaders }) => getPlatformHeaders());
+
+    expect(headers).toMatchObject({
+      'X-Stainless-OS': 'Other:unknown',
+      'X-Stainless-Arch': 'other:unknown',
+      'X-Stainless-Runtime': 'node',
+      'X-Stainless-Runtime-Version': 'unknown',
+    });
+  });
+
+  test.each([
+    ['Edge/105.3.1', 'edge', '105.3.1'],
+    ['MSIE 11.0', 'ie', '11.0.0'],
+    ['Trident/7.0; rv:11.2', 'ie', '11.2.0'],
+    ['Chrome/126.5.2', 'chrome', '126.5.2'],
+    ['Firefox/127.4', 'firefox', '127.4.0'],
+    ['Version/17.3 Safari/605', 'safari', '17.3.0'],
+    ['Mozilla Safari', 'safari', '0.0.0'],
+  ])('identifies %s browser user agents', (userAgent, browser, version) => {
+    const headers = withGlobals({ process: undefined, navigator: { userAgent } }, ({ getPlatformHeaders }) =>
+      getPlatformHeaders(),
+    );
+
+    expect(headers).toMatchObject({
+      'X-Stainless-OS': 'Unknown',
+      'X-Stainless-Arch': 'unknown',
+      'X-Stainless-Runtime': `browser:${browser}`,
+      'X-Stainless-Runtime-Version': version,
+    });
+  });
+
+  test.each([{ userAgent: 'unrecognized browser' }, null, undefined])(
+    'returns unknown runtime information when no platform is recognizable',
+    (navigator) => {
+      const headers = withGlobals({ process: undefined, navigator }, ({ getPlatformHeaders }) =>
+        getPlatformHeaders(),
+      );
+
+      expect(headers).toMatchObject({
+        'X-Stainless-OS': 'Unknown',
+        'X-Stainless-Arch': 'unknown',
+        'X-Stainless-Runtime': 'unknown',
+        'X-Stainless-Runtime-Version': 'unknown',
+      });
+    },
+  );
+
+  test.each([
+    [{ document: {} }, { userAgent: 'browser' }, true],
+    [undefined, { userAgent: 'browser' }, false],
+    [{}, { userAgent: 'browser' }, false],
+    [{ document: {} }, undefined, false],
+  ])(
+    'detects browser globals only when document and navigator are available',
+    (window, navigator, expected) => {
+      expect(withGlobals({ window, navigator }, ({ isRunningInBrowser }) => isRunningInBrowser())).toBe(
+        expected,
+      );
+    },
+  );
+});

--- a/tests/internal/stream-utils.test.ts
+++ b/tests/internal/stream-utils.test.ts
@@ -1,0 +1,129 @@
+import { ReadableStreamToAsyncIterable as adaptStandaloneReadableStream } from 'openai/internal/stream-utils';
+import {
+  CancelReadableStream,
+  ReadableStreamFrom,
+  ReadableStreamToAsyncIterable as adaptShimReadableStream,
+} from 'openai/internal/shims';
+
+describe.each([
+  ['standalone stream adapter', adaptStandaloneReadableStream],
+  ['runtime shim stream adapter', adaptShimReadableStream],
+])('%s', (_name, adapt) => {
+  test('returns streams that are already asynchronously iterable unchanged', () => {
+    const stream = (async function* () {
+      yield 'value';
+    })();
+
+    expect(adapt(stream)).toBe(stream);
+  });
+
+  test('reads values and releases the reader lock when the stream ends', async () => {
+    const reader = {
+      read: jest
+        .fn()
+        .mockResolvedValueOnce({ done: false, value: 'first' })
+        .mockResolvedValueOnce({ done: true }),
+      releaseLock: jest.fn(),
+      cancel: jest.fn(),
+    };
+    const iterator = adapt<string>({ getReader: () => reader });
+
+    expect(iterator[Symbol.asyncIterator]()).toBe(iterator);
+    await expect(iterator.next()).resolves.toEqual({ done: false, value: 'first' });
+    await expect(iterator.next()).resolves.toEqual({ done: true });
+    expect(reader.releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  test('releases the reader lock when reading fails', async () => {
+    const failure = new Error('stream failed');
+    const reader = {
+      read: jest.fn().mockRejectedValue(failure),
+      releaseLock: jest.fn(),
+      cancel: jest.fn(),
+    };
+
+    await expect(adapt({ getReader: () => reader }).next()).rejects.toBe(failure);
+    expect(reader.releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  test('cancels the reader and releases its lock when iteration ends early', async () => {
+    const reader = {
+      read: jest.fn(),
+      releaseLock: jest.fn(),
+      cancel: jest.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(adapt({ getReader: () => reader }).return?.()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+    expect(reader.cancel).toHaveBeenCalledTimes(1);
+    expect(reader.releaseLock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ReadableStreamFrom', () => {
+  test('consumes synchronous and asynchronous iterables', async () => {
+    const synchronous: number[] = [];
+    for await (const value of ReadableStreamFrom([1, 2])) {
+      synchronous.push(value);
+    }
+
+    const asynchronous: string[] = [];
+    for await (const value of ReadableStreamFrom(
+      (async function* () {
+        yield 'first';
+        yield 'second';
+      })(),
+    )) {
+      asynchronous.push(value);
+    }
+
+    expect(synchronous).toEqual([1, 2]);
+    expect(asynchronous).toEqual(['first', 'second']);
+  });
+
+  test('closes the source iterator when the readable stream is canceled', async () => {
+    const returned = jest.fn().mockResolvedValue({ done: true, value: undefined });
+    const iterable = {
+      [Symbol.asyncIterator]() {
+        return {
+          next: jest.fn().mockResolvedValue({ done: false, value: 'first' }),
+          return: returned,
+        };
+      },
+    };
+
+    await ReadableStreamFrom(iterable).cancel();
+
+    expect(returned).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('CancelReadableStream', () => {
+  test('ignores absent and non-object streams', async () => {
+    await expect(CancelReadableStream(null)).resolves.toBeUndefined();
+    await expect(CancelReadableStream(undefined)).resolves.toBeUndefined();
+    await expect(CancelReadableStream('stream')).resolves.toBeUndefined();
+  });
+
+  test('closes asynchronously iterable streams through their iterator', async () => {
+    const returned = jest.fn().mockResolvedValue({ done: true, value: undefined });
+
+    await CancelReadableStream({ [Symbol.asyncIterator]: () => ({ return: returned }) });
+
+    expect(returned).toHaveBeenCalledTimes(1);
+  });
+
+  test('cancels reader-based streams and releases their locks', async () => {
+    const reader = {
+      cancel: jest.fn().mockResolvedValue(undefined),
+      releaseLock: jest.fn(),
+    };
+
+    await CancelReadableStream({ getReader: () => reader });
+
+    expect(reader.cancel).toHaveBeenCalledTimes(1);
+    expect(reader.releaseLock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/internal/uploads-branches.test.ts
+++ b/tests/internal/uploads-branches.test.ts
@@ -1,0 +1,361 @@
+import { buildHeaders } from 'openai/internal/headers';
+import { toFile } from 'openai/internal/to-file';
+import {
+  checkFileSupport,
+  createForm,
+  getName,
+  isAsyncIterable,
+  makeFile,
+  maybeMultipartFormRequestOptions,
+  multipartFormRequestOptions,
+  toStreamingFile,
+} from 'openai/internal/uploads';
+
+describe('streaming upload metadata', () => {
+  test('requires a filename and preserves an explicit content type', () => {
+    async function* chunks() {
+      yield 'content';
+    }
+
+    expect(() => toStreamingFile(chunks(), '')).toThrow('requires a non-empty file name');
+    expect(toStreamingFile(chunks(), 'audio.wav')).not.toHaveProperty('type');
+    expect(toStreamingFile(chunks(), 'audio.wav', { type: 'audio/wav' })).toMatchObject({
+      name: 'audio.wav',
+      type: 'audio/wav',
+    });
+  });
+
+  test.each([
+    [{ name: '/tmp/named.jsonl' }, 'named.jsonl'],
+    [{ url: 'https://example.com/files/audio.wav' }, 'audio.wav'],
+    [{ filename: 'C:\\recordings\\audio.wav' }, 'audio.wav'],
+    [{ path: '/tmp/stream.bin' }, 'stream.bin'],
+    [{ name: '', path: '/tmp/fallback.bin' }, 'fallback.bin'],
+    [{}, undefined],
+    [null, undefined],
+    ['filename.txt', undefined],
+  ] as const)('extracts upload filenames from supported metadata', (value, expected) => {
+    expect(getName(value)).toBe(expected);
+  });
+
+  test('detects async iterables without treating arbitrary objects as streams', () => {
+    const iterable = {
+      async *[Symbol.asyncIterator]() {
+        yield 'content';
+      },
+    };
+
+    expect(isAsyncIterable(iterable)).toBe(true);
+    expect(isAsyncIterable(null)).toBe(false);
+    expect(isAsyncIterable('content')).toBe(false);
+    expect(isAsyncIterable({ [Symbol.asyncIterator]: true })).toBe(false);
+  });
+
+  test('uses a fallback filename when constructing files without one', async () => {
+    const file = makeFile(['content'], undefined, { type: 'text/plain' });
+
+    expect(file.name).toBe('unknown_file');
+    expect(file.type).toBe('text/plain');
+    await expect(file.text()).resolves.toBe('content');
+  });
+
+  test('explains how unsupported Node.js releases can provide the File global', () => {
+    const fileDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'File')!;
+    const nodeDescriptor = Object.getOwnPropertyDescriptor(process.versions, 'node')!;
+
+    try {
+      Object.defineProperty(globalThis, 'File', { configurable: true, value: undefined });
+      Object.defineProperty(process.versions, 'node', { configurable: true, value: '18.20.0' });
+
+      expect(() => checkFileSupport()).toThrow('Update to a supported Node.js LTS release');
+    } finally {
+      Object.defineProperty(process.versions, 'node', nodeDescriptor);
+      Object.defineProperty(globalThis, 'File', fileDescriptor);
+    }
+  });
+});
+
+describe('buffered multipart forms', () => {
+  test('leaves requests without uploadable values unchanged', async () => {
+    const options = { body: { nested: { count: 2, tags: ['first'] } } };
+
+    await expect(maybeMultipartFormRequestOptions(options, fetch)).resolves.toBe(options);
+  });
+
+  test('creates buffered multipart forms for nested File values', async () => {
+    const upload = new File(['file contents'], 'input.jsonl', { type: 'application/jsonl' });
+    const options = await maybeMultipartFormRequestOptions(
+      { body: { nested: { upload }, count: 2, enabled: false } },
+      fetch,
+    );
+
+    expect(options.body).toBeInstanceOf(FormData);
+    const form = options.body as FormData;
+    expect(form.get('count')).toBe('2');
+    expect(form.get('enabled')).toBe('false');
+    expect(form.get('nested[upload]')).toBeInstanceOf(File);
+  });
+
+  test('serializes response bodies and async iterables into buffered File entries', async () => {
+    async function* chunks() {
+      yield new TextEncoder().encode('stream contents');
+    }
+
+    const form = await createForm({ response: new Response('response contents'), stream: chunks() }, fetch);
+
+    const responseFile = form.get('response') as File;
+    const streamFile = form.get('stream') as File;
+    await expect(responseFile.text()).resolves.toBe('response contents');
+    await expect(streamFile.text()).resolves.toBe('stream contents');
+  });
+
+  test('serializes nested arrays and skips undefined entries', async () => {
+    const form = await createForm(
+      {
+        values: ['first', undefined, 3, false],
+        nested: { value: 'nested', omitted: undefined },
+      },
+      fetch,
+    );
+
+    expect(form.getAll('values[]')).toEqual(['first', '3', 'false']);
+    expect(form.get('nested[value]')).toBe('nested');
+    expect(form.has('nested[omitted]')).toBe(false);
+  });
+
+  test('rejects null and unsupported primitive values', async () => {
+    await expect(createForm({ value: null }, fetch)).rejects.toThrow('Received null for "value"');
+    await expect(createForm({ value: BigInt(1) }, fetch)).rejects.toThrow('Invalid value given to form');
+  });
+
+  test('rejects fetch implementations that stringify FormData objects', async () => {
+    class UnsupportedResponse {
+      constructor(private readonly body: FormData) {}
+
+      async text() {
+        return this.body.toString();
+      }
+    }
+    const unsupportedFetch = Object.assign(jest.fn(), { Response: UnsupportedResponse });
+
+    await expect(createForm({}, unsupportedFetch as any)).rejects.toThrow(
+      'fetch function does not support file uploads',
+    );
+    await expect(createForm({}, unsupportedFetch as any)).rejects.toThrow(
+      'fetch function does not support file uploads',
+    );
+    expect(unsupportedFetch).not.toHaveBeenCalled();
+  });
+
+  test('treats failed FormData capability checks as supported and caches the result', async () => {
+    const failingFetch = jest.fn().mockRejectedValue(new Error('capability probe failed'));
+    const client = { fetch: failingFetch };
+
+    await expect(createForm({}, client as any)).resolves.toBeInstanceOf(FormData);
+    await expect(createForm({}, client as any)).resolves.toBeInstanceOf(FormData);
+    expect(failingFetch).toHaveBeenCalledTimes(1);
+    expect(failingFetch).toHaveBeenCalledWith('data:,');
+  });
+});
+
+describe('lazy multipart stream encoding', () => {
+  test('encodes mixed chunk formats and nested form fields without buffering', async () => {
+    async function* nestedChunks() {
+      yield new Uint8Array([69]);
+    }
+
+    async function* chunks() {
+      yield 'A';
+      yield new Uint8Array([66]);
+      yield new DataView(new Uint8Array([67]).buffer);
+      yield new Uint8Array([68]).buffer;
+      yield nestedChunks() as any;
+      yield new Response('F');
+      yield new Response(null);
+      yield new Blob(['G']);
+    }
+
+    const options = await multipartFormRequestOptions(
+      {
+        body: {
+          upload: toStreamingFile(chunks() as any, 'quote"\\\r\n.wav', { type: 'audio/custom' }),
+          values: ['first', 2, false],
+          metadata: { enabled: true, omitted: undefined },
+        },
+      },
+      fetch,
+    );
+
+    const body = await new Response(options.body as ReadableStream).text();
+
+    expect(body).toContain('filename="quote%22%5C%0D%0A.wav"');
+    expect(body).toContain('Content-Type: audio/custom');
+    expect(body).toContain('ABCDEFG');
+    expect(body).toContain('name="values[]"\r\n\r\nfirst');
+    expect(body).toContain('name="values[]"\r\n\r\n2');
+    expect(body).toContain('name="values[]"\r\n\r\nfalse');
+    expect(body).toContain('name="metadata[enabled]"\r\n\r\ntrue');
+    expect(body).not.toContain('metadata[omitted]');
+  });
+
+  test('encodes nested streaming files, named blobs, and response bodies', async () => {
+    async function* stream() {
+      yield 'streamed';
+    }
+
+    const options = await maybeMultipartFormRequestOptions(
+      {
+        body: {
+          nested: [{ stream: toStreamingFile(stream(), 'stream.txt') }],
+          named: new File(['named contents'], 'named.json', { type: 'application/json' }),
+          response: new Response('response contents', { headers: { 'content-type': 'text/plain' } }),
+          readable: new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('readable contents'));
+              controller.close();
+            },
+          }),
+        },
+        headers: { 'x-upload': 'yes' },
+      },
+      fetch,
+    );
+
+    const body = await new Response(options.body as ReadableStream).text();
+    const headers = buildHeaders([options.headers]).values;
+
+    expect(headers.get('x-upload')).toBe('yes');
+    expect(headers.get('content-type')).toMatch(/^multipart\/form-data; boundary=openai-/);
+    expect(body).toContain('name="nested[][stream]"; filename="stream.txt"');
+    expect(body).toContain('filename="named.json"');
+    expect(body).toContain('Content-Type: application/json');
+    expect(body).toContain('Content-Type: text/plain');
+    expect(body).toContain('filename="unknown_file"');
+    expect(body).toContain('streamed');
+    expect(body).toContain('named contents');
+    expect(body).toContain('response contents');
+    expect(body).toContain('readable contents');
+  });
+
+  test('handles Blob implementations that do not expose stream()', async () => {
+    const legacyBlob = new Blob(['legacy blob']);
+    Object.defineProperty(legacyBlob, 'stream', { value: undefined });
+
+    const options = await multipartFormRequestOptions(
+      {
+        body: {
+          upload: toStreamingFile(
+            (async function* () {
+              yield legacyBlob;
+            })(),
+            'legacy.bin',
+          ),
+        },
+      },
+      fetch,
+    );
+
+    await expect(new Response(options.body as ReadableStream).text()).resolves.toContain('legacy blob');
+  });
+
+  test('reports null form fields and invalid stream chunks during consumption', async () => {
+    async function* validChunks() {
+      yield 'valid';
+    }
+
+    async function* invalidChunks() {
+      yield 42 as any;
+    }
+
+    const invalidField = await multipartFormRequestOptions(
+      { body: { upload: toStreamingFile(validChunks(), 'valid.bin'), value: null } },
+      fetch,
+    );
+    await expect(new Response(invalidField.body as ReadableStream).text()).rejects.toThrow(
+      'Received null for "value"',
+    );
+
+    const invalidChunk = await multipartFormRequestOptions(
+      { body: { upload: toStreamingFile(invalidChunks(), 'invalid.bin') } },
+      fetch,
+    );
+    await expect(new Response(invalidChunk.body as ReadableStream).text()).rejects.toThrow(
+      'Invalid streaming file chunk: 42',
+    );
+  });
+
+  test('reports unsupported streaming form field values', async () => {
+    async function* chunks() {
+      yield 'valid';
+    }
+
+    const options = await multipartFormRequestOptions(
+      { body: { upload: toStreamingFile(chunks(), 'audio.wav'), invalid: BigInt(1) } },
+      fetch,
+    );
+
+    await expect(new Response(options.body as ReadableStream).text()).rejects.toThrow(
+      'Invalid value given to form',
+    );
+  });
+});
+
+describe('toFile input normalization', () => {
+  test('resolves promised byte arrays and preserves explicit metadata', async () => {
+    const file = await toFile(Promise.resolve(new Uint8Array([65, 66])), 'bytes.txt', { type: 'text/plain' });
+
+    expect(file.name).toBe('bytes.txt');
+    expect(file.type).toBe('text/plain');
+    await expect(file.text()).resolves.toBe('AB');
+  });
+
+  test('converts compatible File-like objects to native File instances', async () => {
+    const original = new Blob(['file-like']);
+    const fileLike = {
+      name: 'compatible.txt',
+      lastModified: 1,
+      size: original.size,
+      type: original.type,
+      text: original.text.bind(original),
+      slice: original.slice.bind(original),
+      arrayBuffer: original.arrayBuffer.bind(original),
+    };
+
+    const file = await toFile(fileLike);
+
+    expect(file).toBeInstanceOf(File);
+    expect(file.name).toBe('compatible.txt');
+    await expect(file.text()).resolves.toBe('file-like');
+  });
+
+  test('uses explicit response filenames and declared MIME types', async () => {
+    const response = {
+      url: 'https://example.com/original.wav',
+      blob: async () => new Blob(['response'], { type: 'audio/wav' }),
+    };
+
+    const file = await toFile(response, 'override.wav', { type: 'audio/custom' });
+
+    expect(file.name).toBe('override.wav');
+    expect(file.type).toBe('audio/custom');
+    await expect(file.text()).resolves.toBe('response');
+  });
+
+  test('recursively consumes mixed async iterable file chunks', async () => {
+    async function* chunks() {
+      yield new Uint8Array([65]);
+      yield new DataView(new Uint8Array([66]).buffer);
+      yield new Uint8Array([67]).buffer;
+      yield new Blob(['D']);
+    }
+
+    const file = await toFile(chunks(), 'mixed.bin');
+
+    await expect(file.text()).resolves.toBe('ABCD');
+  });
+
+  test('describes invalid null and primitive file inputs', async () => {
+    await expect(toFile(null as any)).rejects.toThrow('Unexpected data type: object');
+    await expect(toFile(123 as any)).rejects.toThrow('Unexpected data type: number');
+  });
+});

--- a/tests/internal/utils.test.ts
+++ b/tests/internal/utils.test.ts
@@ -1,0 +1,208 @@
+import { OpenAIError } from 'openai/core/error';
+import { buildHeaders } from 'openai/internal/headers';
+import { FallbackEncoder } from 'openai/internal/request-options';
+import { concatBytes, decodeUTF8, encodeUTF8 } from 'openai/internal/utils/bytes';
+import { readEnv } from 'openai/internal/utils/env';
+import { stringifyQuery } from 'openai/internal/utils/query';
+import { sleep } from 'openai/internal/utils/sleep';
+import { uuid4 } from 'openai/internal/utils/uuid';
+import {
+  coerceBoolean,
+  coerceFloat,
+  coerceInteger,
+  ensurePresent,
+  hasOwn,
+  isAbsoluteURL,
+  isArray,
+  isEmptyObj,
+  isObj,
+  isReadonlyArray,
+  maybeCoerceBoolean,
+  maybeCoerceFloat,
+  maybeCoerceInteger,
+  maybeObj,
+  safeJSON,
+  validatePositiveInteger,
+} from 'openai/internal/utils/values';
+
+describe('byte utilities', () => {
+  test('concatenates empty and populated byte arrays without mutating inputs', () => {
+    const first = new Uint8Array([1, 2]);
+    const second = new Uint8Array([3]);
+
+    expect(concatBytes([])).toEqual(new Uint8Array());
+    expect(concatBytes([first, new Uint8Array(), second])).toEqual(new Uint8Array([1, 2, 3]));
+    expect(first).toEqual(new Uint8Array([1, 2]));
+    expect(second).toEqual(new Uint8Array([3]));
+  });
+
+  test('round-trips multibyte UTF-8 and reuses cached encoders', () => {
+    const value = 'OpenAI ✓ 🌍';
+
+    expect(decodeUTF8(encodeUTF8(value))).toBe(value);
+    expect(decodeUTF8(encodeUTF8('second call'))).toBe('second call');
+  });
+});
+
+describe('environment and request utilities', () => {
+  const environmentVariable = 'OPENAI_NODE_UNIT_TEST_ENV';
+
+  afterEach(() => {
+    delete process.env[environmentVariable];
+  });
+
+  test('trims environment variables and treats empty or missing values as absent', () => {
+    process.env[environmentVariable] = '  value  ';
+    expect(readEnv(environmentVariable)).toBe('value');
+
+    process.env[environmentVariable] = '   ';
+    expect(readEnv(environmentVariable)).toBeUndefined();
+
+    delete process.env[environmentVariable];
+    expect(readEnv(environmentVariable)).toBeUndefined();
+  });
+
+  test('encodes array query parameters using bracket notation', () => {
+    expect(stringifyQuery({ item: ['first', 'second'], limit: 2 })).toBe(
+      'item%5B%5D=first&item%5B%5D=second&limit=2',
+    );
+  });
+
+  test('encodes fallback request bodies as JSON', () => {
+    expect(FallbackEncoder({ headers: buildHeaders([]), body: { enabled: true } })).toEqual({
+      bodyHeaders: { 'content-type': 'application/json' },
+      body: '{"enabled":true}',
+    });
+  });
+
+  test('generates RFC 4122 version 4 UUIDs', () => {
+    expect(uuid4()).toMatch(/^[\da-f]{8}-[\da-f]{4}-4[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/i);
+  });
+
+  test('resolves after the requested timeout', async () => {
+    jest.useFakeTimers();
+
+    try {
+      const completed = jest.fn();
+      const pending = sleep(25).then(completed);
+
+      jest.advanceTimersByTime(24);
+      await Promise.resolve();
+      expect(completed).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1);
+      await pending;
+      expect(completed).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('value utilities', () => {
+  test.each([
+    ['https://example.com', true],
+    ['CUSTOM+scheme:value', true],
+    ['/relative/path', false],
+    ['//example.com/path', false],
+  ])('detects whether %s has an absolute URL scheme', (value, expected) => {
+    expect(isAbsoluteURL(value)).toBe(expected);
+  });
+
+  test('recognizes mutable and readonly arrays', () => {
+    expect(isArray([])).toBe(true);
+    expect(isArray({ length: 0 })).toBe(false);
+    expect(isReadonlyArray(Object.freeze(['item']))).toBe(true);
+    expect(isReadonlyArray('item')).toBe(false);
+  });
+
+  test('normalizes non-objects while preserving objects and arrays', () => {
+    const object = { value: true };
+    const array: string[] = [];
+
+    expect(maybeObj(object)).toBe(object);
+    expect(maybeObj(array)).toBe(array);
+    expect(maybeObj(null)).toEqual({});
+    expect(maybeObj(undefined)).toEqual({});
+    expect(maybeObj('value')).toEqual({});
+  });
+
+  test('detects inherited enumerable properties when checking emptiness', () => {
+    expect(isEmptyObj(null)).toBe(true);
+    expect(isEmptyObj(undefined)).toBe(true);
+    expect(isEmptyObj({})).toBe(true);
+    expect(isEmptyObj({ value: undefined })).toBe(false);
+    expect(isEmptyObj(Object.create({ inherited: true }))).toBe(false);
+  });
+
+  test('checks own properties without trusting an overwritten hasOwnProperty method', () => {
+    const object = Object.create({ inherited: true }) as Record<string, unknown>;
+    object['own'] = true;
+    object['hasOwnProperty'] = undefined;
+
+    expect(hasOwn(object, 'own')).toBe(true);
+    expect(hasOwn(object, 'inherited')).toBe(false);
+  });
+
+  test.each([
+    [{ value: true }, true],
+    [new Date(), true],
+    [[], false],
+    [null, false],
+    ['value', false],
+  ])('recognizes non-array objects', (value, expected) => {
+    expect(isObj(value)).toBe(expected);
+  });
+
+  test('requires non-null values but preserves falsey values', () => {
+    expect(ensurePresent(0)).toBe(0);
+    expect(ensurePresent(false)).toBe(false);
+    expect(ensurePresent('')).toBe('');
+    expect(() => ensurePresent(null)).toThrow('received null instead');
+    expect(() => ensurePresent(undefined)).toThrow('received undefined instead');
+  });
+
+  test('validates non-negative integers and rejects non-integers', () => {
+    expect(validatePositiveInteger('limit', 0)).toBe(0);
+    expect(validatePositiveInteger('limit', 3)).toBe(3);
+    expect(() => validatePositiveInteger('limit', -1)).toThrow('limit must be a positive integer');
+    expect(() => validatePositiveInteger('limit', 1.5)).toThrow('limit must be an integer');
+    expect(() => validatePositiveInteger('limit', '3')).toThrow(OpenAIError);
+  });
+
+  test('coerces and optionally coerces integers', () => {
+    expect(coerceInteger(1.8)).toBe(2);
+    expect(coerceInteger('12.9')).toBe(12);
+    expect(() => coerceInteger(true)).toThrow('Could not coerce true (type: boolean) into a number');
+    expect(maybeCoerceInteger(null)).toBeUndefined();
+    expect(maybeCoerceInteger(undefined)).toBeUndefined();
+    expect(maybeCoerceInteger('7')).toBe(7);
+  });
+
+  test('coerces and optionally coerces floats', () => {
+    expect(coerceFloat(1.25)).toBe(1.25);
+    expect(coerceFloat('12.5ms')).toBe(12.5);
+    expect(() => coerceFloat(false)).toThrow('Could not coerce false (type: boolean) into a number');
+    expect(maybeCoerceFloat(null)).toBeUndefined();
+    expect(maybeCoerceFloat(undefined)).toBeUndefined();
+    expect(maybeCoerceFloat('2.5')).toBe(2.5);
+  });
+
+  test('coerces and optionally coerces booleans', () => {
+    expect(coerceBoolean(true)).toBe(true);
+    expect(coerceBoolean(false)).toBe(false);
+    expect(coerceBoolean('true')).toBe(true);
+    expect(coerceBoolean('false')).toBe(false);
+    expect(coerceBoolean(1)).toBe(true);
+    expect(coerceBoolean(0)).toBe(false);
+    expect(maybeCoerceBoolean(null)).toBeUndefined();
+    expect(maybeCoerceBoolean(undefined)).toBeUndefined();
+    expect(maybeCoerceBoolean('true')).toBe(true);
+  });
+
+  test('parses valid JSON without throwing for malformed input', () => {
+    expect(safeJSON('{"value":true}')).toEqual({ value: true });
+    expect(safeJSON('null')).toBeNull();
+    expect(safeJSON('{invalid')).toBeUndefined();
+  });
+});

--- a/tests/internal/websocket-adapters.test.ts
+++ b/tests/internal/websocket-adapters.test.ts
@@ -1,0 +1,212 @@
+import { EventEmitter } from 'node:events';
+import { BrowserWebSocket } from 'openai/internal/ws-adapter-browser';
+import { NodeWebSocket } from 'openai/internal/ws-adapter-node';
+import { ReadyState } from 'openai/internal/ws-adapter';
+import { flattenRawData, isRecoverableClose, SendQueue } from 'openai/internal/ws';
+
+class FakeBrowserSocket {
+  readyState = ReadyState.OPEN;
+  binaryType = 'blob';
+  readonly send = jest.fn();
+  readonly close = jest.fn();
+  readonly addEventListener = jest.fn((event: string, listener: (...args: any[]) => void) => {
+    this.listeners.set(event, listener);
+  });
+  readonly removeEventListener = jest.fn((event: string) => {
+    this.listeners.delete(event);
+  });
+  readonly listeners = new Map<string, (...args: any[]) => void>();
+
+  emit(event: string, payload?: unknown) {
+    this.listeners.get(event)?.(payload);
+  }
+}
+
+class FakeNodeSocket extends EventEmitter {
+  readyState = ReadyState.OPEN;
+  readonly send = jest.fn();
+  readonly close = jest.fn();
+}
+
+describe('BrowserWebSocket', () => {
+  test('normalizes platform socket properties and forwards outbound operations', () => {
+    const socket = new FakeBrowserSocket();
+    const adapter = new BrowserWebSocket(socket as any);
+
+    expect(socket.binaryType).toBe('arraybuffer');
+    expect(adapter.platformSocket).toBe(socket);
+    expect(adapter.readyState).toBe(ReadyState.OPEN);
+
+    adapter.send('hello');
+    adapter.close(1000, 'finished');
+
+    expect(socket.send).toHaveBeenCalledWith('hello');
+    expect(socket.close).toHaveBeenCalledWith(1000, 'finished');
+  });
+
+  test('normalizes text, binary, and close event arguments', () => {
+    const socket = new FakeBrowserSocket();
+    const adapter = new BrowserWebSocket(socket as any);
+    const onMessage = jest.fn();
+    const onClose = jest.fn();
+
+    adapter.on('message', onMessage);
+    socket.emit('message', { data: 'hello' });
+    socket.emit('message', { data: new Uint8Array([1, 2]) });
+    adapter.on('close', onClose);
+    socket.emit('close', { code: 1006, reason: 'network interrupted' });
+
+    expect(onMessage).toHaveBeenNthCalledWith(1, 'hello', false);
+    expect(onMessage).toHaveBeenNthCalledWith(2, new Uint8Array([1, 2]), true);
+    expect(onClose).toHaveBeenCalledWith(1006, 'network interrupted');
+  });
+
+  test.each([
+    [{ message: 'explicit message' }, 'explicit message', undefined],
+    [{ error: new Error('nested message') }, 'nested message', 'nested message'],
+    [{}, 'WebSocket error', undefined],
+  ])('normalizes browser error events', (event, message, cause) => {
+    const socket = new FakeBrowserSocket();
+    const adapter = new BrowserWebSocket(socket as any);
+    const listener = jest.fn();
+    adapter.on('error', listener);
+
+    socket.emit('error', event);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const error = listener.mock.calls[0]![0] as Error & { cause?: Error };
+    expect(error.message).toBe(message);
+    expect(error.cause?.message).toBe(cause);
+  });
+
+  test('forwards open listeners and removes regular and one-time listeners', () => {
+    const socket = new FakeBrowserSocket();
+    const adapter = new BrowserWebSocket(socket as any);
+    const onOpen = jest.fn();
+    const once = jest.fn();
+
+    adapter.off('missing', onOpen);
+    adapter.on('open', onOpen);
+    socket.emit('open');
+    adapter.off('open', () => {});
+    adapter.off('open', onOpen);
+
+    adapter.once('message', once);
+    socket.emit('message', { data: 'first' });
+    socket.emit('message', { data: 'second' });
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(once).toHaveBeenCalledTimes(1);
+    expect(once).toHaveBeenCalledWith('first', false);
+    expect(socket.removeEventListener).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('NodeWebSocket', () => {
+  test('forwards platform socket properties and outbound operations', () => {
+    const socket = new FakeNodeSocket();
+    const adapter = new NodeWebSocket(socket as any);
+
+    expect(adapter.platformSocket).toBe(socket);
+    expect(adapter.readyState).toBe(ReadyState.OPEN);
+
+    adapter.send('hello');
+    adapter.close(1001, 'going away');
+
+    expect(socket.send).toHaveBeenCalledWith('hello');
+    expect(socket.close).toHaveBeenCalledWith(1001, 'going away');
+  });
+
+  test.each([
+    [Buffer.from('hello'), false, 'hello'],
+    [[Buffer.from('hel'), Buffer.from('lo')], false, 'hello'],
+    [Uint8Array.from([104, 105]).buffer, false, 'hi'],
+    [Buffer.from([1, 2]), true, Buffer.from([1, 2])],
+    [[Buffer.from([1]), Buffer.from([2])], true, Buffer.from([1, 2])],
+    [Uint8Array.from([1, 2]).buffer, true, Buffer.from([1, 2])],
+  ] as const)('normalizes ws message payloads', (data, isBinary, expected) => {
+    const socket = new FakeNodeSocket();
+    const adapter = new NodeWebSocket(socket as any);
+    const listener = jest.fn();
+    adapter.on('message', listener);
+
+    socket.emit('message', data, isBinary);
+
+    expect(listener).toHaveBeenCalledWith(expected, isBinary);
+  });
+
+  test('normalizes close reasons, preserves pass-through events, and removes listeners', () => {
+    const socket = new FakeNodeSocket();
+    const adapter = new NodeWebSocket(socket as any);
+    const onClose = jest.fn();
+    const onOpen = jest.fn();
+    const once = jest.fn();
+
+    adapter.off('missing', onOpen);
+    adapter.on('close', onClose);
+    adapter.on('open', onOpen);
+    adapter.off('open', () => {});
+    socket.emit('close', 1006, Buffer.from('interrupted'));
+    socket.emit('open');
+    adapter.off('open', onOpen);
+    socket.emit('open');
+
+    adapter.once('message', once);
+    socket.emit('message', Buffer.from('first'), false);
+    socket.emit('message', Buffer.from('second'), false);
+
+    expect(onClose).toHaveBeenCalledWith(1006, 'interrupted');
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(once).toHaveBeenCalledWith('first', false);
+    expect(once).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('WebSocket transport helpers', () => {
+  test('flattens fragmented array views while preserving standalone payloads', () => {
+    const first = new Uint16Array([0x0201]);
+    const second = Uint8Array.from([3]);
+    const standalone = Uint8Array.from([4]);
+
+    expect(flattenRawData([first, second])).toEqual(new Uint8Array([1, 2, 3]));
+    expect(flattenRawData(standalone)).toBe(standalone);
+    expect(flattenRawData('text')).toBe('text');
+  });
+
+  test.each([
+    [1000, false],
+    [1001, true],
+    [1002, false],
+    [1003, false],
+    [1005, true],
+    [1006, true],
+    [1007, false],
+    [1008, false],
+    [1009, false],
+    [1010, false],
+    [1011, true],
+    [1012, true],
+    [1013, true],
+    [1015, true],
+    [4999, false],
+  ])('classifies close code %i as recoverable=%s', (code, expected) => {
+    expect(isRecoverableClose(code)).toBe(expected);
+  });
+
+  test('snapshots ArrayBuffers and fragmented views when queueing raw messages', () => {
+    const queue = new SendQueue(100);
+    const bytes = Uint8Array.from([1, 2]);
+    const buffer = Uint8Array.from([3, 4]).buffer;
+
+    expect(queue.enqueueRaw(bytes)).toBe(true);
+    expect(queue.enqueueRaw(buffer)).toBe(true);
+    expect(queue.enqueueRaw([Uint8Array.from([5]), Uint8Array.from([6])])).toBe(true);
+    bytes[0] = 9;
+
+    expect(queue.drain()).toEqual([
+      { type: 'raw', data: Uint8Array.from([1, 2]) },
+      { type: 'raw', data: Uint8Array.from([3, 4]).buffer },
+      { type: 'raw', data: Uint8Array.from([5, 6]) },
+    ]);
+  });
+});

--- a/tests/lib/AssistantStream.test.ts
+++ b/tests/lib/AssistantStream.test.ts
@@ -1,0 +1,572 @@
+import { APIUserAbortError, OpenAIError } from 'openai/core/error';
+import { ReadableStreamFrom } from 'openai/internal/shims';
+import { AssistantStream } from 'openai/lib/AssistantStream';
+import type { AssistantStreamEvent } from 'openai/resources/beta/assistants';
+
+type Event = Record<string, any>;
+
+function readableEvents(events: Event[]) {
+  const encoder = new TextEncoder();
+  return ReadableStreamFrom(events.map((event) => encoder.encode(JSON.stringify(event) + '\n')));
+}
+
+function assistantStream(events: Event[]): AssistantStream {
+  return AssistantStream.fromReadableStream(readableEvents(events));
+}
+
+function iterableEvents(events: Event[], controller = new AbortController()) {
+  return {
+    controller,
+    async *[Symbol.asyncIterator]() {
+      for (const event of events) {
+        yield event as AssistantStreamEvent;
+      }
+    },
+  };
+}
+
+function completedRun(id = 'run_123') {
+  return { event: 'thread.run.completed', data: { id, status: 'completed' } };
+}
+
+describe('AssistantStream delta accumulation', () => {
+  test('accumulates numbers, nested records, and arrays of primitive values', () => {
+    expect(
+      AssistantStream.accumulateDelta(
+        { count: 1, nested: { value: 'hello' }, strings: ['first'], numbers: [1] },
+        { count: 2, nested: { value: ' world' }, strings: ['second'], numbers: [2] },
+      ),
+    ).toEqual({
+      count: 3,
+      nested: { value: 'hello world' },
+      strings: ['first', 'second'],
+      numbers: [1, 2],
+    });
+  });
+
+  test('replaces null values and special index or type properties', () => {
+    expect(
+      AssistantStream.accumulateDelta(
+        { value: undefined, index: 0, type: 'initial' },
+        { value: 'created', index: 1, type: 'updated' },
+      ),
+    ).toEqual({ value: 'created', index: 1, type: 'updated' });
+  });
+
+  test('inserts and updates indexed object array entries', () => {
+    const result = AssistantStream.accumulateDelta(
+      { entries: [{ index: 0, text: 'first' }] },
+      {
+        entries: [
+          { index: 0, text: ' updated' },
+          { index: 1, text: 'second' },
+        ],
+      },
+    );
+
+    expect(result).toEqual({
+      entries: [
+        { index: 0, text: 'first updated' },
+        { index: 1, text: 'second' },
+      ],
+    });
+  });
+
+  test('rejects malformed indexed array deltas', () => {
+    expect(() => AssistantStream.accumulateDelta({ entries: [{}] }, { entries: ['invalid'] })).toThrow(
+      'Expected array delta entry to be an object',
+    );
+    expect(() => AssistantStream.accumulateDelta({ entries: [{}] }, { entries: [{ index: '0' }] })).toThrow(
+      'property to be a number',
+    );
+
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() => AssistantStream.accumulateDelta({ entries: [{}] }, { entries: [{}] })).toThrow(
+        'Expected array delta entry to have an `index` property',
+      );
+      expect(consoleError).toHaveBeenCalledWith({});
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test('rejects incompatible accumulated value types', () => {
+    expect(() => AssistantStream.accumulateDelta({ value: true }, { value: 'invalid' })).toThrow(
+      'Unhandled record type: value',
+    );
+  });
+});
+
+describe('AssistantStream snapshots and message lifecycle', () => {
+  test('accumulates message content and exposes current and final snapshots', async () => {
+    const initialMessage = { id: 'msg_123', role: 'assistant', status: 'in_progress', content: [] };
+    const finalMessage = {
+      ...initialMessage,
+      status: 'completed',
+      content: [
+        { type: 'text', text: { value: 'hello world', annotations: [] } },
+        { type: 'image_file', image_file: { file_id: 'file_123' } },
+        { type: 'text', text: { value: 'goodbye', annotations: [] } },
+      ],
+    };
+    const finalRun = completedRun();
+    const runner = assistantStream([
+      { event: 'thread.created', data: { id: 'thread_123' } },
+      { event: 'thread.run.created', data: { id: 'run_123', status: 'queued' } },
+      { event: 'thread.run.queued', data: { id: 'run_123', status: 'queued' } },
+      { event: 'thread.run.in_progress', data: { id: 'run_123', status: 'in_progress' } },
+      { event: 'thread.run.cancelling', data: { id: 'run_123', status: 'cancelling' } },
+      { event: 'thread.message.created', data: initialMessage },
+      { event: 'thread.message.in_progress', data: initialMessage },
+      {
+        event: 'thread.message.delta',
+        data: {
+          id: 'msg_123',
+          delta: { content: [{ index: 0, type: 'text', text: { value: 'hello ', annotations: [] } }] },
+        },
+      },
+      {
+        event: 'thread.message.delta',
+        data: { id: 'msg_123', delta: { content: [{ index: 0, type: 'text', text: { value: 'world' } }] } },
+      },
+      {
+        event: 'thread.message.delta',
+        data: {
+          id: 'msg_123',
+          delta: { content: [{ index: 1, type: 'image_file', image_file: { file_id: 'file_123' } }] },
+        },
+      },
+      {
+        event: 'thread.message.delta',
+        data: {
+          id: 'msg_123',
+          delta: { content: [{ index: 2, type: 'text', text: { value: 'goodbye', annotations: [] } }] },
+        },
+      },
+      { event: 'thread.message.completed', data: finalMessage },
+      finalRun,
+    ]);
+    const created = jest.fn();
+    const textCreated = jest.fn();
+    const textDelta = jest.fn();
+    const textDone = jest.fn();
+    const imageDone = jest.fn();
+    const messageDone = jest.fn();
+
+    runner.on('messageCreated', created);
+    runner.on('textCreated', textCreated);
+    runner.on('textDelta', textDelta);
+    runner.on('textDone', textDone);
+    runner.on('imageFileDone', imageDone);
+    runner.on('messageDone', messageDone);
+
+    await runner.done();
+
+    expect(created).toHaveBeenCalledTimes(1);
+    expect(textCreated).toHaveBeenCalledTimes(2);
+    expect(textDelta).toHaveBeenCalledTimes(3);
+    expect(textDone).toHaveBeenCalledTimes(2);
+    expect(imageDone).toHaveBeenCalledTimes(1);
+    expect(messageDone).toHaveBeenCalledWith(finalMessage);
+    expect(runner.currentEvent()).toEqual(finalRun);
+    expect(runner.currentRun()).toEqual(finalRun.data);
+    expect(runner.currentMessageSnapshot()).toBeUndefined();
+    expect(runner.currentRunStepSnapshot()).toBeUndefined();
+    await expect(runner.finalRun()).resolves.toEqual(finalRun.data);
+    await expect(runner.finalRunSteps()).resolves.toEqual([]);
+    await expect(runner.finalMessages()).resolves.toEqual([
+      expect.objectContaining({
+        id: 'msg_123',
+        content: [
+          expect.objectContaining({ text: { value: 'hello world', annotations: [] } }),
+          expect.objectContaining({ image_file: { file_id: 'file_123' } }),
+          expect.objectContaining({ text: { value: 'goodbye', annotations: [] } }),
+        ],
+      }),
+    ]);
+  });
+
+  test('emits the final text content when an incomplete message stops streaming', async () => {
+    const message = { id: 'msg_123', role: 'assistant', content: [] };
+    const runner = assistantStream([
+      { event: 'thread.message.created', data: message },
+      {
+        event: 'thread.message.delta',
+        data: {
+          id: 'msg_123',
+          delta: { content: [{ index: 0, type: 'text', text: { value: 'partial', annotations: [] } }] },
+        },
+      },
+      {
+        event: 'thread.message.incomplete',
+        data: { ...message, content: [{ type: 'text', text: { value: 'partial', annotations: [] } }] },
+      },
+      completedRun(),
+    ]);
+    const textDone = jest.fn();
+    runner.on('textDone', textDone);
+
+    await runner.done();
+
+    expect(textDone).toHaveBeenCalledWith({ value: 'partial', annotations: [] }, expect.any(Object));
+  });
+
+  test.each([
+    'thread.run.requires_action',
+    'thread.run.cancelled',
+    'thread.run.failed',
+    'thread.run.completed',
+    'thread.run.expired',
+    'thread.run.incomplete',
+  ])('recognizes %s as a terminal run state', async (event) => {
+    const run = { id: 'run_123', status: event.split('.').pop() };
+    const runner = assistantStream([{ event, data: run }]);
+
+    await expect(runner.finalRun()).resolves.toEqual(run);
+  });
+});
+
+describe('AssistantStream run-step lifecycle', () => {
+  test('accumulates tool calls and emits created, delta, and completion events', async () => {
+    const initialStep = {
+      id: 'step_123',
+      status: 'in_progress',
+      step_details: { type: 'tool_calls', tool_calls: [] },
+    };
+    const finalStep = {
+      ...initialStep,
+      status: 'completed',
+      step_details: {
+        type: 'tool_calls',
+        tool_calls: [
+          { index: 0, type: 'function', id: 'call_0', function: { name: 'first', arguments: '{"x":1}' } },
+          { index: 1, type: 'function', id: 'call_1', function: { name: 'second', arguments: '{}' } },
+        ],
+      },
+    };
+    const runner = assistantStream([
+      { event: 'thread.run.step.created', data: initialStep },
+      { event: 'thread.run.step.in_progress', data: initialStep },
+      {
+        event: 'thread.run.step.delta',
+        data: {
+          id: 'step_123',
+          delta: {
+            step_details: {
+              type: 'tool_calls',
+              tool_calls: [
+                { index: 0, type: 'function', id: 'call_0', function: { name: 'first', arguments: '{' } },
+              ],
+            },
+          },
+        },
+      },
+      {
+        event: 'thread.run.step.delta',
+        data: {
+          id: 'step_123',
+          delta: {
+            step_details: {
+              type: 'tool_calls',
+              tool_calls: [{ index: 0, function: { arguments: '"x":1}' } }],
+            },
+          },
+        },
+      },
+      {
+        event: 'thread.run.step.delta',
+        data: {
+          id: 'step_123',
+          delta: {
+            step_details: {
+              type: 'tool_calls',
+              tool_calls: [
+                { index: 1, type: 'function', id: 'call_1', function: { name: 'second', arguments: '{}' } },
+              ],
+            },
+          },
+        },
+      },
+      { event: 'thread.run.step.completed', data: finalStep },
+      completedRun(),
+    ]);
+    const stepCreated = jest.fn();
+    const stepDelta = jest.fn();
+    const stepDone = jest.fn();
+    const toolCreated = jest.fn();
+    const toolDelta = jest.fn();
+    const toolDone = jest.fn();
+
+    runner.on('runStepCreated', stepCreated);
+    runner.on('runStepDelta', stepDelta);
+    runner.on('runStepDone', stepDone);
+    runner.on('toolCallCreated', toolCreated);
+    runner.on('toolCallDelta', toolDelta);
+    runner.on('toolCallDone', toolDone);
+
+    await runner.done();
+
+    expect(stepCreated).toHaveBeenCalledTimes(1);
+    expect(stepDelta).toHaveBeenCalledTimes(3);
+    expect(stepDone).toHaveBeenCalledTimes(1);
+    expect(toolCreated).toHaveBeenCalledTimes(2);
+    expect(toolDelta).toHaveBeenCalledTimes(1);
+    expect(toolDone).toHaveBeenCalledTimes(2);
+    await expect(runner.finalRunSteps()).resolves.toEqual([finalStep]);
+  });
+
+  test.each(['thread.run.step.failed', 'thread.run.step.cancelled', 'thread.run.step.expired'])(
+    'finalizes %s run-step snapshots',
+    async (event) => {
+      const step = { id: 'step_123', step_details: { type: 'message_creation', message_creation: {} } };
+      const runner = assistantStream([{ event, data: step }, completedRun()]);
+      const stepDone = jest.fn();
+      runner.on('runStepDone', stepDone);
+
+      await runner.done();
+
+      expect(stepDone).toHaveBeenCalledTimes(1);
+      await expect(runner.finalRunSteps()).resolves.toEqual([step]);
+    },
+  );
+
+  test('rejects run-step deltas received before a snapshot exists', async () => {
+    const runner = assistantStream([
+      { event: 'thread.run.step.delta', data: { id: 'missing', delta: {} } },
+      completedRun(),
+    ]);
+
+    await expect(runner.done()).rejects.toThrow('Received a RunStepDelta before creation of a snapshot');
+  });
+
+  test('finishes an active tool call when the run ends before its step does', async () => {
+    const runner = assistantStream([
+      {
+        event: 'thread.run.step.created',
+        data: { id: 'step_123', step_details: { type: 'tool_calls', tool_calls: [] } },
+      },
+      {
+        event: 'thread.run.step.delta',
+        data: {
+          id: 'step_123',
+          delta: {
+            step_details: {
+              type: 'tool_calls',
+              tool_calls: [{ index: 0, type: 'function', id: 'call_0', function: { arguments: '{}' } }],
+            },
+          },
+        },
+      },
+      completedRun(),
+    ]);
+    const toolDone = jest.fn();
+    runner.on('toolCallDone', toolDone);
+
+    await runner.done();
+
+    expect(toolDone).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AssistantStream factories and async iteration', () => {
+  test('creates a run stream with helper headers and a controlled abort signal', async () => {
+    const runs = { create: jest.fn().mockResolvedValue(iterableEvents([completedRun()])) };
+    const runner = AssistantStream.createAssistantStream(
+      'thread_123',
+      runs as any,
+      { assistant_id: 'assistant_123' },
+      { headers: { 'x-custom': 'value' } },
+    );
+
+    await expect(runner.finalRun()).resolves.toMatchObject({ id: 'run_123' });
+    expect(runs.create).toHaveBeenCalledWith(
+      'thread_123',
+      { assistant_id: 'assistant_123', stream: true },
+      expect.objectContaining({
+        headers: { 'x-custom': 'value', 'X-Stainless-Helper-Method': 'stream' },
+        signal: runner.controller.signal,
+      }),
+    );
+  });
+
+  test('creates a thread-and-run stream with helper headers', async () => {
+    const threads = { createAndRun: jest.fn().mockResolvedValue(iterableEvents([completedRun()])) };
+    const runner = AssistantStream.createThreadAssistantStream(
+      { assistant_id: 'assistant_123' },
+      threads as any,
+      { headers: { 'x-custom': 'value' } },
+    );
+
+    await runner.done();
+
+    expect(threads.createAndRun).toHaveBeenCalledWith(
+      { assistant_id: 'assistant_123', stream: true },
+      expect.objectContaining({
+        headers: { 'x-custom': 'value', 'X-Stainless-Helper-Method': 'stream' },
+        signal: runner.controller.signal,
+      }),
+    );
+  });
+
+  test('creates a tool-output stream with helper headers', async () => {
+    const runs = { submitToolOutputs: jest.fn().mockResolvedValue(iterableEvents([completedRun()])) };
+    const runner = AssistantStream.createToolAssistantStream(
+      'run_123',
+      runs as any,
+      { thread_id: 'thread_123', tool_outputs: [] },
+      { headers: { 'x-custom': 'value' } },
+    );
+
+    await runner.done();
+
+    expect(runs.submitToolOutputs).toHaveBeenCalledWith(
+      'run_123',
+      { thread_id: 'thread_123', tool_outputs: [], stream: true },
+      expect.objectContaining({
+        headers: { 'x-custom': 'value', 'X-Stainless-Helper-Method': 'stream' },
+        signal: runner.controller.signal,
+      }),
+    );
+  });
+
+  test('clones queued events while asynchronously iterating the stream', async () => {
+    const event = completedRun();
+    const runner = assistantStream([event]);
+    const iterator = runner[Symbol.asyncIterator]();
+
+    await runner.done();
+
+    const result = await iterator.next();
+    expect(result).toEqual({ value: event, done: false });
+    expect(result.value).not.toBe(event);
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  test('resolves pending event reads and closes them when the stream ends', async () => {
+    const event = completedRun();
+    const runner = assistantStream([event]);
+    const iterator = runner[Symbol.asyncIterator]();
+    const pending = iterator.next();
+
+    await expect(pending).resolves.toEqual({ value: event, done: false });
+    await runner.done();
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  test('rejects pending event reads when the stream errors or aborts', async () => {
+    const failed = new AssistantStream();
+    const failedIterator = failed[Symbol.asyncIterator]();
+    const pendingFailure = failedIterator.next();
+    const error = new OpenAIError('stream failed');
+    failed._emit('error', error);
+
+    await expect(pendingFailure).rejects.toBe(error);
+
+    const aborted = new AssistantStream();
+    const abortedIterator = aborted[Symbol.asyncIterator]();
+    const pendingAbort = abortedIterator.next();
+    const abortError = new APIUserAbortError();
+    aborted._emit('abort', abortError);
+
+    await expect(pendingAbort).rejects.toBe(abortError);
+  });
+
+  test('closes pending event reads when an otherwise idle stream ends', async () => {
+    const runner = new AssistantStream();
+    const pending = runner[Symbol.asyncIterator]().next();
+
+    runner._emit('end');
+
+    await expect(pending).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  test('aborts the underlying controller when iteration finishes early', async () => {
+    const runner = assistantStream([completedRun()]);
+    const iterator = runner[Symbol.asyncIterator]();
+
+    await expect(iterator.return?.()).resolves.toEqual({ value: undefined, done: true });
+    expect(runner.controller.signal.aborted).toBe(true);
+    await expect(runner.done()).rejects.toThrow(APIUserAbortError);
+  });
+
+  test('rejects streams that end without a final run', async () => {
+    const runner = assistantStream([{ event: 'thread.created', data: { id: 'thread_123' } }]);
+
+    await expect(runner.done()).rejects.toThrow('Final run has not been received');
+    await expect(runner.finalRun()).rejects.toThrow('Final run has not been received');
+  });
+
+  test('rejects final-run lookup when a manually closed stream never received one', async () => {
+    const runner = new AssistantStream();
+    runner._emit('end');
+
+    await expect(runner.finalRun()).rejects.toThrow('Final run was not received.');
+  });
+
+  test('rejects message deltas received before the corresponding message exists', async () => {
+    const runner = assistantStream([
+      { event: 'thread.message.delta', data: { id: 'missing', delta: { content: [] } } },
+      completedRun(),
+    ]);
+
+    await expect(runner.done()).rejects.toThrow('Received a delta with no existing snapshot');
+  });
+
+  test.each(['thread.message.in_progress', 'thread.message.completed', 'thread.message.incomplete'])(
+    'rejects %s events received before the corresponding message exists',
+    async (event) => {
+      const runner = assistantStream([{ event, data: { id: 'missing', content: [] } }, completedRun()]);
+
+      await expect(runner.done()).rejects.toThrow('Received thread message event with no existing snapshot');
+    },
+  );
+
+  test.each(['run', 'thread', 'tool'] as const)(
+    'reports aborted %s streams after their source has finished',
+    async (kind) => {
+      const controller = new AbortController();
+      controller.abort();
+      const stream = iterableEvents([completedRun()], controller);
+      let runner: AssistantStream;
+
+      switch (kind) {
+        case 'run':
+          runner = AssistantStream.createAssistantStream(
+            'thread_123',
+            { create: jest.fn().mockResolvedValue(stream) } as any,
+            { assistant_id: 'assistant_123' },
+          );
+          break;
+        case 'thread':
+          runner = AssistantStream.createThreadAssistantStream({ assistant_id: 'assistant_123' }, {
+            createAndRun: jest.fn().mockResolvedValue(stream),
+          } as any);
+          break;
+        case 'tool':
+          runner = AssistantStream.createToolAssistantStream(
+            'run_123',
+            { submitToolOutputs: jest.fn().mockResolvedValue(stream) } as any,
+            { thread_id: 'thread_123', tool_outputs: [] },
+            undefined,
+          );
+          break;
+      }
+
+      await expect(runner.done()).rejects.toThrow(APIUserAbortError);
+      expect(runner.aborted).toBe(true);
+    },
+  );
+
+  test('ignores forward-compatible assistant events it does not recognize', async () => {
+    const runner = assistantStream([{ event: 'thread.future_event', data: {} }, completedRun()]);
+
+    await expect(runner.finalRun()).resolves.toMatchObject({ id: 'run_123' });
+  });
+
+  test('rejects unexpected streamed error events', async () => {
+    const runner = assistantStream([{ event: 'error', data: { message: 'unexpected' } }, completedRun()]);
+
+    await expect(runner.done()).rejects.toThrow('Encountered an error event in event processing');
+  });
+});

--- a/tests/lib/ResponseAccumulator.events.test.ts
+++ b/tests/lib/ResponseAccumulator.events.test.ts
@@ -1,0 +1,444 @@
+import { OpenAIError } from 'openai/core/error';
+import { accumulateResponse } from 'openai/lib/responses/ResponseAccumulator';
+import type { Response, ResponseStreamEvent } from 'openai/resources/responses/responses';
+
+type OutputItem = Response['output'][number];
+
+function makeResponse(output: OutputItem[] = []): Response {
+  return {
+    id: 'resp_123',
+    object: 'response',
+    created_at: 1,
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    metadata: null,
+    model: 'gpt-5',
+    output,
+    output_text: '',
+    parallel_tool_calls: false,
+    status: 'in_progress',
+    temperature: null,
+    tool_choice: 'auto',
+    tools: [],
+    top_p: null,
+  } as Response;
+}
+
+function outputItem(value: Record<string, unknown>): OutputItem {
+  return value as unknown as OutputItem;
+}
+
+function snapshotFor(item: Record<string, unknown>): Response {
+  return accumulateResponse({
+    type: 'response.created',
+    sequence_number: 0,
+    response: makeResponse([outputItem(item)]),
+  });
+}
+
+function applyEvent(snapshot: Response, event: Record<string, unknown>): Response {
+  return accumulateResponse({ sequence_number: 1, ...event } as ResponseStreamEvent, snapshot);
+}
+
+describe('ResponseAccumulator output and content events', () => {
+  test('replaces completed output items with detached authoritative copies', () => {
+    const snapshot = snapshotFor({
+      type: 'message',
+      id: 'msg_123',
+      role: 'assistant',
+      status: 'in_progress',
+      content: [],
+    });
+    const completed = {
+      type: 'message',
+      id: 'msg_123',
+      role: 'assistant',
+      status: 'completed',
+      content: [{ type: 'output_text', text: 'complete', annotations: [] }],
+    };
+
+    applyEvent(snapshot, {
+      type: 'response.output_item.done',
+      output_index: 0,
+      item: completed,
+    });
+
+    expect(snapshot.output[0]).toEqual(completed);
+    expect(snapshot.output[0]).not.toBe(completed);
+    expect(snapshot.output_text).toBe('complete');
+  });
+
+  test('accumulates and finalizes text, annotations, and refusals', () => {
+    const snapshot = snapshotFor({
+      type: 'message',
+      id: 'msg_123',
+      role: 'assistant',
+      status: 'in_progress',
+      content: [
+        { type: 'output_text', text: '', annotations: [] },
+        { type: 'refusal', refusal: '' },
+      ],
+    });
+
+    applyEvent(snapshot, {
+      type: 'response.output_text.delta',
+      output_index: 0,
+      content_index: 0,
+      delta: 'draft',
+    });
+    expect(snapshot.output_text).toBe('draft');
+
+    applyEvent(snapshot, {
+      type: 'response.output_text.done',
+      output_index: 0,
+      content_index: 0,
+      text: 'final answer',
+    });
+    applyEvent(snapshot, {
+      type: 'response.output_text.annotation.added',
+      output_index: 0,
+      content_index: 0,
+      annotation_index: 0,
+      annotation: { type: 'url_citation', url: 'https://example.com', title: 'Example' },
+    });
+    applyEvent(snapshot, {
+      type: 'response.refusal.delta',
+      output_index: 0,
+      content_index: 1,
+      delta: 'draft refusal',
+    });
+    applyEvent(snapshot, {
+      type: 'response.refusal.done',
+      output_index: 0,
+      content_index: 1,
+      refusal: 'final refusal',
+    });
+
+    expect(snapshot.output_text).toBe('final answer');
+    expect(snapshot.output[0]).toMatchObject({
+      type: 'message',
+      content: [
+        {
+          type: 'output_text',
+          text: 'final answer',
+          annotations: [{ type: 'url_citation', url: 'https://example.com' }],
+        },
+        { type: 'refusal', refusal: 'final refusal' },
+      ],
+    });
+  });
+
+  test('adds and replaces detached message content parts', () => {
+    const snapshot = snapshotFor({
+      type: 'message',
+      id: 'msg_123',
+      role: 'assistant',
+      status: 'in_progress',
+      content: [],
+    });
+    const part = { type: 'output_text', text: 'draft', annotations: [] };
+    const finalPart = { type: 'output_text', text: 'final', annotations: [] };
+
+    applyEvent(snapshot, {
+      type: 'response.content_part.added',
+      output_index: 0,
+      content_index: 0,
+      part,
+    });
+    expect(snapshot.output_text).toBe('draft');
+
+    applyEvent(snapshot, {
+      type: 'response.content_part.done',
+      output_index: 0,
+      content_index: 0,
+      part: finalPart,
+    });
+
+    expect(snapshot.output_text).toBe('final');
+    expect((snapshot.output[0] as { content: unknown[] }).content[0]).toEqual(finalPart);
+    expect((snapshot.output[0] as { content: unknown[] }).content[0]).not.toBe(finalPart);
+  });
+});
+
+describe('ResponseAccumulator tool-call deltas', () => {
+  test.each([
+    [
+      'function_call',
+      'arguments',
+      'response.function_call_arguments.delta',
+      'response.function_call_arguments.done',
+    ],
+    [
+      'custom_tool_call',
+      'input',
+      'response.custom_tool_call_input.delta',
+      'response.custom_tool_call_input.done',
+    ],
+    ['mcp_call', 'arguments', 'response.mcp_call_arguments.delta', 'response.mcp_call_arguments.done'],
+    [
+      'code_interpreter_call',
+      'code',
+      'response.code_interpreter_call_code.delta',
+      'response.code_interpreter_call_code.done',
+    ],
+  ] as const)('accumulates and finalizes %s %s', (itemType, field, deltaEvent, doneEvent) => {
+    const snapshot = snapshotFor({
+      type: itemType,
+      id: 'item_123',
+      [field]: itemType === 'code_interpreter_call' ? null : '',
+    });
+
+    applyEvent(snapshot, { type: deltaEvent, output_index: 0, delta: 'draft' });
+    expect(snapshot.output[0]).toMatchObject({ [field]: 'draft' });
+
+    applyEvent(snapshot, { type: doneEvent, output_index: 0, [field]: 'final' });
+    expect(snapshot.output[0]).toMatchObject({ [field]: 'final' });
+  });
+
+  test.each([
+    ['response.code_interpreter_call.in_progress', 'code_interpreter_call', 'in_progress'],
+    ['response.code_interpreter_call.interpreting', 'code_interpreter_call', 'interpreting'],
+    ['response.code_interpreter_call.completed', 'code_interpreter_call', 'completed'],
+    ['response.file_search_call.in_progress', 'file_search_call', 'in_progress'],
+    ['response.file_search_call.searching', 'file_search_call', 'searching'],
+    ['response.file_search_call.completed', 'file_search_call', 'completed'],
+    ['response.web_search_call.in_progress', 'web_search_call', 'in_progress'],
+    ['response.web_search_call.searching', 'web_search_call', 'searching'],
+    ['response.web_search_call.completed', 'web_search_call', 'completed'],
+    ['response.image_generation_call.in_progress', 'image_generation_call', 'in_progress'],
+    ['response.image_generation_call.generating', 'image_generation_call', 'generating'],
+    ['response.image_generation_call.completed', 'image_generation_call', 'completed'],
+    ['response.mcp_call.in_progress', 'mcp_call', 'in_progress'],
+    ['response.mcp_call.completed', 'mcp_call', 'completed'],
+    ['response.mcp_call.failed', 'mcp_call', 'failed'],
+  ] as const)('applies %s lifecycle status', (eventType, outputType, expectedStatus) => {
+    const snapshot = snapshotFor({ type: outputType, id: 'item_123', status: 'queued' });
+
+    applyEvent(snapshot, { type: eventType, output_index: 0 });
+
+    expect(snapshot.output[0]).toMatchObject({ type: outputType, status: expectedStatus });
+  });
+
+  test('does not apply tool-call events to a different output type', () => {
+    const snapshot = snapshotFor({ type: 'message', content: [], status: 'in_progress' });
+
+    applyEvent(snapshot, {
+      type: 'response.function_call_arguments.delta',
+      output_index: 0,
+      delta: 'ignored',
+    });
+    applyEvent(snapshot, { type: 'response.file_search_call.completed', output_index: 0 });
+
+    expect(snapshot.output[0]).toMatchObject({ type: 'message', status: 'in_progress' });
+  });
+});
+
+describe('ResponseAccumulator reasoning events', () => {
+  test('creates, accumulates, and finalizes reasoning content and summaries', () => {
+    const snapshot = snapshotFor({ type: 'reasoning', id: 'reasoning_123', summary: [] });
+
+    applyEvent(snapshot, {
+      type: 'response.content_part.added',
+      output_index: 0,
+      content_index: 0,
+      part: { type: 'reasoning_text', text: '' },
+    });
+    applyEvent(snapshot, {
+      type: 'response.reasoning_text.delta',
+      output_index: 0,
+      content_index: 0,
+      delta: 'draft reasoning',
+    });
+    applyEvent(snapshot, {
+      type: 'response.reasoning_text.done',
+      output_index: 0,
+      content_index: 0,
+      text: 'final reasoning',
+    });
+    applyEvent(snapshot, {
+      type: 'response.content_part.done',
+      output_index: 0,
+      content_index: 0,
+      part: { type: 'reasoning_text', text: 'authoritative reasoning' },
+    });
+    applyEvent(snapshot, {
+      type: 'response.reasoning_summary_part.added',
+      output_index: 0,
+      summary_index: 0,
+      part: { type: 'summary_text', text: '' },
+    });
+    applyEvent(snapshot, {
+      type: 'response.reasoning_summary_text.delta',
+      output_index: 0,
+      summary_index: 0,
+      delta: 'draft summary',
+    });
+    applyEvent(snapshot, {
+      type: 'response.reasoning_summary_text.done',
+      output_index: 0,
+      summary_index: 0,
+      text: 'final summary',
+    });
+    applyEvent(snapshot, {
+      type: 'response.reasoning_summary_part.done',
+      output_index: 0,
+      summary_index: 0,
+      part: { type: 'summary_text', text: 'authoritative summary' },
+    });
+
+    expect(snapshot.output[0]).toMatchObject({
+      type: 'reasoning',
+      content: [{ type: 'reasoning_text', text: 'authoritative reasoning' }],
+      summary: [{ type: 'summary_text', text: 'authoritative summary' }],
+    });
+  });
+});
+
+describe('ResponseAccumulator lifecycle and error handling', () => {
+  test.each(['response.created', 'response.queued', 'response.in_progress', 'response.completed'] as const)(
+    'replaces the snapshot with a detached %s response',
+    (type) => {
+      const snapshot = makeResponse();
+      const authoritative = makeResponse([
+        outputItem({
+          type: 'message',
+          id: 'msg_123',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'authoritative', annotations: [] }],
+        }),
+      ]);
+      delete (authoritative as Partial<Response>).output_text;
+
+      const result = applyEvent(snapshot, { type, response: authoritative });
+
+      expect(result).not.toBe(snapshot);
+      expect(result).not.toBe(authoritative);
+      expect(result.output_text).toBe('authoritative');
+    },
+  );
+
+  test.each([
+    'response.audio.delta',
+    'response.audio.done',
+    'response.audio.transcript.delta',
+    'response.audio.transcript.done',
+    'response.image_generation_call.partial_image',
+    'response.mcp_list_tools.in_progress',
+    'response.mcp_list_tools.completed',
+    'response.mcp_list_tools.failed',
+    'keepalive',
+    'error',
+  ])('ignores stateless %s events', (type) => {
+    const snapshot = makeResponse();
+
+    expect(applyEvent(snapshot, { type })).toBe(snapshot);
+  });
+
+  test('requires a created event before receiving incremental updates', () => {
+    expect(() =>
+      accumulateResponse({ type: 'response.completed', sequence_number: 0, response: makeResponse() }),
+    ).toThrow("expected 'response.created' event, got response.completed");
+  });
+
+  test('reports missing output and content indices', () => {
+    const missingOutput = makeResponse();
+    const missingContent = snapshotFor({ type: 'message', content: [] });
+
+    expect(() =>
+      applyEvent(missingOutput, { type: 'response.output_item.done', output_index: 1, item: {} }),
+    ).toThrow('missing output at index 1');
+    expect(() =>
+      applyEvent(missingContent, {
+        type: 'response.output_text.delta',
+        output_index: 0,
+        content_index: 1,
+        delta: 'missing',
+      }),
+    ).toThrow('missing content at index 1');
+  });
+
+  test.each([
+    ['response.output_text.delta', { type: 'refusal', refusal: '' }, "expected content to be 'output_text'"],
+    ['response.output_text.done', { type: 'refusal', refusal: '' }, "expected content to be 'output_text'"],
+    [
+      'response.output_text.annotation.added',
+      { type: 'refusal', refusal: '' },
+      "expected content to be 'output_text'",
+    ],
+    ['response.refusal.delta', { type: 'output_text', text: '' }, "expected content to be 'refusal'"],
+    ['response.refusal.done', { type: 'output_text', text: '' }, "expected content to be 'refusal'"],
+  ])('rejects incompatible content for %s', (type, content, expectedMessage) => {
+    const snapshot = snapshotFor({ type: 'message', content: [content] });
+
+    expect(() =>
+      applyEvent(snapshot, {
+        type,
+        output_index: 0,
+        content_index: 0,
+        annotation_index: 0,
+        annotation: {},
+        delta: 'ignored',
+        text: 'ignored',
+        refusal: 'ignored',
+      }),
+    ).toThrow(expectedMessage);
+  });
+
+  test.each(['response.reasoning_text.delta', 'response.reasoning_text.done'])(
+    'requires reasoning content for %s',
+    (type) => {
+      const snapshot = snapshotFor({ type: 'reasoning', summary: [] });
+
+      expect(() =>
+        applyEvent(snapshot, { type, output_index: 0, content_index: 0, delta: '', text: '' }),
+      ).toThrow('missing content at index 0');
+    },
+  );
+
+  test('requires existing reasoning content before finalizing a content part', () => {
+    const snapshot = snapshotFor({ type: 'reasoning', summary: [] });
+
+    expect(() =>
+      applyEvent(snapshot, {
+        type: 'response.content_part.done',
+        output_index: 0,
+        content_index: 0,
+        part: { type: 'reasoning_text', text: 'final' },
+      }),
+    ).toThrow('missing content at index 0');
+  });
+
+  test('rejects reasoning content with an incompatible type', () => {
+    const snapshot = snapshotFor({
+      type: 'reasoning',
+      summary: [],
+      content: [{ type: 'output_text', text: '' }],
+    });
+
+    expect(() =>
+      applyEvent(snapshot, {
+        type: 'response.reasoning_text.delta',
+        output_index: 0,
+        content_index: 0,
+        delta: '',
+      }),
+    ).toThrow("expected content to be 'reasoning_text', got output_text");
+
+    expect(() =>
+      applyEvent(snapshot, {
+        type: 'response.reasoning_text.done',
+        output_index: 0,
+        content_index: 0,
+        text: '',
+      }),
+    ).toThrow("expected content to be 'reasoning_text', got output_text");
+  });
+
+  test('rejects unsupported future response events', () => {
+    expect(() => applyEvent(makeResponse(), { type: 'response.future_event' })).toThrow(OpenAIError);
+    expect(() => applyEvent(makeResponse(), { type: 'response.future_event' })).toThrow(
+      'Unhandled response stream event',
+    );
+  });
+});

--- a/tests/lib/ResponsesParser.behavior.test.ts
+++ b/tests/lib/ResponsesParser.behavior.test.ts
@@ -1,0 +1,242 @@
+import {
+  addOutputText,
+  hasAutoParseableInput,
+  isAutoParsableTool,
+  makeParseableResponseTool,
+  maybeParseResponse,
+  parseResponse,
+  shouldParseToolCall,
+  validateInputTools,
+} from 'openai/lib/ResponsesParser';
+import { makeParseableTextFormat } from 'openai/lib/parser';
+import type {
+  FunctionTool,
+  Response,
+  ResponseCreateParamsBase,
+  ResponseFunctionToolCall,
+} from 'openai/resources/responses/responses';
+
+const strictTool: FunctionTool = {
+  type: 'function',
+  name: 'get_weather',
+  parameters: { type: 'object' },
+  strict: true,
+};
+
+function makeResponse(output: Response['output']): Response {
+  return {
+    id: 'resp_123',
+    object: 'response',
+    created_at: 1,
+    status: 'completed',
+    output,
+  } as Response;
+}
+
+function makeFunctionCall(name = 'get_weather'): ResponseFunctionToolCall {
+  return {
+    type: 'function_call',
+    id: 'fc_123',
+    call_id: 'call_123',
+    name,
+    arguments: '{"city":"Paris"}',
+    status: 'completed',
+  };
+}
+
+describe('response tool parsing', () => {
+  test('detects strict and auto-parseable response tools', () => {
+    const parseable = makeParseableResponseTool(strictTool, {
+      parser: JSON.parse,
+      callback: undefined,
+    });
+
+    expect(isAutoParsableTool(parseable)).toBe(true);
+    expect(isAutoParsableTool(strictTool)).toBe(false);
+    expect(isAutoParsableTool(undefined)).toBe(false);
+    expect(hasAutoParseableInput({ model: 'gpt-5', tools: [parseable] })).toBe(true);
+    expect(hasAutoParseableInput({ model: 'gpt-5', tools: [strictTool] })).toBe(true);
+    expect(hasAutoParseableInput({ model: 'gpt-5', tools: [{ ...strictTool, strict: false }] })).toBe(false);
+    expect(hasAutoParseableInput({ model: 'gpt-5' })).toBe(false);
+    expect(
+      hasAutoParseableInput({
+        model: 'gpt-5',
+        text: {
+          format: makeParseableTextFormat(
+            { type: 'json_schema', name: 'parsed', schema: { type: 'object' } },
+            JSON.parse,
+          ),
+        },
+      }),
+    ).toBe(true);
+  });
+
+  test('retains non-enumerable tool parsing metadata and callbacks', () => {
+    const parser = jest.fn(JSON.parse);
+    const callback = jest.fn();
+    const parseable = makeParseableResponseTool(strictTool, { parser, callback });
+
+    expect(parseable.$parseRaw('{"city":"Paris"}')).toEqual({ city: 'Paris' });
+    expect(parseable.$callback).toBe(callback);
+    expect(Object.keys(parseable)).toEqual(Object.keys(strictTool));
+  });
+
+  test('determines whether a function call matches a strict or parseable tool', () => {
+    const call = makeFunctionCall();
+    const parseable = makeParseableResponseTool(strictTool, {
+      parser: JSON.parse,
+      callback: undefined,
+    });
+
+    expect(shouldParseToolCall(null, call)).toBe(false);
+    expect(shouldParseToolCall(undefined, call)).toBe(false);
+    expect(shouldParseToolCall({ model: 'gpt-5' }, call)).toBe(false);
+    expect(shouldParseToolCall({ model: 'gpt-5', tools: [] }, call)).toBe(false);
+    expect(shouldParseToolCall({ model: 'gpt-5', tools: [{ ...strictTool, strict: false }] }, call)).toBe(
+      false,
+    );
+    expect(shouldParseToolCall({ model: 'gpt-5', tools: [strictTool] }, call)).toBe(true);
+    expect(shouldParseToolCall({ model: 'gpt-5', tools: [parseable] }, call)).toBe(true);
+    expect(shouldParseToolCall({ model: 'gpt-5', tools: [strictTool] }, makeFunctionCall('other'))).toBe(
+      false,
+    );
+  });
+
+  test('accepts only strict function tools for chat completion auto-parsing', () => {
+    expect(() => validateInputTools(undefined)).not.toThrow();
+    expect(() =>
+      validateInputTools([
+        {
+          type: 'function',
+          function: { name: 'get_weather', parameters: { type: 'object' }, strict: true },
+        },
+      ]),
+    ).not.toThrow();
+
+    expect(() =>
+      validateInputTools([
+        {
+          type: 'function',
+          function: { name: 'get_weather', parameters: { type: 'object' }, strict: false },
+        },
+      ]),
+    ).toThrow('get_weather` tool is not marked with `strict: true`');
+
+    expect(() => validateInputTools([{ type: 'custom' } as any])).toThrow(
+      'only `function` tool types support auto-parsing',
+    );
+  });
+});
+
+describe('response output normalization', () => {
+  test('normalizes unparsed function calls, messages, and passthrough items', () => {
+    const response = makeResponse([
+      makeFunctionCall(),
+      {
+        type: 'message',
+        id: 'msg_123',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'hello', annotations: [], logprobs: [] }],
+      },
+      { type: 'reasoning', id: 'reasoning_123', summary: [] },
+    ]);
+
+    const parsed = maybeParseResponse(response, null);
+
+    expect(parsed.output_parsed).toBeNull();
+    expect(parsed.output[0]).toMatchObject({ type: 'function_call', parsed_arguments: null });
+    expect(parsed.output[1]).toMatchObject({
+      type: 'message',
+      content: [{ type: 'output_text', text: 'hello', parsed: null }],
+    });
+    expect(parsed.output[2]).toEqual(response.output[2]);
+    expect(parsed.output_text).toBe('hello');
+  });
+
+  test('parses only matching strict tool calls', () => {
+    const response = makeResponse([makeFunctionCall(), makeFunctionCall('unconfigured')]);
+    const parsed = parseResponse(response, { model: 'gpt-5', tools: [strictTool] });
+
+    expect(parsed.output[0]).toMatchObject({ parsed_arguments: { city: 'Paris' } });
+    expect(parsed.output[1]).toMatchObject({ parsed_arguments: null });
+    expect(parsed.output_parsed).toBeNull();
+  });
+
+  test('does not parse tool calls from incomplete responses', () => {
+    const response = makeResponse([makeFunctionCall()]);
+    response.status = 'incomplete';
+
+    const parsed = parseResponse(response, { model: 'gpt-5', tools: [strictTool] });
+
+    expect(parsed.output[0]).toMatchObject({ parsed_arguments: null });
+  });
+
+  test('leaves message content unparsed when structured output was not requested', () => {
+    const response = makeResponse([
+      {
+        type: 'message',
+        id: 'msg_123',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'ordinary text', annotations: [], logprobs: [] }],
+      },
+    ]);
+
+    const parsed = parseResponse(response, { model: 'gpt-5' });
+
+    expect(parsed.output_parsed).toBeNull();
+  });
+
+  test('uses custom raw text parsers and returns the first parsed message', () => {
+    const rawParser = jest.fn((raw: string) => ({ raw }));
+    const format = {
+      type: 'json_schema',
+      name: 'custom',
+      schema: { type: 'object' },
+      $parseRaw: rawParser,
+    };
+    const response = makeResponse([
+      {
+        type: 'message',
+        id: 'msg_123',
+        role: 'assistant',
+        status: 'completed',
+        content: [
+          { type: 'refusal', refusal: 'no' },
+          { type: 'output_text', text: 'raw value', annotations: [], logprobs: [] },
+        ],
+      },
+    ]);
+
+    const parsed = parseResponse(response, {
+      model: 'gpt-5',
+      text: { format },
+    } as ResponseCreateParamsBase);
+
+    expect(rawParser).toHaveBeenCalledWith('raw value');
+    expect(parsed.output_parsed).toEqual({ raw: 'raw value' });
+    expect(parsed.output_text).toBe('raw value');
+  });
+
+  test('concatenates output text while ignoring non-message and refusal content', () => {
+    const response = makeResponse([
+      makeFunctionCall(),
+      {
+        type: 'message',
+        id: 'msg_123',
+        role: 'assistant',
+        status: 'completed',
+        content: [
+          { type: 'refusal', refusal: 'skip' },
+          { type: 'output_text', text: 'hello ', annotations: [], logprobs: [] },
+          { type: 'output_text', text: 'world', annotations: [], logprobs: [] },
+        ],
+      },
+    ]);
+
+    addOutputText(response);
+
+    expect(response.output_text).toBe('hello world');
+  });
+});

--- a/tests/lib/Util.test.ts
+++ b/tests/lib/Util.test.ts
@@ -1,0 +1,31 @@
+import { allSettledWithThrow } from 'openai/lib/Util';
+
+describe('allSettledWithThrow', () => {
+  test('returns fulfilled values in their original order', async () => {
+    await expect(allSettledWithThrow([Promise.resolve('first'), Promise.resolve('second')])).resolves.toEqual(
+      ['first', 'second'],
+    );
+  });
+
+  test('returns an empty array when there are no promises', async () => {
+    await expect(allSettledWithThrow([])).resolves.toEqual([]);
+  });
+
+  test('logs every rejection and reports how many promises failed', async () => {
+    const firstError = new Error('first failure');
+    const secondError = new Error('second failure');
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        allSettledWithThrow([Promise.reject(firstError), Promise.resolve('ok'), Promise.reject(secondError)]),
+      ).rejects.toThrow('2 promise(s) failed - see the above errors');
+
+      expect(consoleError).toHaveBeenNthCalledWith(1, firstError);
+      expect(consoleError).toHaveBeenNthCalledWith(2, secondError);
+      expect(consoleError).toHaveBeenCalledTimes(2);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/tests/lib/chatCompletionUtils.test.ts
+++ b/tests/lib/chatCompletionUtils.test.ts
@@ -1,0 +1,28 @@
+import { isAssistantMessage, isPresent, isToolMessage } from 'openai/lib/chatCompletionUtils';
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
+
+describe('chat completion message guards', () => {
+  const assistant: ChatCompletionMessageParam = { role: 'assistant', content: 'hello' };
+  const tool: ChatCompletionMessageParam = { role: 'tool', content: 'done', tool_call_id: 'call_123' };
+  const user: ChatCompletionMessageParam = { role: 'user', content: 'hello' };
+
+  test('recognizes only assistant messages', () => {
+    expect(isAssistantMessage(assistant)).toBe(true);
+    expect(isAssistantMessage(tool)).toBe(false);
+    expect(isAssistantMessage(user)).toBe(false);
+    expect(isAssistantMessage(null)).toBe(false);
+    expect(isAssistantMessage(undefined)).toBe(false);
+  });
+
+  test('recognizes only tool messages', () => {
+    expect(isToolMessage(tool)).toBe(true);
+    expect(isToolMessage(assistant)).toBe(false);
+    expect(isToolMessage(user)).toBe(false);
+    expect(isToolMessage(null)).toBe(false);
+    expect(isToolMessage(undefined)).toBe(false);
+  });
+
+  test('retains falsey values while filtering null and undefined', () => {
+    expect([null, undefined, false, 0, '', 'value'].filter(isPresent)).toEqual([false, 0, '', 'value']);
+  });
+});

--- a/tests/lib/core-error.test.ts
+++ b/tests/lib/core-error.test.ts
@@ -1,0 +1,113 @@
+import {
+  APIConnectionError,
+  APIConnectionTimeoutError,
+  APIError,
+  APIUserAbortError,
+  AuthenticationError,
+  BadRequestError,
+  ConflictError,
+  ContentFilterFinishReasonError,
+  InternalServerError,
+  InvalidWebhookSignatureError,
+  LengthFinishReasonError,
+  NotFoundError,
+  OAuthError,
+  OpenAIError,
+  PermissionDeniedError,
+  RateLimitError,
+  SubjectTokenProviderError,
+  UnprocessableEntityError,
+} from 'openai/core/error';
+
+describe('APIError', () => {
+  const headers = new Headers({ 'x-request-id': 'req_123' });
+
+  test.each([
+    [400, BadRequestError],
+    [401, AuthenticationError],
+    [403, PermissionDeniedError],
+    [404, NotFoundError],
+    [409, ConflictError],
+    [422, UnprocessableEntityError],
+    [429, RateLimitError],
+    [500, InternalServerError],
+    [503, InternalServerError],
+    [418, APIError],
+  ] as const)('maps HTTP status %i to its typed error', (status, ExpectedError) => {
+    const error = APIError.generate(
+      status,
+      { error: { message: 'request failed', code: 'bad_request', param: 'model', type: 'invalid_request' } },
+      undefined,
+      headers,
+    );
+
+    expect(error).toBeInstanceOf(ExpectedError);
+    expect(error.status).toBe(status);
+    expect(error.requestID).toBe('req_123');
+    expect(error.code).toBe('bad_request');
+    expect(error.param).toBe('model');
+    expect(error.type).toBe('invalid_request');
+    expect(error.message).toBe(`${status} request failed`);
+  });
+
+  test('classifies responses without a status or headers as connection errors', () => {
+    const cause = new Error('socket closed');
+    const withoutStatus = APIError.generate(undefined, cause, 'network unavailable', undefined);
+    const withoutHeaders = APIError.generate(503, cause, 'network unavailable', undefined);
+
+    expect(withoutStatus).toBeInstanceOf(APIConnectionError);
+    expect(withoutStatus.message).toBe('network unavailable');
+    expect(withoutStatus).toHaveProperty('cause', cause);
+    expect(withoutHeaders).toBeInstanceOf(APIConnectionError);
+  });
+
+  test.each([
+    [418, { message: { reason: 'structured' } }, undefined, '418 {"reason":"structured"}'],
+    [418, { reason: 'body only' }, undefined, '418 {"reason":"body only"}'],
+    [418, undefined, undefined, '418 status code (no body)'],
+    [undefined, undefined, 'fallback', 'fallback'],
+    [undefined, undefined, undefined, '(no status code or body)'],
+  ] as const)('formats errors without assuming a string response body', (status, body, message, expected) => {
+    expect(new APIError(status, body, message, headers).message).toBe(expected);
+  });
+});
+
+describe('specialized SDK errors', () => {
+  test('provides default and custom messages for aborts, connections, and timeouts', () => {
+    expect(new APIUserAbortError().message).toBe('Request was aborted.');
+    expect(new APIUserAbortError({ message: 'cancelled' }).message).toBe('cancelled');
+    expect(new APIConnectionError({}).message).toBe('Connection error.');
+    expect(new APIConnectionTimeoutError().message).toBe('Request timed out.');
+    expect(new APIConnectionTimeoutError({ message: 'deadline exceeded' }).message).toBe('deadline exceeded');
+  });
+
+  test('preserves OAuth error metadata and falls back when the response is empty', () => {
+    const headers = new Headers();
+    const invalidClient = new OAuthError(
+      401,
+      { error: 'invalid_client', error_description: 'bad client' },
+      headers,
+    );
+    const missingDetails = new OAuthError(400, undefined, headers);
+
+    expect(invalidClient.error_code).toBe('invalid_client');
+    expect(invalidClient.status).toBe(401);
+    expect(missingDetails.error_code).toBeUndefined();
+    expect(missingDetails.message).toBe('400 OAuth2 authentication error');
+  });
+
+  test('preserves subject-token provider details and their original cause', () => {
+    const cause = new Error('metadata server unavailable');
+    const error = new SubjectTokenProviderError('could not fetch a token', 'gcp', cause);
+
+    expect(error).toBeInstanceOf(OpenAIError);
+    expect(error.provider).toBe('gcp');
+    expect(error.cause).toBe(cause);
+  });
+
+  test('describes completion finish and webhook signature errors', () => {
+    expect(new LengthFinishReasonError().message).toContain('length limit');
+    expect(new ContentFilterFinishReasonError().message).toContain('content filter');
+    expect(new InvalidWebhookSignatureError('signature mismatch').message).toBe('signature mismatch');
+  });
+});

--- a/tests/lib/core-event-emitter.test.ts
+++ b/tests/lib/core-event-emitter.test.ts
@@ -1,0 +1,103 @@
+import { EventEmitter, InternalEventEmitter } from 'openai/core/EventEmitter';
+
+type Events = {
+  message: (value: string) => void;
+  empty: () => void;
+  error: (error: Error) => void;
+};
+
+class TestEmitter extends EventEmitter<Events> {
+  emitMessage(value: string) {
+    this._emit('message', value);
+  }
+
+  emitEmpty() {
+    this._emit('empty');
+  }
+
+  hasMessageListener() {
+    return this._hasListener('message');
+  }
+}
+
+describe('core EventEmitter', () => {
+  test('invokes listeners in registration order, including repeated listeners', () => {
+    const emitter = new TestEmitter();
+    const values: string[] = [];
+    const repeated = (value: string) => values.push(`repeated:${value}`);
+
+    expect(emitter.on('message', repeated)).toBe(emitter);
+    emitter.on('message', (value) => values.push(`second:${value}`));
+    emitter.on('message', repeated);
+    emitter.emitMessage('event');
+
+    expect(values).toEqual(['repeated:event', 'second:event', 'repeated:event']);
+  });
+
+  test('removes only one matching listener and tolerates unknown listeners', () => {
+    const emitter = new TestEmitter();
+    const listener = jest.fn();
+
+    expect(emitter.off('message', listener)).toBe(emitter);
+    emitter.on('message', listener).on('message', listener);
+    emitter.off('message', () => {});
+    emitter.off('message', listener);
+    emitter.emitMessage('first');
+    emitter.off('message', listener);
+    emitter.emitMessage('second');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith('first');
+    expect(emitter.hasMessageListener()).toBe(false);
+  });
+
+  test('removes one-time listeners while retaining ordinary listeners', () => {
+    const emitter = new TestEmitter();
+    const once = jest.fn();
+    const repeated = jest.fn();
+
+    expect(emitter.once('message', once)).toBe(emitter);
+    emitter.on('message', repeated);
+    expect(emitter.hasMessageListener()).toBe(true);
+    emitter.emitMessage('first');
+    emitter.emitMessage('second');
+
+    expect(once).toHaveBeenCalledTimes(1);
+    expect(repeated).toHaveBeenCalledTimes(2);
+  });
+
+  test('resolves emitted promises with the next matching event', async () => {
+    const emitter = new TestEmitter();
+    const pending = emitter.emitted('message');
+
+    emitter.emitMessage('next');
+    emitter.emitMessage('ignored');
+
+    await expect(pending).resolves.toBe('next');
+    expect(emitter.hasMessageListener()).toBe(false);
+  });
+
+  test('resolves events without arguments and tolerates events without listeners', async () => {
+    const emitter = new TestEmitter();
+    const pending = emitter.emitted('empty');
+
+    emitter.emitEmpty();
+    emitter.emitMessage('unobserved');
+
+    await expect(pending).resolves.toBeUndefined();
+  });
+});
+
+describe('InternalEventEmitter', () => {
+  test('exposes public event dispatch while preserving EventEmitter behavior', () => {
+    const emitter = new InternalEventEmitter<Events>();
+    const listener = jest.fn();
+
+    emitter.once('message', listener);
+    emitter._emit('message', 'first');
+    emitter._emit('message', 'second');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith('first');
+  });
+});

--- a/tests/lib/eventEmitter.test.ts
+++ b/tests/lib/eventEmitter.test.ts
@@ -43,3 +43,56 @@ describe('EventEmitter.emitted', () => {
     await expect(promise).resolves.toBe(error);
   });
 });
+
+describe('EventEmitter listeners', () => {
+  test('invokes repeated listeners in registration order', () => {
+    const emitter = new TestEmitter();
+    const values: string[] = [];
+    const repeated = (value: string) => values.push(`repeated:${value}`);
+
+    expect(emitter.on('foo', repeated)).toBe(emitter);
+    emitter.on('foo', (value) => values.push(`second:${value}`));
+    emitter.on('foo', repeated);
+    emitter.emitFoo('value');
+
+    expect(values).toEqual(['repeated:value', 'second:value', 'repeated:value']);
+  });
+
+  test('removes one matching listener at a time without affecting unknown listeners', () => {
+    const emitter = new TestEmitter();
+    const listener = jest.fn();
+
+    expect(emitter.off('foo', listener)).toBe(emitter);
+    emitter.on('foo', listener).on('foo', listener);
+    emitter.off('foo', () => {});
+    emitter.off('foo', listener);
+    emitter.emitFoo('first');
+    emitter.off('foo', listener);
+    emitter.emitFoo('second');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith('first');
+    expect(emitter.hasListener('foo')).toBe(false);
+  });
+
+  test('automatically removes one-time listeners after their first invocation', () => {
+    const emitter = new TestEmitter();
+    const listener = jest.fn();
+
+    expect(emitter.once('foo', listener)).toBe(emitter);
+    expect(emitter.hasListener('foo')).toBe(true);
+    emitter.emitFoo('first');
+    emitter.emitFoo('second');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith('first');
+    expect(emitter.hasListener('foo')).toBe(false);
+  });
+
+  test('safely emits events without registered listeners', () => {
+    const emitter = new TestEmitter();
+
+    expect(emitter.hasListener('foo')).toBeFalsy();
+    expect(() => emitter.emitFoo('ignored')).not.toThrow();
+  });
+});

--- a/tests/lib/pagination.test.ts
+++ b/tests/lib/pagination.test.ts
@@ -1,0 +1,210 @@
+import {
+  ConversationCursorPage,
+  CursorPage,
+  NextCursorPage,
+  Page,
+  PagePromise,
+} from 'openai/core/pagination';
+import { OpenAIError } from 'openai/core/error';
+import type { FinalRequestOptions } from 'openai/internal/request-options';
+
+type Item = { id: string };
+
+const response = new Response();
+const options: FinalRequestOptions = {
+  method: 'get',
+  path: '/items',
+  query: { limit: 2 },
+};
+
+describe('Page', () => {
+  test('exposes its items without claiming that another page exists', async () => {
+    const client = { requestAPIList: jest.fn() } as any;
+    const page = new Page<Item>(client, response, { object: 'list', data: [{ id: 'first' }] }, options);
+
+    expect(page.object).toBe('list');
+    expect(page.getPaginatedItems()).toEqual([{ id: 'first' }]);
+    expect(page.hasNextPage()).toBe(false);
+    expect(page.nextPageRequestOptions()).toBeNull();
+    await expect(page.getNextPage()).rejects.toThrow(OpenAIError);
+    expect(client.requestAPIList).not.toHaveBeenCalled();
+  });
+
+  test('tolerates an absent data array', () => {
+    const page = new Page<Item>(
+      {} as any,
+      response,
+      { object: 'list', data: undefined as unknown as Item[] },
+      options,
+    );
+
+    expect(page.getPaginatedItems()).toEqual([]);
+  });
+});
+
+describe('PagePromise', () => {
+  test('parses and asynchronously iterates over the resolved page', async () => {
+    const client = { requestAPIList: jest.fn() } as any;
+    const pageResponse = new Response(JSON.stringify({ object: 'list', data: [{ id: 'first' }] }), {
+      headers: { 'content-type': 'application/json', 'x-request-id': 'req_123' },
+    });
+    const promise = new PagePromise<Page<Item>>(
+      client,
+      Promise.resolve({
+        response: pageResponse,
+        options,
+        controller: new AbortController(),
+        requestLogID: 'request_123',
+        retryOfRequestLogID: undefined,
+        startTime: Date.now(),
+      }),
+      Page as any,
+    );
+
+    const items: Item[] = [];
+    for await (const item of promise) {
+      items.push(item);
+    }
+
+    expect(items).toEqual([{ id: 'first' }]);
+    await expect(promise.asResponse()).resolves.toBe(pageResponse);
+    await expect(promise.withResponse()).resolves.toMatchObject({
+      response: pageResponse,
+      request_id: 'req_123',
+    });
+  });
+});
+
+describe('CursorPage', () => {
+  test('uses the last item ID as the cursor while preserving request options', () => {
+    const page = new CursorPage<Item>(
+      {} as any,
+      response,
+      { data: [{ id: 'first' }, { id: 'second' }], has_more: true },
+      options,
+    );
+
+    expect(page.hasNextPage()).toBe(true);
+    expect(page.nextPageRequestOptions()).toEqual({
+      ...options,
+      query: { limit: 2, after: 'second' },
+    });
+  });
+
+  test.each([
+    ['empty pages', { data: [], has_more: true }],
+    ['terminal pages', { data: [{ id: 'first' }], has_more: false }],
+    ['items without usable IDs', { data: [{ id: '' }], has_more: true }],
+  ] as const)('does not paginate %s', (_description, body) => {
+    const page = new CursorPage<Item>({} as any, response, { ...body, data: [...body.data] }, options);
+
+    expect(page.hasNextPage()).toBe(false);
+  });
+
+  test('requests and iterates subsequent pages through the owning client', async () => {
+    const client = { requestAPIList: jest.fn() } as any;
+    const first = new CursorPage<Item>(
+      client,
+      response,
+      { data: [{ id: 'first' }], has_more: true },
+      options,
+    );
+    const second = new CursorPage<Item>(
+      client,
+      response,
+      { data: [{ id: 'second' }], has_more: false },
+      options,
+    );
+    client.requestAPIList.mockResolvedValue(second);
+
+    const pages = [];
+    for await (const page of first.iterPages()) {
+      pages.push(page);
+    }
+
+    expect(pages).toEqual([first, second]);
+    expect(client.requestAPIList).toHaveBeenCalledWith(CursorPage, {
+      ...options,
+      query: { limit: 2, after: 'first' },
+    });
+
+    const items = [];
+    for await (const item of first) {
+      items.push(item);
+    }
+
+    expect(items).toEqual([{ id: 'first' }, { id: 'second' }]);
+  });
+});
+
+describe('ConversationCursorPage', () => {
+  test('uses the server-provided last ID rather than an item ID', () => {
+    const page = new ConversationCursorPage(
+      {} as any,
+      response,
+      { data: [{ value: 'first' }], has_more: true, last_id: 'cursor_123' },
+      options,
+    );
+
+    expect(page.hasNextPage()).toBe(true);
+    expect(page.nextPageRequestOptions()).toEqual({
+      ...options,
+      query: { limit: 2, after: 'cursor_123' },
+    });
+  });
+
+  test('stops when the server omits a cursor or declares the final page', () => {
+    const withoutCursor = new ConversationCursorPage(
+      {} as any,
+      response,
+      { data: [{ value: 'first' }], has_more: true, last_id: '' },
+      options,
+    );
+    const terminal = new ConversationCursorPage(
+      {} as any,
+      response,
+      { data: [{ value: 'first' }], has_more: false, last_id: 'cursor_123' },
+      options,
+    );
+
+    expect(withoutCursor.hasNextPage()).toBe(false);
+    expect(withoutCursor.nextPageRequestOptions()).toBeNull();
+    expect(terminal.hasNextPage()).toBe(false);
+  });
+});
+
+describe('NextCursorPage', () => {
+  test('uses the explicit next cursor while preserving existing query parameters', () => {
+    const page = new NextCursorPage(
+      {} as any,
+      response,
+      { data: [{ id: 'first' }], has_more: true, next: 'cursor_456' },
+      options,
+    );
+
+    expect(page.hasNextPage()).toBe(true);
+    expect(page.nextPageRequestOptions()).toEqual({
+      ...options,
+      query: { limit: 2, after: 'cursor_456' },
+    });
+  });
+
+  test('stops when the next cursor is absent or there are no more pages', () => {
+    const withoutCursor = new NextCursorPage(
+      {} as any,
+      response,
+      { data: [{ id: 'first' }], has_more: true, next: null },
+      options,
+    );
+    const terminal = new NextCursorPage(
+      {} as any,
+      response,
+      { data: [{ id: 'first' }], has_more: false, next: 'cursor_456' },
+      options,
+    );
+
+    expect(withoutCursor.hasNextPage()).toBe(false);
+    expect(withoutCursor.nextPageRequestOptions()).toBeNull();
+    expect(terminal.hasNextPage()).toBe(false);
+  });
+});

--- a/tests/lib/responsesWebSocket.test.ts
+++ b/tests/lib/responsesWebSocket.test.ts
@@ -1,0 +1,343 @@
+import { EventEmitter } from 'node:events';
+import OpenAI from 'openai';
+import { ReadyState, type WebSocketLike } from 'openai/internal/ws-adapter';
+import {
+  ResponsesWSBase as StableResponsesWSBase,
+  type ResponsesWSBaseOptions,
+} from 'openai/resources/responses/ws-base';
+import {
+  ResponsesWSBase as BetaResponsesWSBase,
+  type ResponsesWSBaseOptions as BetaResponsesWSBaseOptions,
+} from 'openai/resources/beta/responses/ws-base';
+import { WebSocketError as StableWebSocketError } from 'openai/resources/responses/internal-base';
+import { WebSocketError as BetaWebSocketError } from 'openai/resources/beta/responses/internal-base';
+
+class FakeResponseSocket extends EventEmitter implements WebSocketLike {
+  readyState: number = ReadyState.CONNECTING;
+  readonly send = jest.fn();
+  readonly close = jest.fn((code = 1000, reason = 'OK') => {
+    this.readyState = ReadyState.CLOSED;
+    this.emit('close', code, reason);
+  });
+
+  open() {
+    this.readyState = ReadyState.OPEN;
+    this.emit('open');
+  }
+}
+
+const variants = [
+  ['stable', StableResponsesWSBase, StableWebSocketError],
+  ['beta', BetaResponsesWSBase, BetaWebSocketError],
+] as const;
+
+describe.each(variants)('%s Responses WebSocket', (_version, Base, WebSocketError) => {
+  const BaseClass = Base as typeof StableResponsesWSBase;
+
+  class TestResponsesWebSocket extends BaseClass<FakeResponseSocket> {
+    readonly connections: FakeResponseSocket[] = [];
+    readonly connectionHeaders: Record<string, string>[] = [];
+
+    constructor(client: OpenAI, options?: ResponsesWSBaseOptions | BetaResponsesWSBaseOptions | undefined) {
+      super(client, options);
+      this._connectInitial();
+    }
+
+    protected _createSocket(_url: URL, headers: Record<string, string>): FakeResponseSocket {
+      const socket = new FakeResponseSocket();
+      this.connections.push(socket);
+      this.connectionHeaders.push(headers);
+      return socket;
+    }
+  }
+
+  function createWebSocket(options?: ResponsesWSBaseOptions) {
+    const client = new OpenAI({ apiKey: 'test-key', baseURL: 'https://example.com/v1/' });
+    return new TestResponsesWebSocket(client, options);
+  }
+
+  async function waitForConnection(websocket: TestResponsesWebSocket, count: number) {
+    for (let attempt = 0; attempt < 20; attempt++) {
+      if (websocket.connections.length >= count) return websocket.connections[count - 1]!;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    throw new Error(`Expected ${count} WebSocket connections`);
+  }
+
+  test('builds the authenticated WebSocket endpoint', () => {
+    const websocket = createWebSocket();
+
+    expect(websocket.url.toString()).toBe('wss://example.com/v1/responses');
+    expect(websocket.connectionHeaders).toEqual([{ Authorization: 'Bearer test-key' }]);
+  });
+
+  test('rejects operations before its socket has been initialized', () => {
+    const websocket = createWebSocket();
+    (websocket as any).socket = undefined;
+
+    expect(() => websocket.send({ type: 'response.create' } as any)).toThrow('failed to initialize socket');
+    expect(() => websocket.sendRaw('message')).toThrow('failed to initialize socket');
+    expect(() => websocket.close()).toThrow('failed to initialize socket');
+    expect(() => websocket.stream()).toThrow('failed to initialize socket');
+  });
+
+  test('sends JSON and raw messages immediately once connected', () => {
+    const websocket = createWebSocket();
+    const socket = websocket.socket;
+    socket.open();
+
+    websocket.send({ type: 'response.create' } as any);
+    websocket.sendRaw([new Uint8Array([1]), new Uint8Array([2])]);
+
+    expect(socket.send).toHaveBeenNthCalledWith(1, '{"type":"response.create"}');
+    expect(socket.send).toHaveBeenNthCalledWith(2, new Uint8Array([1, 2]));
+  });
+
+  test('queues JSON and raw messages while the connection opens', () => {
+    const websocket = createWebSocket();
+
+    websocket.send({ type: 'response.create' } as any);
+    websocket.sendRaw('raw-message');
+    expect(websocket.socket.send).not.toHaveBeenCalled();
+
+    websocket.socket.open();
+
+    expect(websocket.socket.send).toHaveBeenNthCalledWith(1, '{"type":"response.create"}');
+    expect(websocket.socket.send).toHaveBeenNthCalledWith(2, 'raw-message');
+  });
+
+  test('reports queue overflows and disconnected sends to registered error listeners', () => {
+    const websocket = createWebSocket({ maxQueueSize: 1 });
+    const listener = jest.fn();
+    websocket.on('error', listener);
+
+    websocket.send({ type: 'first' } as any);
+    websocket.send({ type: 'second' } as any);
+    websocket.sendRaw('third');
+    websocket.socket.readyState = ReadyState.CLOSED;
+    websocket.send({ type: 'closed' } as any);
+    websocket.sendRaw('closed');
+
+    expect(listener).toHaveBeenCalledTimes(4);
+    expect(listener.mock.calls.map(([error]) => error.message)).toEqual([
+      'send queue is full, message discarded',
+      'send queue is full, message discarded',
+      'cannot send on a closed WebSocket',
+      'cannot send on a closed WebSocket',
+    ]);
+    expect(listener.mock.calls[0]![0]).toBeInstanceOf(WebSocketError);
+  });
+
+  test('reports socket failures while sending, flushing, and closing', () => {
+    const websocket = createWebSocket();
+    const listener = jest.fn();
+    websocket.on('error', listener);
+    websocket.socket.open();
+    websocket.socket.send.mockImplementation(() => {
+      throw new Error('send failed');
+    });
+
+    websocket.send({ type: 'response.create' } as any);
+    websocket.sendRaw('raw-message');
+
+    websocket.socket.close.mockImplementationOnce(() => {
+      throw new Error('close failed');
+    });
+    websocket.close({ code: 1001, reason: 'going away' });
+
+    expect(listener.mock.calls.map(([error]) => error.message)).toEqual([
+      'could not send data',
+      'could not send data',
+      'could not close the connection',
+    ]);
+    expect(listener.mock.calls[0]![0].cause.message).toBe('send failed');
+  });
+
+  test('dispatches JSON, typed events, binary data, invalid JSON, and API errors', () => {
+    const websocket = createWebSocket();
+    const events = jest.fn();
+    const typed = jest.fn();
+    const raw = jest.fn();
+    const errors = jest.fn();
+    websocket.on('event', events);
+    websocket.on('response.created', typed as any);
+    websocket.on('raw', raw);
+    websocket.on('error', errors);
+    const event = { type: 'response.created', response: { id: 'resp_123' } };
+    const apiError = { type: 'error', error: { message: 'request failed' } };
+
+    websocket.socket.emit('message', JSON.stringify(event), false);
+    websocket.socket.emit('message', 'not json', false);
+    websocket.socket.emit('message', Uint8Array.from([1, 2]), true);
+    websocket.socket.emit('message', JSON.stringify(apiError), false);
+    websocket.socket.emit('error', new Error('socket failed'));
+
+    expect(events).toHaveBeenNthCalledWith(1, event);
+    expect(events).toHaveBeenNthCalledWith(2, apiError);
+    expect(typed).toHaveBeenCalledWith(event);
+    expect(raw).toHaveBeenNthCalledWith(1, 'not json');
+    expect(raw).toHaveBeenNthCalledWith(2, Uint8Array.from([1, 2]));
+    expect(errors.mock.calls.map(([error]) => error.message)).toEqual([
+      JSON.stringify(apiError),
+      'socket failed',
+    ]);
+  });
+
+  test.each([
+    [ReadyState.CONNECTING, 'connecting'],
+    [ReadyState.OPEN, 'open'],
+    [ReadyState.CLOSING, 'closing'],
+  ] as const)('starts async iteration with the current socket lifecycle state', async (state, expected) => {
+    const websocket = createWebSocket();
+    websocket.socket.readyState = state;
+    const iterator = websocket.stream();
+
+    await expect(iterator.next()).resolves.toEqual({ value: { type: expected }, done: false });
+    await expect(iterator.return?.()).resolves.toEqual({ value: undefined, done: true });
+    expect(iterator[Symbol.asyncIterator]()).toBe(iterator);
+  });
+
+  test('immediately finishes iteration when the underlying socket is already closed', async () => {
+    const websocket = createWebSocket();
+    websocket.socket.readyState = ReadyState.CLOSED;
+    const iterator = websocket.stream();
+
+    await expect(iterator.next()).resolves.toEqual({
+      value: { type: 'close', code: 1006, reason: '', unsent: [] },
+      done: false,
+    });
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  test('streams messages, raw frames, errors, opens, and permanent close events', async () => {
+    const websocket = createWebSocket();
+    const iterator = websocket.stream();
+    await iterator.next();
+
+    const message = { type: 'response.created', response: { id: 'resp_123' } };
+    websocket.socket.emit('message', JSON.stringify(message), false);
+    websocket.socket.emit('message', 'raw-frame', false);
+    websocket.socket.emit('error', new Error('network error'));
+    websocket.socket.open();
+    websocket.socket.close(1000, 'complete');
+
+    await expect(iterator.next()).resolves.toMatchObject({ value: { type: 'message', message } });
+    await expect(iterator.next()).resolves.toMatchObject({ value: { type: 'raw', data: 'raw-frame' } });
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { type: 'error', error: expect.objectContaining({ message: 'network error' }) },
+    });
+    await expect(iterator.next()).resolves.toMatchObject({ value: { type: 'open' } });
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { type: 'close', code: 1000, reason: 'complete', unsent: [] },
+    });
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  test('finishes pending iterator reads when consumers return early', async () => {
+    const websocket = createWebSocket();
+    websocket.socket.open();
+    const iterator = websocket.stream();
+    await iterator.next();
+    const pending = iterator.next();
+
+    await iterator.return?.();
+
+    await expect(pending).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  test('intentionally closes sockets using default or explicit close information', () => {
+    const defaultClose = createWebSocket();
+    const customClose = createWebSocket();
+    const listener = jest.fn();
+    customClose.on('close', listener);
+
+    defaultClose.close();
+    customClose.close({ code: 1001, reason: 'going away' });
+
+    expect(defaultClose.socket.close).toHaveBeenCalledWith(1000, 'OK');
+    expect(customClose.socket.close).toHaveBeenCalledWith(1001, 'going away');
+    expect(listener).toHaveBeenCalledWith(1001, 'going away', []);
+  });
+
+  test('reconnects after recoverable closes and flushes queued messages', async () => {
+    const reconnect = jest.fn(() => ({ parameters: { starting_after: 'event_123' } }));
+    const websocket = createWebSocket({
+      reconnect: { onReconnecting: reconnect, maxRetries: 1, initialDelay: 0, maxDelay: 0 },
+    });
+    const reconnected = jest.fn();
+    websocket.on('error', jest.fn());
+    websocket.on('reconnected', reconnected);
+    const original = websocket.socket;
+
+    original.readyState = ReadyState.CLOSED;
+    original.emit('close', 1006, 'network interrupted');
+    websocket.send({ type: 'queued-during-reconnect' } as any);
+
+    const replacement = await waitForConnection(websocket, 2);
+    replacement.open();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(reconnect).toHaveBeenCalledWith(
+      expect.objectContaining({ attempt: 1, maxAttempts: 1, closeCode: 1006 }),
+    );
+    expect(websocket.url.toString()).toBe('wss://example.com/v1/responses?starting_after=event_123');
+    expect(replacement.send).toHaveBeenCalledWith('{"type":"queued-during-reconnect"}');
+    expect(reconnected).toHaveBeenCalledTimes(1);
+  });
+
+  test('emits a permanent close when a reconnect callback aborts', async () => {
+    const websocket = createWebSocket({
+      reconnect: {
+        onReconnecting: () => ({ abort: true }),
+        maxRetries: 1,
+        initialDelay: 0,
+      },
+    });
+    const closed = jest.fn();
+    websocket.on('close', closed);
+
+    websocket.socket.readyState = ReadyState.CLOSED;
+    websocket.socket.emit('close', 1006, 'network interrupted');
+    await Promise.resolve();
+
+    expect(closed).toHaveBeenCalledWith(1006, 'reconnect aborted by handler', []);
+    expect(websocket.connections).toHaveLength(1);
+  });
+
+  test('surfaces exceptions raised by reconnect handlers', async () => {
+    const websocket = createWebSocket({
+      reconnect: {
+        onReconnecting: () => {
+          throw new Error('handler failed');
+        },
+        maxRetries: 1,
+      },
+    });
+    const errors = jest.fn();
+    const closed = jest.fn();
+    websocket.on('error', errors);
+    websocket.on('close', closed);
+
+    websocket.socket.readyState = ReadyState.CLOSED;
+    websocket.socket.emit('close', 1006, 'network interrupted');
+    await Promise.resolve();
+
+    expect(errors).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'onReconnecting callback threw', cause: expect.any(Error) }),
+    );
+    expect(closed).toHaveBeenCalledWith(1006, 'onReconnecting callback threw', []);
+  });
+
+  test.each([1000, 1002, 1008])('does not reconnect after non-recoverable close %i', (code) => {
+    const reconnect = jest.fn();
+    const websocket = createWebSocket({ reconnect: { onReconnecting: reconnect } });
+    const closed = jest.fn();
+    websocket.on('close', closed);
+
+    websocket.socket.readyState = ReadyState.CLOSED;
+    websocket.socket.emit('close', code, 'terminal close');
+
+    expect(reconnect).not.toHaveBeenCalled();
+    expect(closed).toHaveBeenCalledWith(code, 'terminal close', []);
+  });
+});

--- a/tests/lib/streaming-core.test.ts
+++ b/tests/lib/streaming-core.test.ts
@@ -1,0 +1,269 @@
+import { APIError, OpenAIError } from 'openai/core/error';
+import { Stream, _iterSSEMessages } from 'openai/core/streaming';
+import { ReadableStreamFrom } from 'openai/internal/shims';
+
+const encoder = new TextEncoder();
+
+function responseForSSE(value: string): Response {
+  return new Response(ReadableStreamFrom([encoder.encode(value)]));
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const item of iterable) {
+    result.push(item);
+  }
+  return result;
+}
+
+describe('Stream.fromSSEResponse', () => {
+  test('parses data events and ignores events after the completion sentinel', async () => {
+    const response = responseForSSE('data: {"id":1}\n\ndata: {"id":2}\n\ndata: [DONE]\n\ndata: not-json\n\n');
+    const stream = Stream.fromSSEResponse<{ id: number }>(response, new AbortController());
+
+    await expect(collect(stream)).resolves.toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  test('optionally preserves the event name alongside its parsed data', async () => {
+    const response = responseForSSE('event: response.output_text.delta\ndata: {"delta":"hello"}\n\n');
+    const stream = Stream.fromSSEResponse(response, new AbortController(), undefined, true);
+
+    await expect(collect(stream)).resolves.toEqual([
+      { event: 'response.output_text.delta', data: { delta: 'hello' } },
+    ]);
+  });
+
+  test('preserves thread events as event/data envelopes', async () => {
+    const response = responseForSSE('event: thread.run.completed\ndata: {"id":"run_123"}\n\n');
+    const stream = Stream.fromSSEResponse(response, new AbortController());
+
+    await expect(collect(stream)).resolves.toEqual([
+      { event: 'thread.run.completed', data: { id: 'run_123' } },
+    ]);
+  });
+
+  test('raises typed API errors embedded in streamed data', async () => {
+    const response = responseForSSE('data: {"error":{"message":"stream failed","code":"bad_request"}}\n\n');
+    const controller = new AbortController();
+    const stream = Stream.fromSSEResponse(response, controller);
+
+    await expect(collect(stream)).rejects.toThrow(APIError);
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  test('reports malformed JSON from normal and thread events', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const ordinary = Stream.fromSSEResponse(responseForSSE('data: {bad-json}\n\n'), new AbortController());
+      const thread = Stream.fromSSEResponse(
+        responseForSSE('event: thread.message.delta\ndata: {bad-json}\n\n'),
+        new AbortController(),
+      );
+
+      await expect(collect(ordinary)).rejects.toThrow(SyntaxError);
+      await expect(collect(thread)).rejects.toThrow(SyntaxError);
+      expect(consoleError).toHaveBeenCalledTimes(4);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test('prevents iterating over an already consumed response stream', async () => {
+    const stream = Stream.fromSSEResponse(responseForSSE('data: {"id":1}\n\n'), new AbortController());
+
+    await collect(stream);
+
+    await expect(collect(stream)).rejects.toThrow('Cannot iterate over a consumed stream');
+  });
+
+  test('aborts the request if the caller stops consuming early', async () => {
+    const controller = new AbortController();
+    const stream = Stream.fromSSEResponse(responseForSSE('data: {"id":1}\n\ndata: {"id":2}\n\n'), controller);
+
+    for await (const _item of stream) {
+      break;
+    }
+
+    expect(controller.signal.aborted).toBe(true);
+  });
+});
+
+describe('Stream.fromReadableStream', () => {
+  test('parses newline-separated JSON while ignoring blank lines and flushing the final line', async () => {
+    const readable = ReadableStreamFrom([encoder.encode('{"id":1}\n\n'), encoder.encode('{"id":2}')]);
+    const stream = Stream.fromReadableStream<{ id: number }>(readable, new AbortController());
+
+    await expect(collect(stream)).resolves.toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  test('prevents reading the same newline-delimited stream twice', async () => {
+    const stream = Stream.fromReadableStream(
+      ReadableStreamFrom([encoder.encode('{"id":1}\n')]),
+      new AbortController(),
+    );
+
+    await collect(stream);
+
+    await expect(collect(stream)).rejects.toThrow('Cannot iterate over a consumed stream');
+  });
+
+  test('cancels readers that were already aborted before consumption', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const reader = {
+      read: jest.fn(),
+      cancel: jest.fn().mockResolvedValue(undefined),
+      releaseLock: jest.fn(),
+    };
+    const stream = Stream.fromReadableStream({ getReader: () => reader } as any, controller);
+
+    await expect(collect(stream)).resolves.toEqual([]);
+    expect(reader.cancel).toHaveBeenCalledTimes(1);
+    expect(reader.releaseLock).toHaveBeenCalledTimes(1);
+    expect(reader.read).not.toHaveBeenCalled();
+  });
+
+  test('cancels readers when an abort arrives while a chunk is being read', async () => {
+    const controller = new AbortController();
+    const reader = {
+      read: jest.fn().mockImplementation(async () => {
+        controller.abort();
+        return { done: false, value: encoder.encode('{"ignored":true}\n') };
+      }),
+      cancel: jest.fn().mockResolvedValue(undefined),
+      releaseLock: jest.fn(),
+    };
+    const stream = Stream.fromReadableStream({ getReader: () => reader } as any, controller);
+
+    await expect(collect(stream)).resolves.toEqual([]);
+    expect(reader.cancel).toHaveBeenCalledTimes(1);
+    expect(reader.releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  test('aborts and reports malformed newline-delimited JSON', async () => {
+    const controller = new AbortController();
+    const stream = Stream.fromReadableStream(
+      ReadableStreamFrom([encoder.encode('{not-json}\n')]),
+      controller,
+    );
+
+    await expect(collect(stream)).rejects.toThrow(SyntaxError);
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  test('cancels and aborts the source if iteration is interrupted', async () => {
+    const controller = new AbortController();
+    const stream = Stream.fromReadableStream(
+      ReadableStreamFrom([encoder.encode('{"id":1}\n{"id":2}\n')]),
+      controller,
+    );
+
+    for await (const _item of stream) {
+      break;
+    }
+
+    expect(controller.signal.aborted).toBe(true);
+  });
+});
+
+describe('Stream.tee', () => {
+  test('lets both readers consume every item at independent speeds', async () => {
+    const controller = new AbortController();
+    const source = new Stream(
+      () =>
+        (async function* () {
+          yield 1;
+          yield 2;
+          yield 3;
+        })(),
+      controller,
+    );
+    const [left, right] = source.tee();
+    const leftIterator = left[Symbol.asyncIterator]();
+    const rightIterator = right[Symbol.asyncIterator]();
+
+    await expect(leftIterator.next()).resolves.toEqual({ value: 1, done: false });
+    await expect(leftIterator.next()).resolves.toEqual({ value: 2, done: false });
+    await expect(rightIterator.next()).resolves.toEqual({ value: 1, done: false });
+    await expect(rightIterator.next()).resolves.toEqual({ value: 2, done: false });
+    await expect(rightIterator.next()).resolves.toEqual({ value: 3, done: false });
+    await expect(leftIterator.next()).resolves.toEqual({ value: 3, done: false });
+    await expect(leftIterator.next()).resolves.toEqual({ value: undefined, done: true });
+    await expect(rightIterator.next()).resolves.toEqual({ value: undefined, done: true });
+    expect(left.controller).toBe(controller);
+    expect(right.controller).toBe(controller);
+  });
+});
+
+describe('Stream.toReadableStream', () => {
+  test('round-trips structured values as newline-delimited JSON', async () => {
+    const original = new Stream(
+      () =>
+        (async function* () {
+          yield { id: 1 };
+          yield { id: 2 };
+        })(),
+      new AbortController(),
+    );
+    const roundTripped = Stream.fromReadableStream<{ id: number }>(
+      original.toReadableStream(),
+      new AbortController(),
+    );
+
+    await expect(collect(roundTripped)).resolves.toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  test('closes the source iterator when the readable stream is canceled', async () => {
+    const returned = jest.fn().mockResolvedValue({ done: true, value: undefined });
+    const source = new Stream(
+      () => ({
+        next: jest.fn().mockResolvedValue({ done: false, value: { id: 1 } }),
+        return: returned,
+      }),
+      new AbortController(),
+    );
+    const reader = source.toReadableStream().getReader();
+
+    await reader.read();
+    await reader.cancel();
+
+    expect(returned).toHaveBeenCalledTimes(1);
+  });
+
+  test('propagates iterator failures through the readable stream', async () => {
+    const failure = new OpenAIError('source failed');
+    const source = new Stream(() => ({ next: jest.fn().mockRejectedValue(failure) }), new AbortController());
+
+    await expect(source.toReadableStream().getReader().read()).rejects.toBe(failure);
+  });
+});
+
+describe('_iterSSEMessages', () => {
+  test('rejects responses without readable bodies and aborts their controller', async () => {
+    const controller = new AbortController();
+
+    await expect(collect(_iterSSEMessages(new Response(null), controller))).rejects.toThrow(
+      'Attempted to iterate over a response with no body',
+    );
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  test('ignores comments and handles CRLF-delimited multiline data', async () => {
+    const response = responseForSSE(': keepalive\r\nevent: update\r\ndata: first\r\ndata: second\r\n\r\n');
+
+    await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toEqual([
+      {
+        event: 'update',
+        data: 'first\nsecond',
+        raw: [': keepalive', 'event: update', 'data: first', 'data: second'],
+      },
+    ]);
+  });
+
+  test('ignores an SSE message that ends without its required blank-line delimiter', async () => {
+    const response = responseForSSE('data: {"flushed":true}\n');
+
+    await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toEqual([]);
+  });
+});

--- a/tests/lib/transform-branches.test.ts
+++ b/tests/lib/transform-branches.test.ts
@@ -1,0 +1,249 @@
+import type { JSONSchema } from 'openai/lib/jsonschema';
+import {
+  assertNoNestedSchemaIds,
+  forEachJSONSchemaChild,
+  hasOnlyRefAndAnnotations,
+  normalizeObjectAllOfForExclusivity,
+  resolveLocalRef,
+  rewriteLocalRefsIntoMovedOneOfBranches,
+  toStrictJsonSchema,
+} from 'openai/lib/transform';
+
+describe('JSON Schema child traversal', () => {
+  test('visits schema-valued keywords without descending into literal payloads', () => {
+    const visited: Array<{ path: string; keyword: string; value: unknown }> = [];
+    const schema = {
+      type: 'object',
+      additionalProperties: false,
+      items: { type: 'string' },
+      anyOf: [{ type: 'number' }, true],
+      $defs: { named: { type: 'boolean' } },
+      dependencies: { schema: { type: 'object' }, property: ['name'] },
+      default: { anyOf: [{ type: 'ignored' }] },
+      enum: [{ type: 'ignored' }],
+    };
+
+    forEachJSONSchemaChild(schema, ['root'], (value, path, keyword) => {
+      visited.push({ path: path.join('/'), keyword, value });
+    });
+
+    expect(visited).toEqual([
+      { path: 'root/additionalProperties', keyword: 'additionalProperties', value: false },
+      { path: 'root/anyOf/0', keyword: 'anyOf', value: { type: 'number' } },
+      { path: 'root/anyOf/1', keyword: 'anyOf', value: true },
+      { path: 'root/items', keyword: 'items', value: { type: 'string' } },
+      { path: 'root/$defs/named', keyword: '$defs', value: { type: 'boolean' } },
+      { path: 'root/dependencies/schema', keyword: 'dependencies', value: { type: 'object' } },
+    ]);
+  });
+
+  test('visits explicitly present undefined single-schema placeholders', () => {
+    const paths: string[] = [];
+
+    forEachJSONSchemaChild({ contains: undefined }, [], (_schema, path) => paths.push(path.join('/')));
+
+    expect(paths).toEqual(['contains']);
+  });
+});
+
+describe('local JSON Schema reference resolution', () => {
+  const root = {
+    type: 'object',
+    $defs: {
+      'slash/key': { type: 'string' },
+      'tilde~key': { type: 'number' },
+      'percent%key': { type: 'boolean' },
+    },
+    properties: {
+      union: { anyOf: [{ type: 'string' }, false] },
+      nested: { type: 'object', properties: { value: { type: 'number' } } },
+    },
+    dependencies: { schema: { type: 'object' }, property: ['name'] },
+    default: { nested: { type: 'string' } },
+    enum: [{ type: 'string' }],
+  } as JSONSchema;
+
+  test('resolves the document root and escaped or encoded property names', () => {
+    expect(resolveLocalRef(root, '#')).toBe(root);
+    expect(resolveLocalRef(root, '#/$defs/slash~1key')).toEqual({ type: 'string' });
+    expect(resolveLocalRef(root, '#/$defs/tilde~0key')).toEqual({ type: 'number' });
+    expect(resolveLocalRef(root, '#/$defs/percent%25key')).toEqual({ type: 'boolean' });
+    expect(resolveLocalRef(root, '#/properties%2Funion%2FanyOf%2F0')).toEqual({ type: 'string' });
+  });
+
+  test('resolves boolean and object definitions in schema arrays and dependency maps', () => {
+    expect(resolveLocalRef(root, '#/properties/union/anyOf/0')).toEqual({ type: 'string' });
+    expect(resolveLocalRef(root, '#/properties/union/anyOf/1')).toBe(false);
+    expect(resolveLocalRef(root, '#/dependencies/schema')).toEqual({ type: 'object' });
+    expect(resolveLocalRef(root, '#/dependencies/property')).toBeUndefined();
+  });
+
+  test.each([
+    'https://example.com/schema.json',
+    '#not-a-pointer',
+    '#/%E0%A4%A',
+    '#/$defs/slash~2key',
+    '#/$defs/tilde~',
+    '#/$defs/missing',
+    '#/properties/union/anyOf',
+    '#/properties/union/anyOf/01',
+    '#/properties/union/anyOf/-1',
+    '#/properties/union/anyOf/5',
+    '#/properties/nested/properties/missing',
+    '#/default/nested',
+    '#/enum/0',
+  ])('rejects invalid or non-schema reference %s', (ref) => {
+    expect(resolveLocalRef(root, ref)).toBeUndefined();
+  });
+});
+
+describe('reference annotations and resource identity', () => {
+  test('allows annotation siblings and local definition maps on reference schemas', () => {
+    expect(
+      hasOnlyRefAndAnnotations({
+        $ref: '#/$defs/Value',
+        title: 'Value',
+        description: 'Annotation',
+        $comment: 'Comment',
+        $defs: { Value: { type: 'string' } },
+        definitions: {},
+      }),
+    ).toBe(true);
+    expect(hasOnlyRefAndAnnotations({ $ref: '#/$defs/Value', type: 'string' })).toBe(false);
+  });
+
+  test('allows root resource IDs but rejects nested schema resource IDs', () => {
+    expect(() =>
+      assertNoNestedSchemaIds({ $id: 'https://example.com/root', properties: { value: { $id: undefined } } }),
+    ).not.toThrow();
+
+    expect(() =>
+      assertNoNestedSchemaIds({
+        type: 'object',
+        properties: { value: { type: 'string', $id: 'https://example.com/nested' } },
+      }),
+    ).toThrow('separate JSON Schema resource scope');
+  });
+});
+
+describe('oneOf reference rewrites', () => {
+  test('rewrites pointers that traverse an actual moved oneOf schema branch', () => {
+    const root = {
+      type: 'object',
+      properties: {
+        variant: {
+          oneOf: [{ type: 'object', properties: { 'slash/key': { type: 'string' } } }],
+        },
+        alias: { $ref: '#/properties/variant/oneOf/0/properties/slash~1key' },
+      },
+    } as JSONSchema;
+
+    rewriteLocalRefsIntoMovedOneOfBranches(root);
+
+    expect(root.properties?.['alias']).toEqual({
+      $ref: '#/properties/variant/anyOf/0/properties/slash~1key',
+    });
+  });
+
+  test.each(['#', '#/%ZZ', '#/properties/missing/oneOf/0', 'https://example.com/schema.json'])(
+    'preserves unresolved or external reference %s',
+    (ref) => {
+      const root: JSONSchema = { type: 'object', properties: { alias: { $ref: ref } } };
+
+      rewriteLocalRefsIntoMovedOneOfBranches(root);
+
+      expect(root.properties?.['alias']).toEqual({ $ref: ref });
+    },
+  );
+});
+
+describe('object intersection normalization for exclusivity', () => {
+  test('returns undefined when no intersection needs to be normalized', () => {
+    const schema: JSONSchema = { type: 'object', properties: { value: { type: 'string' } } };
+
+    expect(normalizeObjectAllOfForExclusivity(schema, schema)).toBeUndefined();
+  });
+
+  test('merges compatible object branches without mutating the original schema', () => {
+    const schema: JSONSchema = {
+      allOf: [
+        { type: 'object', properties: { first: { type: 'string' } }, required: ['first'] },
+        { type: 'object', properties: { second: { type: 'number' } }, required: ['second'] },
+      ],
+    };
+    const original = structuredClone(schema);
+
+    expect(normalizeObjectAllOfForExclusivity(schema, schema)).toMatchObject({
+      type: 'object',
+      properties: { first: { type: 'string' }, second: { type: 'number' } },
+      required: ['first', 'second'],
+    });
+    expect(schema).toEqual(original);
+  });
+
+  test.each([
+    { allOf: [false] },
+    { allOf: [{ type: 'object', properties: { value: { type: 'string' } } }, { type: 'string' }] },
+    { allOf: [{ type: 'object', required: [1] }, { type: 'object' }] },
+  ] as unknown as JSONSchema[])('fails closed for unsupported intersection shapes', (schema) => {
+    expect(normalizeObjectAllOfForExclusivity(schema, schema)).toBeUndefined();
+  });
+});
+
+describe('strict schema edge cases', () => {
+  test('rejects validation siblings on a root local reference and its aliases', () => {
+    expect(() =>
+      toStrictJsonSchema({
+        $ref: '#/$defs/Target',
+        properties: {},
+        $defs: { Target: { type: 'object', properties: {} } },
+      }),
+    ).toThrow('non-metadata siblings');
+
+    expect(() =>
+      toStrictJsonSchema({
+        $ref: '#/$defs/Alias',
+        $defs: {
+          Alias: { $ref: '#/$defs/Target', type: 'object' },
+          Target: { type: 'object', properties: {} },
+        },
+      }),
+    ).toThrow('non-annotation siblings');
+  });
+
+  test.each([1, ['value', 1]])('rejects malformed required property declarations', (required) => {
+    expect(() =>
+      toStrictJsonSchema({
+        type: 'object',
+        properties: { value: { type: 'string' } },
+        required,
+      } as JSONSchema),
+    ).toThrow('Expected `required` to be an array of strings');
+  });
+
+  test.each([
+    { enum: ['non-null'] },
+    { enum: 'invalid' },
+    { oneOf: [{ type: 'null' }, { type: 'null' }] },
+    { type: ['string', 'null'], not: { type: 'null' } },
+  ] as unknown as JSONSchema[])(
+    'does not silently accept optional properties when null is not proven valid',
+    (property) => {
+      expect(() =>
+        toStrictJsonSchema({
+          type: 'object',
+          properties: { optional: property },
+        }),
+      ).toThrow();
+    },
+  );
+
+  test.each([{ anyOf: [false, false] }, { anyOf: [true] }, { anyOf: [false, true] }] as const)(
+    'rejects root unions that cannot be reduced to a single object branch',
+    ({ anyOf }) => {
+      expect(() => toStrictJsonSchema({ type: 'object', anyOf: [...anyOf] } as JSONSchema)).toThrow(
+        'Root schema must not use `anyOf`',
+      );
+    },
+  );
+});

--- a/tests/realtime-websocket.test.ts
+++ b/tests/realtime-websocket.test.ts
@@ -1,0 +1,362 @@
+import OpenAI, { AzureOpenAI } from 'openai';
+import { OpenAIRealtimeWebSocket as StableBrowserRealtime } from 'openai/realtime/websocket';
+import { OpenAIRealtimeWS as StableNodeRealtime } from 'openai/realtime/ws';
+import { OpenAIRealtimeWebSocket as BetaBrowserRealtime } from 'openai/beta/realtime/websocket';
+import { OpenAIRealtimeWS as BetaNodeRealtime } from 'openai/beta/realtime/ws';
+import * as WS from 'ws';
+
+type Listener = (event: any) => void;
+
+type FakeNodeSocket = {
+  url: URL;
+  options: { headers?: Record<string, string> };
+  on: jest.Mock;
+  send: jest.Mock;
+  close: jest.Mock;
+  dispatch: (event: string, value: unknown) => void;
+};
+
+jest.mock('ws', () => ({
+  WebSocket: jest.fn().mockImplementation((url: URL, options: FakeNodeSocket['options']) => {
+    const listeners = new Map<string, Listener>();
+
+    return {
+      url,
+      options,
+      on: jest.fn((event: string, listener: Listener) => listeners.set(event, listener)),
+      send: jest.fn(),
+      close: jest.fn(),
+      dispatch: (event: string, value: unknown) => listeners.get(event)?.(value),
+    } satisfies FakeNodeSocket;
+  }),
+}));
+
+class FakeBrowserSocket {
+  static instances: FakeBrowserSocket[] = [];
+
+  readonly listeners = new Map<string, Listener>();
+  readonly send = jest.fn();
+  readonly close = jest.fn();
+
+  constructor(
+    readonly url: string,
+    readonly protocols: string[],
+  ) {
+    FakeBrowserSocket.instances.push(this);
+  }
+
+  addEventListener(event: string, listener: Listener): void {
+    this.listeners.set(event, listener);
+  }
+
+  dispatch(event: string, value: unknown): void {
+    this.listeners.get(event)?.(value);
+  }
+}
+
+const originalWebSocket = globalThis.WebSocket;
+const nodeSocketConstructor = WS.WebSocket as unknown as jest.Mock;
+
+function lastBrowserSocket(): FakeBrowserSocket {
+  return FakeBrowserSocket.instances[FakeBrowserSocket.instances.length - 1]!;
+}
+
+function lastNodeSocket(): FakeNodeSocket {
+  return nodeSocketConstructor.mock.results[nodeSocketConstructor.mock.results.length - 1]!
+    .value as FakeNodeSocket;
+}
+
+function onRealtimeEvent(realtime: unknown, event: string, listener: Listener): void {
+  (realtime as { on: (event: string, listener: Listener) => unknown }).on(event, listener);
+}
+
+function createClient(apiKey: string | (() => Promise<string>) = 'test-key'): OpenAI {
+  return new OpenAI({ apiKey, baseURL: 'https://example.com/v1/' });
+}
+
+function createAzureClient(options: { tokenProvider?: boolean; deployment?: string } = {}): AzureOpenAI {
+  return new AzureOpenAI({
+    apiVersion: '2024-10-01-preview',
+    baseURL: 'https://azure.example.com/openai/',
+    ...(options.tokenProvider ?
+      { azureADTokenProvider: async () => 'azure-token' }
+    : { apiKey: 'azure-key' }),
+    ...(options.deployment === undefined ? {} : { deployment: options.deployment }),
+  });
+}
+
+beforeEach(() => {
+  FakeBrowserSocket.instances = [];
+  nodeSocketConstructor.mockClear();
+  Object.defineProperty(globalThis, 'WebSocket', {
+    configurable: true,
+    value: FakeBrowserSocket,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  Object.defineProperty(globalThis, 'WebSocket', {
+    configurable: true,
+    value: originalWebSocket,
+    writable: true,
+  });
+});
+
+describe.each([
+  { name: 'stable', Realtime: StableBrowserRealtime, beta: false },
+  { name: 'beta', Realtime: BetaBrowserRealtime, beta: true },
+])('$name browser realtime websocket', ({ Realtime, beta }) => {
+  test('opens model and sideband sessions with the expected authentication protocols', () => {
+    const client = createClient();
+    const model = new Realtime({ model: 'gpt-realtime' }, client);
+
+    expect(model.url.toString()).toBe('wss://example.com/v1/realtime?model=gpt-realtime');
+    expect(lastBrowserSocket().protocols).toEqual([
+      'realtime',
+      'openai-insecure-api-key.test-key',
+      ...(beta ? ['openai-beta.realtime-v1'] : []),
+    ]);
+
+    const sideband = new Realtime({ callID: 'call-123' }, client);
+    expect(sideband.url.searchParams.get('call_id')).toBe('call-123');
+  });
+
+  test('rejects function-based credentials until create resolves the token', async () => {
+    const client = createClient(async () => 'rotating-key');
+
+    expect(() => new Realtime({ model: 'gpt-realtime' }, client)).toThrow(
+      'Cannot open Realtime WebSocket with a function-based apiKey',
+    );
+
+    const realtime = await Realtime.create(client, { model: 'gpt-realtime' });
+    expect(realtime.socket).toBe(lastBrowserSocket());
+    expect(lastBrowserSocket().protocols).toContain('openai-insecure-api-key.rotating-key');
+  });
+
+  test('refuses an unsafe browser environment but permits ephemeral credentials', () => {
+    const client = createClient();
+    const ephemeral = createClient('ek_temporary');
+    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: { document: {} } });
+    Object.defineProperty(globalThis, 'navigator', { configurable: true, value: {} });
+
+    try {
+      expect(() => new Realtime({ model: 'gpt-realtime' }, client)).toThrow(
+        "It looks like you're running in a browser-like environment",
+      );
+      expect(new Realtime({ model: 'gpt-realtime' }, ephemeral).socket).toBe(lastBrowserSocket());
+    } finally {
+      if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
+      else Reflect.deleteProperty(globalThis, 'window');
+
+      if (originalNavigator) Object.defineProperty(globalThis, 'navigator', originalNavigator);
+      else Reflect.deleteProperty(globalThis, 'navigator');
+    }
+  });
+
+  test('dispatches valid events and reports malformed messages and socket failures', () => {
+    const realtime = new Realtime({ model: 'gpt-realtime' }, createClient());
+    const socket = lastBrowserSocket();
+    const events = jest.fn();
+    const created = jest.fn();
+    const errors = jest.fn();
+
+    onRealtimeEvent(realtime, 'event', events);
+    onRealtimeEvent(realtime, 'response.created', created);
+    onRealtimeEvent(realtime, 'error', errors);
+
+    socket.dispatch('message', { data: JSON.stringify({ type: 'response.created', id: 'evt_1' }) });
+    expect(events).toHaveBeenCalledWith({ type: 'response.created', id: 'evt_1' });
+    expect(created).toHaveBeenCalled();
+
+    socket.dispatch('message', {
+      data: JSON.stringify({
+        type: 'error',
+        event_id: 'evt_2',
+        error: { message: 'request rejected', code: 'invalid_request', param: null, type: 'error' },
+      }),
+    });
+    socket.dispatch('message', { data: '{invalid' });
+    socket.dispatch('error', { message: 'socket failed' });
+    expect(errors).toHaveBeenCalledTimes(3);
+  });
+
+  test('serializes outgoing events and closes with defaults and custom options', () => {
+    const realtime = new Realtime({ model: 'gpt-realtime' }, createClient());
+    const socket = lastBrowserSocket();
+
+    realtime.send({ type: 'session.update' } as any);
+    expect(socket.send).toHaveBeenCalledWith(JSON.stringify({ type: 'session.update' }));
+
+    realtime.close();
+    realtime.close({ code: 1001, reason: 'done' });
+    expect(socket.close).toHaveBeenNthCalledWith(1, 1000, 'OK');
+    expect(socket.close).toHaveBeenNthCalledWith(2, 1001, 'done');
+  });
+
+  test('reports failures while sending and closing', () => {
+    const realtime = new Realtime({ model: 'gpt-realtime' }, createClient());
+    const socket = lastBrowserSocket();
+    const errors = jest.fn();
+    onRealtimeEvent(realtime, 'error', errors);
+
+    socket.send.mockImplementationOnce(() => {
+      throw new Error('send failed');
+    });
+    socket.close.mockImplementationOnce(() => {
+      throw new Error('close failed');
+    });
+
+    realtime.send({ type: 'session.update' } as any);
+    realtime.close();
+    expect(errors).toHaveBeenCalledTimes(2);
+  });
+
+  test('places Azure API keys in the URL and redacts them after opening', async () => {
+    const realtime = await Realtime.azure(createAzureClient({ deployment: 'chat' }));
+
+    expect(lastBrowserSocket().url).toContain('api-key=azure-key');
+    expect(lastBrowserSocket().protocols).not.toContain('openai-insecure-api-key.azure-key');
+    expect(realtime.url.searchParams.get('api-key')).toBe('<REDACTED>');
+  });
+
+  test('places rotating Azure credentials in Authorization and redacts them', async () => {
+    const realtime = await Realtime.azure(createAzureClient({ deployment: 'chat', tokenProvider: true }));
+
+    expect(new URL(lastBrowserSocket().url).searchParams.get('Authorization')).toBe('Bearer azure-token');
+    expect(realtime.url.searchParams.get('Authorization')).toBe('<REDACTED>');
+  });
+
+  test('rejects Azure connections without a deployment', async () => {
+    await expect(Realtime.azure(createAzureClient())).rejects.toThrow('No deployment name provided');
+  });
+
+  test('rejects Azure connections without a resolved API key', async () => {
+    const client = createAzureClient({ deployment: 'chat' });
+    client.apiKey = null;
+
+    await expect(Realtime.azure(client)).rejects.toThrow('Azure OpenAI Realtime requires an API key');
+  });
+});
+
+describe.each([
+  { name: 'stable', Realtime: StableNodeRealtime, beta: false },
+  { name: 'beta', Realtime: BetaNodeRealtime, beta: true },
+])('$name Node realtime websocket', ({ Realtime, beta }) => {
+  test('opens authenticated model and sideband sessions and preserves custom headers', () => {
+    const client = createClient();
+    const model = new Realtime(
+      { model: 'gpt-realtime', options: { headers: { 'X-Custom': 'value' } } },
+      client,
+    );
+
+    expect(model.url.toString()).toBe('wss://example.com/v1/realtime?model=gpt-realtime');
+    expect(lastNodeSocket().options.headers).toMatchObject({
+      Authorization: 'Bearer test-key',
+      'X-Custom': 'value',
+      ...(beta ? { 'OpenAI-Beta': 'realtime=v1' } : {}),
+    });
+
+    const sideband = new Realtime({ callID: 'call-123' }, client);
+    expect(sideband.url.searchParams.get('call_id')).toBe('call-123');
+  });
+
+  test('requires function-based credentials to be resolved with create', async () => {
+    const client = createClient(async () => 'rotating-key');
+
+    expect(() => new Realtime({ model: 'gpt-realtime' }, client)).toThrow(
+      'Cannot open Realtime WebSocket with a function-based apiKey',
+    );
+
+    await Realtime.create(client, { model: 'gpt-realtime' });
+    expect(lastNodeSocket().options.headers).toMatchObject({ Authorization: 'Bearer rotating-key' });
+  });
+
+  test('dispatches valid events and reports malformed messages and socket failures', () => {
+    const realtime = new Realtime({ model: 'gpt-realtime' }, createClient());
+    const socket = lastNodeSocket();
+    const events = jest.fn();
+    const created = jest.fn();
+    const errors = jest.fn();
+
+    onRealtimeEvent(realtime, 'event', events);
+    onRealtimeEvent(realtime, 'response.created', created);
+    onRealtimeEvent(realtime, 'error', errors);
+
+    socket.dispatch('message', JSON.stringify({ type: 'response.created', id: 'evt_1' }));
+    expect(events).toHaveBeenCalledWith({ type: 'response.created', id: 'evt_1' });
+    expect(created).toHaveBeenCalled();
+
+    socket.dispatch(
+      'message',
+      JSON.stringify({
+        type: 'error',
+        event_id: 'evt_2',
+        error: { message: 'request rejected', code: 'invalid_request', param: null, type: 'error' },
+      }),
+    );
+    socket.dispatch('message', '{invalid');
+    socket.dispatch('error', new Error('socket failed'));
+    expect(errors).toHaveBeenCalledTimes(3);
+  });
+
+  test('sends JSON events and closes with default and custom settings', () => {
+    const realtime = new Realtime({ model: 'gpt-realtime' }, createClient());
+    const socket = lastNodeSocket();
+
+    realtime.send({ type: 'session.update' } as any);
+    realtime.close();
+    realtime.close({ code: 1001, reason: 'done' });
+
+    expect(socket.send).toHaveBeenCalledWith(JSON.stringify({ type: 'session.update' }));
+    expect(socket.close).toHaveBeenNthCalledWith(1, 1000, 'OK');
+    expect(socket.close).toHaveBeenNthCalledWith(2, 1001, 'done');
+  });
+
+  test('reports send and close failures to error listeners', () => {
+    const realtime = new Realtime({ model: 'gpt-realtime' }, createClient());
+    const socket = lastNodeSocket();
+    const errors = jest.fn();
+    onRealtimeEvent(realtime, 'error', errors);
+
+    socket.send.mockImplementationOnce(() => {
+      throw new Error('send failed');
+    });
+    socket.close.mockImplementationOnce(() => {
+      throw new Error('close failed');
+    });
+
+    realtime.send({ type: 'session.update' } as any);
+    realtime.close();
+    expect(errors).toHaveBeenCalledTimes(2);
+  });
+
+  test('authenticates Azure sessions with an API-key header', async () => {
+    await Realtime.azure(createAzureClient({ deployment: 'chat' }));
+
+    expect(lastNodeSocket().options.headers).toMatchObject({ 'api-key': 'azure-key' });
+    expect(lastNodeSocket().options.headers).not.toHaveProperty('Authorization');
+  });
+
+  test('authenticates Azure token-provider sessions with a bearer header', async () => {
+    await Realtime.azure(createAzureClient({ deployment: 'chat', tokenProvider: true }));
+
+    expect(lastNodeSocket().options.headers).toMatchObject({ Authorization: 'Bearer azure-token' });
+    expect(lastNodeSocket().options.headers).not.toHaveProperty('api-key');
+  });
+
+  test('requires an Azure deployment', async () => {
+    await expect(Realtime.azure(createAzureClient())).rejects.toThrow('No deployment name provided');
+  });
+
+  test('requires a resolved Azure API key', async () => {
+    const client = createAzureClient({ deployment: 'chat' });
+    client.apiKey = null;
+
+    await expect(Realtime.azure(client)).rejects.toThrow('Azure OpenAI Realtime requires an API key');
+  });
+});

--- a/tests/resource-exports.test.ts
+++ b/tests/resource-exports.test.ts
@@ -1,0 +1,42 @@
+import { readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const repositoryRoot = join(__dirname, '..');
+const resourcesDirectory = join(repositoryRoot, 'src', 'resources');
+
+function findResourceIndexes(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+
+    if (entry.isDirectory()) return findResourceIndexes(path);
+    return entry.name === 'index.ts' ? [path] : [];
+  });
+}
+
+const realtimeModules = ['realtime', 'beta/realtime'].flatMap((directory) => {
+  const moduleDirectory = join(repositoryRoot, 'src', directory);
+
+  return readdirSync(moduleDirectory)
+    .filter((name) => name.endsWith('.ts'))
+    .map((name) => join(moduleDirectory, name));
+});
+
+const resourceIndexes = [...findResourceIndexes(resourcesDirectory), ...realtimeModules].map(
+  (modulePath) => ({
+    path: relative(repositoryRoot, modulePath),
+    modulePath,
+  }),
+);
+
+describe.each(resourceIndexes)('SDK exports: $path', ({ modulePath }) => {
+  test('exposes every declared runtime export', () => {
+    const exports = require(modulePath) as Record<string, unknown>;
+    const names = Object.keys(exports);
+
+    expect(names.length).toBeGreaterThan(0);
+
+    for (const name of names) {
+      expect(exports[name]).toBeDefined();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Separate Stainless-generated API contract tests from handwritten unit tests with dedicated `test:unit`, `test:generated`, and `test:coverage` commands.
- Add focused coverage for streaming, response accumulation, WebSocket adapters and reconnects, authentication, pagination, uploads, platform detection, resource exports, and generated helper methods.
- Measure every executable SDK source file with V8 coverage, excluding only vendored and type-only files, and enforce 98% statements/lines, 90% branches, and 93% functions in the required CI test-matrix check.

## Validation
- Full coverage suite: 1,980 tests passed; 1 existing test skipped.
- Coverage: 98.83% statements/lines, 90.72% branches, and 93.50% functions.
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `./node_modules/.bin/eslint .`
- `./node_modules/.bin/prettier --check .`
- `node --experimental-strip-types scripts/check-node-version-policy.ts`

## Related Linear issues
- [SDK-205 — Define a meaningful test-coverage target and automate reporting](https://linear.app/openai/issue/SDK-205/define-a-meaningful-test-coverage-target-and-automate-reporting)