### PR TITLE
chore(lint): enable unicorn/prefer-code-point

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -95,7 +95,6 @@ const compatibilityRules = [
   'unicorn/no-useless-undefined',
   'unicorn/numeric-separators-style',
   'unicorn/prefer-at',
-  'unicorn/prefer-code-point',
   'unicorn/prefer-event-target',
   'unicorn/prefer-module',
   'unicorn/prefer-node-protocol',

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -181,6 +181,7 @@ const encodeDefinitionPathPart = (part: string) => {
 
   let encoded = encodedDefinitionPathPartPrefix;
   for (let i = 0; i < part.length; i++) {
+    // oxlint-disable-next-line unicorn/prefer-code-point -- preserve UTF-16 code-unit encoding
     encoded += part.charCodeAt(i).toString(16).padStart(4, '0');
   }
   return encoded;

--- a/src/internal/qs/utils.ts
+++ b/src/internal/qs/utils.ts
@@ -169,6 +169,7 @@ export const encode: (
     const arr = [];
 
     for (let i = 0; i < segment.length; ++i) {
+      // oxlint-disable-next-line unicorn/prefer-code-point -- combine UTF-16 surrogate code units below
       let c = segment.charCodeAt(i);
       if (
         c === 0x2d || // -
@@ -201,6 +202,7 @@ export const encode: (
       }
 
       i += 1;
+      // oxlint-disable-next-line unicorn/prefer-code-point -- combine UTF-16 surrogate code units manually
       c = 0x10000 + (((c & 0x3ff) << 10) | (segment.charCodeAt(i) & 0x3ff));
 
       arr[arr.length] =

--- a/tests/path.test.ts
+++ b/tests/path.test.ts
@@ -439,7 +439,7 @@ describe('encodeURIPath', () => {
   const testCases: string[] = [
     '',
     // Every ASCII character
-    ...Array.from({ length: 0x7f }, (_, i) => String.fromCharCode(i)),
+    ...Array.from({ length: 0x7f }, (_, i) => String.fromCodePoint(i)),
     // Unicode BMP codepoint
     'å',
     // Unicode supplementary codepoint

--- a/tests/qs/stringify.test.ts
+++ b/tests/qs/stringify.test.ts
@@ -1614,7 +1614,7 @@ describe('stringify()', function () {
               if (typeof buffer === 'string') {
                 return buffer;
               }
-              return String.fromCharCode(buffer.readUInt8(0) + 97);
+              return String.fromCodePoint(buffer.readUInt8(0) + 97);
             },
           },
         ),


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/prefer-code-point` compatibility exception from `oxlint.config.ts`.
- Use code-point APIs where safe and document three intentional UTF-16 code-unit sites.
- Baseline count: 5 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 83; stacked on https://github.com/openai/openai-node/pull/2172.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2166
https://github.com/openai/openai-node/pull/2167
https://github.com/openai/openai-node/pull/2168
https://github.com/openai/openai-node/pull/2169
https://github.com/openai/openai-node/pull/2170
https://github.com/openai/openai-node/pull/2171
https://github.com/openai/openai-node/pull/2172
https://github.com/openai/openai-node/pull/2173 :point_left: this PR
https://github.com/openai/openai-node/pull/2174
https://github.com/openai/openai-node/pull/2175
https://github.com/openai/openai-node/pull/2176
https://github.com/openai/openai-node/pull/2177
https://github.com/openai/openai-node/pull/2178
https://github.com/openai/openai-node/pull/2179
https://github.com/openai/openai-node/pull/2180
https://github.com/openai/openai-node/pull/2181
https://github.com/openai/openai-node/pull/2182
https://github.com/openai/openai-node/pull/2183
https://github.com/openai/openai-node/pull/2184
https://github.com/openai/openai-node/pull/2185