### PR TITLE
fix(responses): correct finalResponse error message and drop duplicate spread

### DIFF
--- a/src/lib/ResponsesParser.ts
+++ b/src/lib/ResponsesParser.ts
@@ -220,7 +220,6 @@ function parseToolCall<Params extends ResponseCreateParamsBase>(
 
   return {
     ...toolCall,
-    ...toolCall,
     parsed_arguments:
       isAutoParsableTool(inputTool) ? inputTool.$parseRaw(toolCall.arguments)
       : inputTool?.strict ? JSON.parse(toolCall.arguments)

--- a/src/lib/responses/ResponseStream.ts
+++ b/src/lib/responses/ResponseStream.ts
@@ -289,12 +289,12 @@ export class ResponseStream<ParsedT = null>
 
   /**
    * @returns a promise that resolves with the final Response, or rejects
-   * if an error occurred or the stream ended prematurely without producing a REsponse.
+   * if an error occurred or the stream ended prematurely without producing a Response.
    */
   async finalResponse(): Promise<ParsedResponse<ParsedT>> {
     await this.done();
     const response = this.#finalResponse;
-    if (!response) throw new OpenAIError('stream ended without producing a ChatCompletion');
+    if (!response) throw new OpenAIError('stream ended without producing a Response');
     return response;
   }
 }


### PR DESCRIPTION
## What

Two small fixes in the handwritten Responses helpers (`src/lib/`):

1. **`ResponseStream.finalResponse()` reported the wrong type.** When the stream ends without producing a result, it threw `OpenAIError('stream ended without producing a ChatCompletion')` and its JSDoc read `...without producing a REsponse`. This helper returns a `Response`, not a `ChatCompletion` — the message was copied from the Chat Completions helper. Corrected both the thrown message and the doc typo.

2. **Removed a redundant duplicate `...toolCall` spread** in `ResponsesParser.parseToolCall`. The object literal spread `toolCall` twice (`{ ...toolCall, ...toolCall, parsed_arguments }`). Spreading the same object twice is identical to spreading it once, so this is a pure no-op cleanup. It has been present since the file was first added.

## Why

The `ChatCompletion` wording is misleading when debugging Responses streaming, and the duplicate spread is dead code.

## Testing

- `prettier --check` and `eslint` pass on both files.
- `tsc` typechecks cleanly.
- Existing `tests/lib/ResponseStream.test.ts` and `tests/lib/ResponsesParser*.test.ts` suites pass.

No behavioral change beyond the corrected error string.