### PR TITLE
chore(lint): enable logical-assignment-operators

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -20,7 +20,6 @@ const compatibilityRules = [
   'import/no-cycle',
   'jsdoc/no-defaults',
   'jsdoc/require-param-description',
-  'logical-assignment-operators',
   'max-classes-per-file',
   'no-await-in-loop',
   'no-bitwise',

--- a/src/core/EventEmitter.ts
+++ b/src/core/EventEmitter.ts
@@ -22,8 +22,7 @@ export class EventEmitter<EventTypes extends Record<string, (...args: any) => an
    * @returns this, so that calls can be chained
    */
   on<Event extends keyof EventTypes>(event: Event, listener: EventListener<EventTypes, Event>): this {
-    const listeners: EventListeners<EventTypes, Event> =
-      this.#listeners[event] || (this.#listeners[event] = []);
+    const listeners: EventListeners<EventTypes, Event> = (this.#listeners[event] ||= []);
     listeners.push({ listener });
     return this;
   }
@@ -49,8 +48,7 @@ export class EventEmitter<EventTypes extends Record<string, (...args: any) => an
    * @returns this, so that calls can be chained
    */
   once<Event extends keyof EventTypes>(event: Event, listener: EventListener<EventTypes, Event>): this {
-    const listeners: EventListeners<EventTypes, Event> =
-      this.#listeners[event] || (this.#listeners[event] = []);
+    const listeners: EventListeners<EventTypes, Event> = (this.#listeners[event] ||= []);
     listeners.push({ listener, once: true });
     return this;
   }

--- a/src/lib/EventEmitter.ts
+++ b/src/lib/EventEmitter.ts
@@ -22,8 +22,7 @@ export class EventEmitter<EventTypes extends Record<string, (...args: any) => an
    * @returns this, so that calls can be chained
    */
   on<Event extends keyof EventTypes>(event: Event, listener: EventListener<EventTypes, Event>): this {
-    const listeners: EventListeners<EventTypes, Event> =
-      this.#listeners[event] || (this.#listeners[event] = []);
+    const listeners: EventListeners<EventTypes, Event> = (this.#listeners[event] ||= []);
     listeners.push({ listener });
     return this;
   }
@@ -49,8 +48,7 @@ export class EventEmitter<EventTypes extends Record<string, (...args: any) => an
    * @returns this, so that calls can be chained
    */
   once<Event extends keyof EventTypes>(event: Event, listener: EventListener<EventTypes, Event>): this {
-    const listeners: EventListeners<EventTypes, Event> =
-      this.#listeners[event] || (this.#listeners[event] = []);
+    const listeners: EventListeners<EventTypes, Event> = (this.#listeners[event] ||= []);
     listeners.push({ listener, once: true });
     return this;
   }

--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -114,8 +114,7 @@ export class EventStream<EventTypes extends BaseEvents> {
    * @returns this ChatCompletionStream, so that calls can be chained
    */
   on<Event extends keyof EventTypes>(event: Event, listener: EventListener<EventTypes, Event>): this {
-    const listeners: EventListeners<EventTypes, Event> =
-      this.#listeners[event] || (this.#listeners[event] = []);
+    const listeners: EventListeners<EventTypes, Event> = (this.#listeners[event] ||= []);
     listeners.push({ listener });
     return this;
   }
@@ -141,8 +140,7 @@ export class EventStream<EventTypes extends BaseEvents> {
    * @returns this ChatCompletionStream, so that calls can be chained
    */
   once<Event extends keyof EventTypes>(event: Event, listener: EventListener<EventTypes, Event>): this {
-    const listeners: EventListeners<EventTypes, Event> =
-      this.#listeners[event] || (this.#listeners[event] = []);
+    const listeners: EventListeners<EventTypes, Event> = (this.#listeners[event] ||= []);
     listeners.push({ listener, once: true });
     return this;
   }


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `logical-assignment-operators` compatibility exception from `oxlint.config.ts`.
- Use `||=` for six listener-array initializations while preserving falsy semantics.
- Baseline count: 6 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 85; stacked on https://github.com/openai/openai-node/pull/2174.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2166
https://github.com/openai/openai-node/pull/2167
https://github.com/openai/openai-node/pull/2168
https://github.com/openai/openai-node/pull/2169
https://github.com/openai/openai-node/pull/2170
https://github.com/openai/openai-node/pull/2171
https://github.com/openai/openai-node/pull/2172
https://github.com/openai/openai-node/pull/2173
https://github.com/openai/openai-node/pull/2174
https://github.com/openai/openai-node/pull/2175 :point_left: this PR
https://github.com/openai/openai-node/pull/2176
https://github.com/openai/openai-node/pull/2177
https://github.com/openai/openai-node/pull/2178
https://github.com/openai/openai-node/pull/2179
https://github.com/openai/openai-node/pull/2180
https://github.com/openai/openai-node/pull/2181
https://github.com/openai/openai-node/pull/2182
https://github.com/openai/openai-node/pull/2183
https://github.com/openai/openai-node/pull/2184
https://github.com/openai/openai-node/pull/2185