### PR TITLE
chore(lint): enable no-void

### DIFF
--- a/ecosystem-tests/node-ts-cjs-auto/moduleResolution/node/type-tests.ts
+++ b/ecosystem-tests/node-ts-cjs-auto/moduleResolution/node/type-tests.ts
@@ -9,5 +9,5 @@ async function typeTests() {
       model: 'whisper-1',
     })
     .asResponse();
-  response.body;
+  return response.body;
 }

--- a/examples/chat-completions/stream-to-client-express.ts
+++ b/examples/chat-completions/stream-to-client-express.ts
@@ -26,26 +26,24 @@ app.use(express.text());
 //   })
 //
 // See examples/chat-completions/stream-to-client-browser.ts for a more complete example.
-app.post('/', async (req: Request, res: Response) => {
-  try {
-    console.log('Received request:', req.body);
+const handleRequest = async (req: Request, res: Response) => {
+  console.log('Received request:', req.body);
 
-    const stream = openai.chat.completions.stream({
-      model: 'gpt-3.5-turbo',
-      stream: true,
-      messages: [{ role: 'user', content: req.body }],
-    });
+  const stream = openai.chat.completions.stream({
+    model: 'gpt-3.5-turbo',
+    stream: true,
+    messages: [{ role: 'user', content: req.body }],
+  });
 
-    res.header('Content-Type', 'text/plain');
-    for await (const chunk of stream.toReadableStream()) {
-      res.write(chunk);
-    }
-
-    res.end();
-  } catch (e) {
-    console.error(e);
+  res.header('Content-Type', 'text/plain');
+  for await (const chunk of stream.toReadableStream()) {
+    res.write(chunk);
   }
-});
+
+  res.end();
+};
+
+app.post('/', (req: Request, res: Response) => handleRequest(req, res).catch(console.error));
 
 app.listen('3000', () => {
   console.log('Started proxy express server');

--- a/examples/chat-completions/stream-to-client-raw.ts
+++ b/examples/chat-completions/stream-to-client-raw.ts
@@ -28,29 +28,27 @@ app.use(express.text());
 //     }
 //   })
 //
-app.post('/', async (req: Request, res: Response) => {
-  try {
-    console.log('Received request:', req.body);
+const handleRequest = async (req: Request, res: Response) => {
+  console.log('Received request:', req.body);
 
-    const stream = await openai.chat.completions.create({
-      model: 'gpt-3.5-turbo',
-      stream: true,
-      messages: [{ role: 'user', content: req.body }],
-    });
+  const stream = await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    stream: true,
+    messages: [{ role: 'user', content: req.body }],
+  });
 
-    res.header('Content-Type', 'text/plain');
+  res.header('Content-Type', 'text/plain');
 
-    // Sends each content stream chunk-by-chunk, such that the client
-    // ultimately receives a single string.
-    for await (const chunk of stream) {
-      res.write(chunk.choices[0]?.delta.content || '');
-    }
-
-    res.end();
-  } catch (e) {
-    console.error(e);
+  // Sends each content stream chunk-by-chunk, such that the client
+  // ultimately receives a single string.
+  for await (const chunk of stream) {
+    res.write(chunk.choices[0]?.delta.content || '');
   }
-});
+
+  res.end();
+};
+
+app.post('/', (req: Request, res: Response) => handleRequest(req, res).catch(console.error));
 
 app.listen('3000', () => {
   console.log('Started proxy express server');

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -56,7 +56,6 @@ const compatibilityRules = [
   'prefer-object-has-own',
   'prefer-template',
   'promise/avoid-new',
-  'promise/no-multiple-resolved',
   'promise/param-names',
   'promise/prefer-await-to-callbacks',
   'promise/prefer-await-to-then',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -43,7 +43,6 @@ const compatibilityRules = [
   'no-useless-concat',
   'no-useless-return',
   'no-var',
-  'no-void',
   'no-warning-comments',
   'node/global-require',
   'object-shorthand',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -77,7 +77,6 @@ const compatibilityRules = [
   'typescript/no-invalid-void-type',
   'typescript/no-namespace',
   'typescript/no-non-null-assertion',
-  'typescript/no-unsafe-function-type',
   'typescript/no-wrapper-object-types',
   'typescript/parameter-properties',
   'typescript/prefer-for-of',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -49,7 +49,6 @@ const compatibilityRules = [
   'node/global-require',
   'object-shorthand',
   'oxc/no-accumulating-spread',
-  'oxc/no-async-endpoint-handlers',
   'oxc/no-barrel-file',
   'prefer-arrow-callback',
   'prefer-destructuring',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -38,7 +38,6 @@ const compatibilityRules = [
   'no-shadow',
   'no-sparse-arrays',
   'no-unsafe-optional-chaining',
-  'no-unused-expressions',
   'no-unused-vars',
   'no-use-before-define',
   'no-useless-concat',

--- a/src/helpers/audio.ts
+++ b/src/helpers/audio.ts
@@ -61,6 +61,7 @@ async function nodejsPlayAudio(stream: NodeJS.ReadableStream | Response | File):
       ffplay.on('close', (code: number) => {
         if (code !== 0) {
           reject(new Error(`ffplay process exited with code ${code}`));
+          return;
         }
         resolve();
       });

--- a/src/internal/qs/stringify.ts
+++ b/src/internal/qs/stringify.ts
@@ -82,7 +82,7 @@ function inner_stringify(
   let tmp_sc = sideChannel;
   let step = 0;
   let find_flag = false;
-  while ((tmp_sc = tmp_sc.get(sentinel)) !== void undefined && !find_flag) {
+  while ((tmp_sc = tmp_sc.get(sentinel)) !== undefined && !find_flag) {
     // Where object last appeared in the ref tree
     const pos = tmp_sc.get(object);
     step += 1;
@@ -151,7 +151,7 @@ function inner_stringify(
       // @ts-expect-error values only
       obj = maybe_map(obj, encoder);
     }
-    obj_keys = [{ value: obj.length > 0 ? obj.join(',') || null : void undefined }];
+    obj_keys = [{ value: obj.length > 0 ? obj.join(',') || null : undefined }];
   } else if (isArray(filter)) {
     obj_keys = filter;
   } else {

--- a/src/lib/ChatCompletionStream.ts
+++ b/src/lib/ChatCompletionStream.ts
@@ -445,7 +445,6 @@ export class ChatCompletionStream<ParsedT = null>
     params: ChatCompletionCreateParams,
     options?: RequestOptions,
   ): Promise<ParsedChatCompletion<ParsedT>> {
-    super._createChatCompletion;
     this._listenForAbort(options?.signal);
     this.#beginRequest();
 

--- a/src/lib/ResponsesParser.ts
+++ b/src/lib/ResponsesParser.ts
@@ -162,7 +162,7 @@ type ToolOptions = {
 
 export type AutoParseableResponseTool<
   OptionsT extends ToolOptions,
-  HasFunction = OptionsT['function'] extends Function ? true : false,
+  HasFunction = OptionsT['function'] extends (...args: never[]) => unknown ? true : false,
 > = FunctionTool & {
   __arguments: OptionsT['arguments']; // type-level only
   __name: OptionsT['name']; // type-level only

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -105,7 +105,7 @@ type ToolOptions = {
 
 export type AutoParseableTool<
   OptionsT extends ToolOptions,
-  HasFunction = OptionsT['function'] extends Function ? true : false,
+  HasFunction = OptionsT['function'] extends (...args: never[]) => unknown ? true : false,
 > = ChatCompletionFunctionTool & {
   __arguments: OptionsT['arguments']; // type-level only
   __name: OptionsT['name']; // type-level only

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -453,8 +453,7 @@ function _typeTests() {
           function: (_args, _runner, context) => {
             const eventId: string = context.eventId;
             // @ts-expect-error tool context only includes eventId
-            context.missing;
-            return eventId;
+            return context.missing ?? eventId;
           },
           parameters: {},
           description: 'updates an event',

--- a/tests/qs/stringify.test.ts
+++ b/tests/qs/stringify.test.ts
@@ -1418,7 +1418,7 @@ describe('stringify()', function () {
         expect(prefix).toBe('');
         expect(value).toBe(obj);
       } else if (prefix === 'c') {
-        return void 0;
+        return undefined;
       } else if (value instanceof Date) {
         // st.equal(prefix, 'e[f]');
         expect(prefix).toBe('e[f]');

--- a/tests/utils/mock-fetch.ts
+++ b/tests/utils/mock-fetch.ts
@@ -50,12 +50,12 @@ export function mockFetch(): { fetch: Fetch; handleRequest: (handle: Fetch) => P
     return new Promise<void>((resolve, reject) => {
       fetchQueue.shift()?.(async (req, init) => {
         try {
-          return await handle(req, init);
+          const response = await handle(req, init);
+          resolve();
+          return response;
         } catch (err) {
           reject(err);
           return err as any;
-        } finally {
-          resolve();
         }
       });
     });


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `no-void` compatibility exception from `oxlint.config.ts`.
- Replace the three disallowed value-producing `void` expressions with `undefined`.
- Leave statement-form `void` uses intact because Ultracite's preset explicitly allows them.
- Baseline count: 3 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 74; stacked on https://github.com/openai/openai-node/pull/2163.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2160
https://github.com/openai/openai-node/pull/2161
https://github.com/openai/openai-node/pull/2162
https://github.com/openai/openai-node/pull/2163
https://github.com/openai/openai-node/pull/2164 :point_left: this PR
https://github.com/openai/openai-node/pull/2165