### PR TITLE
chore(lint): enable unicorn/no-lonely-if

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -89,7 +89,6 @@ const compatibilityRules = [
   'unicorn/no-array-sort',
   'unicorn/no-await-expression-member',
   'unicorn/no-console-spaces',
-  'unicorn/no-lonely-if',
   'unicorn/no-negated-condition',
   'unicorn/no-nested-ternary',
   'unicorn/no-typeof-undefined',

--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -525,11 +525,9 @@ export class AssistantStream
       case 'thread.run.step.expired':
         this.#currentRunStepSnapshot = undefined;
         const details = event.data.step_details;
-        if (details.type == 'tool_calls') {
-          if (this.#currentToolCall) {
-            this._emit('toolCallDone', this.#currentToolCall as ToolCall);
-            this.#currentToolCall = undefined;
-          }
+        if (details.type == 'tool_calls' && this.#currentToolCall) {
+          this._emit('toolCallDone', this.#currentToolCall as ToolCall);
+          this.#currentToolCall = undefined;
         }
         this._emit('runStepDone', event.data, accumulatedRunStep);
         break;

--- a/src/lib/transform.ts
+++ b/src/lib/transform.ts
@@ -593,25 +593,25 @@ function isNullable(schema: JSONSchemaDefinition, root: JSONSchema, seenRefs = n
     return false;
   }
 
-  if (schema.allOf !== undefined) {
-    if (!Array.isArray(schema.allOf) || !schema.allOf.every((variant) => isNullable(variant, root))) {
-      return false;
-    }
+  if (
+    schema.allOf !== undefined &&
+    (!Array.isArray(schema.allOf) || !schema.allOf.every((variant) => isNullable(variant, root)))
+  ) {
+    return false;
   }
 
-  if (schema.anyOf !== undefined) {
-    if (!Array.isArray(schema.anyOf) || !schema.anyOf.some((variant) => isNullable(variant, root))) {
-      return false;
-    }
+  if (
+    schema.anyOf !== undefined &&
+    (!Array.isArray(schema.anyOf) || !schema.anyOf.some((variant) => isNullable(variant, root)))
+  ) {
+    return false;
   }
 
-  if (schema.oneOf !== undefined) {
-    if (
-      !Array.isArray(schema.oneOf) ||
-      schema.oneOf.filter((variant) => isNullable(variant, root)).length !== 1
-    ) {
-      return false;
-    }
+  if (
+    schema.oneOf !== undefined &&
+    (!Array.isArray(schema.oneOf) || schema.oneOf.filter((variant) => isNullable(variant, root)).length !== 1)
+  ) {
+    return false;
   }
 
   // Conditional and negated schemas need a full JSON Schema evaluator to prove
@@ -739,27 +739,25 @@ function ensureStrictJsonSchema(
 
   // Handle intersections (allOf)
   const allOf = jsonSchema.allOf;
-  if (Array.isArray(allOf)) {
-    if (allOf.length === 1 && hasOnlyAnnotationSiblings(jsonSchema, 'allOf')) {
-      const branch = allOf[0]!;
-      if (branch === false) {
-        throw new Error(
-          `Schema at \`${
-            path.join('/') || '<root>'
-          }\` uses \`allOf: [false]\`, which cannot be represented in strict Structured Outputs.`,
-        );
-      }
-      if (branch === true) {
-        // true is the neutral schema for an intersection, so removing this
-        // branch preserves validation while retaining the parent annotations.
-        delete jsonSchema.allOf;
-      } else {
-        const resolved = ensureStrictJsonSchema(branch, [...path, 'allOf', '0'], root);
-        const annotations = { ...jsonSchema };
-        delete annotations.allOf;
-        Object.assign(jsonSchema, resolved, annotations);
-        delete jsonSchema.allOf;
-      }
+  if (Array.isArray(allOf) && allOf.length === 1 && hasOnlyAnnotationSiblings(jsonSchema, 'allOf')) {
+    const branch = allOf[0]!;
+    if (branch === false) {
+      throw new Error(
+        `Schema at \`${
+          path.join('/') || '<root>'
+        }\` uses \`allOf: [false]\`, which cannot be represented in strict Structured Outputs.`,
+      );
+    }
+    if (branch === true) {
+      // true is the neutral schema for an intersection, so removing this
+      // branch preserves validation while retaining the parent annotations.
+      delete jsonSchema.allOf;
+    } else {
+      const resolved = ensureStrictJsonSchema(branch, [...path, 'allOf', '0'], root);
+      const annotations = { ...jsonSchema };
+      delete annotations.allOf;
+      Object.assign(jsonSchema, resolved, annotations);
+      delete jsonSchema.allOf;
     }
   }
 


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/no-lonely-if` compatibility exception from `oxlint.config.ts`.
- Combine five nested predicates while preserving short-circuit behavior.
- Baseline count: 5 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 82; stacked on https://github.com/openai/openai-node/pull/2171.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2166
https://github.com/openai/openai-node/pull/2167
https://github.com/openai/openai-node/pull/2168
https://github.com/openai/openai-node/pull/2169
https://github.com/openai/openai-node/pull/2170
https://github.com/openai/openai-node/pull/2171
https://github.com/openai/openai-node/pull/2172 :point_left: this PR
https://github.com/openai/openai-node/pull/2173
https://github.com/openai/openai-node/pull/2174
https://github.com/openai/openai-node/pull/2175
https://github.com/openai/openai-node/pull/2176
https://github.com/openai/openai-node/pull/2177
https://github.com/openai/openai-node/pull/2178
https://github.com/openai/openai-node/pull/2179
https://github.com/openai/openai-node/pull/2180
https://github.com/openai/openai-node/pull/2181
https://github.com/openai/openai-node/pull/2182
https://github.com/openai/openai-node/pull/2183
https://github.com/openai/openai-node/pull/2184
https://github.com/openai/openai-node/pull/2185