### PR TITLE
chore(lint): enable radix

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -94,7 +94,6 @@ const compatibilityRules = [
   'promise/prefer-await-to-callbacks',
   'promise/prefer-await-to-then',
   'promise/prefer-catch',
-  'radix',
   'require-await',
   'require-unicode-regexp',
   'sort-keys',

--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -60,7 +60,7 @@ export const checkFileSupport = () => {
   if (typeof File === 'undefined') {
     const { process } = globalThis as any;
     const isOldNode =
-      typeof process?.versions?.node === 'string' && parseInt(process.versions.node.split('.')) < 20;
+      typeof process?.versions?.node === 'string' && parseInt(process.versions.node.split('.'), 10) < 20;
     throw new Error(
       '`File` is not defined as a global, which is required for file uploads.' +
         (isOldNode


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `radix` compatibility exception from `oxlint.config.ts`.
- Apply the required safe Ultracite autofixes and focused handwritten-code cleanup.

## Additional context & links

- Oxlint cleanup stack, part 13; stacked on https://github.com/openai/openai-node/pull/2082.
- Preserves Stainless-generated-file exclusions and the test/example import exception.

### Validation

- Ultracite 7.8.4 formatting and lint check.
- TypeScript 6.0.3 type check.
- Complete handwritten Vitest suite.

## Stack

https://github.com/openai/openai-node/pull/2071  
https://github.com/openai/openai-node/pull/2072  
https://github.com/openai/openai-node/pull/2073  
https://github.com/openai/openai-node/pull/2074  
https://github.com/openai/openai-node/pull/2075  
https://github.com/openai/openai-node/pull/2076  
https://github.com/openai/openai-node/pull/2077  
https://github.com/openai/openai-node/pull/2078  
https://github.com/openai/openai-node/pull/2079  
https://github.com/openai/openai-node/pull/2080  
https://github.com/openai/openai-node/pull/2081  
https://github.com/openai/openai-node/pull/2082  
https://github.com/openai/openai-node/pull/2083 :point_left: this PR  
https://github.com/openai/openai-node/pull/2084  
https://github.com/openai/openai-node/pull/2085
