### PR TITLE
chore(lint): enable unicorn/custom-error-definition

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -75,7 +75,6 @@ const compatibilityRules = [
   'unicorn/catch-error-name',
   'unicorn/consistent-assert',
   'unicorn/consistent-function-scoping',
-  'unicorn/custom-error-definition',
   'unicorn/filename-case',
   'unicorn/import-style',
   'unicorn/new-for-builtins',

--- a/src/_vendor/partial-json-parser/parser.ts
+++ b/src/_vendor/partial-json-parser/parser.ts
@@ -32,8 +32,10 @@ const Allow = {
 };
 
 // The JSON string segment was unable to be parsed completely
+// oxlint-disable-next-line unicorn/custom-error-definition -- preserve the vendored exported class name
 class PartialJSON extends Error {}
 
+// oxlint-disable-next-line unicorn/custom-error-definition -- preserve the vendored exported class name
 class MalformedJSON extends Error {}
 
 /**

--- a/src/beta/realtime/internal-base.ts
+++ b/src/beta/realtime/internal-base.ts
@@ -4,6 +4,8 @@ import { OpenAIError } from '../../error';
 import OpenAI, { AzureOpenAI } from '../../index';
 
 export class OpenAIRealtimeError extends OpenAIError {
+  override name = 'OpenAIRealtimeError';
+
   /**
    * The error data that the API sent back in an `error` event.
    */

--- a/src/realtime/internal-base.ts
+++ b/src/realtime/internal-base.ts
@@ -9,6 +9,8 @@ import { OpenAIError } from '../error';
 import OpenAI, { AzureOpenAI } from '../index';
 
 export class OpenAIRealtimeError extends OpenAIError {
+  override name = 'OpenAIRealtimeError';
+
   /**
    * The error data that the API sent back in an `error` event.
    */


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/custom-error-definition` compatibility exception from `oxlint.config.ts`.
- Set Realtime error names and preserve two vendored exported class identities locally.
- Baseline count: 6 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 89; stacked on https://github.com/openai/openai-node/pull/2178.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2166
https://github.com/openai/openai-node/pull/2167
https://github.com/openai/openai-node/pull/2168
https://github.com/openai/openai-node/pull/2169
https://github.com/openai/openai-node/pull/2170
https://github.com/openai/openai-node/pull/2171
https://github.com/openai/openai-node/pull/2172
https://github.com/openai/openai-node/pull/2173
https://github.com/openai/openai-node/pull/2174
https://github.com/openai/openai-node/pull/2175
https://github.com/openai/openai-node/pull/2176
https://github.com/openai/openai-node/pull/2177
https://github.com/openai/openai-node/pull/2178
https://github.com/openai/openai-node/pull/2179 :point_left: this PR
https://github.com/openai/openai-node/pull/2180
https://github.com/openai/openai-node/pull/2181
https://github.com/openai/openai-node/pull/2182
https://github.com/openai/openai-node/pull/2183
https://github.com/openai/openai-node/pull/2184
https://github.com/openai/openai-node/pull/2185