### PR TITLE
chore(lint): enable typescript/consistent-generic-constructors

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -103,7 +103,6 @@ const compatibilityRules = [
   'typescript/array-type',
   'typescript/ban-ts-comment',
   'typescript/ban-types',
-  'typescript/consistent-generic-constructors',
   'typescript/consistent-indexed-object-style',
   'typescript/consistent-type-definitions',
   'typescript/consistent-type-imports',

--- a/src/helpers/standard-schema.ts
+++ b/src/helpers/standard-schema.ts
@@ -315,7 +315,7 @@ function areMutuallyExclusive(left: unknown, right: unknown, root: JSONSchema): 
 function resolveLocalRefForExclusivity(
   schema: unknown,
   root: JSONSchema,
-  seenRefs: Set<string> = new Set(),
+  seenRefs = new Set<string>(),
 ): unknown | undefined {
   if (!schema || typeof schema !== 'object' || Array.isArray(schema)) return schema;
 

--- a/src/lib/transform.ts
+++ b/src/lib/transform.ts
@@ -170,10 +170,7 @@ export function toStrictJsonSchema(schema: JSONSchema): JSONSchema {
   return strictSchema;
 }
 
-function stripUndefinedSchemaKeywords(
-  schema: JSONSchemaDefinition,
-  visited: Set<JSONSchema> = new Set(),
-): void {
+function stripUndefinedSchemaKeywords(schema: JSONSchemaDefinition, visited = new Set<JSONSchema>()): void {
   if (typeof schema === 'boolean' || !isObject(schema) || visited.has(schema)) {
     return;
   }
@@ -557,11 +554,7 @@ function normalizeSingletonTypeArrays(schema: JSONSchemaDefinition): void {
   });
 }
 
-function isNullable(
-  schema: JSONSchemaDefinition,
-  root: JSONSchema,
-  seenRefs: Set<string> = new Set(),
-): boolean {
+function isNullable(schema: JSONSchemaDefinition, root: JSONSchema, seenRefs = new Set<string>()): boolean {
   if (typeof schema === 'boolean') {
     return schema;
   }
@@ -940,7 +933,7 @@ function isSchemaDefinition(value: unknown): value is JSONSchemaDefinition {
 function isObjectOnlySchema(
   schema: JSONSchemaDefinition,
   root: JSONSchema,
-  seenRefs: Set<string> = new Set(),
+  seenRefs = new Set<string>(),
 ): boolean {
   if (typeof schema === 'boolean' || !isObject(schema)) {
     return false;
@@ -983,7 +976,7 @@ function isObjectOnlySchema(
 function isArrayOnlySchema(
   schema: JSONSchemaDefinition,
   root: JSONSchema,
-  seenRefs: Set<string> = new Set(),
+  seenRefs = new Set<string>(),
 ): boolean {
   if (typeof schema === 'boolean' || !isObject(schema)) {
     return false;
@@ -1606,7 +1599,7 @@ function normalizeObjectAllOfBranches(
   schema: JSONSchemaDefinition,
   path: string[],
   root: JSONSchema,
-  normalizing: Set<JSONSchema> = new Set(),
+  normalizing = new Set<JSONSchema>(),
 ): void {
   if (typeof schema === 'boolean' || !isObject(schema)) {
     return;
@@ -1688,7 +1681,7 @@ function mergeObjectAllOf(
   jsonSchema: JSONSchema,
   path: string[],
   root: JSONSchema,
-  normalizing: Set<JSONSchema> = new Set(),
+  normalizing = new Set<JSONSchema>(),
 ): boolean {
   const allOf = jsonSchema.allOf;
   if (!Array.isArray(allOf) || allOf.length === 0) {


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `typescript/consistent-generic-constructors` compatibility exception from `oxlint.config.ts`.
- Apply the required safe Ultracite autofixes and focused handwritten-code cleanup.

## Additional context & links

- Oxlint cleanup stack, part 10; stacked on https://github.com/openai/openai-node/pull/2079.
- Preserves Stainless-generated-file exclusions and the test/example import exception.

### Validation

- Ultracite 7.8.4 formatting and lint check.
- TypeScript 6.0.3 type check.
- Complete handwritten Vitest suite.

## Stack

https://github.com/openai/openai-node/pull/2071  
https://github.com/openai/openai-node/pull/2072  
https://github.com/openai/openai-node/pull/2073  
https://github.com/openai/openai-node/pull/2074  
https://github.com/openai/openai-node/pull/2075  
https://github.com/openai/openai-node/pull/2076  
https://github.com/openai/openai-node/pull/2077  
https://github.com/openai/openai-node/pull/2078  
https://github.com/openai/openai-node/pull/2079  
https://github.com/openai/openai-node/pull/2080 :point_left: this PR  
https://github.com/openai/openai-node/pull/2081  
https://github.com/openai/openai-node/pull/2082  
https://github.com/openai/openai-node/pull/2083  
https://github.com/openai/openai-node/pull/2084  
https://github.com/openai/openai-node/pull/2085
