### PR TITLE
chore(lint): enable no-lonely-if

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -32,7 +32,6 @@ const compatibilityRules = [
   'no-eq-null',
   'no-inline-comments',
   'no-inner-declarations',
-  'no-lonely-if',
   'no-negated-condition',
   'no-nested-ternary',
   'no-param-reassign',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -111,7 +111,6 @@ const compatibilityRules = [
   'unicorn/no-useless-undefined',
   'unicorn/numeric-separators-style',
   'unicorn/prefer-at',
-  'unicorn/prefer-bigint-literals',
   'unicorn/prefer-code-point',
   'unicorn/prefer-event-target',
   'unicorn/prefer-module',

--- a/src/azure.ts
+++ b/src/azure.ts
@@ -112,10 +112,8 @@ export class AzureOpenAI extends OpenAI {
         endpointEnd--;
       }
       baseURL = `${endpoint.slice(0, endpointEnd)}/openai`;
-    } else {
-      if (endpoint) {
-        throw new Errors.OpenAIError('baseURL and endpoint are mutually exclusive');
-      }
+    } else if (endpoint) {
+      throw new Errors.OpenAIError('baseURL and endpoint are mutually exclusive');
     }
 
     super({

--- a/src/beta/realtime/internal-base.ts
+++ b/src/beta/realtime/internal-base.ts
@@ -119,12 +119,10 @@ export function buildRealtimeURL(
     }
     url.searchParams.set('api-version', client.apiVersion);
     url.searchParams.set('deployment', config.model!);
+  } else if (hasCallID) {
+    url.searchParams.set('call_id', config.callID!);
   } else {
-    if (hasCallID) {
-      url.searchParams.set('call_id', config.callID!);
-    } else {
-      url.searchParams.set('model', config.model!);
-    }
+    url.searchParams.set('model', config.model!);
   }
   return url;
 }

--- a/src/realtime/internal-base.ts
+++ b/src/realtime/internal-base.ts
@@ -151,12 +151,10 @@ export function buildRealtimeURL(
       url.searchParams.set('api-version', client.apiVersion);
       url.searchParams.set('deployment', config.model!);
     }
+  } else if (hasCallID) {
+    url.searchParams.set('call_id', config.callID!);
   } else {
-    if (hasCallID) {
-      url.searchParams.set('call_id', config.callID!);
-    } else {
-      url.searchParams.set('model', config.model!);
-    }
+    url.searchParams.set('model', config.model!);
   }
   return url;
 }

--- a/tests/internal/uploads-branches.test.ts
+++ b/tests/internal/uploads-branches.test.ts
@@ -127,7 +127,7 @@ describe('buffered multipart forms', () => {
 
   test('rejects null and unsupported primitive values', async () => {
     await expect(createForm({ value: null }, fetch)).rejects.toThrow('Received null for "value"');
-    await expect(createForm({ value: BigInt(1) }, fetch)).rejects.toThrow('Invalid value given to form');
+    await expect(createForm({ value: 1n }, fetch)).rejects.toThrow('Invalid value given to form');
   });
 
   test('rejects fetch implementations that stringify FormData objects', async () => {
@@ -304,7 +304,7 @@ describe('lazy multipart stream encoding', () => {
     }
 
     const options = await multipartFormRequestOptions(
-      { body: { upload: toStreamingFile(chunks(), 'audio.wav'), invalid: BigInt(1) } },
+      { body: { upload: toStreamingFile(chunks(), 'audio.wav'), invalid: 1n } },
       fetch,
     );
 

--- a/tests/qs/stringify.test.ts
+++ b/tests/qs/stringify.test.ts
@@ -35,7 +35,7 @@ describe('stringify()', function () {
   });
 
   test('stringifies bigints', function () {
-    var three = BigInt(3);
+    var three = 3n;
     // @ts-expect-error
     var encodeWithN = function (value, defaultEncoder, charset) {
       var result = defaultEncoder(value, defaultEncoder, charset);


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `no-lonely-if` compatibility exception from `oxlint.config.ts`.
- Flatten the 3 existing handwritten-code `else { if }` branches without changing their conditions or bodies.

## Additional context & links

- Oxlint cleanup stack, part 65; stacked on https://github.com/openai/openai-node/pull/2144.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2141
https://github.com/openai/openai-node/pull/2143
https://github.com/openai/openai-node/pull/2144
https://github.com/openai/openai-node/pull/2145 :point_left: this PR
https://github.com/openai/openai-node/pull/2146
https://github.com/openai/openai-node/pull/2147
https://github.com/openai/openai-node/pull/2148
https://github.com/openai/openai-node/pull/2149
