### PR TITLE
chore(lint): enable no-useless-return

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -38,7 +38,6 @@ const compatibilityRules = [
   'no-unsafe-optional-chaining',
   'no-unused-vars',
   'no-use-before-define',
-  'no-useless-return',
   'no-var',
   'no-warning-comments',
   'node/global-require',

--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -214,7 +214,7 @@ export class AbstractChatCompletionRunner<
       }
     }
 
-    return;
+    return undefined;
   }
 
   /**
@@ -243,7 +243,7 @@ export class AbstractChatCompletionRunner<
       }
     }
 
-    return;
+    return undefined;
   }
 
   async finalFunctionToolCallResult(): Promise<string | undefined> {
@@ -498,8 +498,6 @@ export class AbstractChatCompletionRunner<
 
       await afterCompletion?.(chatCompletion, runner);
     }
-
-    return;
   }
 
   #stringifyFunctionCallResult(rawContent: unknown): string {

--- a/src/lib/ChatCompletionStream.ts
+++ b/src/lib/ChatCompletionStream.ts
@@ -1009,7 +1009,7 @@ type AssertIsEmpty<T extends {}> = keyof T extends never ? T : never;
  * destructured.
  */
 function assertIsEmpty<T extends {}>(obj: AssertIsEmpty<T>): asserts obj is AssertIsEmpty<T> {
-  return;
+  void obj;
 }
 
 function assertNever(_x: never) {}

--- a/tests/utils/typing.ts
+++ b/tests/utils/typing.ts
@@ -1,9 +1,9 @@
 type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
 
 export const expectType = <T>(_expression: T): void => {
-  return;
+  void _expression;
 };
 
 export const compareType = <T1, T2>(_expression: Equal<T1, T2>): void => {
-  return;
+  void _expression;
 };


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `no-useless-return` compatibility exception from `oxlint.config.ts`.
- Remove or make explicit six redundant bare returns without weakening typecheck control flow.
- Baseline count: 6 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 87; stacked on https://github.com/openai/openai-node/pull/2176.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2166
https://github.com/openai/openai-node/pull/2167
https://github.com/openai/openai-node/pull/2168
https://github.com/openai/openai-node/pull/2169
https://github.com/openai/openai-node/pull/2170
https://github.com/openai/openai-node/pull/2171
https://github.com/openai/openai-node/pull/2172
https://github.com/openai/openai-node/pull/2173
https://github.com/openai/openai-node/pull/2174
https://github.com/openai/openai-node/pull/2175
https://github.com/openai/openai-node/pull/2176
https://github.com/openai/openai-node/pull/2177 :point_left: this PR
https://github.com/openai/openai-node/pull/2178
https://github.com/openai/openai-node/pull/2179
https://github.com/openai/openai-node/pull/2180
https://github.com/openai/openai-node/pull/2181
https://github.com/openai/openai-node/pull/2182
https://github.com/openai/openai-node/pull/2183
https://github.com/openai/openai-node/pull/2184
https://github.com/openai/openai-node/pull/2185