### PR TITLE
chore(lint): enable unicorn/require-module-specifiers

### DIFF
--- a/ecosystem-tests/node-ts-cjs-web/types-test.ts
+++ b/ecosystem-tests/node-ts-cjs-web/types-test.ts
@@ -5,4 +5,5 @@ async function typeTests(client: OpenAI) {
   const url: string = response.url;
 }
 
+// oxlint-disable-next-line unicorn/require-module-specifiers -- keep this type-test file a module
 export {};

--- a/ecosystem-tests/node-ts-esm-web/types-test.ts
+++ b/ecosystem-tests/node-ts-esm-web/types-test.ts
@@ -5,4 +5,5 @@ async function typeTests(client: OpenAI) {
   const url: string = response.url;
 }
 
+// oxlint-disable-next-line unicorn/require-module-specifiers -- keep this type-test file a module
 export {};

--- a/ecosystem-tests/vercel-edge/tests/test.ts
+++ b/ecosystem-tests/vercel-edge/tests/test.ts
@@ -18,4 +18,5 @@ it(
 );
 
 // make isolatedModules happy
+// oxlint-disable-next-line unicorn/require-module-specifiers -- keep this test file a module
 export {};

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -109,7 +109,6 @@ const compatibilityRules = [
   'unicorn/prefer-string-slice',
   'unicorn/prefer-ternary',
   'unicorn/prefer-type-error',
-  'unicorn/require-module-specifiers',
   'unicorn/switch-case-braces',
   'unicorn/text-encoding-identifier-case',
   'vars-on-top',

--- a/tsconfig.dist-src.d.ts
+++ b/tsconfig.dist-src.d.ts
@@ -1,4 +1,5 @@
 // Keep published source navigation independent of consumers installing @types/node.
+// oxlint-disable-next-line unicorn/require-module-specifiers -- keep ambient globals scoped to a module
 export {};
 
 declare global {


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/require-module-specifiers` compatibility exception from `oxlint.config.ts`.
- Localize four intentional empty module-marker exports with explanations.
- Baseline count: 4 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 80; stacked on https://github.com/openai/openai-node/pull/2169.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2166
https://github.com/openai/openai-node/pull/2167
https://github.com/openai/openai-node/pull/2168
https://github.com/openai/openai-node/pull/2169
https://github.com/openai/openai-node/pull/2170 :point_left: this PR
https://github.com/openai/openai-node/pull/2171
https://github.com/openai/openai-node/pull/2172
https://github.com/openai/openai-node/pull/2173
https://github.com/openai/openai-node/pull/2174
https://github.com/openai/openai-node/pull/2175
https://github.com/openai/openai-node/pull/2176
https://github.com/openai/openai-node/pull/2177
https://github.com/openai/openai-node/pull/2178
https://github.com/openai/openai-node/pull/2179
https://github.com/openai/openai-node/pull/2180
https://github.com/openai/openai-node/pull/2181
https://github.com/openai/openai-node/pull/2182
https://github.com/openai/openai-node/pull/2183
https://github.com/openai/openai-node/pull/2184
https://github.com/openai/openai-node/pull/2185