### PR TITLE
fix: defer release PR output parsing

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -293,8 +293,9 @@ jobs:
         if: steps.release.outputs.prs_created == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_PR: ${{ fromJSON(steps.release.outputs.pr).number }}
+          RELEASE_PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
+          RELEASE_PR="$(jq -er '.number' <<< "${RELEASE_PR_JSON}")"
           if [[ "$(gh pr view "${RELEASE_PR}" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq '.isDraft')" == 'false' ]]; then
             gh pr ready "${RELEASE_PR}" --repo "${GITHUB_REPOSITORY}" --undo
           fi


### PR DESCRIPTION
Fixes the post-merge failure in the new Create releases workflow.

When the legacy Stainless release PR gate skips release-please, GitHub still evaluates step environment expressions. Parsing the empty `steps.release.outputs.pr` value with `fromJSON` therefore fails before the re-draft step can be skipped.

Move JSON parsing into the guarded shell body so it runs only when `prs_created == 'true'`, and use `jq -e` to retain strict validation.

Failed run: https://github.com/openai/openai-node/actions/runs/30846459093

Validation:
- `pnpm lint`
- focused `jq -er '.number'` payload check
- thermo-nuclear code quality review