### PR TITLE
fix(helpers): preserve constrained object oneOf schemas

### DIFF
--- a/src/helpers/standard-schema.ts
+++ b/src/helpers/standard-schema.ts
@@ -387,17 +387,36 @@ function normalizeStructuredOutputSchema(schema: JSONSchema): JSONSchema {
           'Standard JSON Schema generated both `anyOf` and `oneOf`, which cannot be represented in an OpenAI strict schema',
         );
       }
-      // `false` can never validate, so it cannot overlap another oneOf
-      // branch. Keep it in place until the existing anyOf normalization runs
-      // so local refs into surviving branch indices can be rewritten before
-      // the impossible alternatives are removed.
-      const possibleBranches = record['oneOf'].filter((branch) => branch !== false);
-      if (!areOneOfBranchesMutuallyExclusive(possibleBranches, normalizedSchema)) {
-        throw new OpenAIError(
-          'Standard JSON Schema generated a `oneOf` whose branches are not provably mutually exclusive. OpenAI strict schemas do not support `oneOf`; use `anyOf` or add a discriminator with distinct literal values.',
+      const hasObjectShape =
+        record['type'] === 'object' ||
+        (Array.isArray(record['type']) && record['type'].includes('object')) ||
+        ['properties', 'required', 'additionalProperties', 'patternProperties', 'propertyNames'].some(
+          (keyword) => record[keyword] !== undefined,
         );
+      const hasOwnObjectConstraints = [
+        'properties',
+        'required',
+        'additionalProperties',
+        'patternProperties',
+        'propertyNames',
+        'minProperties',
+        'maxProperties',
+        'dependentRequired',
+        'dependentSchemas',
+      ].some((keyword) => record[keyword] !== undefined);
+      if (!hasObjectShape || !hasOwnObjectConstraints) {
+        // `false` can never validate, so it cannot overlap another oneOf
+        // branch. Keep it in place until the existing anyOf normalization runs
+        // so local refs into surviving branch indices can be rewritten before
+        // the impossible alternatives are removed.
+        const possibleBranches = record['oneOf'].filter((branch) => branch !== false);
+        if (!areOneOfBranchesMutuallyExclusive(possibleBranches, normalizedSchema)) {
+          throw new OpenAIError(
+            'Standard JSON Schema generated a `oneOf` whose branches are not provably mutually exclusive. OpenAI strict schemas do not support `oneOf`; use `anyOf` or add a discriminator with distinct literal values.',
+          );
+        }
+        oneOfSchemas.push(record);
       }
-      oneOfSchemas.push(record);
     }
 
     forEachJSONSchemaChild(record, [], (child) => visitSchema(child));

--- a/tests/helpers/standard-schema.test.ts
+++ b/tests/helpers/standard-schema.test.ts
@@ -193,6 +193,26 @@ describe('Standard Schema helpers', () => {
     expect(format.json_schema.schema).toEqual(strictWeatherJSONSchema);
   });
 
+  it('preserves oneOf when an object schema has its own constraints', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          required: ['name'],
+          additionalProperties: false,
+          oneOf: [{ type: 'string' }, { type: 'number' }],
+        },
+      },
+      required: ['value'],
+      additionalProperties: false,
+    };
+    const { standardSchema } = makeStandardSchema(schema);
+
+    expect(standardResponseFormat(standardSchema, 'value').json_schema.schema).toEqual(schema);
+  });
+
   it('normalizes provably exclusive oneOf branches before strictifying schemas', () => {
     const oneOfSchema = {
       type: 'object',


### PR DESCRIPTION
Fixes #2152.

The Standard Schema helper rewrites every provably exclusive `oneOf` into `anyOf`. For a schema node that already has its own object constraints, this changes the schema into a shape that the strictifier rejects, even though the original `oneOf` is accepted.

This change:
- preserves `oneOf` on object-shaped nodes with their own object constraints;
- continues normalizing standalone and redundant object-union wrappers;
- adds a regression test for a raw JSON Schema with `type: object`, object properties, and `oneOf`.

Validation:
- `git diff --check` passed.
- Node syntax checks passed for the changed TypeScript files.
- pnpm dependency installation and Vitest were blocked because the sandbox could not resolve registry.npmjs.org.