### PR TITLE
chore(lint): enable unicorn/prefer-query-selector

### DIFF
--- a/ecosystem-tests/browser-direct-import/public/index.js
+++ b/ecosystem-tests/browser-direct-import/public/index.js
@@ -13,7 +13,7 @@ async function runTests() {
   /** @type {TestResult[]} */
   const results = [];
   function displayResults() {
-    let pre = document.getElementById('results');
+    let pre = document.querySelector('#results');
     if (!pre) {
       pre = document.createElement('pre');
       pre.id = 'results';
@@ -39,7 +39,7 @@ async function runTests() {
     }
     displayResults();
   }
-  const runningEl = document.getElementById('running');
+  const runningEl = document.querySelector('#running');
   if (runningEl) runningEl.remove();
 }
 

--- a/ecosystem-tests/ts-browser-webpack/src/index.ts
+++ b/ecosystem-tests/ts-browser-webpack/src/index.ts
@@ -16,7 +16,7 @@ type TestResult = { path: string[]; passed: boolean; error?: string };
 async function runTests() {
   const results: TestResult[] = [];
   function displayResults() {
-    let pre = document.getElementById('results');
+    let pre = document.querySelector('#results');
     if (!pre) {
       pre = document.createElement('pre');
       pre.id = 'results';
@@ -42,7 +42,7 @@ async function runTests() {
     }
     displayResults();
   }
-  const runningEl = document.getElementById('running');
+  const runningEl = document.querySelector('#running');
   if (runningEl) runningEl.remove();
 }
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -103,7 +103,6 @@ const compatibilityRules = [
   'unicorn/prefer-node-protocol',
   'unicorn/prefer-number-properties',
   'unicorn/prefer-optional-catch-binding',
-  'unicorn/prefer-query-selector',
   'unicorn/prefer-response-static-json',
   'unicorn/prefer-spread',
   'unicorn/prefer-string-replace-all',


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/prefer-query-selector` compatibility exception from `oxlint.config.ts`.
- Use `querySelector()` for four fixed-ID ecosystem fixture lookups.
- Baseline count: 4 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 79; stacked on https://github.com/openai/openai-node/pull/2168.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2166
https://github.com/openai/openai-node/pull/2167
https://github.com/openai/openai-node/pull/2168
https://github.com/openai/openai-node/pull/2169 :point_left: this PR
https://github.com/openai/openai-node/pull/2170
https://github.com/openai/openai-node/pull/2171
https://github.com/openai/openai-node/pull/2172
https://github.com/openai/openai-node/pull/2173
https://github.com/openai/openai-node/pull/2174
https://github.com/openai/openai-node/pull/2175
https://github.com/openai/openai-node/pull/2176
https://github.com/openai/openai-node/pull/2177
https://github.com/openai/openai-node/pull/2178
https://github.com/openai/openai-node/pull/2179
https://github.com/openai/openai-node/pull/2180
https://github.com/openai/openai-node/pull/2181
https://github.com/openai/openai-node/pull/2182
https://github.com/openai/openai-node/pull/2183
https://github.com/openai/openai-node/pull/2184
https://github.com/openai/openai-node/pull/2185