### PR TITLE
fix(types): improve responses.create overload resolution with optional parameters

### DIFF
--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -95,11 +95,14 @@ export class Responses extends APIResource {
    * const response = await client.responses.create();
    * ```
    */
-  create(body: ResponseCreateParamsNonStreaming, options?: RequestOptions): APIPromise<Response>;
   create(
     body: ResponseCreateParamsStreaming,
     options?: RequestOptions,
   ): APIPromise<Stream<ResponseStreamEvent>>;
+  create(
+    body: ResponseCreateParamsNonStreaming,
+    options?: RequestOptions,
+  ): APIPromise<Response>;
   create(
     body: ResponseCreateParamsBase,
     options?: RequestOptions,


### PR DESCRIPTION
The `responses.create()` method had ambiguous TypeScript overload signatures that caused type inference to fail when using optional parameters like `previous_response_id` without explicit type annotations. TypeScript could not determine which overload to match and defaulted to `any`, requiring users to manually annotate parameter types with `ResponseCreateParamsNonStreaming`.

The root cause was the presence of three overloads with insufficient specificity ordering. The `ResponseCreateParamsBase` overload competed with the more specific `ResponseCreateParamsNonStreaming` and `ResponseCreateParamsStreaming` overloads when optional parameters were present.

This fix reorders the overload signatures to prioritize the most specific types first (streaming, then non-streaming), followed by the base interface overload as a fallback. This ensures TypeScript's overload resolution correctly infers return types based on the `stream` parameter without requiring explicit type annotations. When `stream` is undefined or explicitly `false`, the non-streaming overload matches and returns `APIPromise<Response>`. When `stream` is `true`, the streaming overload matches and returns `APIPromise<Stream<ResponseStreamEvent>>`.

The change maintains backward compatibility while fixing the type inference issue for parameters like `previous_response_id`, `instructions`, and other optional fields.

Fixes #1547
