### PR TITLE
fix(embeddings): handle compatible endpoints that return float arrays

### DIFF
--- a/src/resources/embeddings.ts
+++ b/src/resources/embeddings.ts
@@ -57,7 +57,16 @@ export class Embeddings extends APIResource {
       if (response && response.data) {
         response.data.forEach((embeddingBase64Obj) => {
           const embeddingBase64Str = embeddingBase64Obj.embedding as unknown as string;
-          embeddingBase64Obj.embedding = toFloat32Array(embeddingBase64Str);
+          // Some OpenAI-compatible endpoints (e.g., ollama, LM Studio) ignore the encoding_format
+          // parameter and always return float arrays. Check if the embedding is already an array
+          // before attempting base64 decoding.
+          if (Array.isArray(embeddingBase64Str)) {
+            // Already a float array, no decoding needed
+            embeddingBase64Obj.embedding = embeddingBase64Str;
+          } else {
+            // Base64 string, decode it
+            embeddingBase64Obj.embedding = toFloat32Array(embeddingBase64Str);
+          }
         });
       }
 

--- a/tests/api-resources/embeddings.test.ts
+++ b/tests/api-resources/embeddings.test.ts
@@ -69,6 +69,52 @@ describe('resource embeddings', () => {
 
     expect(typeof response.data?.[0]?.embedding).toBe('string');
   });
+
+  test('create: should handle OpenAI-compatible endpoints that return float arrays despite base64 request', async () => {
+    const { fetch, handleRequest } = mockFetch();
+
+    // Simulate ollama/LM Studio behavior: ignore encoding_format and return float array
+    handleRequest(async (_, init) => {
+      const floatArray = Array.from({ length: 1024 }, (_, i) => i * 0.01);
+      return new Response(
+        JSON.stringify({
+          object: 'list',
+          data: [
+            {
+              object: 'embedding',
+              index: 0,
+              embedding: floatArray,
+            },
+          ],
+          model: 'snowflake-arctic-embed-l-v2.0',
+          usage: { prompt_tokens: 1, total_tokens: 1 },
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+    });
+
+    const client = new OpenAI({
+      fetch,
+      apiKey: 'My API Key',
+      baseURL: 'http://localhost:11434',
+    });
+
+    const response = await client.embeddings.create({
+      input: 'test',
+      model: 'snowflake-arctic-embed-l-v2.0',
+    });
+
+    // Should preserve all 1024 dimensions, not truncate to 256
+    expect(Array.isArray(response.data?.[0]?.embedding)).toBe(true);
+    expect(response.data?.[0]?.embedding.length).toBe(1024);
+    expect(response.data?.[0]?.embedding[0]).toBe(0);
+    expect(response.data?.[0]?.embedding[1]).toBe(0.01);
+  });
 });
 
 function makeClient(): OpenAI {


### PR DESCRIPTION
## Changes being requested

- Fixed embedding dimension truncation when using OpenAI-compatible endpoints (ollama, LM Studio)
- Added type check in `src/resources/embeddings.ts` to detect when embeddings are already returned as float arrays
- Added regression test for endpoints that ignore the `encoding_format` parameter

## Additional context & links

Some OpenAI-compatible endpoints like ollama and LM Studio ignore the `encoding_format` parameter and always return embeddings as float arrays instead of base64-encoded strings. The SDK was attempting to decode these arrays as base64, which caused Buffer.from() to interpret the array as bytes rather than a base64 string. For a 1024-element float array, this created a 1024-byte buffer, which when divided by 4 (Float32Array.BYTES_PER_ELEMENT) resulted in exactly 256 dimensions.

The fix adds an Array.isArray() check before attempting base64 decoding. If the embedding is already an array, it's used directly. Otherwise, it's decoded from base64 as before. This preserves backward compatibility with the official OpenAI API while supporting endpoints that return float arrays.

Fixes #1542
