### PR TITLE
chore(lint): enable jsdoc/empty-tags

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -21,7 +21,6 @@ const compatibilityRules = [
   'import/newline-after-import',
   'import/no-cycle',
   'import/no-mutable-exports',
-  'jsdoc/check-property-names',
   'jsdoc/check-tag-names',
   'jsdoc/empty-tags',
   'jsdoc/no-defaults',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -21,7 +21,6 @@ const compatibilityRules = [
   'import/newline-after-import',
   'import/no-cycle',
   'import/no-mutable-exports',
-  'import/no-named-as-default-member',
   'import/no-self-import',
   'jsdoc/check-property-names',
   'jsdoc/check-tag-names',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -22,7 +22,6 @@ const compatibilityRules = [
   'import/no-cycle',
   'import/no-mutable-exports',
   'jsdoc/check-tag-names',
-  'jsdoc/empty-tags',
   'jsdoc/no-defaults',
   'jsdoc/require-param-description',
   'jsdoc/require-property-description',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -18,7 +18,6 @@ const compatibilityRules = [
   'guard-for-in',
   'import/consistent-type-specifier-style',
   'import/first',
-  'import/namespace',
   'import/newline-after-import',
   'import/no-cycle',
   'import/no-mutable-exports',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -21,7 +21,6 @@ const compatibilityRules = [
   'import/newline-after-import',
   'import/no-cycle',
   'import/no-mutable-exports',
-  'import/no-self-import',
   'jsdoc/check-property-names',
   'jsdoc/check-tag-names',
   'jsdoc/empty-tags',


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `jsdoc/empty-tags` compatibility exception from `oxlint.config.ts`.
- Baseline: 0 handwritten-code violations on `main`.
- No source changes are needed; existing handwritten files already satisfy the preset rule.

## Additional context & links

- Oxlint cleanup stack, part 20; stacked on https://github.com/openai/openai-node/pull/2093.
- Preserves Stainless-generated-file exclusions and repository-specific import policy.

### Validation

- Ultracite 7.8.4 formatting and lint check.
- TypeScript 6.0.3 type check.
- Oxlint configuration regression tests.

### Stack

https://github.com/openai/openai-node/pull/2090
https://github.com/openai/openai-node/pull/2091
https://github.com/openai/openai-node/pull/2092
https://github.com/openai/openai-node/pull/2093
https://github.com/openai/openai-node/pull/2094 :point_left: this PR
https://github.com/openai/openai-node/pull/2095
https://github.com/openai/openai-node/pull/2096
https://github.com/openai/openai-node/pull/2097
https://github.com/openai/openai-node/pull/2098
https://github.com/openai/openai-node/pull/2099
https://github.com/openai/openai-node/pull/2100
https://github.com/openai/openai-node/pull/2101
https://github.com/openai/openai-node/pull/2102
https://github.com/openai/openai-node/pull/2103
https://github.com/openai/openai-node/pull/2104
https://github.com/openai/openai-node/pull/2105
https://github.com/openai/openai-node/pull/2106
https://github.com/openai/openai-node/pull/2107
https://github.com/openai/openai-node/pull/2108
https://github.com/openai/openai-node/pull/2109
https://github.com/openai/openai-node/pull/2110
https://github.com/openai/openai-node/pull/2111
https://github.com/openai/openai-node/pull/2112
https://github.com/openai/openai-node/pull/2113
https://github.com/openai/openai-node/pull/2114
https://github.com/openai/openai-node/pull/2115
https://github.com/openai/openai-node/pull/2116
https://github.com/openai/openai-node/pull/2117
https://github.com/openai/openai-node/pull/2118
https://github.com/openai/openai-node/pull/2119
https://github.com/openai/openai-node/pull/2120
https://github.com/openai/openai-node/pull/2121
https://github.com/openai/openai-node/pull/2122
https://github.com/openai/openai-node/pull/2123
