### PR TITLE
chore(lint): enable unicorn/no-useless-switch-case

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -94,7 +94,6 @@ const compatibilityRules = [
   'unicorn/no-negated-condition',
   'unicorn/no-nested-ternary',
   'unicorn/no-typeof-undefined',
-  'unicorn/no-useless-switch-case',
   'unicorn/no-useless-undefined',
   'unicorn/numeric-separators-style',
   'unicorn/prefer-at',

--- a/src/_vendor/zod-to-json-schema/parsers/union.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/union.ts
@@ -65,9 +65,6 @@ export function parseUnionDef(
         case 'object':
           if (x._def.value === null) return [...acc, 'null' as const];
           return acc;
-        case 'symbol':
-        case 'undefined':
-        case 'function':
         default:
           return acc;
       }

--- a/src/internal/ws-adapter-browser.ts
+++ b/src/internal/ws-adapter-browser.ts
@@ -115,7 +115,6 @@ export class BrowserWebSocket implements WebSocketLike {
           listener(err);
         };
 
-      case 'open':
       default:
         return listener as DOMEventHandler;
     }


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/no-useless-switch-case` compatibility exception from `oxlint.config.ts`.
- Remove four redundant switch labels while retaining catch-all defaults.
- Baseline count: 4 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 78; stacked on https://github.com/openai/openai-node/pull/2167.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2166
https://github.com/openai/openai-node/pull/2167
https://github.com/openai/openai-node/pull/2168 :point_left: this PR
https://github.com/openai/openai-node/pull/2169
https://github.com/openai/openai-node/pull/2170
https://github.com/openai/openai-node/pull/2171
https://github.com/openai/openai-node/pull/2172
https://github.com/openai/openai-node/pull/2173
https://github.com/openai/openai-node/pull/2174
https://github.com/openai/openai-node/pull/2175
https://github.com/openai/openai-node/pull/2176
https://github.com/openai/openai-node/pull/2177
https://github.com/openai/openai-node/pull/2178
https://github.com/openai/openai-node/pull/2179
https://github.com/openai/openai-node/pull/2180
https://github.com/openai/openai-node/pull/2181
https://github.com/openai/openai-node/pull/2182
https://github.com/openai/openai-node/pull/2183
https://github.com/openai/openai-node/pull/2184
https://github.com/openai/openai-node/pull/2185