### PR TITLE
fix(format): restore formatting for generated SDK files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -145,8 +145,8 @@ This repository uses [Ultracite](https://www.ultracite.ai/) with
 [Oxlint](https://oxc.rs/docs/guide/usage/linter.html) to format and lint its code.
 The Ultracite presets live in `oxfmt.config.ts` and `oxlint.config.ts`, with
 repository-specific formatting options, import rules, fixture exceptions, and
-generated-file exclusions layered on top. Files with the Stainless-generated
-header are excluded from both formatting and linting; handwritten files in the
+generated-file lint exclusions layered on top. Files with the Stainless-generated
+header are formatted but excluded from linting; handwritten files in the
 same directories remain checked. Existing handwritten patterns are explicitly
 exempted from incompatible Ultracite rules, while the remaining preset rules stay
 enabled.

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -1,7 +1,6 @@
 const requireConfig = require('node:module').createRequire(__filename);
 const { defineConfig } = requireConfig('oxfmt');
 const ultracite = requireConfig('ultracite/oxfmt').default;
-const stainlessGeneratedFiles = requireConfig('./scripts/stainless-generated-files.cjs');
 
 module.exports = defineConfig({
   ...ultracite,
@@ -22,6 +21,5 @@ module.exports = defineConfig({
     'api_reference/openapi.transformed.yml',
     'dist/**',
     'coverage/**',
-    ...stainlessGeneratedFiles,
   ],
 });

--- a/tests/oxlint-config.test.ts
+++ b/tests/oxlint-config.test.ts
@@ -54,3 +54,33 @@ test('inherits Ultracite native plugins and enforces their rules', () => {
     rmSync(fixtureRoot, { recursive: true, force: true });
   }
 });
+
+test('formats generated SDK files without linting them', () => {
+  const generatedPath = 'src/client.ts';
+  const unformatted = [
+    '// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.',
+    '',
+    'export const generated = "formatted";',
+    '',
+  ].join('\n');
+
+  const formatted = spawnSync(process.execPath, [oxfmt, `--stdin-filepath=${generatedPath}`], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    input: unformatted,
+  });
+
+  expect(formatted.status).toBe(0);
+  expect(formatted.stdout).toContain("export const generated = 'formatted';");
+
+  const linted = spawnSync(
+    process.execPath,
+    [oxlint, '--format', 'json', '--no-error-on-unmatched-pattern', generatedPath],
+    { cwd: repoRoot, encoding: 'utf8' },
+  );
+
+  expect(linted.status).toBe(0);
+
+  const result = JSON.parse(linted.stdout) as { number_of_files: number };
+  expect(result.number_of_files).toBe(0);
+});


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Restore formatting for Stainless-generated SDK files without enabling linting for those files.

The Ultracite migration currently excludes generated files from both Oxfmt and Oxlint. Excluding them from linting is intentional: generated SDK output should not need to satisfy handwritten-code lint rules. Excluding them from formatting is not intentional: SDK generation should still produce consistently formatted source files.

When generated output bypasses formatting, subsequent SDK updates accumulate formatting-only churn and can produce avoidable merge conflicts. This change restores the intended boundary:

- **Formatting:** generated and handwritten SDK files are formatted consistently.
- **Linting:** only handwritten files are linted; Stainless-generated files remain excluded.

The generated files already checked into the repository pass the formatter unchanged, so this does not introduce a generated-source reformat.

### Implementation details

Remove the generated-file exclusion from Oxfmt only, preserve the existing Oxlint exclusion, document the distinction, and add a regression test covering both behaviors.

## Additional context & links

Validated with:

- `node node_modules/vitest/vitest.mjs run tests/oxlint-config.test.ts` — 2 tests passed.
- `node node_modules/oxfmt/bin/oxfmt --check .` — all 597 matched files passed.
- `node node_modules/oxlint/bin/oxlint .` — passed.