### PR TITLE
fix(lint): recognize Castiron-generated headers

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -145,8 +145,8 @@ This repository uses [Ultracite](https://www.ultracite.ai/) with
 [Oxlint](https://oxc.rs/docs/guide/usage/linter.html) to format and lint its code.
 The Ultracite presets live in `oxfmt.config.ts` and `oxlint.config.ts`, with
 repository-specific formatting options, import rules, fixture exceptions, and
-generated-file lint exclusions layered on top. Files with the Stainless-generated
-header are formatted but excluded from linting; handwritten files in the
+generated-file lint exclusions layered on top. Files with a Stainless- or
+Castiron-generated header are formatted but excluded from linting; handwritten files in the
 same directories remain checked. Existing handwritten patterns are explicitly
 exempted from incompatible Ultracite rules, while the remaining preset rules stay
 enabled.

--- a/scripts/stainless-generated-files.cjs
+++ b/scripts/stainless-generated-files.cjs
@@ -2,7 +2,10 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const repositoryRoot = path.resolve(__dirname, '..');
-const generatedHeader = '// File generated from our OpenAPI spec by Stainless.';
+const generatedHeaders = [
+  '// File generated from our OpenAPI spec by Stainless.',
+  '// File generated from our OpenAPI spec by Castiron.',
+];
 const ignoredDirectories = new Set(['.git', 'coverage', 'dist', 'node_modules']);
 
 function findGeneratedFiles(directory) {
@@ -11,7 +14,8 @@ function findGeneratedFiles(directory) {
 
     if (entry.isDirectory()) return ignoredDirectories.has(entry.name) ? [] : findGeneratedFiles(file);
     if (!entry.isFile() || !/\.[cm]?[jt]sx?$/.test(entry.name)) return [];
-    if (!fs.readFileSync(file, 'utf8').startsWith(generatedHeader)) return [];
+    const content = fs.readFileSync(file, 'utf8');
+    if (!generatedHeaders.some((header) => content.startsWith(header))) return [];
 
     return [path.relative(repositoryRoot, file).split(path.sep).join('/')];
   });

--- a/tests/oxlint-config.test.ts
+++ b/tests/oxlint-config.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -50,6 +50,30 @@ test('inherits Ultracite native plugins and enforces their rules', () => {
     );
 
     expect(formatted.status).toBe(0);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('recognizes both Stainless and Castiron generated SDK files', () => {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'openai-node-generated-files-'));
+
+  try {
+    const scriptsDirectory = join(fixtureRoot, 'scripts');
+    mkdirSync(scriptsDirectory);
+    const generatedFilesScript = join(scriptsDirectory, 'stainless-generated-files.cjs');
+    copyFileSync(join(repoRoot, 'scripts/stainless-generated-files.cjs'), generatedFilesScript);
+
+    for (const generator of ['Stainless', 'Castiron']) {
+      writeFileSync(
+        join(fixtureRoot, `${generator.toLowerCase()}.ts`),
+        `// File generated from our OpenAPI spec by ${generator}. See CONTRIBUTING.md for details.\n`,
+      );
+    }
+    writeFileSync(join(fixtureRoot, 'handwritten.ts'), 'export const handwritten = true;\n');
+
+    const generatedFiles = require(generatedFilesScript) as string[];
+    expect(generatedFiles).toEqual(['castiron.ts', 'stainless.ts']);
   } finally {
     rmSync(fixtureRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
Recognize the new Castiron header alongside the existing Stainless header.