### PR TITLE
[SDK-201] Replace deprecated module resolution settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "tsconfig-paths": "^4.0.0",
     "tslib": "^2.8.1",
     "typescript": "6.0.3",
+    "typescript-4-9": "npm:typescript@4.9.5",
     "vitest": "4.1.10",
     "ws": "^8.18.0",
     "yargs": "^17.7.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ts-node": "^10.5.0",
     "tsconfig-paths": "^4.0.0",
     "tslib": "^2.8.1",
-    "typescript": "5.8.3",
+    "typescript": "6.0.3",
     "vitest": "4.1.10",
     "ws": "^8.18.0",
     "yargs": "^17.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      typescript-4-9:
+        specifier: npm:typescript@4.9.5
+        version: typescript@4.9.5
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@types/node@24.12.4)(vite@8.1.5(@types/node@24.12.4))
@@ -3107,6 +3110,11 @@ packages:
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
+
+  typescript@4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
 
   typescript@5.6.1-rc:
     resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
@@ -6488,6 +6496,8 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  typescript@4.9.5: {}
 
   typescript@5.6.1-rc: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         version: 0.6.3
       jest:
         specifier: ^29.4.0
-        version: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3))
+        version: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3))
       oxfmt:
         specifier: 0.60.0
         version: 0.60.0
@@ -85,10 +85,10 @@ importers:
         version: 1.0.4
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3)))(typescript@6.0.3)
       ts-node:
         specifier: ^10.5.0
-        version: 10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3)
+        version: 10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3)
       tsconfig-paths:
         specifier: ^4.0.0
         version: 4.2.0
@@ -96,8 +96,8 @@ importers:
         specifier: ^2.8.1
         version: 2.8.1
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@types/node@24.12.4)(vite@8.1.5(@types/node@24.12.4))
@@ -3113,8 +3113,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -3948,7 +3948,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -3962,7 +3962,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -4958,13 +4958,13 @@ snapshots:
 
   cookie@0.7.2: {}
 
-  create-jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3)):
+  create-jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -5421,16 +5421,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3)):
+  jest-cli@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3))
+      create-jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -5440,7 +5440,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3)):
+  jest-config@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/test-sequencer': 29.7.0
@@ -5466,7 +5466,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 24.12.4
-      ts-node: 10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3)
+      ts-node: 10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -5688,12 +5688,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3)):
+  jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3))
+      jest-cli: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -6430,18 +6430,18 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3)))(typescript@5.8.3):
+  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3))
+      jest: 29.7.0(@types/node@24.12.4)(ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.8.1
       type-fest: 4.41.0
-      typescript: 5.8.3
+      typescript: 6.0.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.29.7
@@ -6450,7 +6450,7 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.29.7)
       jest-util: 29.7.0
 
-  ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@5.8.3):
+  ts-node@10.9.2(@swc/core@1.15.40)(@types/node@24.12.4)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -6464,7 +6464,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.8.3
+      typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -6491,7 +6491,7 @@ snapshots:
 
   typescript@5.6.1-rc: {}
 
-  typescript@5.8.3: {}
+  typescript@6.0.3: {}
 
   uglify-js@3.19.3:
     optional: true

--- a/scripts/_vendor/tsc-multi/src/build.ts
+++ b/scripts/_vendor/tsc-multi/src/build.ts
@@ -16,7 +16,7 @@ const WORKER_TS_NODE_ENV = {
   TS_NODE_COMPILER_OPTIONS: JSON.stringify({
     esModuleInterop: true,
     module: 'commonjs',
-    moduleResolution: 'node',
+    moduleResolution: 'bundler',
     target: 'es2020',
   }),
 };

--- a/scripts/build
+++ b/scripts/build
@@ -9,7 +9,7 @@ node scripts/utils/check-version.cjs
 # Build into dist and will publish the package from there,
 # so that src/resources/foo.ts becomes <package root>/resources/foo.js
 # This way importing from `"openai/resources/foo"` works
-# even with `"moduleResolution": "node"`
+# even with `"moduleResolution": "bundler"`
 
 rm -rf dist; mkdir dist
 # Copy src to dist/src and build from dist/src into dist, so that

--- a/scripts/build
+++ b/scripts/build
@@ -29,6 +29,7 @@ node -r ts-node/register/transpile-only scripts/_vendor/tsc-multi/src/cli.ts
 # when building .mjs
 node scripts/utils/fix-index-exports.cjs
 cp tsconfig.dist-src.json dist/src/tsconfig.json
+cp tsconfig.dist-src.d.ts dist/src/tsconfig.dist-src.d.ts
 
 node scripts/utils/postprocess-files.cjs
 

--- a/scripts/lint
+++ b/scripts/lint
@@ -39,6 +39,12 @@ node --test scripts/oxlint-regression.test.cjs
 echo "==> Building"
 ./scripts/build
 
+echo "==> Checking published source types (TypeScript 4.9)"
+./node_modules/typescript-4-9/bin/tsc --project dist/src/tsconfig.json --noEmit
+
+echo "==> Checking published source types (TypeScript 6)"
+./node_modules/typescript/bin/tsc --project dist/src/tsconfig.json --noEmit
+
 echo "==> Checking types"
 ./node_modules/typescript/bin/tsc
 

--- a/scripts/lint
+++ b/scripts/lint
@@ -45,6 +45,9 @@ echo "==> Checking published source types (TypeScript 4.9)"
 echo "==> Checking published source types (TypeScript 6)"
 ./node_modules/typescript/bin/tsc --project dist/src/tsconfig.json --noEmit
 
+echo "==> Checking isolated packed browser/edge consumer"
+node --experimental-strip-types scripts/test-packed-package.ts
+
 echo "==> Checking types"
 ./node_modules/typescript/bin/tsc
 

--- a/scripts/test-packed-package.ts
+++ b/scripts/test-packed-package.ts
@@ -13,11 +13,13 @@
 
   interface RunOptions {
     cwd?: string;
+    env?: NodeJS.ProcessEnv;
   }
 
   const root = path.resolve(__dirname, '..');
   const dist = path.join(root, 'dist');
   const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'openai-node-packed-'));
+  const npmCache = path.join(temporaryDirectory, '.npm-cache');
   const run = (command: string, args: string[], options: RunOptions = {}): string =>
     childProcess.execFileSync(command, args, {
       cwd: temporaryDirectory,
@@ -31,9 +33,11 @@
   try {
     assert(fs.existsSync(path.join(dist, 'package.json')), 'Run pnpm build before packed-package tests');
 
-    const packOutput = run('npm', ['pack', '--silent', '--pack-destination', temporaryDirectory], {
-      cwd: dist,
-    }).trim();
+    const packOutput = run(
+      'npm',
+      ['pack', '--silent', '--cache', npmCache, '--pack-destination', temporaryDirectory],
+      { cwd: dist },
+    ).trim();
     const tarballName = packOutput.split(/\r?\n/).pop();
     assert(tarballName, 'npm pack did not report a tarball');
     const tarball = path.join(temporaryDirectory, tarballName);
@@ -63,8 +67,83 @@
         "new OpenAI({ apiKey: 'test' });",
       ].join('\n'),
     );
+    fs.writeFileSync(
+      path.join(temporaryDirectory, 'consumer.ts'),
+      [
+        "import OpenAI, { AzureOpenAI } from 'openai';",
+        "new OpenAI({ apiKey: 'test', dangerouslyAllowBrowser: true });",
+        'void AzureOpenAI;',
+      ].join('\n'),
+    );
+    fs.writeFileSync(
+      path.join(temporaryDirectory, 'tsconfig.json'),
+      JSON.stringify({
+        files: ['consumer.ts'],
+        compilerOptions: {
+          target: 'ES2020',
+          lib: ['DOM', 'DOM.Iterable', 'ES2020'],
+          module: 'Node16',
+          moduleResolution: 'Node16',
+          types: [],
+          strict: true,
+          skipLibCheck: false,
+          noEmit: true,
+        },
+      }),
+    );
 
-    run('npm', ['install', '--offline', '--ignore-scripts', '--no-audit', '--no-fund', tarball]);
+    run('npm', [
+      'install',
+      '--offline',
+      '--ignore-scripts',
+      '--no-audit',
+      '--no-fund',
+      '--cache',
+      npmCache,
+      tarball,
+    ]);
+
+    const installedPackageRoot = path.join(temporaryDirectory, 'node_modules/openai');
+    const installedSourceConfig = path.join(installedPackageRoot, 'src/tsconfig.json');
+    const declarationMap = JSON.parse(
+      fs.readFileSync(path.join(installedPackageRoot, 'index.d.ts.map'), 'utf8'),
+    ) as { sourceRoot?: string; sources: string[] };
+    const isolatedEnvironment = { ...process.env };
+    delete isolatedEnvironment['NODE_PATH'];
+
+    assert(
+      declarationMap.sources.some(
+        (source) =>
+          path.resolve(installedPackageRoot, declarationMap.sourceRoot ?? '', source) ===
+          path.join(installedPackageRoot, 'src/index.ts'),
+      ),
+      'Packed declaration maps no longer navigate to the installed SDK source',
+    );
+    assert(
+      !fs.existsSync(path.join(temporaryDirectory, 'node_modules/@types/node')),
+      'Packed browser/edge consumer unexpectedly installed @types/node',
+    );
+    run(
+      process.execPath,
+      [
+        '-e',
+        "try { require.resolve('@types/node/package.json'); throw new Error('Unexpected inherited @types/node'); } catch (error) { if (error.code !== 'MODULE_NOT_FOUND') throw error; }",
+      ],
+      { env: isolatedEnvironment },
+    );
+
+    for (const compiler of [
+      path.join(root, 'node_modules/typescript-4-9/bin/tsc'),
+      path.join(root, 'node_modules/typescript/bin/tsc'),
+    ]) {
+      run(process.execPath, [compiler, '--project', path.join(temporaryDirectory, 'tsconfig.json')], {
+        env: isolatedEnvironment,
+      });
+      run(process.execPath, [compiler, '--project', installedSourceConfig, '--noEmit'], {
+        env: isolatedEnvironment,
+      });
+    }
+
     run(process.execPath, ['consumer.cjs']);
     run(process.execPath, ['consumer.mjs']);
 

--- a/scripts/test-packed-package.ts
+++ b/scripts/test-packed-package.ts
@@ -16,6 +16,11 @@
     env?: NodeJS.ProcessEnv;
   }
 
+  interface SourceMap {
+    sourceRoot?: string;
+    sources: string[];
+  }
+
   const root = path.resolve(__dirname, '..');
   const dist = path.join(root, 'dist');
   const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'openai-node-packed-'));
@@ -29,6 +34,33 @@
     });
   const readPackage = (file: string): PackageMetadata =>
     JSON.parse(fs.readFileSync(file, 'utf8')) as PackageMetadata;
+  const findSourceMaps = (directory: string): string[] => {
+    const maps: string[] = [];
+    const entries = fs.readdirSync(directory, { withFileTypes: true }) as import('node:fs').Dirent[];
+    for (const entry of entries) {
+      const resolved = path.join(directory, entry.name);
+      if (entry.isDirectory() && entry.name !== 'node_modules') {
+        maps.push(...findSourceMaps(resolved));
+      } else if (entry.isFile() && entry.name.endsWith('.map')) {
+        maps.push(resolved);
+      }
+    }
+    return maps;
+  };
+  const standaloneZodParsers = new Set([
+    '_vendor/zod-to-json-schema/parsers/any.ts',
+    '_vendor/zod-to-json-schema/parsers/boolean.ts',
+    '_vendor/zod-to-json-schema/parsers/never.ts',
+    '_vendor/zod-to-json-schema/parsers/undefined.ts',
+    '_vendor/zod-to-json-schema/parsers/unknown.ts',
+  ]);
+  const requiresOptionalPeer = (source: string): boolean =>
+    (source.startsWith('_vendor/zod-to-json-schema/') && !standaloneZodParsers.has(source)) ||
+    source === 'helpers/zod.ts' ||
+    source === 'helpers/audio.ts' ||
+    source === 'providers/bedrock/aws.ts' ||
+    source === 'auth/index.ts' ||
+    source === 'auth/subject-token-providers.ts';
 
   try {
     assert(fs.existsSync(path.join(dist, 'package.json')), 'Run pnpm build before packed-package tests');
@@ -71,14 +103,40 @@
       path.join(temporaryDirectory, 'consumer.ts'),
       [
         "import OpenAI, { AzureOpenAI } from 'openai';",
+        "import type { ResponsesWS } from 'openai/resources/responses/ws';",
+        "import type { ResponsesWS as BetaResponsesWS } from 'openai/resources/beta/responses/ws';",
+        "import type { OpenAIRealtimeWS as RealtimeWS } from 'openai/realtime/ws';",
+        "import type { OpenAIRealtimeWS as BetaRealtimeWS } from 'openai/beta/realtime/ws';",
         "new OpenAI({ apiKey: 'test', dangerouslyAllowBrowser: true });",
         'void AzureOpenAI;',
+        'void (null as unknown as ResponsesWS | BetaResponsesWS | RealtimeWS | BetaRealtimeWS);',
+      ].join('\n'),
+    );
+    const websocketPeer = path.join(temporaryDirectory, 'websocket-peer.d.ts');
+    fs.writeFileSync(
+      websocketPeer,
+      [
+        "declare module 'ws' {",
+        '  export interface ClientOptions {',
+        '    headers?: Record<string, string> | undefined;',
+        '  }',
+        '  export class WebSocket {',
+        '    constructor(address: string | URL, options?: ClientOptions);',
+        '    readonly readyState: number;',
+        '    send(data: string | ArrayBufferLike | ArrayBufferView): void;',
+        '    close(code?: number, reason?: string): void;',
+        "    on(event: 'message', listener: (data: ArrayBuffer | Uint8Array | Uint8Array[], isBinary: boolean) => void): this;",
+        "    on(event: 'error', listener: (error: Error) => void): this;",
+        '    on(event: string, listener: (...args: unknown[]) => void): this;',
+        '    removeListener(event: string, listener: (...args: unknown[]) => void): this;',
+        '  }',
+        '}',
       ].join('\n'),
     );
     fs.writeFileSync(
       path.join(temporaryDirectory, 'tsconfig.json'),
       JSON.stringify({
-        files: ['consumer.ts'],
+        files: ['consumer.ts', 'websocket-peer.d.ts'],
         compilerOptions: {
           target: 'ES2020',
           lib: ['DOM', 'DOM.Iterable', 'ES2020'],
@@ -104,21 +162,12 @@
     ]);
 
     const installedPackageRoot = path.join(temporaryDirectory, 'node_modules/openai');
-    const installedSourceConfig = path.join(installedPackageRoot, 'src/tsconfig.json');
-    const declarationMap = JSON.parse(
-      fs.readFileSync(path.join(installedPackageRoot, 'index.d.ts.map'), 'utf8'),
-    ) as { sourceRoot?: string; sources: string[] };
+    const installedSourceRoot = path.join(installedPackageRoot, 'src');
+    const installedSourceConfig = path.join(installedSourceRoot, 'tsconfig.json');
+    const installedSourceShim = path.join(installedSourceRoot, 'tsconfig.dist-src.d.ts');
     const isolatedEnvironment = { ...process.env };
     delete isolatedEnvironment['NODE_PATH'];
 
-    assert(
-      declarationMap.sources.some(
-        (source) =>
-          path.resolve(installedPackageRoot, declarationMap.sourceRoot ?? '', source) ===
-          path.join(installedPackageRoot, 'src/index.ts'),
-      ),
-      'Packed declaration maps no longer navigate to the installed SDK source',
-    );
     assert(
       !fs.existsSync(path.join(temporaryDirectory, 'node_modules/@types/node')),
       'Packed browser/edge consumer unexpectedly installed @types/node',
@@ -132,6 +181,73 @@
       { env: isolatedEnvironment },
     );
 
+    const mappedSources = new Map<string, string>();
+    const sourceMaps = findSourceMaps(installedPackageRoot).sort();
+    for (const mapPath of sourceMaps) {
+      const sourceMap = JSON.parse(fs.readFileSync(mapPath, 'utf8')) as SourceMap;
+      for (const source of sourceMap.sources) {
+        const resolvedSource: string = path.resolve(
+          path.dirname(mapPath),
+          sourceMap.sourceRoot ?? '',
+          source,
+        );
+        const relativeSource: string = path.relative(installedSourceRoot, resolvedSource);
+        assert(
+          relativeSource !== '..' &&
+            !relativeSource.startsWith(`..${path.sep}`) &&
+            !path.isAbsolute(relativeSource),
+          `Packed source map resolves outside its published source directory: ${mapPath}`,
+        );
+        assert(fs.existsSync(resolvedSource), `Packed source-map source is missing: ${resolvedSource}`);
+        mappedSources.set(relativeSource.split(path.sep).join('/'), resolvedSource);
+      }
+    }
+
+    assert.equal(
+      mappedSources.get('index.ts'),
+      path.join(installedSourceRoot, 'index.ts'),
+      'Packed source maps no longer navigate to the installed SDK source',
+    );
+
+    for (const websocketSource of [
+      'resources/responses/ws',
+      'resources/beta/responses/ws',
+      'realtime/ws',
+      'beta/realtime/ws',
+      'internal/ws-adapter-node',
+    ]) {
+      for (const extension of ['.d.ts.map', '.d.mts.map', '.js.map', '.mjs.map']) {
+        const websocketMap = `${websocketSource}${extension}`;
+        assert(
+          fs.existsSync(path.join(installedPackageRoot, websocketMap)),
+          `Packed websocket source map is missing: ${websocketMap}`,
+        );
+      }
+    }
+
+    // Zod/AWS helpers require optional peers; Node-only helpers require @types/node.
+    // Validate every other mapped source without installing either in this consumer.
+    const browserSafeSources = Array.from(mappedSources.entries())
+      .filter(([source]) => !requiresOptionalPeer(source))
+      .map(([, source]) => source)
+      .sort();
+    const sourceNavigationConfig = path.join(temporaryDirectory, 'source-navigation.tsconfig.json');
+    fs.writeFileSync(
+      sourceNavigationConfig,
+      JSON.stringify({
+        extends: installedSourceConfig,
+        files: [installedSourceShim, websocketPeer, ...browserSafeSources],
+        include: [],
+        exclude: [],
+        compilerOptions: {
+          types: [],
+          strict: true,
+          skipLibCheck: false,
+          noEmit: true,
+        },
+      }),
+    );
+
     for (const compiler of [
       path.join(root, 'node_modules/typescript-4-9/bin/tsc'),
       path.join(root, 'node_modules/typescript/bin/tsc'),
@@ -140,6 +256,9 @@
         env: isolatedEnvironment,
       });
       run(process.execPath, [compiler, '--project', installedSourceConfig, '--noEmit'], {
+        env: isolatedEnvironment,
+      });
+      run(process.execPath, [compiler, '--project', sourceNavigationConfig], {
         env: isolatedEnvironment,
       });
     }
@@ -155,7 +274,9 @@
       'Packed package engine metadata differs from package.json',
     );
 
-    console.log(`Packed npm artifact passed CommonJS and ESM checks on ${process.version}.`);
+    console.log(
+      `Packed npm artifact passed CommonJS, ESM, and ${browserSafeSources.length}/${mappedSources.size} source checks across ${sourceMaps.length} source maps on ${process.version}.`,
+    );
   } finally {
     fs.rmSync(temporaryDirectory, { recursive: true, force: true });
   }

--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -214,7 +214,7 @@ const isReadableStream = (value: unknown): value is ReadableStream<BlobPart> =>
 const isStreamingFile = (value: unknown): value is StreamingFile =>
   typeof value === 'object' && value !== null && brand_privateStreamingFile in value;
 
-const isUploadable = (value: unknown) =>
+const isUploadable = (value: unknown): value is Uploadable =>
   typeof value === 'object' &&
   value !== null &&
   (value instanceof Response ||

--- a/tests/lib/ResponseAccumulator.test.ts
+++ b/tests/lib/ResponseAccumulator.test.ts
@@ -1,5 +1,9 @@
 import { accumulateResponse } from 'openai/lib/responses/ResponseAccumulator';
-import type { Response, ResponseStreamEvent } from 'openai/resources/responses/responses';
+import type {
+  Response,
+  ResponseOutputMessage,
+  ResponseStreamEvent,
+} from 'openai/resources/responses/responses';
 
 describe('ResponseAccumulator', () => {
   it('accumulates a final response snapshot from stream events', () => {
@@ -66,7 +70,7 @@ describe('ResponseAccumulator', () => {
           status: 'completed',
           output: [
             {
-              ...snapshot.output[0]!,
+              ...(snapshot.output[0]! as ResponseOutputMessage),
               status: 'completed',
             },
           ],

--- a/tsconfig.dist-src.d.ts
+++ b/tsconfig.dist-src.d.ts
@@ -1,0 +1,8 @@
+// Keep published source navigation independent of consumers installing @types/node.
+declare const process: {
+  readonly env: Record<string, string | undefined>;
+};
+
+declare const Buffer: {
+  from(input: string, encoding: string): Uint8Array & { readonly buffer: ArrayBuffer };
+};

--- a/tsconfig.dist-src.d.ts
+++ b/tsconfig.dist-src.d.ts
@@ -1,8 +1,30 @@
 // Keep published source navigation independent of consumers installing @types/node.
-declare const process: {
-  readonly env: Record<string, string | undefined>;
-};
+export {};
 
-declare const Buffer: {
-  from(input: string, encoding: string): Uint8Array & { readonly buffer: ArrayBuffer };
-};
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      [key: string]: string | undefined;
+    }
+
+    interface Process {
+      env: ProcessEnv;
+    }
+  }
+
+  var process: NodeJS.Process;
+
+  interface Buffer<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike> extends ArrayLike<number> {
+    readonly buffer: TArrayBuffer;
+    readonly byteLength: number;
+    readonly byteOffset: number;
+  }
+
+  interface BufferConstructor {
+    from(input: string, encoding: 'base64' | 'utf-8'): Buffer<ArrayBuffer> & Uint8Array;
+    from(input: ArrayBuffer): Buffer<ArrayBuffer> & Uint8Array;
+    concat(list: readonly Buffer[]): Buffer<ArrayBuffer> & Uint8Array;
+  }
+
+  var Buffer: BufferConstructor;
+}

--- a/tsconfig.dist-src.json
+++ b/tsconfig.dist-src.json
@@ -6,6 +6,6 @@
   "compilerOptions": {
     "target": "ES2015",
     "lib": ["DOM", "DOM.Iterable", "ES2018"],
-    "moduleResolution": "node"
+    "moduleResolution": "bundler"
   }
 }

--- a/tsconfig.dist-src.json
+++ b/tsconfig.dist-src.json
@@ -2,13 +2,13 @@
   // this config is included in the published src directory to prevent TS errors
   // from appearing when users go to source, and VSCode opens the source .ts file
   // via declaration maps
-  "include": ["index.ts"],
+  "include": ["index.ts", "tsconfig.dist-src.d.ts"],
   "compilerOptions": {
     "target": "ES2015",
     "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "module": "Node16",
     "moduleResolution": "Node16",
-    "types": ["node"],
+    "types": [],
     "skipLibCheck": true
   }
 }

--- a/tsconfig.dist-src.json
+++ b/tsconfig.dist-src.json
@@ -5,7 +5,10 @@
   "include": ["index.ts"],
   "compilerOptions": {
     "target": "ES2015",
-    "lib": ["DOM", "DOM.Iterable", "ES2018"],
-    "moduleResolution": "bundler"
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "types": ["node"],
+    "skipLibCheck": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "es2020",
     "lib": ["es2020"],
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "paths": {
       "openai/*": ["./src/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
   "compilerOptions": {
     "target": "es2020",
     "lib": ["es2020"],
+    "types": ["jest", "node"],
+    "rootDir": ".",
     "module": "commonjs",
     "moduleResolution": "bundler",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary

- upgrade the repository from TypeScript 5.8.3 to 6.0.3
- replace deprecated `moduleResolution: "node"` with `"bundler"` in the authoring and published source-navigation configs
- update the vendored `tsc-multi` worker bootstrap so it does not retain the deprecated resolver internally
- make TS6's required `rootDir` and ambient Jest/Node types explicit
- narrow one response-output test fixture for TS6's stricter union checking

## Validation

- `pnpm lint`
  - Oxfmt and Oxlint (inherited from #2044)
  - dual CommonJS/ESM build and runtime loading checks
  - TypeScript type-check
  - Are The Types Wrong?
  - publint

## Notes

- Stacked on #2044, which replaces ESLint and TypeScript-ESLint with Oxlint/Oxfmt.
- TypeScript 6 explicitly supports `moduleResolution: "bundler"` with `module: "commonjs"`, preserving the existing authoring and dual-emission strategy while removing the resolver deprecated ahead of TypeScript 7.

Linear: https://linear.app/openai/issue/SDK-201/replace-deprecated-tsconfig-module-resolution-settings
