### PR TITLE
chore(lint): enable unicorn/prefer-ternary

### DIFF
--- a/examples/images/picture.ts
+++ b/examples/images/picture.ts
@@ -17,11 +17,7 @@ const inputImages = process.argv.slice(2);
  *   ./examples/images/picture.ts image-1.png image-2.png
  */
 async function main() {
-  if (inputImages.length === 0) {
-    await createImage();
-  } else {
-    await createImageEdit(inputImages);
-  }
+  await (inputImages.length === 0 ? createImage() : createImageEdit(inputImages));
 }
 
 async function createImage() {

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -93,7 +93,6 @@ const compatibilityRules = [
   'unicorn/prefer-spread',
   'unicorn/prefer-string-replace-all',
   'unicorn/prefer-string-slice',
-  'unicorn/prefer-ternary',
   'unicorn/prefer-type-error',
   'unicorn/switch-case-braces',
   'unicorn/text-encoding-identifier-case',

--- a/src/helpers/audio.ts
+++ b/src/helpers/audio.ts
@@ -40,11 +40,10 @@ async function nodejsPlayAudio(stream: NodeJS.ReadableStream | Response | File):
       let source: NodeJS.ReadableStream;
       if (isResponse(stream)) {
         const body = stream.body! as NodeReadableStream | NodeJS.ReadableStream;
-        if ('pipe' in body && typeof body.pipe === 'function') {
-          source = body;
-        } else {
-          source = Readable.fromWeb(body as NodeReadableStream);
-        }
+        source =
+          'pipe' in body && typeof body.pipe === 'function'
+            ? body
+            : Readable.fromWeb(body as NodeReadableStream);
       } else if (isFile(stream)) {
         source = Readable.from(stream.stream());
       } else {

--- a/src/internal/qs/stringify.ts
+++ b/src/internal/qs/stringify.ts
@@ -370,13 +370,12 @@ export function stringify(object: any, opts: StringifyOptions = {}) {
   let prefix = options.addQueryPrefix === true ? '?' : '';
 
   if (options.charsetSentinel) {
-    if (options.charset === 'iso-8859-1') {
-      // encodeURIComponent('&#10003;'), the "numeric entity" representation of a checkmark
-      prefix += 'utf8=%26%2310003%3B&';
-    } else {
-      // encodeURIComponent('✓')
-      prefix += 'utf8=%E2%9C%93&';
-    }
+    prefix +=
+      options.charset === 'iso-8859-1'
+        ? // encodeURIComponent('&#10003;'), the "numeric entity" representation of a checkmark
+          'utf8=%26%2310003%3B&'
+        : // encodeURIComponent('✓')
+          'utf8=%E2%9C%93&';
   }
 
   return joined.length > 0 ? prefix + joined : '';

--- a/src/internal/qs/utils.ts
+++ b/src/internal/qs/utils.ts
@@ -105,11 +105,7 @@ export function merge(
   return Object.keys(source).reduce(function (acc, key) {
     const value = source[key];
 
-    if (has(acc, key)) {
-      acc[key] = merge(acc[key], value, options);
-    } else {
-      acc[key] = value;
-    }
+    acc[key] = has(acc, key) ? merge(acc[key], value, options) : value;
     return acc;
   }, mergeTarget);
 }

--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -343,11 +343,7 @@ async function* iterateBytes(value: unknown): AsyncGenerator<Uint8Array> {
   } else if (value instanceof ArrayBuffer) {
     yield new Uint8Array(value);
   } else if (value instanceof Response) {
-    if (value.body) {
-      yield* iterateBytes(value.body);
-    } else {
-      yield* iterateBytes(await value.blob());
-    }
+    yield* iterateBytes(value.body || (await value.blob()));
   } else if (value instanceof Blob) {
     if (typeof value.stream === 'function') {
       yield* iterateBytes(value.stream());

--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -687,11 +687,7 @@ export class AssistantStream
           }
 
           const accEntry = accValue[index];
-          if (accEntry == null) {
-            accValue[index] = deltaEntry;
-          } else {
-            accValue[index] = this.accumulateDelta(accEntry, deltaEntry);
-          }
+          accValue[index] = accEntry == null ? deltaEntry : this.accumulateDelta(accEntry, deltaEntry);
         }
         continue;
       } else {


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/prefer-ternary` compatibility exception from `oxlint.config.ts`.
- Resolve the existing violations while preserving behavior.
- Baseline count: 6 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 96; stacked on `main`.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188 :point_left: this PR
https://github.com/openai/openai-node/pull/2190
https://github.com/openai/openai-node/pull/2191
https://github.com/openai/openai-node/pull/2189
https://github.com/openai/openai-node/pull/2192
https://github.com/openai/openai-node/pull/2193
https://github.com/openai/openai-node/pull/2195
https://github.com/openai/openai-node/pull/2194
https://github.com/openai/openai-node/pull/2204
https://github.com/openai/openai-node/pull/2196
https://github.com/openai/openai-node/pull/2197
https://github.com/openai/openai-node/pull/2198
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201
https://github.com/openai/openai-node/pull/2202
https://github.com/openai/openai-node/pull/2203
https://github.com/openai/openai-node/pull/2205
https://github.com/openai/openai-node/pull/2206
https://github.com/openai/openai-node/pull/2207