### PR TITLE
build: migrate release workflow to upstream release-please

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -160,6 +160,22 @@ $ pnpm fix
 Changes made to this repository via the automated release PR pipeline should publish to npm automatically. If
 the changes aren't made through the automated pipeline, you may want to make releases manually.
 
+### Override an automated release version
+
+Do not edit an automated release PR title to change its version. The title must match the version generated in
+`package.json`, and CI rejects mismatches so that the package, changelog, tag, and release stay consistent.
+
+To select a different version, merge a conventional commit with a `Release-As: <version>` footer into `main`.
+For example:
+
+```text
+chore: set the next release version
+
+Release-As: 7.4.0
+```
+
+Release Please will then regenerate the release PR files and title with that version.
+
 ### Publish with a GitHub workflow
 
 You can release to package managers by using [the `Publish NPM` GitHub action](https://www.github.com/openai/openai-node/actions/workflows/publish-npm.yml). This requires a setup organization or repository secret to be set up.

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -6,6 +6,13 @@ on:
     branches:
       - main
       - next
+  pull_request:
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
 
 jobs:
   promote:
@@ -25,16 +32,50 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          ahead_by="$(gh api "repos/${GITHUB_REPOSITORY}/compare/main...next" --jq '.ahead_by')"
-          if [[ "${ahead_by}" == '0' ]]; then
+          if git diff --quiet origin/main HEAD --; then
             echo 'No Stainless changes to promote.'
             exit 0
           fi
 
+          last_promoted_sha="$(
+            gh pr list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --state merged \
+              --base main \
+              --head next \
+              --limit 100 \
+              --json headRefOid,mergedAt \
+              --jq 'sort_by(.mergedAt) | last | .headRefOid // empty'
+          )"
+
+          if [[ -n "${last_promoted_sha}" ]]; then
+            if ! git cat-file -e "${last_promoted_sha}^{commit}" 2>/dev/null; then
+              git fetch --no-tags origin "${last_promoted_sha}"
+            fi
+            if ! git merge-base --is-ancestor "${last_promoted_sha}" HEAD; then
+              echo "Last promoted commit ${last_promoted_sha} is not an ancestor of next."
+              echo 'Refusing to classify a rewritten promotion range.'
+              exit 1
+            fi
+            promotion_range="${last_promoted_sha}..HEAD"
+          else
+            promotion_range='origin/main..HEAD'
+          fi
+
+          commit_subjects="$(git log "${promotion_range}" --format='%s')"
+          commit_messages="$(git log "${promotion_range}" --format='%s%n%b')"
+          conventional_commit='^(feat|fix|perf|revert|chore|docs|style|refactor|test|build|ci)(\([^)]*\))?!?:'
+          if ! grep -Eq "${conventional_commit}" <<< "${commit_subjects}" && \
+            ! grep -Eq '^BREAKING[ -]CHANGE:' <<< "${commit_messages}"; then
+            echo "No releasable commits in ${promotion_range}; skipping promotion."
+            exit 0
+          fi
+
           promotion_type='fix(api)'
-          if git log origin/main..HEAD --format='%s%n%b' | grep -Eq '(^[[:alpha:]]+(\([^)]*\))?!:)|(^BREAKING[ -]CHANGE:)'; then
+          if grep -Eq '^[[:alpha:]]+(\([^)]*\))?!:' <<< "${commit_subjects}" || \
+            grep -Eq '^BREAKING[ -]CHANGE:' <<< "${commit_messages}"; then
             promotion_type='feat(api)!'
-          elif git log origin/main..HEAD --format='%s' | grep -Eq '^feat(\([^)]*\))?:'; then
+          elif grep -Eq '^feat(\([^)]*\))?:' <<< "${commit_subjects}"; then
             promotion_type='feat(api)'
           fi
           promotion_title="${promotion_type}: promote Stainless-generated changes"
@@ -70,6 +111,36 @@ jobs:
             gh pr ready "${promotion_pr}" --repo "${GITHUB_REPOSITORY}" --undo
           fi
 
+  validate-release-version:
+    name: validate release PR version
+    if: >-
+      ${{
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.ref == 'release-please--branches--main--components--openai' &&
+        github.repository == 'openai/openai-node'
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Compare the release title with the generated version
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          package_version="$(jq -r -e '.version' package.json)"
+          expected_title="release: ${package_version}"
+          if [[ "${PR_TITLE}" != "${expected_title}" ]]; then
+            echo "Release PR title '${PR_TITLE}' does not match package.json version ${package_version}."
+            echo 'Do not edit the title to override the release version.'
+            echo 'Add a conventional commit with a Release-As: <version> footer instead.'
+            exit 1
+          fi
+
   release:
     name: release
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-node'
@@ -78,9 +149,6 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-
     steps:
       - name: Check for the legacy Stainless release PR
         id: cutover
@@ -120,15 +188,66 @@ jobs:
             gh pr ready "${RELEASE_PR}" --repo "${GITHUB_REPOSITORY}" --undo
           fi
 
-  publish:
-    name: publish
+  publication-check:
+    name: check publication state
     if: >-
       ${{
         always() &&
         !cancelled() &&
-        needs.release.outputs.release_created == 'true'
+        github.event_name == 'push' &&
+        github.ref == 'refs/heads/main' &&
+        github.repository == 'openai/openai-node'
       }}
     needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check whether the current release needs publishing
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          package_version="$(jq -r -e '.version' package.json)"
+          release_tag="v${package_version}"
+
+          set +e
+          release_info="$(gh api --silent "repos/${GITHUB_REPOSITORY}/releases/tags/${release_tag}" 2>&1)"
+          release_status=$?
+          set -e
+          if [[ ${release_status} -ne 0 ]]; then
+            if grep -q 'HTTP 404' <<< "${release_info}"; then
+              echo "No GitHub release exists for ${release_tag}; nothing to publish."
+              echo 'should_publish=false' >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+            echo "Unable to check for GitHub release ${release_tag}:"
+            echo "${release_info}"
+            exit 1
+          fi
+
+          set +e
+          bash ./bin/check-npm-version
+          version_status=$?
+          set -e
+
+          if [[ ${version_status} -eq 0 ]]; then
+            echo 'should_publish=false' >> "${GITHUB_OUTPUT}"
+          elif [[ ${version_status} -eq 1 ]]; then
+            echo 'should_publish=true' >> "${GITHUB_OUTPUT}"
+          else
+            exit "${version_status}"
+          fi
+
+  publish:
+    name: publish
+    if: needs.publication-check.outputs.should_publish == 'true'
+    needs: publication-check
     runs-on: ubuntu-latest
     environment: publish
     permissions:

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          legacy_pr="$(bash ./bin/find-legacy-release-pr)"
+          legacy_pr="$(bash ./bin/find-legacy-release-pr open-number)"
           if [[ -n "${legacy_pr}" ]]; then
             echo "Waiting for legacy release PR #${legacy_pr} before promoting next directly."
             exit 0
@@ -46,7 +46,7 @@ jobs:
             exit 0
           fi
 
-          last_promoted_sha="$(
+          promotion_start="$(
             gh pr list \
               --repo "${GITHUB_REPOSITORY}" \
               --state merged \
@@ -57,19 +57,23 @@ jobs:
               --jq 'sort_by(.mergedAt) | last | .headRefOid // empty'
           )"
 
-          if [[ -n "${last_promoted_sha}" ]]; then
-            if ! git cat-file -e "${last_promoted_sha}^{commit}" 2>/dev/null; then
-              git fetch --no-tags origin "${last_promoted_sha}"
+          if [[ -z "${promotion_start}" ]]; then
+            promotion_start="$(bash ./bin/find-legacy-release-pr merged-next-sha)"
+          fi
+
+          if [[ -n "${promotion_start}" ]]; then
+            if ! git cat-file -e "${promotion_start}^{commit}" 2>/dev/null; then
+              git fetch --no-tags origin "${promotion_start}"
             fi
-            if ! git merge-base --is-ancestor "${last_promoted_sha}" HEAD; then
-              echo "Last promoted commit ${last_promoted_sha} is not an ancestor of next."
+            if ! git merge-base --is-ancestor "${promotion_start}" HEAD; then
+              echo "Promotion boundary ${promotion_start} is not an ancestor of next."
               echo 'Refusing to classify a rewritten promotion range.'
               exit 1
             fi
-            promotion_range="${last_promoted_sha}..HEAD"
           else
-            promotion_range='origin/main..HEAD'
+            promotion_start='origin/main'
           fi
+          promotion_range="${promotion_start}..HEAD"
 
           commit_subjects="$(git log "${promotion_range}" --not origin/main --format='%s')"
           commit_messages="$(git log "${promotion_range}" --not origin/main --format='%s%n%b')"
@@ -183,7 +187,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          legacy_pr="$(bash ./bin/find-legacy-release-pr)"
+          legacy_pr="$(bash ./bin/find-legacy-release-pr open-number)"
           echo "legacy_pr=${legacy_pr}" >> "${GITHUB_OUTPUT}"
           if [[ -n "${legacy_pr}" ]]; then
             echo "Waiting for legacy release PR #${legacy_pr} to merge or close before cutover."

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -11,6 +11,33 @@ jobs:
     name: release
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-node'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+
+    steps:
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        id: release
+        with:
+          # Use the default token until the openai-sdks App credentials are provisioned.
+          token: ${{ github.token }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          target-branch: main
+
+  publish:
+    name: publish
+    if: >-
+      ${{
+        always() &&
+        !cancelled() &&
+        needs.release.outputs.release_created == 'true'
+      }}
+    needs: release
+    runs-on: ubuntu-latest
     environment: publish
     permissions:
       contents: read
@@ -19,29 +46,18 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: stainless-api/trigger-release-please@bb6677c5a04578eec1ccfd9e1913b5b78ed64c61 # v1.4.0
-        id: release
-        with:
-          repo: ${{ github.event.repository.full_name }}
-          stainless-api-key: ${{ secrets.STAINLESS_API_KEY }}
-
       - name: Set up pnpm
-        if: ${{ steps.release.outputs.releases_created }}
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
-
       - name: Set up Node
-        if: ${{ steps.release.outputs.releases_created }}
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: '.nvmrc'
           cache: pnpm
 
       - name: Install dependencies
-        if: ${{ steps.release.outputs.releases_created }}
         run: |
           pnpm install --frozen-lockfile
 
       - name: Publish to NPM
-        if: ${{ steps.release.outputs.releases_created }}
         run: |
           bash ./bin/publish-npm

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -35,6 +35,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          legacy_pr="$(bash ./bin/find-legacy-release-pr)"
+          if [[ -n "${legacy_pr}" ]]; then
+            echo "Waiting for legacy release PR #${legacy_pr} before promoting next directly."
+            exit 0
+          fi
+
           if git diff --quiet origin/main HEAD --; then
             echo 'No Stainless changes to promote.'
             exit 0
@@ -65,12 +71,12 @@ jobs:
             promotion_range='origin/main..HEAD'
           fi
 
-          commit_subjects="$(git log "${promotion_range}" --format='%s')"
-          commit_messages="$(git log "${promotion_range}" --format='%s%n%b')"
+          commit_subjects="$(git log "${promotion_range}" --not origin/main --format='%s')"
+          commit_messages="$(git log "${promotion_range}" --not origin/main --format='%s%n%b')"
           conventional_commit='^(feat|fix|perf|revert|chore|docs|style|refactor|test|build|ci)(\([^)]*\))?!?:'
           if ! grep -Eq "${conventional_commit}" <<< "${commit_subjects}" && \
             ! grep -Eq '^BREAKING[ -]CHANGE:' <<< "${commit_messages}"; then
-            echo "No releasable commits in ${promotion_range}; skipping promotion."
+            echo "No unreleased conventional commits in ${promotion_range}; skipping promotion."
             exit 0
           fi
 
@@ -177,14 +183,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          legacy_pr="$(
-            gh pr list \
-              --repo "${GITHUB_REPOSITORY}" \
-              --state open \
-              --head 'release-please--branches--main--changes--next--components--openai' \
-              --json number \
-              --jq '.[0].number // empty'
-          )"
+          legacy_pr="$(bash ./bin/find-legacy-release-pr)"
           echo "legacy_pr=${legacy_pr}" >> "${GITHUB_OUTPUT}"
           if [[ -n "${legacy_pr}" ]]; then
             echo "Waiting for legacy release PR #${legacy_pr} to merge or close before cutover."

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -9,7 +9,7 @@ on:
     workflows:
       - CI
     types:
-      - completed
+      - requested
     branches:
       - next
   pull_request:

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -18,6 +18,9 @@ jobs:
   promote:
     name: promote Stainless changes
     if: github.ref == 'refs/heads/next' && github.repository == 'openai/openai-node'
+    concurrency:
+      group: promote-stainless-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -80,6 +83,12 @@ jobs:
           fi
           promotion_title="${promotion_type}: promote Stainless-generated changes"
 
+          current_next_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/next" --jq '.object.sha')"
+          if [[ "${current_next_sha}" != "${GITHUB_SHA}" ]]; then
+            echo "A newer next commit (${current_next_sha}) superseded this run (${GITHUB_SHA})."
+            exit 0
+          fi
+
           promotion_pr="$(
             gh pr list \
               --repo "${GITHUB_REPOSITORY}" \
@@ -132,14 +141,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          package_version="$(jq -r -e '.version' package.json)"
-          expected_title="release: ${package_version}"
-          if [[ "${PR_TITLE}" != "${expected_title}" ]]; then
-            echo "Release PR title '${PR_TITLE}' does not match package.json version ${package_version}."
-            echo 'Do not edit the title to override the release version.'
-            echo 'Add a conventional commit with a Release-As: <version> footer instead.'
-            exit 1
-          fi
+          bash ./bin/check-release-version "${PR_TITLE}"
 
   release:
     name: release
@@ -150,6 +152,26 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Validate a merged release PR version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          release_pr_title="$(
+            gh api \
+              -H 'Accept: application/vnd.github+json' \
+              "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+              --jq '[.[] | select(
+                .merged_at != null and
+                .base.ref == "main" and
+                .head.ref == "release-please--branches--main--components--openai"
+              )][0].title // empty'
+          )"
+          if [[ -n "${release_pr_title}" ]]; then
+            bash ./bin/check-release-version "${release_pr_title}"
+          fi
+
       - name: Check for the legacy Stainless release PR
         id: cutover
         env:
@@ -204,6 +226,7 @@ jobs:
       contents: read
     outputs:
       should_publish: ${{ steps.check.outputs.should_publish }}
+      release_tag: ${{ steps.check.outputs.release_tag }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -230,6 +253,7 @@ jobs:
             echo "${release_info}"
             exit 1
           fi
+          echo "release_tag=${release_tag}" >> "${GITHUB_OUTPUT}"
 
           set +e
           bash ./bin/check-npm-version
@@ -256,6 +280,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.publication-check.outputs.release_tag }}
 
       - name: Set up pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -10,6 +10,7 @@ on:
       - CI
     types:
       - requested
+      - completed
     branches:
       - next
   pull_request:
@@ -22,6 +23,44 @@ on:
       - synchronize
 
 jobs:
+  redraft-promotion:
+    name: re-draft promotion PR
+    if: >-
+      ${{
+        github.repository == 'openai/openai-node' &&
+        github.event_name == 'workflow_run' &&
+        github.event.action == 'requested' &&
+        github.event.workflow_run.event == 'push'
+      }}
+    concurrency:
+      group: promote-stainless-next
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Re-draft the existing promotion PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          promotion_pr="$(
+            gh pr list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --state open \
+              --base main \
+              --head next \
+              --json isDraft,number \
+              --jq '.[0] // empty'
+          )"
+          if [[ -z "${promotion_pr}" || "$(jq -r '.isDraft' <<< "${promotion_pr}")" == 'true' ]]; then
+            exit 0
+          fi
+          gh pr ready \
+            "$(jq -r -e '.number' <<< "${promotion_pr}")" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --undo
+
   promote:
     name: promote Stainless changes
     if: >-
@@ -31,7 +70,9 @@ jobs:
           github.event_name == 'push' ||
           (
             github.event_name == 'workflow_run' &&
-            github.event.workflow_run.event == 'push'
+            github.event.action == 'completed' &&
+            github.event.workflow_run.event == 'push' &&
+            github.event.workflow_run.conclusion == 'success'
           ) ||
           (
             github.event_name == 'pull_request' &&
@@ -59,7 +100,7 @@ jobs:
         with:
           fetch-depth: 0
           path: .next
-          ref: refs/heads/next
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || 'refs/heads/next' }}
 
       - name: Create or re-draft the promotion PR
         env:
@@ -68,6 +109,30 @@ jobs:
           legacy_pr="$(bash ./bin/find-legacy-release-pr open-number)"
           if [[ -n "${legacy_pr}" ]]; then
             echo "Waiting for legacy release PR #${legacy_pr} before promoting next directly."
+            exit 0
+          fi
+
+          checked_out_next_sha="$(git -C .next rev-parse HEAD)"
+          current_next_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/next" --jq '.object.sha')"
+          if [[ "${current_next_sha}" != "${checked_out_next_sha}" ]]; then
+            echo "A newer next commit (${current_next_sha}) superseded this run (${checked_out_next_sha})."
+            exit 0
+          fi
+
+          successful_ci_runs="$(
+            gh run list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --workflow ci.yml \
+              --branch next \
+              --commit "${checked_out_next_sha}" \
+              --event push \
+              --status success \
+              --limit 1 \
+              --json headSha \
+              --jq 'length'
+          )"
+          if [[ "${successful_ci_runs}" != '1' ]]; then
+            echo "No successful next CI run exists for ${checked_out_next_sha}; leaving promotion deferred."
             exit 0
           fi
 
@@ -125,13 +190,6 @@ jobs:
             promotion_type='fix(api)'
           fi
           promotion_title="${promotion_type}: promote Stainless-generated changes"
-
-          checked_out_next_sha="$(git -C .next rev-parse HEAD)"
-          current_next_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/next" --jq '.object.sha')"
-          if [[ "${current_next_sha}" != "${checked_out_next_sha}" ]]; then
-            echo "A newer next commit (${current_next_sha}) superseded this run (${checked_out_next_sha})."
-            exit 0
-          fi
 
           promotion_pr="$(
             gh pr list \

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -1,12 +1,57 @@
-# Watches the default branch for release-please output, then publishes newly
-# created SDK releases to npm.
+# Promotes Stainless-generated changes from `next`, then watches the default
+# branch for release-please output and publishes newly created SDK releases.
 name: Create releases
 on:
   push:
     branches:
       - main
+      - next
 
 jobs:
+  promote:
+    name: promote Stainless changes
+    if: github.ref == 'refs/heads/next' && github.repository == 'openai/openai-node'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Create or re-draft the promotion PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ahead_by="$(gh api "repos/${GITHUB_REPOSITORY}/compare/main...next" --jq '.ahead_by')"
+          if [[ "${ahead_by}" == '0' ]]; then
+            echo 'No Stainless changes to promote.'
+            exit 0
+          fi
+
+          promotion_pr="$(
+            gh pr list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --state open \
+              --base main \
+              --head next \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
+
+          if [[ -z "${promotion_pr}" ]]; then
+            gh pr create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --base main \
+              --head next \
+              --draft \
+              --title 'feat(api): promote Stainless-generated changes' \
+              --body 'Promotes the latest Stainless-generated SDK changes from `next`. Mark this PR ready for review to run CI.'
+            exit 0
+          fi
+
+          if [[ "$(gh pr view "${promotion_pr}" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq '.isDraft')" == 'false' ]]; then
+            gh pr ready "${promotion_pr}" --repo "${GITHUB_REPOSITORY}" --undo
+          fi
+
   release:
     name: release
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-node'
@@ -27,6 +72,16 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main
+
+      - name: Re-draft the updated release PR
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_PR: ${{ fromJSON(steps.release.outputs.pr).number }}
+        run: |
+          if [[ "$(gh pr view "${RELEASE_PR}" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq '.isDraft')" == 'false' ]]; then
+            gh pr ready "${RELEASE_PR}" --repo "${GITHUB_REPOSITORY}" --undo
+          fi
 
   publish:
     name: publish

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -241,6 +241,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
 
       - name: Check whether the current release needs publishing
         id: check
@@ -251,7 +253,7 @@ jobs:
           release_tag="v${package_version}"
 
           set +e
-          release_info="$(gh api --silent "repos/${GITHUB_REPOSITORY}/releases/tags/${release_tag}" 2>&1)"
+          release_info="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${release_tag}" 2>&1)"
           release_status=$?
           set -e
           if [[ ${release_status} -ne 0 ]]; then
@@ -264,7 +266,29 @@ jobs:
             echo "${release_info}"
             exit 1
           fi
+
+          release_target="$(jq -r -e '.target_commitish' <<< "${release_info}")"
+          if [[ ! "${release_target}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "GitHub release ${release_tag} does not identify an immutable commit: ${release_target}"
+            exit 1
+          fi
+
           release_sha="$(bash ./bin/resolve-tag-commit "${release_tag}")"
+          if [[ "${release_sha}" != "${release_target}" ]]; then
+            echo "Release tag ${release_tag} resolves to ${release_sha}, not release commit ${release_target}."
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "${release_sha}" "${GITHUB_SHA}"; then
+            echo "Release commit ${release_sha} is not reachable from protected main commit ${GITHUB_SHA}."
+            exit 1
+          fi
+
+          release_package_version="$(git show "${release_sha}:package.json" | jq -r -e '.version')"
+          if [[ "${release_package_version}" != "${package_version}" ]]; then
+            echo "Release commit ${release_sha} contains version ${release_package_version}, expected ${package_version}."
+            exit 1
+          fi
+
           echo "release_sha=${release_sha}" >> "${GITHUB_OUTPUT}"
 
           set +e

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -17,6 +17,10 @@ jobs:
       pull-requests: write
 
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
       - name: Create or re-draft the promotion PR
         env:
           GH_TOKEN: ${{ github.token }}
@@ -26,6 +30,14 @@ jobs:
             echo 'No Stainless changes to promote.'
             exit 0
           fi
+
+          promotion_type='fix(api)'
+          if git log origin/main..HEAD --format='%s%n%b' | grep -Eq '(^[[:alpha:]]+(\([^)]*\))?!:)|(^BREAKING[ -]CHANGE:)'; then
+            promotion_type='feat(api)!'
+          elif git log origin/main..HEAD --format='%s' | grep -Eq '^feat(\([^)]*\))?:'; then
+            promotion_type='feat(api)'
+          fi
+          promotion_title="${promotion_type}: promote Stainless-generated changes"
 
           promotion_pr="$(
             gh pr list \
@@ -43,10 +55,16 @@ jobs:
               --base main \
               --head next \
               --draft \
-              --title 'feat(api): promote Stainless-generated changes' \
+              --title "${promotion_title}" \
               --body 'Promotes the latest Stainless-generated SDK changes from `next`. Mark this PR ready for review to run CI.'
             exit 0
           fi
+
+          gh api \
+            --method PATCH \
+            "repos/${GITHUB_REPOSITORY}/pulls/${promotion_pr}" \
+            -f title="${promotion_title}" \
+            --silent
 
           if [[ "$(gh pr view "${promotion_pr}" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq '.isDraft')" == 'false' ]]; then
             gh pr ready "${promotion_pr}" --repo "${GITHUB_REPOSITORY}" --undo
@@ -64,8 +82,27 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
 
     steps:
+      - name: Check for the legacy Stainless release PR
+        id: cutover
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          legacy_pr="$(
+            gh pr list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --state open \
+              --head 'release-please--branches--main--changes--next--components--openai' \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
+          echo "legacy_pr=${legacy_pr}" >> "${GITHUB_OUTPUT}"
+          if [[ -n "${legacy_pr}" ]]; then
+            echo "Waiting for legacy release PR #${legacy_pr} to merge or close before cutover."
+          fi
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
+        if: steps.cutover.outputs.legacy_pr == ''
         with:
           # Use the default token until the openai-sdks App credentials are provisioned.
           token: ${{ github.token }}

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -310,7 +310,7 @@ jobs:
     needs: publication-check
     runs-on: ubuntu-latest
     concurrency:
-      group: publish-npm
+      group: publish-npm-${{ needs.publication-check.outputs.release_sha }}
       cancel-in-progress: false
     environment: publish
     permissions:

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -87,6 +87,7 @@ jobs:
       cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       pull-requests: write
 

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -8,6 +8,7 @@ on:
       - next
   pull_request:
     types:
+      - closed
       - edited
       - opened
       - ready_for_review
@@ -17,9 +18,21 @@ on:
 jobs:
   promote:
     name: promote Stainless changes
-    if: github.ref == 'refs/heads/next' && github.repository == 'openai/openai-node'
+    if: >-
+      ${{
+        github.repository == 'openai/openai-node' &&
+        (
+          github.event_name == 'push' ||
+          (
+            github.event_name == 'pull_request' &&
+            github.event.action == 'closed' &&
+            github.event.pull_request.merged == false &&
+            github.event.pull_request.head.ref == 'release-please--branches--main--changes--next--components--openai'
+          )
+        )
+      }}
     concurrency:
-      group: promote-stainless-${{ github.ref }}
+      group: promote-stainless-next
       cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
@@ -30,6 +43,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          ref: refs/heads/next
 
       - name: Create or re-draft the promotion PR
         env:
@@ -93,9 +107,10 @@ jobs:
           fi
           promotion_title="${promotion_type}: promote Stainless-generated changes"
 
+          checked_out_next_sha="$(git rev-parse HEAD)"
           current_next_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/next" --jq '.object.sha')"
-          if [[ "${current_next_sha}" != "${GITHUB_SHA}" ]]; then
-            echo "A newer next commit (${current_next_sha}) superseded this run (${GITHUB_SHA})."
+          if [[ "${current_next_sha}" != "${checked_out_next_sha}" ]]; then
+            echo "A newer next commit (${current_next_sha}) superseded this run (${checked_out_next_sha})."
             exit 0
           fi
 
@@ -155,7 +170,12 @@ jobs:
 
   release:
     name: release
-    if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-node'
+    if: >-
+      ${{
+        github.event_name == 'push' &&
+        github.ref == 'refs/heads/main' &&
+        github.repository == 'openai/openai-node'
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -164,23 +184,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Validate a merged release PR version
+      - name: Validate pending release PR versions
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          release_pr_title="$(
-            gh api \
-              -H 'Accept: application/vnd.github+json' \
-              "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
-              --jq '[.[] | select(
-                .merged_at != null and
-                .base.ref == "main" and
-                .head.ref == "release-please--branches--main--components--openai"
-              )][0].title // empty'
-          )"
-          if [[ -n "${release_pr_title}" ]]; then
-            bash ./bin/check-release-version "${release_pr_title}"
-          fi
+          bash ./bin/check-pending-release-versions
 
       - name: Check for the legacy Stainless release PR
         id: cutover
@@ -284,7 +292,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ needs.publication-check.outputs.release_tag }}
+          ref: refs/tags/${{ needs.publication-check.outputs.release_tag }}
 
       - name: Set up pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -237,7 +237,7 @@ jobs:
       contents: read
     outputs:
       should_publish: ${{ steps.check.outputs.should_publish }}
-      release_tag: ${{ steps.check.outputs.release_tag }}
+      release_sha: ${{ steps.check.outputs.release_sha }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -264,7 +264,8 @@ jobs:
             echo "${release_info}"
             exit 1
           fi
-          echo "release_tag=${release_tag}" >> "${GITHUB_OUTPUT}"
+          release_sha="$(bash ./bin/resolve-tag-commit "${release_tag}")"
+          echo "release_sha=${release_sha}" >> "${GITHUB_OUTPUT}"
 
           set +e
           bash ./bin/check-npm-version
@@ -295,7 +296,13 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: refs/tags/${{ needs.publication-check.outputs.release_tag }}
+          ref: ${{ needs.publication-check.outputs.release_sha }}
+
+      - name: Verify release commit
+        env:
+          RELEASE_SHA: ${{ needs.publication-check.outputs.release_sha }}
+        run: |
+          [[ "$(git rev-parse HEAD)" == "${RELEASE_SHA}" ]]
 
       - name: Set up pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -284,6 +284,9 @@ jobs:
     if: needs.publication-check.outputs.should_publish == 'true'
     needs: publication-check
     runs-on: ubuntu-latest
+    concurrency:
+      group: publish-npm
+      cancel-in-progress: false
     environment: publish
     permissions:
       contents: read

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches:
       - main
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+    branches:
       - next
   pull_request:
     types:
@@ -23,6 +29,10 @@ jobs:
         github.repository == 'openai/openai-node' &&
         (
           github.event_name == 'push' ||
+          (
+            github.event_name == 'workflow_run' &&
+            github.event.workflow_run.event == 'push'
+          ) ||
           (
             github.event_name == 'pull_request' &&
             github.event.action == 'closed' &&
@@ -43,6 +53,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          ref: refs/heads/main
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          path: .next
           ref: refs/heads/next
 
       - name: Create or re-draft the promotion PR
@@ -55,7 +71,7 @@ jobs:
             exit 0
           fi
 
-          if git diff --quiet origin/main HEAD --; then
+          if git -C .next diff --quiet origin/main HEAD --; then
             echo 'No Stainless changes to promote.'
             exit 0
           fi
@@ -76,10 +92,10 @@ jobs:
           fi
 
           if [[ -n "${promotion_start}" ]]; then
-            if ! git cat-file -e "${promotion_start}^{commit}" 2>/dev/null; then
-              git fetch --no-tags origin "${promotion_start}"
+            if ! git -C .next cat-file -e "${promotion_start}^{commit}" 2>/dev/null; then
+              git -C .next fetch --no-tags origin "${promotion_start}"
             fi
-            if ! git merge-base --is-ancestor "${promotion_start}" HEAD; then
+            if ! git -C .next merge-base --is-ancestor "${promotion_start}" HEAD; then
               echo "Promotion boundary ${promotion_start} is not an ancestor of next."
               echo 'Refusing to classify a rewritten promotion range.'
               exit 1
@@ -89,8 +105,8 @@ jobs:
           fi
           promotion_range="${promotion_start}..HEAD"
 
-          commit_subjects="$(git log "${promotion_range}" --not origin/main --format='%s')"
-          commit_messages="$(git log "${promotion_range}" --not origin/main --format='%s%n%b')"
+          commit_subjects="$(git -C .next log "${promotion_range}" --not origin/main --format='%s')"
+          commit_messages="$(git -C .next log "${promotion_range}" --not origin/main --format='%s%n%b')"
           conventional_commit='^(feat|fix|perf|revert|chore|docs|style|refactor|test|build|ci)(\([^)]*\))?!?:'
           if ! grep -Eq "${conventional_commit}" <<< "${commit_subjects}" && \
             ! grep -Eq '^BREAKING[ -]CHANGE:' <<< "${commit_messages}"; then
@@ -98,16 +114,19 @@ jobs:
             exit 0
           fi
 
-          promotion_type='fix(api)'
+          # Stainless can label generated API additions as chores. Keep only
+          # explicit patch-class commits at patch severity; default the rest
+          # to a backwards-compatible feature release.
+          promotion_type='feat(api)'
           if grep -Eq '^[[:alpha:]]+(\([^)]*\))?!:' <<< "${commit_subjects}" || \
             grep -Eq '^BREAKING[ -]CHANGE:' <<< "${commit_messages}"; then
             promotion_type='feat(api)!'
-          elif grep -Eq '^feat(\([^)]*\))?:' <<< "${commit_subjects}"; then
-            promotion_type='feat(api)'
+          elif ! grep -Eq '^(feat|chore|docs|style|refactor|test|build|ci)(\([^)]*\))?:' <<< "${commit_subjects}"; then
+            promotion_type='fix(api)'
           fi
           promotion_title="${promotion_type}: promote Stainless-generated changes"
 
-          checked_out_next_sha="$(git rev-parse HEAD)"
+          checked_out_next_sha="$(git -C .next rev-parse HEAD)"
           current_next_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/next" --jq '.object.sha')"
           if [[ "${current_next_sha}" != "${checked_out_next_sha}" ]]; then
             echo "A newer next commit (${current_next_sha}) superseded this run (${checked_out_next_sha})."

--- a/bin/check-npm-version
+++ b/bin/check-npm-version
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Exit 0 when the package version exists, 1 when it is available to publish,
+# and 2 when the registry returns an unexpected response.
+set -euo pipefail
+
+PACKAGE_NAME="$(jq -r -e '.name' package.json)"
+VERSION="$(jq -r -e '.version' package.json)"
+
+set +e
+NPM_INFO="$(npm view "$PACKAGE_NAME@$VERSION" version --json 2>/dev/null)"
+NPM_STATUS=$?
+set -e
+
+if [[ $NPM_STATUS -eq 0 ]]; then
+  if ! PUBLISHED_VERSION="$(jq -r -e '.' <<< "$NPM_INFO")"; then
+    echo "ERROR: npm returned invalid data for $PACKAGE_NAME@$VERSION:" >&2
+    echo "$NPM_INFO" >&2
+    exit 2
+  fi
+  if [[ "$PUBLISHED_VERSION" == "$VERSION" ]]; then
+    echo "$PACKAGE_NAME@$VERSION is already published"
+    exit 0
+  fi
+elif jq -e '.error.code == "E404"' <<< "$NPM_INFO" > /dev/null 2>&1; then
+  echo "$PACKAGE_NAME@$VERSION has not been published"
+  exit 1
+fi
+
+echo "ERROR: npm returned unexpected data for $PACKAGE_NAME@$VERSION:" >&2
+echo "$NPM_INFO" >&2
+exit 2

--- a/bin/check-pending-release-versions
+++ b/bin/check-pending-release-versions
@@ -4,7 +4,6 @@ set -euo pipefail
 
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 
-RELEASE_BRANCH='release-please--branches--main--components--openai'
 PENDING_RELEASES="$(
   gh pr list \
     --repo "$GITHUB_REPOSITORY" \
@@ -12,7 +11,7 @@ PENDING_RELEASES="$(
     --base main \
     --label 'autorelease: pending' \
     --limit 1000 \
-    --json number,title,headRefName,mergeCommit
+    --json number,title,mergeCommit
 )"
 
 while IFS= read -r RELEASE; do
@@ -28,4 +27,4 @@ while IFS= read -r RELEASE; do
 
   echo "Validating pending release PR #${PR_NUMBER} at ${MERGE_SHA}."
   bash ./bin/check-release-version "$PR_TITLE" "$PACKAGE_VERSION"
-done < <(jq -c --arg branch "$RELEASE_BRANCH" '.[] | select(.headRefName == $branch)' <<< "$PENDING_RELEASES")
+done < <(jq -c '.[]' <<< "$PENDING_RELEASES")

--- a/bin/check-pending-release-versions
+++ b/bin/check-pending-release-versions
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+RELEASE_BRANCH='release-please--branches--main--components--openai'
+PENDING_RELEASES="$(
+  gh pr list \
+    --repo "$GITHUB_REPOSITORY" \
+    --state merged \
+    --base main \
+    --label 'autorelease: pending' \
+    --limit 1000 \
+    --json number,title,headRefName,mergeCommit
+)"
+
+while IFS= read -r RELEASE; do
+  [[ -z "$RELEASE" ]] && continue
+
+  PR_NUMBER="$(jq -r -e '.number' <<< "$RELEASE")"
+  PR_TITLE="$(jq -r -e '.title' <<< "$RELEASE")"
+  MERGE_SHA="$(jq -r -e '.mergeCommit.oid' <<< "$RELEASE")"
+  PACKAGE_VERSION="$(
+    gh api "repos/${GITHUB_REPOSITORY}/contents/package.json?ref=${MERGE_SHA}" \
+      --jq '.content | @base64d | fromjson | .version'
+  )"
+
+  echo "Validating pending release PR #${PR_NUMBER} at ${MERGE_SHA}."
+  bash ./bin/check-release-version "$PR_TITLE" "$PACKAGE_VERSION"
+done < <(jq -c --arg branch "$RELEASE_BRANCH" '.[] | select(.headRefName == $branch)' <<< "$PENDING_RELEASES")

--- a/bin/check-release-version
+++ b/bin/check-release-version
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+RELEASE_TITLE="${1:?release PR title is required}"
+PACKAGE_VERSION="$(jq -r -e '.version' package.json)"
+EXPECTED_TITLE="release: ${PACKAGE_VERSION}"
+
+if [[ "$RELEASE_TITLE" != "$EXPECTED_TITLE" ]]; then
+  echo "Release PR title '$RELEASE_TITLE' does not match package.json version $PACKAGE_VERSION."
+  echo 'Do not edit the title to override the release version.'
+  echo 'Merge a conventional commit with a Release-As: <version> footer into main instead.'
+  exit 1
+fi

--- a/bin/check-release-version
+++ b/bin/check-release-version
@@ -3,7 +3,11 @@
 set -euo pipefail
 
 RELEASE_TITLE="${1:?release PR title is required}"
-PACKAGE_VERSION="$(jq -r -e '.version' package.json)"
+if [[ $# -ge 2 ]]; then
+  PACKAGE_VERSION="$2"
+else
+  PACKAGE_VERSION="$(jq -r -e '.version' package.json)"
+fi
 EXPECTED_TITLE="release: ${PACKAGE_VERSION}"
 
 if [[ "$RELEASE_TITLE" != "$EXPECTED_TITLE" ]]; then

--- a/bin/find-legacy-release-pr
+++ b/bin/find-legacy-release-pr
@@ -4,9 +4,33 @@ set -euo pipefail
 
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 
-gh pr list \
-  --repo "$GITHUB_REPOSITORY" \
-  --state open \
-  --head 'release-please--branches--main--changes--next--components--openai' \
-  --json number \
-  --jq '.[0].number // empty'
+LEGACY_BRANCH='release-please--branches--main--changes--next--components--openai'
+
+case "${1:-open-number}" in
+  open-number)
+    gh pr list \
+      --repo "$GITHUB_REPOSITORY" \
+      --state open \
+      --head "$LEGACY_BRANCH" \
+      --json number \
+      --jq '.[0].number // empty'
+    ;;
+  merged-next-sha)
+    LEGACY_HEAD="$(
+      gh pr list \
+        --repo "$GITHUB_REPOSITORY" \
+        --state merged \
+        --head "$LEGACY_BRANCH" \
+        --limit 100 \
+        --json headRefOid,mergedAt \
+        --jq 'sort_by(.mergedAt) | last | .headRefOid // empty'
+    )"
+    if [[ -n "$LEGACY_HEAD" ]]; then
+      gh api "repos/${GITHUB_REPOSITORY}/git/commits/${LEGACY_HEAD}" --jq '.parents[0].sha'
+    fi
+    ;;
+  *)
+    echo "usage: $0 [open-number|merged-next-sha]" >&2
+    exit 2
+    ;;
+esac

--- a/bin/find-legacy-release-pr
+++ b/bin/find-legacy-release-pr
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+gh pr list \
+  --repo "$GITHUB_REPOSITORY" \
+  --state open \
+  --head 'release-please--branches--main--changes--next--components--openai' \
+  --json number \
+  --jq '.[0].number // empty'

--- a/bin/publish-npm
+++ b/bin/publish-npm
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 
-set -eux
+set -euo pipefail
+
+set +e
+bash ./bin/check-npm-version
+VERSION_STATUS=$?
+set -e
+if [[ $VERSION_STATUS -eq 0 ]]; then
+  exit 0
+elif [[ $VERSION_STATUS -ne 1 ]]; then
+  exit "$VERSION_STATUS"
+fi
 
 if [[ ${NPM_TOKEN:-} ]]; then
   npm config set '//registry.npmjs.org/:_authToken' "$NPM_TOKEN"
@@ -26,20 +36,21 @@ VERSION="$(jq -r -e '.version' ./package.json)"
 #     "detail": "'the_package' is not in this registry..."
 #   }
 # }
-NPM_INFO="$(npm view "$PACKAGE_NAME" version --json 2>/dev/null || true)"
+set +e
+NPM_INFO="$(npm view "$PACKAGE_NAME" version --json 2>/dev/null)"
+NPM_STATUS=$?
+set -e
 
 # Check if we got an E404 error
-if echo "$NPM_INFO" | jq -e '.error.code == "E404"' > /dev/null 2>&1; then
+if [[ $NPM_STATUS -eq 0 ]]; then
+  LAST_VERSION="$(jq -r -e '.' <<< "$NPM_INFO")"
+elif echo "$NPM_INFO" | jq -e '.error.code == "E404"' > /dev/null 2>&1; then
   # Package doesn't exist yet, no last version
   LAST_VERSION=""
-elif echo "$NPM_INFO" | jq -e '.error' > /dev/null 2>&1; then
-  # Report other errors
+else
   echo "ERROR: npm returned unexpected data:"
   echo "$NPM_INFO"
   exit 1
-else
-  # Success - get the version
-  LAST_VERSION=$(echo "$NPM_INFO" | jq -r '.') # strip quotes
 fi
 
 # Check if current version is pre-release (e.g. alpha / beta / rc)

--- a/bin/resolve-tag-commit
+++ b/bin/resolve-tag-commit
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+TAG_NAME="${1:?tag name is required}"
+TAG_REF="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG_NAME}")"
+OBJECT_TYPE="$(jq -r -e '.object.type' <<< "$TAG_REF")"
+OBJECT_SHA="$(jq -r -e '.object.sha' <<< "$TAG_REF")"
+
+while [[ "$OBJECT_TYPE" == 'tag' ]]; do
+  TAG_OBJECT="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${OBJECT_SHA}")"
+  OBJECT_TYPE="$(jq -r -e '.object.type' <<< "$TAG_OBJECT")"
+  OBJECT_SHA="$(jq -r -e '.object.sha' <<< "$TAG_OBJECT")"
+done
+
+if [[ "$OBJECT_TYPE" != 'commit' ]]; then
+  echo "ERROR: ${TAG_NAME} resolves to a ${OBJECT_TYPE}, not a commit" >&2
+  exit 1
+fi
+
+echo "$OBJECT_SHA"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,13 +2,14 @@
   "packages": {
     ".": {}
   },
-  "$schema": "https://raw.githubusercontent.com/stainless-api/release-please/main/schemas/config.json",
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "versioning": "prerelease",
   "prerelease": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
+  "draft-pull-request": true,
   "pull-request-header": "Automated Release PR",
   "pull-request-title-pattern": "release: ${version}",
   "changelog-sections": [


### PR DESCRIPTION
## Summary

Migrate the release workflow from `stainless-api/trigger-release-please` to the standard `googleapis/release-please-action`.

## What changed

- switched `.github/workflows/create-releases.yml` to manifest-mode `googleapis/release-please-action`
- pinned the action to the latest upstream commit SHA verified during the migration
- split the workflow into separate `release` and `publish` jobs so broader release-please permissions are not granted during publish
- updated the publish job guard to run when `release_created` is true even if the release job later reports failure
- configured release-please to create draft release PRs, allowing `ready_for_review` to trigger normal CI when using `GITHUB_TOKEN`
- updated `release-please-config.json` to point at the upstream `googleapis/release-please` schema

## Why

- removes the dependency on the Stainless-specific wrapper action
- aligns this repo with the standard upstream release-please setup
- preserves the existing release-PR model while tightening permission scope in the publish path
- avoids a partial-failure case where a GitHub release could be created but npm publish would be skipped
- preserves CI coverage for release PRs created with the repository `GITHUB_TOKEN`

## Validation

- `pnpm lint`
- YAML and JSON parse validation
- release-please config schema validation
- `git diff --check`

## Notes

- the workflow uses `github.token` for release-please, not a PAT or GitHub App token
- supersedes #1875 so the branch lives directly in `openai/openai-node`
