### PR TITLE
chore(lint): enable unicorn/no-array-sort

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -74,7 +74,6 @@ const compatibilityRules = [
   'unicorn/import-style',
   'unicorn/no-array-for-each',
   'unicorn/no-array-reduce',
-  'unicorn/no-array-sort',
   'unicorn/no-await-expression-member',
   'unicorn/no-console-spaces',
   'unicorn/no-negated-condition',

--- a/scripts/check-node-version-policy.ts
+++ b/scripts/check-node-version-policy.ts
@@ -109,11 +109,11 @@
     [...policySupported, ...policyForward].every((version) => /^\d+$/.test(version)),
     'Policy matrix versions must be major lines',
   );
+  const sortedPolicyRows = [...policyRows];
+  sortedPolicyRows.sort((left, right) => Number(left.major) - Number(right.major));
   assert.deepEqual(
     policyRows.map(({ major: version }) => version),
-    [...policyRows]
-      .sort((left, right) => Number(left.major) - Number(right.major))
-      .map(({ major: version }) => version),
+    sortedPolicyRows.map(({ major: version }) => version),
     'NODE_VERSION_POLICY.md compatibility rows must be ordered by major',
   );
   assert(matrixEntries.length > 0, 'Policy produces an empty Node.js test matrix');

--- a/scripts/stainless-generated-files.cjs
+++ b/scripts/stainless-generated-files.cjs
@@ -21,4 +21,7 @@ function findGeneratedFiles(directory) {
   });
 }
 
-module.exports = findGeneratedFiles(repositoryRoot).sort();
+const generatedFiles = findGeneratedFiles(repositoryRoot);
+generatedFiles.sort();
+
+module.exports = generatedFiles;

--- a/scripts/test-packed-package.ts
+++ b/scripts/test-packed-package.ts
@@ -182,7 +182,8 @@
     );
 
     const mappedSources = new Map<string, string>();
-    const sourceMaps = findSourceMaps(installedPackageRoot).sort();
+    const sourceMaps = findSourceMaps(installedPackageRoot);
+    sourceMaps.sort();
     for (const mapPath of sourceMaps) {
       const sourceMap = JSON.parse(fs.readFileSync(mapPath, 'utf8')) as SourceMap;
       for (const source of sourceMap.sources) {
@@ -229,8 +230,8 @@
     // Validate every other mapped source without installing either in this consumer.
     const browserSafeSources = Array.from(mappedSources.entries())
       .filter(([source]) => !requiresOptionalPeer(source))
-      .map(([, source]) => source)
-      .sort();
+      .map(([, source]) => source);
+    browserSafeSources.sort();
     const sourceNavigationConfig = path.join(temporaryDirectory, 'source-navigation.tsconfig.json');
     fs.writeFileSync(
       sourceNavigationConfig,

--- a/src/internal/qs/stringify.ts
+++ b/src/internal/qs/stringify.ts
@@ -156,7 +156,10 @@ function inner_stringify(
     obj_keys = filter;
   } else {
     const keys = Object.keys(obj);
-    obj_keys = sort ? keys.sort(sort) : keys;
+    if (sort) {
+      keys.sort(sort);
+    }
+    obj_keys = keys;
   }
 
   const encoded_prefix = encodeDotInKeys ? String(prefix).replace(/\./g, '%2E') : String(prefix);

--- a/src/lib/transform.ts
+++ b/src/lib/transform.ts
@@ -1998,8 +1998,10 @@ function schemasEqual(left: unknown, right: unknown): boolean {
 
   const leftRecord = left as Record<string, unknown>;
   const rightRecord = right as Record<string, unknown>;
-  const leftKeys = Object.keys(leftRecord).sort();
-  const rightKeys = Object.keys(rightRecord).sort();
+  const leftKeys = Object.keys(leftRecord);
+  const rightKeys = Object.keys(rightRecord);
+  leftKeys.sort();
+  rightKeys.sort();
 
   if (leftKeys.length !== rightKeys.length) {
     return false;


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/no-array-sort` compatibility exception from `oxlint.config.ts`.
- Resolve the existing violations while preserving behavior.
- Baseline count: 7 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 99; stacked on https://github.com/openai/openai-node/pull/2191.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188
https://github.com/openai/openai-node/pull/2190
https://github.com/openai/openai-node/pull/2191
https://github.com/openai/openai-node/pull/2189 :point_left: this PR
https://github.com/openai/openai-node/pull/2192
https://github.com/openai/openai-node/pull/2193
https://github.com/openai/openai-node/pull/2195
https://github.com/openai/openai-node/pull/2194
https://github.com/openai/openai-node/pull/2204
https://github.com/openai/openai-node/pull/2196
https://github.com/openai/openai-node/pull/2197
https://github.com/openai/openai-node/pull/2198
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201
https://github.com/openai/openai-node/pull/2202
https://github.com/openai/openai-node/pull/2203
https://github.com/openai/openai-node/pull/2205
https://github.com/openai/openai-node/pull/2206
https://github.com/openai/openai-node/pull/2207