### PR TITLE
chore(lint): enable unicorn/prefer-dom-node-append

### DIFF
--- a/ecosystem-tests/browser-direct-import/public/index.js
+++ b/ecosystem-tests/browser-direct-import/public/index.js
@@ -17,7 +17,7 @@ async function runTests() {
     if (!pre) {
       pre = document.createElement('pre');
       pre.id = 'results';
-      document.body.appendChild(pre);
+      document.body.append(pre);
     }
     pre.innerText = JSON.stringify(results, null, 2);
   }

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -265,7 +265,7 @@ async function main() {
       args.skip[idx] = (projectName + '').toLowerCase();
     });
 
-    projectNames = projectNames.filter((projectName) => (args.skip as string[]).indexOf(projectName) < 0);
+    projectNames = projectNames.filter((projectName) => !(args.skip as string[]).includes(projectName));
 
     args.skip.forEach((projectName) => {
       projectNamesSet.delete(projectName as any);

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -364,8 +364,8 @@ async function main() {
       const queue = [...projectsToRun];
       const runningProjects = new Set();
 
-      const cursorLeft = '\x1B[G';
-      const eraseLine = '\x1B[2K';
+      const cursorLeft = '\u001B[G';
+      const eraseLine = '\u001B[2K';
 
       let progressDisplayed = false;
       function clearProgress() {

--- a/ecosystem-tests/ts-browser-webpack/src/index.ts
+++ b/ecosystem-tests/ts-browser-webpack/src/index.ts
@@ -20,7 +20,7 @@ async function runTests() {
     if (!pre) {
       pre = document.createElement('pre');
       pre.id = 'results';
-      document.body.appendChild(pre);
+      document.body.append(pre);
     }
     pre.innerText = JSON.stringify(results, null, 2);
   }

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -110,7 +110,6 @@ const compatibilityRules = [
   'unicorn/no-array-sort',
   'unicorn/no-await-expression-member',
   'unicorn/no-console-spaces',
-  'unicorn/no-hex-escape',
   'unicorn/no-lonely-if',
   'unicorn/no-negated-condition',
   'unicorn/no-nested-ternary',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -124,7 +124,6 @@ const compatibilityRules = [
   'unicorn/prefer-dom-node-append',
   'unicorn/prefer-dom-node-text-content',
   'unicorn/prefer-event-target',
-  'unicorn/prefer-includes',
   'unicorn/prefer-module',
   'unicorn/prefer-node-protocol',
   'unicorn/prefer-number-properties',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -121,7 +121,6 @@ const compatibilityRules = [
   'unicorn/prefer-bigint-literals',
   'unicorn/prefer-class-fields',
   'unicorn/prefer-code-point',
-  'unicorn/prefer-dom-node-append',
   'unicorn/prefer-dom-node-text-content',
   'unicorn/prefer-event-target',
   'unicorn/prefer-module',

--- a/src/internal/qs/utils.ts
+++ b/src/internal/qs/utils.ts
@@ -218,7 +218,7 @@ export const encode: (
 
 export function compact(value: any) {
   const queue = [{ obj: { o: value }, prop: 'o' }];
-  const refs = [];
+  const refs: object[] = [];
 
   for (let i = 0; i < queue.length; ++i) {
     const item = queue[i];
@@ -229,7 +229,7 @@ export function compact(value: any) {
     for (let j = 0; j < keys.length; ++j) {
       const key = keys[j]!;
       const val = obj[key];
-      if (typeof val === 'object' && val !== null && refs.indexOf(val) === -1) {
+      if (typeof val === 'object' && val !== null && !refs.includes(val)) {
         queue.push({ obj: obj, prop: key });
         refs.push(val);
       }


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/prefer-dom-node-append` compatibility exception from `oxlint.config.ts`.
- Resolve the 2 existing handwritten-code diagnostics with focused, behavior-preserving cleanup.

## Additional context & links

- Oxlint cleanup stack, part 52; stacked on https://github.com/openai/openai-node/pull/2130.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2129
https://github.com/openai/openai-node/pull/2130
https://github.com/openai/openai-node/pull/2131 :point_left: this PR
https://github.com/openai/openai-node/pull/2132
https://github.com/openai/openai-node/pull/2133
https://github.com/openai/openai-node/pull/2134
https://github.com/openai/openai-node/pull/2135
https://github.com/openai/openai-node/pull/2136
https://github.com/openai/openai-node/pull/2137
https://github.com/openai/openai-node/pull/2138
https://github.com/openai/openai-node/pull/2139
https://github.com/openai/openai-node/pull/2140
https://github.com/openai/openai-node/pull/2141
