### PR TITLE
chore(lint): enable unicorn/prefer-number-properties

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -93,7 +93,6 @@ const compatibilityRules = [
   'unicorn/prefer-event-target',
   'unicorn/prefer-module',
   'unicorn/prefer-node-protocol',
-  'unicorn/prefer-number-properties',
   'unicorn/prefer-optional-catch-binding',
   'unicorn/prefer-response-static-json',
   'unicorn/prefer-spread',

--- a/src/_vendor/partial-json-parser/parser.ts
+++ b/src/_vendor/partial-json-parser/parser.ts
@@ -117,7 +117,7 @@ const _parseJSON = (jsonString: string, allow: number) => {
       (Allow.NAN & allow && length - index < 3 && 'NaN'.startsWith(jsonString.substring(index)))
     ) {
       index += 3;
-      return NaN;
+      return Number.NaN;
     }
     return parseNum();
   };

--- a/src/internal/qs/utils.ts
+++ b/src/internal/qs/utils.ts
@@ -159,7 +159,7 @@ export const encode: (
 
   if (charset === 'iso-8859-1') {
     return escape(string).replace(/%u[0-9a-f]{4}/gi, function ($0) {
-      return '%26%23' + parseInt($0.slice(2), 16) + '%3B';
+      return '%26%23' + Number.parseInt($0.slice(2), 16) + '%3B';
     });
   }
 

--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -60,7 +60,8 @@ export const checkFileSupport = () => {
   if (typeof File === 'undefined') {
     const { process } = globalThis as any;
     const isOldNode =
-      typeof process?.versions?.node === 'string' && parseInt(process.versions.node.split('.'), 10) < 20;
+      typeof process?.versions?.node === 'string' &&
+      Number.parseInt(process.versions.node.split('.'), 10) < 20;
     throw new Error(
       '`File` is not defined as a global, which is required for file uploads.' +
         (isOldNode

--- a/tests/qs/stringify.test.ts
+++ b/tests/qs/stringify.test.ts
@@ -216,7 +216,7 @@ describe('stringify()', function () {
     // }, TypeError);
     expect(() => {
       // @ts-expect-error
-      stringify({ a: [], b: 'zz' }, { encodeDotInKeys: NaN });
+      stringify({ a: [], b: 'zz' }, { encodeDotInKeys: Number.NaN });
     }).toThrow(TypeError);
 
     // st['throws'](function () {
@@ -360,7 +360,7 @@ describe('stringify()', function () {
     // }, TypeError);
     expect(() => {
       // @ts-expect-error
-      stringify({ a: [], b: 'zz' }, { allowEmptyArrays: NaN });
+      stringify({ a: [], b: 'zz' }, { allowEmptyArrays: Number.NaN });
     }).toThrow(TypeError);
 
     // st['throws'](function () {

--- a/tests/qs/utils.test.ts
+++ b/tests/qs/utils.test.ts
@@ -150,7 +150,21 @@ describe('combine()', function () {
 });
 
 test('is_buffer()', function () {
-  for (const x of [null, undefined, true, false, '', 'abc', 42, 0, NaN, {}, [], function () {}, /a/g]) {
+  for (const x of [
+    null,
+    undefined,
+    true,
+    false,
+    '',
+    'abc',
+    42,
+    0,
+    Number.NaN,
+    {},
+    [],
+    function () {},
+    /a/g,
+  ]) {
     // t.equal(is_buffer(x), false, inspect(x) + ' is not a buffer');
     expect(is_buffer(x)).toEqual(false);
   }


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/prefer-number-properties` compatibility exception from `oxlint.config.ts`.
- Replace six safe global numeric references with `Number.*` equivalents.
- Baseline count: 6 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 90; stacked on https://github.com/openai/openai-node/pull/2179.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2166
https://github.com/openai/openai-node/pull/2167
https://github.com/openai/openai-node/pull/2168
https://github.com/openai/openai-node/pull/2169
https://github.com/openai/openai-node/pull/2170
https://github.com/openai/openai-node/pull/2171
https://github.com/openai/openai-node/pull/2172
https://github.com/openai/openai-node/pull/2173
https://github.com/openai/openai-node/pull/2174
https://github.com/openai/openai-node/pull/2175
https://github.com/openai/openai-node/pull/2176
https://github.com/openai/openai-node/pull/2177
https://github.com/openai/openai-node/pull/2178
https://github.com/openai/openai-node/pull/2179
https://github.com/openai/openai-node/pull/2180 :point_left: this PR
https://github.com/openai/openai-node/pull/2181
https://github.com/openai/openai-node/pull/2182
https://github.com/openai/openai-node/pull/2183
https://github.com/openai/openai-node/pull/2184
https://github.com/openai/openai-node/pull/2185