### PR TITLE
chore(lint): enable no-else-return

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -23,7 +23,6 @@ const compatibilityRules = [
   'max-classes-per-file',
   'no-await-in-loop',
   'no-bitwise',
-  'no-else-return',
   'no-empty-function',
   'no-eq-null',
   'no-inline-comments',

--- a/scripts/_vendor/tsc-multi/src/transformer.ts
+++ b/scripts/_vendor/tsc-multi/src/transformer.ts
@@ -326,9 +326,8 @@ export function createTransformer<T extends ts.SourceFile | ts.Bundle>(
             return pureClassAssignment(visitNode(file, visitor) as ts.SourceFile);
           }),
         ) as any;
-      } else {
-        assert(false);
       }
+      assert(false);
     };
   };
 }

--- a/src/_vendor/partial-json-parser/parser.ts
+++ b/src/_vendor/partial-json-parser/parser.ts
@@ -163,14 +163,14 @@ const _parseJSON = (jsonString: string, allow: number) => {
           Object.defineProperty(obj, key, { value, writable: true, enumerable: true, configurable: true });
         } catch (e) {
           if (Allow.OBJ & allow) return obj;
-          else throw e;
+          throw e;
         }
         skipBlank();
         if (jsonString[index] === ',') index++; // skip comma
       }
     } catch (e) {
       if (Allow.OBJ & allow) return obj;
-      else markPartialJSON("Expected '}' at end of object");
+      markPartialJSON("Expected '}' at end of object");
     }
     index++; // skip final brace
     return obj;

--- a/src/_vendor/zod-to-json-schema/parsers/object.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/object.ts
@@ -10,14 +10,13 @@ function decideAdditionalProperties(def: ZodObjectDef, refs: Refs) {
           ...refs,
           currentPath: [...refs.currentPath, 'additionalProperties'],
         }) ?? true);
-  } else {
-    return def.catchall._def.typeName === 'ZodNever'
-      ? def.unknownKeys === 'passthrough'
-      : (parseDef(def.catchall._def, {
-          ...refs,
-          currentPath: [...refs.currentPath, 'additionalProperties'],
-        }) ?? true);
   }
+  return def.catchall._def.typeName === 'ZodNever'
+    ? def.unknownKeys === 'passthrough'
+    : (parseDef(def.catchall._def, {
+        ...refs,
+        currentPath: [...refs.currentPath, 'additionalProperties'],
+      }) ?? true);
 }
 
 export type JsonSchema7ObjectType = {

--- a/src/_vendor/zod-to-json-schema/parsers/tuple.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/tuple.ts
@@ -36,19 +36,18 @@ export function parseTupleDef(
         currentPath: [...refs.currentPath, 'additionalItems'],
       }),
     };
-  } else {
-    return {
-      type: 'array',
-      minItems: def.items.length,
-      maxItems: def.items.length,
-      items: def.items
-        .map((x, i) =>
-          parseDef(x._def, {
-            ...refs,
-            currentPath: [...refs.currentPath, 'items', `${i}`],
-          }),
-        )
-        .reduce((acc: JsonSchema7Type[], x) => (x === undefined ? acc : [...acc, x]), []),
-    };
   }
+  return {
+    type: 'array',
+    minItems: def.items.length,
+    maxItems: def.items.length,
+    items: def.items
+      .map((x, i) =>
+        parseDef(x._def, {
+          ...refs,
+          currentPath: [...refs.currentPath, 'items', `${i}`],
+        }),
+      )
+      .reduce((acc: JsonSchema7Type[], x) => (x === undefined ? acc : [...acc, x]), []),
+  };
 }

--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -624,9 +624,8 @@ export class AssistantStream
         //No changes on other thread events
         if (snapshot) {
           return [snapshot, newContent];
-        } else {
-          throw new Error('Received thread message event with no existing snapshot');
         }
+        throw new Error('Received thread message event with no existing snapshot');
     }
     throw new Error('Tried to accumulate a non-message event');
   }

--- a/src/lib/ResponsesParser.ts
+++ b/src/lib/ResponsesParser.ts
@@ -50,9 +50,8 @@ export function maybeParseResponse<
               parsed: null,
             })),
           };
-        } else {
-          return item;
         }
+        return item;
       }),
     };
 


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `no-else-return` compatibility exception from `oxlint.config.ts`.
- Flatten seven `else` branches that follow unconditional returns.
- Baseline count: 7 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 91; stacked on https://github.com/openai/openai-node/pull/2180.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2166
https://github.com/openai/openai-node/pull/2167
https://github.com/openai/openai-node/pull/2168
https://github.com/openai/openai-node/pull/2169
https://github.com/openai/openai-node/pull/2170
https://github.com/openai/openai-node/pull/2171
https://github.com/openai/openai-node/pull/2172
https://github.com/openai/openai-node/pull/2173
https://github.com/openai/openai-node/pull/2174
https://github.com/openai/openai-node/pull/2175
https://github.com/openai/openai-node/pull/2176
https://github.com/openai/openai-node/pull/2177
https://github.com/openai/openai-node/pull/2178
https://github.com/openai/openai-node/pull/2179
https://github.com/openai/openai-node/pull/2180
https://github.com/openai/openai-node/pull/2181 :point_left: this PR
https://github.com/openai/openai-node/pull/2182
https://github.com/openai/openai-node/pull/2183
https://github.com/openai/openai-node/pull/2184
https://github.com/openai/openai-node/pull/2185