### PR TITLE
chore(lint): enable no-regex-spaces

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -62,7 +62,6 @@ const compatibilityRules = [
   'no-plusplus',
   'no-promise-executor-return',
   'no-prototype-builtins',
-  'no-regex-spaces',
   'no-sequences',
   'no-shadow',
   'no-sparse-arrays',

--- a/scripts/utils/fix-index-exports.cjs
+++ b/scripts/utils/fix-index-exports.cjs
@@ -11,6 +11,6 @@ let after = before.replace(
   `exports = module.exports = function (...args) {
     return new exports.default(...args)
   }
-  $1`.replace(/^  /gm, ''),
+  $1`.replace(/^ {2}/gm, ''),
 );
 fs.writeFileSync(indexJs, after, 'utf8');


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `no-regex-spaces` compatibility exception from `oxlint.config.ts`.
- Apply the required safe Ultracite autofixes and focused handwritten-code cleanup.

## Additional context & links

- Oxlint cleanup stack, part 7; stacked on https://github.com/openai/openai-node/pull/2076.
- Preserves Stainless-generated-file exclusions and the test/example import exception.

### Validation

- Ultracite 7.8.4 formatting and lint check.
- TypeScript 6.0.3 type check.
- Complete handwritten Vitest suite.

## Stack

https://github.com/openai/openai-node/pull/2071  
https://github.com/openai/openai-node/pull/2072  
https://github.com/openai/openai-node/pull/2073  
https://github.com/openai/openai-node/pull/2074  
https://github.com/openai/openai-node/pull/2075  
https://github.com/openai/openai-node/pull/2076  
https://github.com/openai/openai-node/pull/2077 :point_left: this PR  
https://github.com/openai/openai-node/pull/2078  
https://github.com/openai/openai-node/pull/2079  
https://github.com/openai/openai-node/pull/2080  
https://github.com/openai/openai-node/pull/2081  
https://github.com/openai/openai-node/pull/2082  
https://github.com/openai/openai-node/pull/2083  
https://github.com/openai/openai-node/pull/2084  
https://github.com/openai/openai-node/pull/2085
