### PR TITLE
chore(lint): enable no-useless-concat

### DIFF
--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -154,9 +154,7 @@ async function startProxy() {
   proxy.on('connect', (req, clientSocket, head) => {
     console.log('got proxied connection');
     const serverSocket = connect(443, 'api.openai.com', () => {
-      clientSocket.write(
-        'HTTP/1.1 200 Connection Established\r\n' + 'Proxy-agent: Node.js-Proxy\r\n' + '\r\n',
-      );
+      clientSocket.write('HTTP/1.1 200 Connection Established\r\nProxy-agent: Node.js-Proxy\r\n\r\n');
       serverSocket.write(head);
       serverSocket.pipe(clientSocket);
       clientSocket.pipe(serverSocket);

--- a/ecosystem-tests/proxy.ts
+++ b/ecosystem-tests/proxy.ts
@@ -8,9 +8,7 @@ async function startProxy() {
 
   proxy.on('connect', (req, clientSocket, head) => {
     const serverSocket = connect(443, 'api.openai.com', () => {
-      clientSocket.write(
-        'HTTP/1.1 200 Connection Established\r\n' + 'Proxy-agent: Node.js-Proxy\r\n' + '\r\n',
-      );
+      clientSocket.write('HTTP/1.1 200 Connection Established\r\nProxy-agent: Node.js-Proxy\r\n\r\n');
       serverSocket.write(head);
       serverSocket.pipe(clientSocket);
       clientSocket.pipe(serverSocket);

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -40,7 +40,6 @@ const compatibilityRules = [
   'no-unsafe-optional-chaining',
   'no-unused-vars',
   'no-use-before-define',
-  'no-useless-concat',
   'no-useless-return',
   'no-var',
   'no-warning-comments',

--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -267,7 +267,7 @@ async function* iterateMultipartBody(body: unknown, boundary: string): AsyncGene
       yield encodeUTF8(
         `Content-Disposition: form-data; name="${escapeHeaderValue(key)}"; filename="${escapeHeaderValue(
           filename,
-        )}"\r\n` + `Content-Type: ${type}\r\n\r\n`,
+        )}"\r\nContent-Type: ${type}\r\n\r\n`,
       );
       yield* iterateBytes(getStreamingFileData(value));
     } else {


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `no-useless-concat` compatibility exception from `oxlint.config.ts`.
- Collapse adjacent literal concatenations without changing emitted bytes.
- Baseline count: 5 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 81; stacked on https://github.com/openai/openai-node/pull/2170.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2166
https://github.com/openai/openai-node/pull/2167
https://github.com/openai/openai-node/pull/2168
https://github.com/openai/openai-node/pull/2169
https://github.com/openai/openai-node/pull/2170
https://github.com/openai/openai-node/pull/2171 :point_left: this PR
https://github.com/openai/openai-node/pull/2172
https://github.com/openai/openai-node/pull/2173
https://github.com/openai/openai-node/pull/2174
https://github.com/openai/openai-node/pull/2175
https://github.com/openai/openai-node/pull/2176
https://github.com/openai/openai-node/pull/2177
https://github.com/openai/openai-node/pull/2178
https://github.com/openai/openai-node/pull/2179
https://github.com/openai/openai-node/pull/2180
https://github.com/openai/openai-node/pull/2181
https://github.com/openai/openai-node/pull/2182
https://github.com/openai/openai-node/pull/2183
https://github.com/openai/openai-node/pull/2184
https://github.com/openai/openai-node/pull/2185