### PR TITLE
chore(lint): enable oxc/no-barrel-file

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -41,7 +41,6 @@ const compatibilityRules = [
   'node/global-require',
   'object-shorthand',
   'oxc/no-accumulating-spread',
-  'oxc/no-barrel-file',
   'prefer-arrow-callback',
   'prefer-destructuring',
   'prefer-named-capture-group',
@@ -136,6 +135,20 @@ module.exports = defineConfig({
       ],
       rules: {
         'typescript/no-invalid-void-type': 'off',
+      },
+    },
+    {
+      files: [
+        'src/_vendor/zod-to-json-schema/index.ts',
+        'src/api-promise.ts',
+        'src/pagination.ts',
+        'src/resource.ts',
+        'src/resources.ts',
+        'src/streaming.ts',
+        'src/uploads.ts',
+      ],
+      rules: {
+        'oxc/no-barrel-file': 'off',
       },
     },
     {


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `oxc/no-barrel-file` compatibility exception from `oxlint.config.ts`.
- Enable the rule globally while scoping seven intentional public/vendor barrel entrypoints.
- Baseline count: 7 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 93; stacked on https://github.com/openai/openai-node/pull/2182.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2166
https://github.com/openai/openai-node/pull/2167
https://github.com/openai/openai-node/pull/2168
https://github.com/openai/openai-node/pull/2169
https://github.com/openai/openai-node/pull/2170
https://github.com/openai/openai-node/pull/2171
https://github.com/openai/openai-node/pull/2172
https://github.com/openai/openai-node/pull/2173
https://github.com/openai/openai-node/pull/2174
https://github.com/openai/openai-node/pull/2175
https://github.com/openai/openai-node/pull/2176
https://github.com/openai/openai-node/pull/2177
https://github.com/openai/openai-node/pull/2178
https://github.com/openai/openai-node/pull/2179
https://github.com/openai/openai-node/pull/2180
https://github.com/openai/openai-node/pull/2181
https://github.com/openai/openai-node/pull/2182
https://github.com/openai/openai-node/pull/2183 :point_left: this PR
https://github.com/openai/openai-node/pull/2184
https://github.com/openai/openai-node/pull/2185