### PR TITLE
chore(lint): enable typescript/no-wrapper-object-types

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -69,7 +69,6 @@ const compatibilityRules = [
   'typescript/no-inferrable-types',
   'typescript/no-namespace',
   'typescript/no-non-null-assertion',
-  'typescript/no-wrapper-object-types',
   'typescript/parameter-properties',
   'typescript/prefer-for-of',
   'typescript/prefer-ts-expect-error',

--- a/src/_vendor/zod-to-json-schema/parsers/bigint.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/bigint.ts
@@ -5,11 +5,11 @@ import { ErrorMessages, setResponseValueAndErrors } from '../errorMessages';
 export type JsonSchema7BigintType = {
   type: 'integer';
   format: 'int64';
-  minimum?: BigInt;
-  exclusiveMinimum?: BigInt;
-  maximum?: BigInt;
-  exclusiveMaximum?: BigInt;
-  multipleOf?: BigInt;
+  minimum?: bigint;
+  exclusiveMinimum?: bigint;
+  maximum?: bigint;
+  exclusiveMaximum?: bigint;
+  multipleOf?: bigint;
   errorMessage?: ErrorMessages<JsonSchema7BigintType>;
 };
 

--- a/src/_vendor/zod-to-json-schema/util.ts
+++ b/src/_vendor/zod-to-json-schema/util.ts
@@ -4,7 +4,7 @@ export const zodDef = (zodSchema: ZodSchema | ZodTypeDef): ZodTypeDef => {
   return '_def' in zodSchema ? zodSchema._def : zodSchema;
 };
 
-export function isEmptyObj(obj: Object | null | undefined): boolean {
+export function isEmptyObj(obj: object | null | undefined): boolean {
   if (!obj) return true;
   // oxlint-disable-next-line guard-for-in -- inherited enumerable properties make the object non-empty
   for (const _k in obj) return false;


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `typescript/no-wrapper-object-types` compatibility exception from `oxlint.config.ts`.
- Replace wrapper object types with primitive `object` and `bigint` types.
- Baseline count: 6 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 88; stacked on https://github.com/openai/openai-node/pull/2177.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2166
https://github.com/openai/openai-node/pull/2167
https://github.com/openai/openai-node/pull/2168
https://github.com/openai/openai-node/pull/2169
https://github.com/openai/openai-node/pull/2170
https://github.com/openai/openai-node/pull/2171
https://github.com/openai/openai-node/pull/2172
https://github.com/openai/openai-node/pull/2173
https://github.com/openai/openai-node/pull/2174
https://github.com/openai/openai-node/pull/2175
https://github.com/openai/openai-node/pull/2176
https://github.com/openai/openai-node/pull/2177
https://github.com/openai/openai-node/pull/2178 :point_left: this PR
https://github.com/openai/openai-node/pull/2179
https://github.com/openai/openai-node/pull/2180
https://github.com/openai/openai-node/pull/2181
https://github.com/openai/openai-node/pull/2182
https://github.com/openai/openai-node/pull/2183
https://github.com/openai/openai-node/pull/2184
https://github.com/openai/openai-node/pull/2185