### PR TITLE
chore(lint): enable unicorn/throw-new-error

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -181,7 +181,6 @@ const compatibilityRules = [
   'unicorn/require-module-specifiers',
   'unicorn/switch-case-braces',
   'unicorn/text-encoding-identifier-case',
-  'unicorn/throw-new-error',
   'vars-on-top',
   'yoda',
 ];

--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -286,7 +286,7 @@ export class AssistantStream
 
   async finalRun(): Promise<Run> {
     await this.done();
-    if (!this.#finalRun) throw Error('Final run was not received.');
+    if (!this.#finalRun) throw new Error('Final run was not received.');
 
     return this.#finalRun;
   }
@@ -394,7 +394,7 @@ export class AssistantStream
       throw new OpenAIError(`stream has ended, this shouldn't happen`);
     }
 
-    if (!this.#finalRun) throw Error('Final run has not been received');
+    if (!this.#finalRun) throw new Error('Final run has not been received');
 
     return this.#finalRun;
   }
@@ -431,7 +431,7 @@ export class AssistantStream
               if (snapshot && snapshot.type == 'text') {
                 this._emit('textDelta', textDelta, snapshot.text);
               } else {
-                throw Error('The snapshot associated with this text delta is not text or missing');
+                throw new Error('The snapshot associated with this text delta is not text or missing');
               }
             }
 
@@ -552,7 +552,7 @@ export class AssistantStream
       case 'thread.run.step.delta':
         let snapshot = this.#runStepSnapshots[event.data.id] as Runs.RunStep;
         if (!snapshot) {
-          throw Error('Received a RunStepDelta before creation of a snapshot');
+          throw new Error('Received a RunStepDelta before creation of a snapshot');
         }
 
         let data = event.data;
@@ -590,7 +590,7 @@ export class AssistantStream
 
       case 'thread.message.delta':
         if (!snapshot) {
-          throw Error(
+          throw new Error(
             'Received a delta with no existing snapshot (there should be one from message creation)',
           );
         }
@@ -623,10 +623,10 @@ export class AssistantStream
         if (snapshot) {
           return [snapshot, newContent];
         } else {
-          throw Error('Received thread message event with no existing snapshot');
+          throw new Error('Received thread message event with no existing snapshot');
         }
     }
-    throw Error('Tried to accumulate a non-message event');
+    throw new Error('Tried to accumulate a non-message event');
   }
 
   #accumulateContent(
@@ -694,7 +694,7 @@ export class AssistantStream
         }
         continue;
       } else {
-        throw Error(`Unhandled record type: ${key}, deltaValue: ${deltaValue}, accValue: ${accValue}`);
+        throw new Error(`Unhandled record type: ${key}, deltaValue: ${deltaValue}, accValue: ${accValue}`);
       }
       acc[key] = accValue;
     }


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/throw-new-error` compatibility exception from `oxlint.config.ts`.
- Apply the required safe Ultracite autofixes and focused handwritten-code cleanup.

## Additional context & links

- Oxlint cleanup stack, part 9; stacked on https://github.com/openai/openai-node/pull/2078.
- Preserves Stainless-generated-file exclusions and the test/example import exception.

### Validation

- Ultracite 7.8.4 formatting and lint check.
- TypeScript 6.0.3 type check.
- Complete handwritten Vitest suite.

## Stack

https://github.com/openai/openai-node/pull/2071  
https://github.com/openai/openai-node/pull/2072  
https://github.com/openai/openai-node/pull/2073  
https://github.com/openai/openai-node/pull/2074  
https://github.com/openai/openai-node/pull/2075  
https://github.com/openai/openai-node/pull/2076  
https://github.com/openai/openai-node/pull/2077  
https://github.com/openai/openai-node/pull/2078  
https://github.com/openai/openai-node/pull/2079 :point_left: this PR  
https://github.com/openai/openai-node/pull/2080  
https://github.com/openai/openai-node/pull/2081  
https://github.com/openai/openai-node/pull/2082  
https://github.com/openai/openai-node/pull/2083  
https://github.com/openai/openai-node/pull/2084  
https://github.com/openai/openai-node/pull/2085
