### PR TITLE
chore(lint): enable no-unsafe-optional-chaining

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -34,7 +34,6 @@ const compatibilityRules = [
   'no-promise-executor-return',
   'no-shadow',
   'no-sparse-arrays',
-  'no-unsafe-optional-chaining',
   'no-unused-vars',
   'no-use-before-define',
   'no-var',

--- a/src/lib/ResponsesParser.ts
+++ b/src/lib/ResponsesParser.ts
@@ -132,8 +132,8 @@ function parseTextFormat<
     return null;
   }
 
-  if ('$parseRaw' in params.text?.format) {
-    const text_format = params.text?.format as unknown as AutoParseableTextFormat<ParsedT>;
+  if ('$parseRaw' in params.text.format) {
+    const text_format = params.text.format as unknown as AutoParseableTextFormat<ParsedT>;
     return text_format.$parseRaw(content);
   }
 

--- a/tests/generated-resource-helpers.test.ts
+++ b/tests/generated-resource-helpers.test.ts
@@ -66,9 +66,9 @@ describe('vector store file helpers', () => {
     ).resolves.toEqual(completed);
     expect(mockedSleep).toHaveBeenCalledWith(expected);
 
-    const headers = (retrieve.mock.calls[0]![2]?.headers as NullableHeaders).values;
-    expect(headers.get('X-Stainless-Poll-Helper')).toBe('true');
-    expect(headers.get('X-Stainless-Custom-Poll-Interval')).toBe(interval ? String(interval) : null);
+    const headers = (retrieve.mock.calls[0]?.[2]?.headers as NullableHeaders | undefined)?.values;
+    expect(headers?.get('X-Stainless-Poll-Helper')).toBe('true');
+    expect(headers?.get('X-Stainless-Custom-Poll-Interval')).toBe(interval ? String(interval) : null);
   });
 
   test.each(['completed', 'failed'] as const)('returns a file in the %s terminal state', async (status) => {
@@ -145,8 +145,8 @@ describe('vector store file batch helpers', () => {
       batches.poll('vs_123', 'batch_123', interval ? { pollIntervalMs: interval } : {}),
     ).resolves.toEqual(completed);
     expect(mockedSleep).toHaveBeenCalledWith(expected);
-    const headers = (retrieve.mock.calls[0]![2]?.headers as NullableHeaders).values;
-    expect(headers.get('X-Stainless-Poll-Helper')).toBe('true');
+    const headers = (retrieve.mock.calls[0]?.[2]?.headers as NullableHeaders | undefined)?.values;
+    expect(headers?.get('X-Stainless-Poll-Helper')).toBe('true');
   });
 
   test.each(['completed', 'failed', 'cancelled'] as const)(
@@ -232,8 +232,8 @@ describe('assistant run helpers', () => {
 
       await expect(runs.poll('run_123', { thread_id: 'thread_123' })).resolves.toEqual(completed);
       expect(mockedSleep).toHaveBeenCalledWith(9);
-      const headers = (retrieve.mock.calls[0]![2]?.headers as NullableHeaders).values;
-      expect(headers.get('X-Stainless-Poll-Helper')).toBe('true');
+      const headers = (retrieve.mock.calls[0]?.[2]?.headers as NullableHeaders | undefined)?.values;
+      expect(headers?.get('X-Stainless-Poll-Helper')).toBe('true');
     },
   );
 

--- a/tests/lib/provider.test.ts
+++ b/tests/lib/provider.test.ts
@@ -63,7 +63,7 @@ describe('provider', () => {
       'https://provider.example/v1/models',
     );
     expect(requestedURL).toBe('https://provider.example/v1/models');
-    expect((requestedInit?.headers as Headers).get('authorization')).toBe('Provider token');
+    expect((requestedInit?.headers as Headers | undefined)?.get('authorization')).toBe('Provider token');
     expect(callApiKey).not.toHaveBeenCalled();
     expect(authHeaders).not.toHaveBeenCalled();
     expect(validateHeaders).not.toHaveBeenCalled();
@@ -180,7 +180,7 @@ describe('provider', () => {
       }),
       maxRetries: 1,
       fetch: async (_url, init) => {
-        if ((init?.headers as Headers).get('x-attempt') === '1') {
+        if (new Headers(init?.headers).get('x-attempt') === '1') {
           return new Response(undefined, {
             status: 429,
             headers: { 'Retry-After-Ms': '1' },

--- a/tests/lib/transform.test.ts
+++ b/tests/lib/transform.test.ts
@@ -2552,7 +2552,9 @@ describe('toStrictJsonSchema', () => {
       };
 
       const strict = toStrictJsonSchema(schema);
-      const properties = (strict.properties?.['value'] as JSONSchema).properties;
+      const valueSchema = strict.properties?.['value'] as JSONSchema | undefined;
+      if (!valueSchema) throw new Error('Expected value schema');
+      const properties = valueSchema.properties;
 
       expect(properties).toEqual(
         Object.fromEntries([


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `no-unsafe-optional-chaining` compatibility exception from `oxlint.config.ts`.
- Carry optionality or add explicit guards at seven unsafe chain uses.
- Baseline count: 7 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 92; stacked on https://github.com/openai/openai-node/pull/2181.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2166
https://github.com/openai/openai-node/pull/2167
https://github.com/openai/openai-node/pull/2168
https://github.com/openai/openai-node/pull/2169
https://github.com/openai/openai-node/pull/2170
https://github.com/openai/openai-node/pull/2171
https://github.com/openai/openai-node/pull/2172
https://github.com/openai/openai-node/pull/2173
https://github.com/openai/openai-node/pull/2174
https://github.com/openai/openai-node/pull/2175
https://github.com/openai/openai-node/pull/2176
https://github.com/openai/openai-node/pull/2177
https://github.com/openai/openai-node/pull/2178
https://github.com/openai/openai-node/pull/2179
https://github.com/openai/openai-node/pull/2180
https://github.com/openai/openai-node/pull/2181
https://github.com/openai/openai-node/pull/2182 :point_left: this PR
https://github.com/openai/openai-node/pull/2183
https://github.com/openai/openai-node/pull/2184
https://github.com/openai/openai-node/pull/2185