### PR TITLE
chore(lint): enable no-case-declarations

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -23,7 +23,6 @@ const compatibilityRules = [
   'max-classes-per-file',
   'no-await-in-loop',
   'no-bitwise',
-  'no-case-declarations',
   'no-else-return',
   'no-empty-function',
   'no-eq-null',

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -138,7 +138,7 @@ const get$ref = (
     // e.g. if we need to reference a schema at
     // `["#","definitions","contactPerson","properties","person1","properties","name"]`
     // then we'll extract it out to `contactPerson_properties_person1_properties_name`
-    case 'extract-to-root':
+    case 'extract-to-root': {
       const name = item.path
         .slice(refs.basePath.length + 1)
         // The first part is either the root schema name or an extracted definition
@@ -154,6 +154,7 @@ const get$ref = (
       }
 
       return { $ref: [...refs.basePath, refs.definitionPath, name].join('/') };
+    }
     case 'relative':
       return { $ref: getRelativePath(refs.currentPath, item.path) };
     case 'none':

--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -490,7 +490,7 @@ export class AssistantStream
       case 'thread.run.step.created':
         this._emit('runStepCreated', event.data);
         break;
-      case 'thread.run.step.delta':
+      case 'thread.run.step.delta': {
         const delta = event.data.delta;
         if (
           delta.step_details &&
@@ -519,10 +519,11 @@ export class AssistantStream
 
         this._emit('runStepDelta', event.data.delta, accumulatedRunStep);
         break;
+      }
       case 'thread.run.step.completed':
       case 'thread.run.step.failed':
       case 'thread.run.step.cancelled':
-      case 'thread.run.step.expired':
+      case 'thread.run.step.expired': {
         this.#currentRunStepSnapshot = undefined;
         const details = event.data.step_details;
         if (details.type == 'tool_calls' && this.#currentToolCall) {
@@ -531,6 +532,7 @@ export class AssistantStream
         }
         this._emit('runStepDone', event.data, accumulatedRunStep);
         break;
+      }
       case 'thread.run.step.in_progress':
         break;
     }
@@ -547,7 +549,7 @@ export class AssistantStream
         this.#runStepSnapshots[event.data.id] = event.data;
         return event.data;
 
-      case 'thread.run.step.delta':
+      case 'thread.run.step.delta': {
         const snapshot = this.#runStepSnapshots[event.data.id] as Runs.RunStep;
         if (!snapshot) {
           throw new Error('Received a RunStepDelta before creation of a snapshot');
@@ -561,6 +563,7 @@ export class AssistantStream
         }
 
         return this.#runStepSnapshots[event.data.id] as Runs.RunStep;
+      }
 
       case 'thread.run.step.completed':
       case 'thread.run.step.failed':
@@ -586,7 +589,7 @@ export class AssistantStream
         //On creation the snapshot is just the initial message
         return [event.data, newContent];
 
-      case 'thread.message.delta':
+      case 'thread.message.delta': {
         if (!snapshot) {
           throw new Error(
             'Received a delta with no existing snapshot (there should be one from message creation)',
@@ -613,6 +616,7 @@ export class AssistantStream
         }
 
         return [snapshot, newContent];
+      }
 
       case 'thread.message.in_progress':
       case 'thread.message.completed':


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `no-case-declarations` compatibility exception from `oxlint.config.ts`.
- Brace five switch case bodies that contain lexical declarations.
- Baseline count: 6 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 86; stacked on https://github.com/openai/openai-node/pull/2175.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2166
https://github.com/openai/openai-node/pull/2167
https://github.com/openai/openai-node/pull/2168
https://github.com/openai/openai-node/pull/2169
https://github.com/openai/openai-node/pull/2170
https://github.com/openai/openai-node/pull/2171
https://github.com/openai/openai-node/pull/2172
https://github.com/openai/openai-node/pull/2173
https://github.com/openai/openai-node/pull/2174
https://github.com/openai/openai-node/pull/2175
https://github.com/openai/openai-node/pull/2176 :point_left: this PR
https://github.com/openai/openai-node/pull/2177
https://github.com/openai/openai-node/pull/2178
https://github.com/openai/openai-node/pull/2179
https://github.com/openai/openai-node/pull/2180
https://github.com/openai/openai-node/pull/2181
https://github.com/openai/openai-node/pull/2182
https://github.com/openai/openai-node/pull/2183
https://github.com/openai/openai-node/pull/2184
https://github.com/openai/openai-node/pull/2185