### PR TITLE
test: run Bash harness tests on Windows

### DIFF
--- a/tests/test-script.test.ts
+++ b/tests/test-script.test.ts
@@ -26,6 +26,23 @@ const generatedTopLevelTests = readdirSync(path.join(process.cwd(), 'tests')).fi
     ),
 );
 
+function toBashPath(path: string): string {
+  if (process.platform !== 'win32') {
+    return path;
+  }
+  return path
+    .replace(/^[A-Za-z]:[\\/]/u, (prefix) => `/${prefix.charAt(0).toLowerCase()}/`)
+    .split('\\')
+    .join('/');
+}
+
+function toBashArgument(arg: string): string {
+  if (process.platform !== 'win32' || !/^[A-Za-z]:[\\/]/u.test(arg)) {
+    return arg;
+  }
+  return arg.split('\\').join('/');
+}
+
 describe('scripts/test', () => {
   let fixtureDir: string;
 
@@ -72,20 +89,30 @@ printf '%s\\0' "$@" > "$VITEST_ARGS_FILE"
   function runTestScript(args: string[], suite = 'all'): { jestArgs: string[]; vitestArgs: string[] } {
     const jestArgsFile = path.join(fixtureDir, 'jest-args');
     const vitestArgsFile = path.join(fixtureDir, 'vitest-args');
-    const result = spawnSync(path.join(fixtureDir, 'scripts/test'), args, {
-      encoding: 'utf-8',
-      env: {
-        ...process.env,
-        JEST_ARGS_FILE: jestArgsFile,
-        OPENAI_TEST_SUITE: suite,
-        PATH: `${path.join(fixtureDir, 'bin')}:${process.env['PATH']}`,
-        VITEST_ARGS_FILE: vitestArgsFile,
+    const result = spawnSync(
+      'bash',
+      [
+        '-c',
+        'PATH="$1:$PATH"; shift; exec "$@"',
+        'bash',
+        toBashPath(path.join(fixtureDir, 'bin')),
+        toBashPath(path.join(fixtureDir, 'scripts/test')),
+        ...args.map(toBashArgument),
+      ],
+      {
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          JEST_ARGS_FILE: toBashPath(jestArgsFile),
+          OPENAI_TEST_SUITE: suite,
+          VITEST_ARGS_FILE: toBashPath(vitestArgsFile),
+        },
       },
-    });
+    );
 
     if (result.status !== 0) {
       throw new Error(
-        `scripts/test exited with ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+        `scripts/test exited with ${result.status}\nerror:\n${result.error?.message}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
       );
     }
 
@@ -163,11 +190,15 @@ printf '%s\\0' "$@" > "$VITEST_ARGS_FILE"
   });
 
   test.each([
-    { label: 'relative', testPath: './tests/index.test.ts' },
-    { label: 'absolute', testPath: path.join(process.cwd(), 'tests/index.test.ts') },
-  ])('routes $label generated path filters only to Jest', ({ testPath }) => {
+    { label: 'relative', testPath: './tests/index.test.ts', expectedTestPath: './tests/index.test.ts' },
+    {
+      label: 'absolute',
+      testPath: path.join(process.cwd(), 'tests/index.test.ts'),
+      expectedTestPath: toBashArgument(path.join(process.cwd(), 'tests/index.test.ts')),
+    },
+  ])('routes $label generated path filters only to Jest', ({ testPath, expectedTestPath }) => {
     expect(runTestScript([testPath])).toEqual({
-      jestArgs: ['--runInBand', testPath],
+      jestArgs: ['--runInBand', expectedTestPath],
       vitestArgs: [],
     });
   });


### PR DESCRIPTION
## Problem

On Windows, the handwritten `tests/test-script.test.ts` suite cannot launch the copied `scripts/test` fixture. Node's `spawnSync()` does not execute an extensionless Bash script through its shebang on Windows, so the harness fails with `status: null` / `ENOENT`.

This became part of the handwritten unit baseline after #2034 organized the test suites. The branch has since been rebased onto the current dual-runner Jest/Vitest harness.

## Root cause

The fixture spawned `scripts/test` directly and relied on a POSIX `PATH` override. Windows needs Bash to be invoked explicitly, and Git Bash prepends its own utility directories during startup, so the fixture's fake binaries must be prepended from inside the shell. Windows temporary paths and absolute test-path arguments also need shell-compatible normalization.

## Fix

- run the fixture through `bash -c`
- keep all dynamic values positional and quoted
- prepend the fixture bin directory after Bash starts
- normalize Windows fixture paths and absolute test-path arguments
- preserve the current Jest/Vitest routing and suite selection
- include `spawnSync` errors in failure diagnostics

## Tests

Revalidated on Windows after rebasing onto current `main@fbd2541`:

- `pnpm exec vitest run --config vitest.config.mts tests/test-script.test.ts` — 27/27 passed
- `pnpm exec ultracite check tests/test-script.test.ts` — passed
- `pnpm exec tsc --pretty false` — passed
- `bash ./scripts/build` — passed
- `git diff --check` — passed
- `CI=1 pnpm test:unit` — 1,689 passed / 1 existing unrelated Windows-only failure in `tests/oxlint-config.test.ts` because `spawnSync('pnpm')` returns `ENOENT`

## Compatibility / Risk

Test-only change. SDK runtime code, generated resources, exports, and package behavior are unchanged. Non-Windows path handling remains a no-op.