### PR TITLE
chore(lint): enable typescript/no-inferrable-types

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -62,7 +62,6 @@ const compatibilityRules = [
   'typescript/no-dynamic-delete',
   'typescript/no-explicit-any',
   'typescript/no-import-type-side-effects',
-  'typescript/no-inferrable-types',
   'typescript/no-namespace',
   'typescript/no-non-null-assertion',
   'typescript/parameter-properties',

--- a/src/auth/subject-token-providers.ts
+++ b/src/auth/subject-token-providers.ts
@@ -22,7 +22,7 @@ async function defaultReadFile(path: string): Promise<string> {
 }
 
 export function k8sServiceAccountTokenProvider(
-  tokenPath: string = '/var/run/secrets/kubernetes.io/serviceaccount/token',
+  tokenPath = '/var/run/secrets/kubernetes.io/serviceaccount/token',
   config?: {
     readFile?: ReadFile;
   },
@@ -134,7 +134,7 @@ export function azureManagedIdentityTokenProvider(
 }
 
 export function gcpIDTokenProvider(
-  audience: string = 'https://api.openai.com/v1',
+  audience = 'https://api.openai.com/v1',
   config?: { timeout?: number; fetch?: Fetch },
 ): SubjectTokenProvider {
   const timeout = config?.timeout || 10000;

--- a/src/azure.ts
+++ b/src/azure.ts
@@ -43,7 +43,7 @@ export interface AzureClientOptions extends Omit<ClientOptions, 'provider'> {
 /** API Client for interfacing with the Azure OpenAI API. */
 export class AzureOpenAI extends OpenAI {
   deploymentName: string | undefined;
-  apiVersion: string = '';
+  apiVersion = '';
 
   /**
    * API Client for interfacing with the Azure OpenAI API.

--- a/src/internal/ws.ts
+++ b/src/internal/ws.ts
@@ -84,10 +84,10 @@ function rawByteLength(data: RawWebSocketData): number {
  */
 export class SendQueue<T = unknown> {
   private _queue: QueueEntry[] = [];
-  private _bytes: number = 0;
+  private _bytes = 0;
   private _maxBytes: number;
 
-  constructor(maxBytes: number = 1_048_576) {
+  constructor(maxBytes = 1_048_576) {
     this._maxBytes = maxBytes;
   }
 

--- a/src/lib/ChatCompletionRunner.ts
+++ b/src/lib/ChatCompletionRunner.ts
@@ -84,7 +84,7 @@ export class ChatCompletionRunner<ParsedT = null> extends AbstractChatCompletion
   override _addMessage(
     this: ChatCompletionRunner<ParsedT>,
     message: ChatCompletionMessageParam,
-    emit: boolean = true,
+    emit = true,
   ) {
     super._addMessage(message, emit);
     if (isAssistantMessage(message) && message.content) {

--- a/tests/uploads.test.ts
+++ b/tests/uploads.test.ts
@@ -5,7 +5,7 @@ import type { ResponseLike } from 'openai/internal/to-file';
 import { toFile } from 'openai/core/uploads';
 
 class MyClass {
-  name: string = 'foo';
+  name = 'foo';
 }
 
 function mockResponse({ url, content }: { url: string; content?: Blob }): ResponseLike {


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `typescript/no-inferrable-types` compatibility exception from `oxlint.config.ts`.
- Remove seven primitive annotations inferred from their initializers.
- Baseline count: 7 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 95; stacked on https://github.com/openai/openai-node/pull/2184.
- Preserves generated-file exclusions and repository-specific import policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`

## Stack

https://github.com/openai/openai-node/pull/2166
https://github.com/openai/openai-node/pull/2167
https://github.com/openai/openai-node/pull/2168
https://github.com/openai/openai-node/pull/2169
https://github.com/openai/openai-node/pull/2170
https://github.com/openai/openai-node/pull/2171
https://github.com/openai/openai-node/pull/2172
https://github.com/openai/openai-node/pull/2173
https://github.com/openai/openai-node/pull/2174
https://github.com/openai/openai-node/pull/2175
https://github.com/openai/openai-node/pull/2176
https://github.com/openai/openai-node/pull/2177
https://github.com/openai/openai-node/pull/2178
https://github.com/openai/openai-node/pull/2179
https://github.com/openai/openai-node/pull/2180
https://github.com/openai/openai-node/pull/2181
https://github.com/openai/openai-node/pull/2182
https://github.com/openai/openai-node/pull/2183
https://github.com/openai/openai-node/pull/2184
https://github.com/openai/openai-node/pull/2185 :point_left: this PR