### PR TITLE
ci: prepare checks for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - '**'
+      - '!gh-readonly-queue/**'
       - '!integrated/**'
       - '!stl-preview-head/**'
       - '!stl-preview-base/**'
@@ -17,13 +18,16 @@ on:
     branches-ignore:
       - 'stl-preview-head/**'
       - 'stl-preview-base/**'
+  merge_group:
+    types:
+      - checks_requested
 
 jobs:
   lint:
     timeout-minutes: 10
     name: lint
     runs-on: ${{ github.repository == 'stainless-sdks/openai-typescript' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review') && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    if: (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review') && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
     permissions:
       contents: read
     steps:
@@ -48,7 +52,7 @@ jobs:
     timeout-minutes: 5
     name: build
     runs-on: ${{ github.repository == 'stainless-sdks/openai-typescript' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review') && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    if: (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review') && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
     permissions:
       contents: read
       id-token: write
@@ -92,7 +96,7 @@ jobs:
   node_matrix:
     name: Read Node.js test matrix
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review'
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review'
     permissions:
       contents: read
     outputs:
@@ -114,7 +118,7 @@ jobs:
     needs: node_matrix
     timeout-minutes: 10
     runs-on: ${{ github.repository == 'stainless-sdks/openai-typescript' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review'
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review'
     continue-on-error: ${{ matrix.experimental }}
     permissions:
       contents: read
@@ -153,8 +157,8 @@ jobs:
           node --experimental-strip-types scripts/test-packed-package.ts
 
   test_matrix:
-    name: ${{ (github.event_name == 'push' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review') && 'test matrix' || 'test matrix (not run)' }}
-    if: ${{ always() && (github.event_name == 'push' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review') }}
+    name: ${{ (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review') && 'test matrix' || 'test matrix (not run)' }}
+    if: ${{ always() && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review') }}
     needs: [test]
     runs-on: ubuntu-latest
     permissions: {}

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
       - next
+  merge_group:
+    types:
+      - checks_requested
 
 jobs:
   detect_breaking_changes:
@@ -15,14 +18,20 @@ jobs:
     if: github.repository == 'openai/openai-node'
     permissions:
       contents: read
+    env:
+      BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+      FETCH_DEPTH: 0
     steps:
       - name: Calculate fetch-depth
+        if: github.event_name == 'pull_request'
+        env:
+          PR_COMMITS: ${{ github.event.pull_request.commits }}
         run: |
-          echo "FETCH_DEPTH=$(expr ${{ github.event.pull_request.commits }} + 1)" >> $GITHUB_ENV
+          echo "FETCH_DEPTH=$((PR_COMMITS + 1))" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          # Ensure we can check out the pull request base in the script below.
+          # Ensure the comparison base is available to the script below.
           fetch-depth: ${{ env.FETCH_DEPTH }}
 
       - name: Set up pnpm
@@ -42,5 +51,5 @@ jobs:
         run: |
           # Try to check out previous versions of the breaking change detection script. This ensures that
           # we still detect breaking changes when entire files and their tests are removed.
-          git checkout "${{ github.event.pull_request.base.sha }}" -- ./scripts/detect-breaking-changes 2>/dev/null || true
-          DETECT_BREAKING_CHANGES_COMPAT=1 ./scripts/detect-breaking-changes ${{ github.event.pull_request.base.sha }}
+          git checkout "$BASE_SHA" -- ./scripts/detect-breaking-changes 2>/dev/null || true
+          DETECT_BREAKING_CHANGES_COMPAT=1 ./scripts/detect-breaking-changes "$BASE_SHA"


### PR DESCRIPTION
## Summary

- trigger required CI for GitHub `merge_group` checks
- keep `lint`, `build`, and the aggregate `test matrix` check active for queued merge commits
- compare breaking changes against the merge-group base commit
- exclude `gh-readonly-queue/**` from ordinary push CI so queue-branch pushes cannot duplicate or interfere with the merge-group run

## Why

GitHub Actions required checks must listen for the separate `merge_group` event before the merge queue is enabled. Without this prerequisite, queued pull requests would wait for checks that never report.

## Impact

Once the repository merge queue is enabled, required CI will run again when an approved pull request enters the queue, validating the prospective merge commit against the latest `main` and any changes ahead of it. Existing pull-request, push, Stainless staging, examples, and ecosystem behavior is preserved.

## Validation

- workflow YAML parsed successfully
- focused merge-group trigger, job-gate, queue-branch exclusion, and base-SHA assertions
- `git diff --check`
- thermo-nuclear code-quality review: no findings

Local dependency bootstrap was not used as evidence because pnpm's supply-chain policy currently rejects four lockfile entries already present on `main`; GitHub CI remains authoritative for the repository checks.

## Follow-up

After this PR merges, update the existing `main` ruleset to enable squash-based merge queueing while preserving all current protections and bypass actors, then read back the effective rules and live queue configuration.