### PR TITLE
chore(lint): enable no-new-wrappers

### DIFF
--- a/ecosystem-tests/browser-direct-import/public/index.js
+++ b/ecosystem-tests/browser-direct-import/public/index.js
@@ -17,7 +17,7 @@ async function runTests() {
     if (!pre) {
       pre = document.createElement('pre');
       pre.id = 'results';
-      document.body.appendChild(pre);
+      document.body.append(pre);
     }
     pre.innerText = JSON.stringify(results, null, 2);
   }

--- a/ecosystem-tests/browser-direct-import/public/index.js
+++ b/ecosystem-tests/browser-direct-import/public/index.js
@@ -19,7 +19,7 @@ async function runTests() {
       pre.id = 'results';
       document.body.append(pre);
     }
-    pre.innerText = JSON.stringify(results, null, 2);
+    pre.textContent = JSON.stringify(results, null, 2);
   }
   for (const { path, run, timeout } of tests) {
     console.log('running', ...path);

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -265,7 +265,7 @@ async function main() {
       args.skip[idx] = (projectName + '').toLowerCase();
     });
 
-    projectNames = projectNames.filter((projectName) => (args.skip as string[]).indexOf(projectName) < 0);
+    projectNames = projectNames.filter((projectName) => !(args.skip as string[]).includes(projectName));
 
     args.skip.forEach((projectName) => {
       projectNamesSet.delete(projectName as any);

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -364,8 +364,8 @@ async function main() {
       const queue = [...projectsToRun];
       const runningProjects = new Set();
 
-      const cursorLeft = '\x1B[G';
-      const eraseLine = '\x1B[2K';
+      const cursorLeft = '\u001B[G';
+      const eraseLine = '\u001B[2K';
 
       let progressDisplayed = false;
       function clearProgress() {

--- a/ecosystem-tests/ts-browser-webpack/src/index.ts
+++ b/ecosystem-tests/ts-browser-webpack/src/index.ts
@@ -20,7 +20,7 @@ async function runTests() {
     if (!pre) {
       pre = document.createElement('pre');
       pre.id = 'results';
-      document.body.appendChild(pre);
+      document.body.append(pre);
     }
     pre.innerText = JSON.stringify(results, null, 2);
   }

--- a/ecosystem-tests/ts-browser-webpack/src/index.ts
+++ b/ecosystem-tests/ts-browser-webpack/src/index.ts
@@ -22,7 +22,7 @@ async function runTests() {
       pre.id = 'results';
       document.body.append(pre);
     }
-    pre.innerText = JSON.stringify(results, null, 2);
+    pre.textContent = JSON.stringify(results, null, 2);
   }
   for (const { path, run, timeout } of tests) {
     console.log('running', ...path);

--- a/examples/responses/websocket.ts
+++ b/examples/responses/websocket.ts
@@ -76,12 +76,10 @@ type RunTurnResult = {
 
 type OpenableSocket = {
   readyState: number;
-  on(event: 'open', listener: () => void): void;
+  on(event: 'open' | 'close', listener: () => void): void;
   on(event: 'error', listener: (err: Error) => void): void;
-  on(event: 'close', listener: () => void): void;
-  off(event: 'open', listener: () => void): void;
+  off(event: 'open' | 'close', listener: () => void): void;
   off(event: 'error', listener: (err: Error) => void): void;
-  off(event: 'close', listener: () => void): void;
 };
 
 type CLIArgs = {

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -35,7 +35,6 @@ const compatibilityRules = [
   'no-inline-comments',
   'no-inner-declarations',
   'no-lonely-if',
-  'no-multi-assign',
   'no-negated-condition',
   'no-nested-ternary',
   'no-new-wrappers',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -136,7 +136,6 @@ const compatibilityRules = [
   'unicorn/switch-case-braces',
   'unicorn/text-encoding-identifier-case',
   'vars-on-top',
-  'yoda',
 ];
 
 module.exports = defineConfig({

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -14,7 +14,6 @@ const compatibilityRules = [
   'func-name-matching',
   'func-names',
   'func-style',
-  'guard-for-in',
   'import/consistent-type-specifier-style',
   'import/first',
   'import/newline-after-import',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -116,7 +116,6 @@ const compatibilityRules = [
   'unicorn/numeric-separators-style',
   'unicorn/prefer-at',
   'unicorn/prefer-bigint-literals',
-  'unicorn/prefer-class-fields',
   'unicorn/prefer-code-point',
   'unicorn/prefer-event-target',
   'unicorn/prefer-module',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -121,7 +121,6 @@ const compatibilityRules = [
   'unicorn/prefer-bigint-literals',
   'unicorn/prefer-class-fields',
   'unicorn/prefer-code-point',
-  'unicorn/prefer-dom-node-text-content',
   'unicorn/prefer-event-target',
   'unicorn/prefer-module',
   'unicorn/prefer-node-protocol',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -110,7 +110,6 @@ const compatibilityRules = [
   'unicorn/no-array-sort',
   'unicorn/no-await-expression-member',
   'unicorn/no-console-spaces',
-  'unicorn/no-hex-escape',
   'unicorn/no-lonely-if',
   'unicorn/no-negated-condition',
   'unicorn/no-nested-ternary',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -35,7 +35,6 @@ const compatibilityRules = [
   'no-lonely-if',
   'no-negated-condition',
   'no-nested-ternary',
-  'no-new-wrappers',
   'no-param-reassign',
   'no-plusplus',
   'no-promise-executor-return',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -32,7 +32,6 @@ const compatibilityRules = [
   'no-empty',
   'no-empty-function',
   'no-eq-null',
-  'no-fallthrough',
   'no-inline-comments',
   'no-inner-declarations',
   'no-lonely-if',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -124,7 +124,6 @@ const compatibilityRules = [
   'unicorn/prefer-dom-node-append',
   'unicorn/prefer-dom-node-text-content',
   'unicorn/prefer-event-target',
-  'unicorn/prefer-includes',
   'unicorn/prefer-module',
   'unicorn/prefer-node-protocol',
   'unicorn/prefer-number-properties',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -127,7 +127,6 @@ const compatibilityRules = [
   'unicorn/prefer-number-properties',
   'unicorn/prefer-optional-catch-binding',
   'unicorn/prefer-query-selector',
-  'unicorn/prefer-regexp-test',
   'unicorn/prefer-response-static-json',
   'unicorn/prefer-spread',
   'unicorn/prefer-string-replace-all',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -22,7 +22,6 @@ const compatibilityRules = [
   'jsdoc/check-tag-names',
   'jsdoc/no-defaults',
   'jsdoc/require-param-description',
-  'jsdoc/require-yields',
   'logical-assignment-operators',
   'max-classes-per-file',
   'no-await-in-loop',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -121,7 +121,6 @@ const compatibilityRules = [
   'unicorn/prefer-bigint-literals',
   'unicorn/prefer-class-fields',
   'unicorn/prefer-code-point',
-  'unicorn/prefer-dom-node-append',
   'unicorn/prefer-dom-node-text-content',
   'unicorn/prefer-event-target',
   'unicorn/prefer-module',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -91,7 +91,6 @@ const compatibilityRules = [
   'typescript/parameter-properties',
   'typescript/prefer-for-of',
   'typescript/prefer-ts-expect-error',
-  'typescript/unified-signatures',
   'unicorn/catch-error-name',
   'unicorn/consistent-assert',
   'unicorn/consistent-existence-index-check',

--- a/scripts/utils/make-dist-package-json.cjs
+++ b/scripts/utils/make-dist-package-json.cjs
@@ -2,6 +2,8 @@ const pkgJson = require(process.env['PKG_JSON_PATH'] || '../../package.json');
 
 function processExportMap(m) {
   for (const key in m) {
+    if (!Object.hasOwn(m, key)) continue;
+
     const value = m[key];
     if (typeof value === 'string') m[key] = value.replace(/^\.\/dist\//, './');
     else processExportMap(value);

--- a/src/_vendor/partial-json-parser/parser.ts
+++ b/src/_vendor/partial-json-parser/parser.ts
@@ -103,7 +103,7 @@ const _parseJSON = (jsonString: string, allow: number) => {
     if (
       jsonString.substring(index, index + 9) === '-Infinity' ||
       (Allow.MINUS_INFINITY & allow &&
-        1 < length - index &&
+        length - index > 1 &&
         length - index < 9 &&
         '-Infinity'.startsWith(jsonString.substring(index)))
     ) {
@@ -203,7 +203,7 @@ const _parseJSON = (jsonString: string, allow: number) => {
       } catch (e) {
         if (Allow.NUM & allow) {
           try {
-            if ('.' === jsonString[jsonString.length - 1])
+            if (jsonString[jsonString.length - 1] === '.')
               return JSON.parse(jsonString.substring(0, jsonString.lastIndexOf('.')));
             return JSON.parse(jsonString.substring(0, jsonString.lastIndexOf('e')));
           } catch (e) {}

--- a/src/_vendor/zod-to-json-schema/parsers/string.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/string.ts
@@ -342,7 +342,7 @@ const processRegExp = (regexOrFunction: RegExp | (() => RegExp), refs: Refs): st
 
     if (flags.i) {
       if (inCharGroup) {
-        if (source[i].match(/[a-z]/)) {
+        if (/[a-z]/.test(source[i])) {
           if (inCharRange) {
             pattern += source[i];
             pattern += `${source[i - 2]}-${source[i]}`.toUpperCase();
@@ -355,7 +355,7 @@ const processRegExp = (regexOrFunction: RegExp | (() => RegExp), refs: Refs): st
           }
           continue;
         }
-      } else if (source[i].match(/[a-z]/)) {
+      } else if (/[a-z]/.test(source[i])) {
         pattern += `[${source[i]}${source[i].toUpperCase()}]`;
         continue;
       }

--- a/src/_vendor/zod-to-json-schema/parsers/string.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/string.ts
@@ -220,6 +220,7 @@ export function parseStringDef(def: ZodStringDef, refs: Refs): JsonSchema7String
         }
         case 'nanoid': {
           addPattern(res, zodPatterns.nanoid, check.message, refs);
+          break;
         }
         case 'toLowerCase':
         case 'toUpperCase':

--- a/src/_vendor/zod-to-json-schema/parsers/union.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/union.ts
@@ -64,6 +64,7 @@ export function parseUnionDef(
           return [...acc, 'integer' as const];
         case 'object':
           if (x._def.value === null) return [...acc, 'null' as const];
+          return acc;
         case 'symbol':
         case 'undefined':
         case 'function':

--- a/src/_vendor/zod-to-json-schema/util.ts
+++ b/src/_vendor/zod-to-json-schema/util.ts
@@ -6,6 +6,7 @@ export const zodDef = (zodSchema: ZodSchema | ZodTypeDef): ZodTypeDef => {
 
 export function isEmptyObj(obj: Object | null | undefined): boolean {
   if (!obj) return true;
+  // oxlint-disable-next-line guard-for-in -- inherited enumerable properties make the object non-empty
   for (const _k in obj) return false;
   return true;
 }

--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -277,6 +277,8 @@ export async function* _iterSSEMessages(
 /**
  * Given an async iterable iterator, iterates over it and yields full
  * SSE chunks, i.e. yields when a double new-line is encountered.
+ *
+ * @yields {Uint8Array} A complete SSE chunk.
  */
 async function* iterSSEChunks(iterator: AsyncIterableIterator<Bytes>): AsyncGenerator<Uint8Array> {
   let data = new Uint8Array();

--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -314,11 +314,10 @@ async function* iterSSEChunks(iterator: AsyncIterableIterator<Bytes>): AsyncGene
 
 class SSEDecoder {
   private data: string[];
-  private event: string | null;
+  private event: string | null = null;
   private chunks: string[];
 
   constructor() {
-    this.event = null;
     this.data = [];
     this.chunks = [];
   }

--- a/src/internal/qs/utils.ts
+++ b/src/internal/qs/utils.ts
@@ -218,7 +218,7 @@ export const encode: (
 
 export function compact(value: any) {
   const queue = [{ obj: { o: value }, prop: 'o' }];
-  const refs = [];
+  const refs: object[] = [];
 
   for (let i = 0; i < queue.length; ++i) {
     const item = queue[i];
@@ -229,7 +229,7 @@ export function compact(value: any) {
     for (let j = 0; j < keys.length; ++j) {
       const key = keys[j]!;
       const val = obj[key];
-      if (typeof val === 'object' && val !== null && refs.indexOf(val) === -1) {
+      if (typeof val === 'object' && val !== null && !refs.includes(val)) {
         queue.push({ obj: obj, prop: key });
         refs.push(val);
       }

--- a/src/lib/ChatCompletionStream.ts
+++ b/src/lib/ChatCompletionStream.ts
@@ -530,10 +530,12 @@ export class ChatCompletionStream<ParsedT = null>
     let snapshot = this.#currentChatCompletionSnapshot;
     const { choices, ...rest } = chunk;
     if (!snapshot) {
-      snapshot = this.#currentChatCompletionSnapshot = {
+      const newSnapshot: ChatCompletionSnapshot = {
         ...rest,
         choices: [],
       };
+      this.#currentChatCompletionSnapshot = newSnapshot;
+      snapshot = newSnapshot;
     } else if (chunk.id) {
       Object.assign(snapshot, rest);
     }
@@ -541,7 +543,9 @@ export class ChatCompletionStream<ParsedT = null>
     for (const { delta, finish_reason, index, logprobs = null, ...other } of chunk.choices) {
       let choice = snapshot.choices[index];
       if (!choice) {
-        choice = snapshot.choices[index] = { finish_reason, index, message: {}, logprobs, ...other };
+        const newChoice = { finish_reason, index, message: {}, logprobs, ...other };
+        snapshot.choices[index] = newChoice;
+        choice = newChoice;
       }
 
       if (logprobs) {

--- a/src/lib/RunnableFunction.ts
+++ b/src/lib/RunnableFunction.ts
@@ -136,11 +136,10 @@ export type RunnableTools<FunctionsArgs extends BaseFunctionsArgs, ToolContext =
  * argument type matches the `parse` return type.
  */
 export class ParsingToolFunction<Args extends object, ToolContext = unknown> {
-  type: 'function';
+  type = 'function' as const;
   function: RunnableFunctionWithParse<Args, ToolContext>;
 
   constructor(input: RunnableFunctionWithParse<Args, ToolContext>) {
-    this.type = 'function';
     this.function = input;
   }
 }

--- a/tests/path.test.ts
+++ b/tests/path.test.ts
@@ -38,8 +38,10 @@ describe('path template tag function', () => {
 
     const emptyObject = {};
     const mathObject = Math;
-    const numberObject = Object(0);
-    const stringObject = Object('');
+    // oxlint-disable-next-line no-new-wrappers -- intentionally test a boxed Number path parameter
+    const numberObject = new Number();
+    // oxlint-disable-next-line no-new-wrappers -- intentionally test a boxed String path parameter
+    const stringObject = new String();
     const basicClass = new (class {
       readonly kind = 'class';
     })();

--- a/tests/path.test.ts
+++ b/tests/path.test.ts
@@ -38,8 +38,8 @@ describe('path template tag function', () => {
 
     const emptyObject = {};
     const mathObject = Math;
-    const numberObject = new Number();
-    const stringObject = new String();
+    const numberObject = Object(0);
+    const stringObject = Object('');
     const basicClass = new (class {
       readonly kind = 'class';
     })();


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `no-new-wrappers` compatibility exception from `oxlint.config.ts`.
- Resolve the 2 existing handwritten-code diagnostics with focused, behavior-preserving cleanup.

## Additional context & links

- Oxlint cleanup stack, part 62; stacked on https://github.com/openai/openai-node/pull/2140.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2129
https://github.com/openai/openai-node/pull/2130
https://github.com/openai/openai-node/pull/2131
https://github.com/openai/openai-node/pull/2132
https://github.com/openai/openai-node/pull/2133
https://github.com/openai/openai-node/pull/2134
https://github.com/openai/openai-node/pull/2135
https://github.com/openai/openai-node/pull/2136
https://github.com/openai/openai-node/pull/2137
https://github.com/openai/openai-node/pull/2138
https://github.com/openai/openai-node/pull/2139
https://github.com/openai/openai-node/pull/2140
https://github.com/openai/openai-node/pull/2141 :point_left: this PR
