### PR TITLE
chore(lint): enable unicorn/new-for-builtins

### DIFF
--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -388,7 +388,7 @@ async function main() {
       showProgress();
 
       await Promise.all(
-        [...Array(jobs).keys()].map(async () => {
+        Array.from({ length: jobs }, (_, index) => index).map(async () => {
           while (queue.length) {
             const project = queue.shift();
             if (!project) {

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -72,7 +72,6 @@ const compatibilityRules = [
   'unicorn/consistent-function-scoping',
   'unicorn/filename-case',
   'unicorn/import-style',
-  'unicorn/new-for-builtins',
   'unicorn/no-anonymous-default-export',
   'unicorn/no-array-for-each',
   'unicorn/no-array-reduce',

--- a/src/_vendor/zod-to-json-schema/parsers/string.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/string.ts
@@ -36,7 +36,7 @@ export const zodPatterns = {
   emoji: () => {
     if (emojiRegex === undefined) {
       const emojiPattern = '^(\\p{Extended_Pictographic}|\\p{Emoji_Component})+$';
-      emojiRegex = RegExp(emojiPattern, 'u');
+      emojiRegex = new RegExp(emojiPattern, 'u');
     }
     return emojiRegex;
   },
@@ -145,10 +145,10 @@ export function parseStringDef(def: ZodStringDef, refs: Refs): JsonSchema7String
           addPattern(res, zodPatterns.cuid2, check.message, refs);
           break;
         case 'startsWith':
-          addPattern(res, RegExp(`^${processPattern(check.value)}`), check.message, refs);
+          addPattern(res, new RegExp(`^${processPattern(check.value)}`), check.message, refs);
           break;
         case 'endsWith':
-          addPattern(res, RegExp(`${processPattern(check.value)}$`), check.message, refs);
+          addPattern(res, new RegExp(`${processPattern(check.value)}$`), check.message, refs);
           break;
 
         case 'datetime':
@@ -180,7 +180,7 @@ export function parseStringDef(def: ZodStringDef, refs: Refs): JsonSchema7String
           );
           break;
         case 'includes': {
-          addPattern(res, RegExp(processPattern(check.value)), check.message, refs);
+          addPattern(res, new RegExp(processPattern(check.value)), check.message, refs);
           break;
         }
         case 'ip': {

--- a/tests/path.test.ts
+++ b/tests/path.test.ts
@@ -38,9 +38,9 @@ describe('path template tag function', () => {
 
     const emptyObject = {};
     const mathObject = Math;
-    // oxlint-disable-next-line no-new-wrappers -- intentionally test a boxed Number path parameter
+    // oxlint-disable-next-line no-new-wrappers, unicorn/new-for-builtins -- intentionally test a boxed Number path parameter
     const numberObject = new Number();
-    // oxlint-disable-next-line no-new-wrappers -- intentionally test a boxed String path parameter
+    // oxlint-disable-next-line no-new-wrappers, unicorn/new-for-builtins -- intentionally test a boxed String path parameter
     const stringObject = new String();
     const basicClass = new (class {
       readonly kind = 'class';


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/new-for-builtins` compatibility exception from `oxlint.config.ts`.
- Resolve the existing violations while preserving behavior.
- Baseline count: 7 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 97; stacked on https://github.com/openai/openai-node/pull/2188.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188
https://github.com/openai/openai-node/pull/2190 :point_left: this PR
https://github.com/openai/openai-node/pull/2191
https://github.com/openai/openai-node/pull/2189
https://github.com/openai/openai-node/pull/2192
https://github.com/openai/openai-node/pull/2193
https://github.com/openai/openai-node/pull/2195
https://github.com/openai/openai-node/pull/2194
https://github.com/openai/openai-node/pull/2204
https://github.com/openai/openai-node/pull/2196
https://github.com/openai/openai-node/pull/2197
https://github.com/openai/openai-node/pull/2198
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201
https://github.com/openai/openai-node/pull/2202
https://github.com/openai/openai-node/pull/2203
https://github.com/openai/openai-node/pull/2205
https://github.com/openai/openai-node/pull/2206
https://github.com/openai/openai-node/pull/2207