### PR TITLE
chore(lint): enable prefer-object-spread

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -88,7 +88,6 @@ const compatibilityRules = [
   'prefer-destructuring',
   'prefer-named-capture-group',
   'prefer-object-has-own',
-  'prefer-object-spread',
   'prefer-regex-literals',
   'prefer-template',
   'promise/avoid-new',

--- a/src/lib/ChatCompletionStream.ts
+++ b/src/lib/ChatCompletionStream.ts
@@ -546,7 +546,7 @@ export class ChatCompletionStream<ParsedT = null>
 
       if (logprobs) {
         if (!choice.logprobs) {
-          choice.logprobs = Object.assign({}, logprobs);
+          choice.logprobs = { ...logprobs };
         } else {
           const { content, refusal, ...rest } = logprobs;
           assertIsEmpty(rest);

--- a/src/lib/ResponsesParser.ts
+++ b/src/lib/ResponsesParser.ts
@@ -98,7 +98,7 @@ export function parseResponse<
     },
   );
 
-  const parsed: Omit<ParsedResponse<ParsedT>, 'output_parsed'> = Object.assign({}, response, { output });
+  const parsed: Omit<ParsedResponse<ParsedT>, 'output_parsed'> = { ...response, output };
   if (needsOutputText(response, parsed)) {
     addOutputText(parsed);
   }


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `prefer-object-spread` compatibility exception from `oxlint.config.ts`.
- Apply the required safe Ultracite autofixes and focused handwritten-code cleanup.

## Additional context & links

- Oxlint cleanup stack, part 8; stacked on https://github.com/openai/openai-node/pull/2077.
- Preserves Stainless-generated-file exclusions and the test/example import exception.

### Validation

- Ultracite 7.8.4 formatting and lint check.
- TypeScript 6.0.3 type check.
- Complete handwritten Vitest suite.

## Stack

https://github.com/openai/openai-node/pull/2071  
https://github.com/openai/openai-node/pull/2072  
https://github.com/openai/openai-node/pull/2073  
https://github.com/openai/openai-node/pull/2074  
https://github.com/openai/openai-node/pull/2075  
https://github.com/openai/openai-node/pull/2076  
https://github.com/openai/openai-node/pull/2077  
https://github.com/openai/openai-node/pull/2078 :point_left: this PR  
https://github.com/openai/openai-node/pull/2079  
https://github.com/openai/openai-node/pull/2080  
https://github.com/openai/openai-node/pull/2081  
https://github.com/openai/openai-node/pull/2082  
https://github.com/openai/openai-node/pull/2083  
https://github.com/openai/openai-node/pull/2084  
https://github.com/openai/openai-node/pull/2085
