### PR TITLE
chore(lint): enable oxc/no-async-endpoint-handlers

### DIFF
--- a/examples/chat-completions/stream-to-client-express.ts
+++ b/examples/chat-completions/stream-to-client-express.ts
@@ -26,26 +26,24 @@ app.use(express.text());
 //   })
 //
 // See examples/chat-completions/stream-to-client-browser.ts for a more complete example.
-app.post('/', async (req: Request, res: Response) => {
-  try {
-    console.log('Received request:', req.body);
+const handleRequest = async (req: Request, res: Response) => {
+  console.log('Received request:', req.body);
 
-    const stream = openai.chat.completions.stream({
-      model: 'gpt-3.5-turbo',
-      stream: true,
-      messages: [{ role: 'user', content: req.body }],
-    });
+  const stream = openai.chat.completions.stream({
+    model: 'gpt-3.5-turbo',
+    stream: true,
+    messages: [{ role: 'user', content: req.body }],
+  });
 
-    res.header('Content-Type', 'text/plain');
-    for await (const chunk of stream.toReadableStream()) {
-      res.write(chunk);
-    }
-
-    res.end();
-  } catch (e) {
-    console.error(e);
+  res.header('Content-Type', 'text/plain');
+  for await (const chunk of stream.toReadableStream()) {
+    res.write(chunk);
   }
-});
+
+  res.end();
+};
+
+app.post('/', (req: Request, res: Response) => handleRequest(req, res).catch(console.error));
 
 app.listen('3000', () => {
   console.log('Started proxy express server');

--- a/examples/chat-completions/stream-to-client-raw.ts
+++ b/examples/chat-completions/stream-to-client-raw.ts
@@ -28,29 +28,27 @@ app.use(express.text());
 //     }
 //   })
 //
-app.post('/', async (req: Request, res: Response) => {
-  try {
-    console.log('Received request:', req.body);
+const handleRequest = async (req: Request, res: Response) => {
+  console.log('Received request:', req.body);
 
-    const stream = await openai.chat.completions.create({
-      model: 'gpt-3.5-turbo',
-      stream: true,
-      messages: [{ role: 'user', content: req.body }],
-    });
+  const stream = await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    stream: true,
+    messages: [{ role: 'user', content: req.body }],
+  });
 
-    res.header('Content-Type', 'text/plain');
+  res.header('Content-Type', 'text/plain');
 
-    // Sends each content stream chunk-by-chunk, such that the client
-    // ultimately receives a single string.
-    for await (const chunk of stream) {
-      res.write(chunk.choices[0]?.delta.content || '');
-    }
-
-    res.end();
-  } catch (e) {
-    console.error(e);
+  // Sends each content stream chunk-by-chunk, such that the client
+  // ultimately receives a single string.
+  for await (const chunk of stream) {
+    res.write(chunk.choices[0]?.delta.content || '');
   }
-});
+
+  res.end();
+};
+
+app.post('/', (req: Request, res: Response) => handleRequest(req, res).catch(console.error));
 
 app.listen('3000', () => {
   console.log('Started proxy express server');

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -49,7 +49,6 @@ const compatibilityRules = [
   'node/global-require',
   'object-shorthand',
   'oxc/no-accumulating-spread',
-  'oxc/no-async-endpoint-handlers',
   'oxc/no-barrel-file',
   'prefer-arrow-callback',
   'prefer-destructuring',


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `oxc/no-async-endpoint-handlers` compatibility exception from `oxlint.config.ts`.
- Move the two Express streaming examples behind non-async route callbacks that explicitly catch async worker rejections.
- Baseline count: 2 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 70; stacked on https://github.com/openai/openai-node/pull/2149.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2160 :point_left: this PR
https://github.com/openai/openai-node/pull/2161
https://github.com/openai/openai-node/pull/2162
https://github.com/openai/openai-node/pull/2163
https://github.com/openai/openai-node/pull/2164
https://github.com/openai/openai-node/pull/2165