### PR TITLE
chore(lint): enable unicorn/escape-case

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -134,7 +134,6 @@ const compatibilityRules = [
   'unicorn/consistent-function-scoping',
   'unicorn/custom-error-definition',
   'unicorn/error-message',
-  'unicorn/escape-case',
   'unicorn/filename-case',
   'unicorn/import-style',
   'unicorn/new-for-builtins',


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/escape-case` compatibility exception from `oxlint.config.ts`.
- No source changes are needed; checked handwritten files already satisfy the rule.

## Additional context & links

- Oxlint cleanup stack, part 4; stacked on https://github.com/openai/openai-node/pull/2073.
- Preserves Stainless-generated-file exclusions and the test/example import exception.

### Validation

- Ultracite 7.8.4 formatting and lint check.
- TypeScript 6.0.3 type check.
- Oxlint configuration regression test.

## Stack

https://github.com/openai/openai-node/pull/2071  
https://github.com/openai/openai-node/pull/2072  
https://github.com/openai/openai-node/pull/2073  
https://github.com/openai/openai-node/pull/2074 :point_left: this PR  
https://github.com/openai/openai-node/pull/2075  
https://github.com/openai/openai-node/pull/2076  
https://github.com/openai/openai-node/pull/2077  
https://github.com/openai/openai-node/pull/2078  
https://github.com/openai/openai-node/pull/2079  
https://github.com/openai/openai-node/pull/2080  
https://github.com/openai/openai-node/pull/2081  
https://github.com/openai/openai-node/pull/2082  
https://github.com/openai/openai-node/pull/2083  
https://github.com/openai/openai-node/pull/2084  
https://github.com/openai/openai-node/pull/2085
