### PR TITLE
chore(lint): enable import/newline-after-import

### DIFF
--- a/ecosystem-tests/node-ts-esm/iitm.js
+++ b/ecosystem-tests/node-ts-esm/iitm.js
@@ -1,2 +1,3 @@
 import {register} from 'node:module'
+
 register('import-in-the-middle/hook.mjs', import.meta.url)

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -1,4 +1,5 @@
 const requireConfig = require('node:module').createRequire(__filename);
+
 const { defineConfig } = requireConfig('oxfmt');
 const ultracite = requireConfig('ultracite/oxfmt').default;
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -1,4 +1,5 @@
 const requireConfig = require('node:module').createRequire(__filename);
+
 const { defineConfig } = requireConfig('oxlint');
 const core = requireConfig('ultracite/oxlint/core').default;
 const stainlessGeneratedFiles = requireConfig('./scripts/stainless-generated-files.cjs');
@@ -16,7 +17,6 @@ const compatibilityRules = [
   'func-style',
   'import/consistent-type-specifier-style',
   'import/first',
-  'import/newline-after-import',
   'import/no-cycle',
   'jsdoc/no-defaults',
   'jsdoc/require-param-description',

--- a/scripts/lint-generated.cjs
+++ b/scripts/lint-generated.cjs
@@ -5,6 +5,7 @@ const path = require('node:path');
 
 const repositoryRoot = path.resolve(__dirname, '..');
 const generatedFiles = require('./stainless-generated-files.cjs');
+
 const oxlint = path.join(repositoryRoot, 'node_modules', 'oxlint', 'bin', 'oxlint');
 const generatedConfig = path.join(repositoryRoot, 'oxlint.generated.config.json');
 const maximumFixPasses = 10;

--- a/scripts/utils/attw-report.cjs
+++ b/scripts/utils/attw-report.cjs
@@ -1,4 +1,5 @@
 const fs = require('fs');
+
 const problems = Object.values(JSON.parse(fs.readFileSync('.attw.json', 'utf-8')).problems)
   .flat()
   .filter(

--- a/src/_vendor/zod-to-json-schema/index.ts
+++ b/src/_vendor/zod-to-json-schema/index.ts
@@ -34,4 +34,5 @@ export * from './parsers/union';
 export * from './parsers/unknown';
 export * from './zodToJsonSchema';
 import { zodToJsonSchema } from './zodToJsonSchema';
+
 export default zodToJsonSchema;


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `import/newline-after-import` compatibility exception from `oxlint.config.ts`.
- Add the six required import-boundary blank lines.
- Baseline count: 6 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 84; stacked on https://github.com/openai/openai-node/pull/2173.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2166
https://github.com/openai/openai-node/pull/2167
https://github.com/openai/openai-node/pull/2168
https://github.com/openai/openai-node/pull/2169
https://github.com/openai/openai-node/pull/2170
https://github.com/openai/openai-node/pull/2171
https://github.com/openai/openai-node/pull/2172
https://github.com/openai/openai-node/pull/2173
https://github.com/openai/openai-node/pull/2174 :point_left: this PR
https://github.com/openai/openai-node/pull/2175
https://github.com/openai/openai-node/pull/2176
https://github.com/openai/openai-node/pull/2177
https://github.com/openai/openai-node/pull/2178
https://github.com/openai/openai-node/pull/2179
https://github.com/openai/openai-node/pull/2180
https://github.com/openai/openai-node/pull/2181
https://github.com/openai/openai-node/pull/2182
https://github.com/openai/openai-node/pull/2183
https://github.com/openai/openai-node/pull/2184
https://github.com/openai/openai-node/pull/2185