### PR TITLE
ci: use GitHub App for Release Please

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,12 @@ jobs:
     timeout-minutes: 10
     name: examples
     runs-on: ubuntu-latest
-    if: github.repository == 'openai/openai-node'
+    if: >-
+      ${{
+        github.repository == 'openai/openai-node' &&
+        github.ref != 'refs/heads/release-please--branches--main--components--openai' &&
+        github.head_ref != 'release-please--branches--main--components--openai'
+      }}
     environment: ci
     permissions:
       contents: read
@@ -183,6 +188,11 @@ jobs:
     name: ecosystem tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    if: >-
+      ${{
+        github.ref != 'refs/heads/release-please--branches--main--components--openai' &&
+        github.head_ref != 'release-please--branches--main--components--openai'
+      }}
     environment: ci
     permissions:
       contents: read

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -46,7 +46,7 @@ jobs:
         github.repository == 'openai/openai-node'
       }}
     runs-on: ubuntu-latest
-    environment: castiron-promotion
+    environment: release
     permissions: {}
     steps:
       - name: Create release app token

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -46,24 +46,33 @@ jobs:
         github.repository == 'openai/openai-node'
       }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+    environment: castiron-promotion
+    permissions: {}
     steps:
+      - name: Create release app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.OPENAI_SDKS_APP_CLIENT_ID }}
+          private-key: ${{ secrets.OPENAI_SDKS_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Validate pending release PR versions
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           bash ./bin/check-pending-release-versions
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
-          # Use the default token until the openai-sdks App credentials are provisioned.
-          token: ${{ github.token }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main
@@ -71,7 +80,7 @@ jobs:
       - name: Re-draft the updated release PR
         if: steps.release.outputs.prs_created == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
           RELEASE_PR="$(jq -er '.number' <<< "${RELEASE_PR_JSON}")"


### PR DESCRIPTION
## Summary

- mint a repository-scoped installation token for the `openai-sdks` GitHub App from environment configuration
- use that token for checkout, release validation, Release Please, and release PR re-drafting while disabling the release job's built-in `GITHUB_TOKEN` permissions
- keep API-key-backed example and ecosystem jobs off the automated Release Please branch for both push and pull-request events

## Why

Release Please currently authenticates with `GITHUB_TOKEN`. Events created with that token do not normally start downstream workflows. A GitHub App installation token triggers the normal push and pull-request workflows, so release PR updates receive the repository's standard CI coverage.

## Repository configuration

- verified App: `openai-sdks` (App ID `3705508`, client ID `Iv23li2AtcmhLHO07J87`)
- environment: `release`
- environment variable: `OPENAI_SDKS_APP_CLIENT_ID` (configured)
- environment secret: `OPENAI_SDKS_APP_PRIVATE_KEY` (configured)
- the `release` environment is restricted to `main` and has no required-reviewer or wait-timer gate, so ordinary Release Please runs do not pause for approval

## Validation

- `actionlint` v1.7.7 on the changed workflows
- Ruby YAML parser on the changed workflows
- release-branch expression cases for push and pull-request events
- `git diff --check`
- thermo-nuclear code quality review
- GitHub CI: lint, build, Node 22/24/26 tests, examples, ecosystem tests, breaking-change detection, and CodeQL