### PR TITLE
chore(lint): enable no-useless-constructor

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -73,7 +73,6 @@ const compatibilityRules = [
   'no-unused-vars',
   'no-use-before-define',
   'no-useless-concat',
-  'no-useless-constructor',
   'no-useless-escape',
   'no-useless-rename',
   'no-useless-return',


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `no-useless-constructor` compatibility exception from `oxlint.config.ts`.
- No source changes are needed; checked handwritten files already satisfy the rule.

## Additional context & links

- Oxlint cleanup stack, part 2; stacked on https://github.com/openai/openai-node/pull/2071.
- Preserves Stainless-generated-file exclusions and the test/example import exception.

### Validation

- Ultracite 7.8.4 formatting and lint check.
- TypeScript 6.0.3 type check.
- Oxlint configuration regression test.

## Stack

https://github.com/openai/openai-node/pull/2071  
https://github.com/openai/openai-node/pull/2072 :point_left: this PR  
https://github.com/openai/openai-node/pull/2073  
https://github.com/openai/openai-node/pull/2074  
https://github.com/openai/openai-node/pull/2075  
https://github.com/openai/openai-node/pull/2076  
https://github.com/openai/openai-node/pull/2077  
https://github.com/openai/openai-node/pull/2078  
https://github.com/openai/openai-node/pull/2079  
https://github.com/openai/openai-node/pull/2080  
https://github.com/openai/openai-node/pull/2081  
https://github.com/openai/openai-node/pull/2082  
https://github.com/openai/openai-node/pull/2083  
https://github.com/openai/openai-node/pull/2084  
https://github.com/openai/openai-node/pull/2085
