### PR TITLE
chore(lint): enable no-template-curly-in-string

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -66,7 +66,6 @@ const compatibilityRules = [
   'no-sequences',
   'no-shadow',
   'no-sparse-arrays',
-  'no-template-curly-in-string',
   'no-throw-literal',
   'no-unmodified-loop-condition',
   'no-unsafe-optional-chaining',


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `no-template-curly-in-string` compatibility exception from `oxlint.config.ts` so the existing Ultracite preset enforces the rule.
- No source changes are needed; all checked handwritten files already satisfy the rule.

## Additional context & links

- Oxlint cleanup stack, part 1; based on `main`.
- Preserves Stainless-generated-file exclusions and the test/example import exception.

### Validation

- Ultracite 7.8.4 formatting and lint check.
- TypeScript 6.0.3 type check.
- Oxlint configuration regression test.
- Baseline handwritten Vitest suite: 62 files, 1,454 tests passing.

## Stack

https://github.com/openai/openai-node/pull/2071 :point_left: this PR  
https://github.com/openai/openai-node/pull/2072  
https://github.com/openai/openai-node/pull/2073  
https://github.com/openai/openai-node/pull/2074  
https://github.com/openai/openai-node/pull/2075  
https://github.com/openai/openai-node/pull/2076  
https://github.com/openai/openai-node/pull/2077  
https://github.com/openai/openai-node/pull/2078  
https://github.com/openai/openai-node/pull/2079  
https://github.com/openai/openai-node/pull/2080  
https://github.com/openai/openai-node/pull/2081  
https://github.com/openai/openai-node/pull/2082  
https://github.com/openai/openai-node/pull/2083  
https://github.com/openai/openai-node/pull/2084  
https://github.com/openai/openai-node/pull/2085
