### PR TITLE
chore(lint): enable import/no-duplicates

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -21,7 +21,6 @@ const compatibilityRules = [
   'import/namespace',
   'import/newline-after-import',
   'import/no-cycle',
-  'import/no-duplicates',
   'import/no-mutable-exports',
   'import/no-named-as-default-member',
   'import/no-self-import',

--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -1,14 +1,11 @@
-import { OpenAIError } from './error';
+import { OpenAIError, APIError } from './error';
 import { type ReadableStream } from '../internal/shim-types';
-import { makeReadableStream } from '../internal/shims';
+import { makeReadableStream, ReadableStreamToAsyncIterable } from '../internal/shims';
 import { findDoubleNewlineIndex, LineDecoder } from '../internal/decoders/line';
-import { ReadableStreamToAsyncIterable } from '../internal/shims';
 import { isAbortError } from '../internal/errors';
 import { encodeUTF8 } from '../internal/utils/bytes';
 import { loggerFor } from '../internal/utils/log';
 import type { OpenAI } from '../client';
-
-import { APIError } from './error';
 
 type Bytes = string | ArrayBuffer | Uint8Array | null | undefined;
 

--- a/src/internal/to-file.ts
+++ b/src/internal/to-file.ts
@@ -1,6 +1,5 @@
-import { BlobPart, getName, makeFile, isAsyncIterable } from './uploads';
+import { BlobPart, getName, makeFile, isAsyncIterable, checkFileSupport } from './uploads';
 import type { FilePropertyBag } from './builtin-types';
-import { checkFileSupport } from './uploads';
 
 type BlobLikePart = string | ArrayBuffer | ArrayBufferView | BlobLike | DataView;
 

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -8,8 +8,8 @@ import {
   type ChatCompletionToolRunnerParams,
   ChatCompletionStreamingRunner,
   type ChatCompletionStreamingToolRunnerParams,
+  type ChatCompletionMessageParam,
 } from 'openai/resources/chat/completions';
-import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 import type { RunnableToolFunction } from 'openai/lib/RunnableFunction';
 import { isAssistantMessage } from '../../src/lib/chatCompletionUtils';
 import { mockFetch } from '../utils/mock-fetch';

--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -1,6 +1,5 @@
 import { vi } from 'vitest';
-import { AzureOpenAI } from 'openai';
-import { APIUserAbortError } from 'openai';
+import { AzureOpenAI, APIUserAbortError } from 'openai';
 import { type Response, RequestInit, RequestInfo } from 'openai/internal/builtin-types';
 
 const defaultFetch = fetch;

--- a/tests/lib/workload-identity.test.ts
+++ b/tests/lib/workload-identity.test.ts
@@ -1,7 +1,6 @@
 import { vi } from 'vitest';
-import OpenAI from 'openai';
+import OpenAI, { OAuthError, SubjectTokenProviderError } from 'openai';
 import type { Response, RequestInit } from 'openai/internal/builtin-types';
-import { OAuthError, SubjectTokenProviderError } from 'openai';
 
 const originalFetch = global.fetch;
 


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `import/no-duplicates` compatibility exception from `oxlint.config.ts`.
- Apply the required safe Ultracite autofixes and focused handwritten-code cleanup.

## Additional context & links

- Oxlint cleanup stack, part 11; stacked on https://github.com/openai/openai-node/pull/2080.
- Preserves Stainless-generated-file exclusions and the test/example import exception.

### Validation

- Ultracite 7.8.4 formatting and lint check.
- TypeScript 6.0.3 type check.
- Complete handwritten Vitest suite.

## Stack

https://github.com/openai/openai-node/pull/2071  
https://github.com/openai/openai-node/pull/2072  
https://github.com/openai/openai-node/pull/2073  
https://github.com/openai/openai-node/pull/2074  
https://github.com/openai/openai-node/pull/2075  
https://github.com/openai/openai-node/pull/2076  
https://github.com/openai/openai-node/pull/2077  
https://github.com/openai/openai-node/pull/2078  
https://github.com/openai/openai-node/pull/2079  
https://github.com/openai/openai-node/pull/2080  
https://github.com/openai/openai-node/pull/2081 :point_left: this PR  
https://github.com/openai/openai-node/pull/2082  
https://github.com/openai/openai-node/pull/2083  
https://github.com/openai/openai-node/pull/2084  
https://github.com/openai/openai-node/pull/2085
