### PR TITLE
chore(lint): enable unicorn/no-anonymous-default-export

### DIFF
--- a/ecosystem-tests/vercel-edge/src/pages/api/edge-test.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/edge-test.ts
@@ -40,7 +40,7 @@ function expectSimilar(received: string, expected: string, maxDistance: number) 
   throw new Error(message);
 }
 
-export default async (request: NextRequest) => {
+export default async function handler(request: NextRequest) {
   try {
     console.error('creating client');
     const client = new OpenAI();
@@ -70,4 +70,4 @@ export default async (request: NextRequest) => {
     console.error(error instanceof Error ? error.stack : String(error));
     return new NextResponse('Internal Server Error', { status: 500 });
   }
-};
+}

--- a/ecosystem-tests/vercel-edge/src/pages/api/node-test.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/node-test.ts
@@ -30,7 +30,7 @@ function expectSimilar(received: string, expected: string, maxDistance: number) 
   throw new Error(message);
 }
 
-export default async (request: NextApiRequest, response: NextApiResponse) => {
+export default async function handler(request: NextApiRequest, response: NextApiResponse) {
   try {
     console.error('creating client');
     const client = new OpenAI();
@@ -60,4 +60,4 @@ export default async (request: NextApiRequest, response: NextApiResponse) => {
     console.error(error instanceof Error ? error.stack : String(error));
     response.status(500).end('Internal Server Error');
   }
-};
+}

--- a/ecosystem-tests/vercel-edge/src/pages/api/query-params.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/query-params.ts
@@ -11,10 +11,10 @@ export const config = {
   ],
 };
 
-export default async (request: NextRequest) => {
+export default async function handler(request: NextRequest) {
   const openai = new OpenAI();
 
   const result = await openai.beta.assistants.list({ limit: 10 });
 
   return NextResponse.json(result);
-};
+}

--- a/ecosystem-tests/vercel-edge/src/pages/api/response.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/response.ts
@@ -11,7 +11,7 @@ export const config = {
   ],
 };
 
-export default async (request: NextRequest) => {
+export default async function handler(request: NextRequest) {
   const openai = new OpenAI();
 
   const result = await openai.completions.create({
@@ -19,4 +19,4 @@ export default async (request: NextRequest) => {
     model: 'gpt-3.5-turbo-instruct',
   });
   return NextResponse.json(result);
-};
+}

--- a/ecosystem-tests/vercel-edge/src/pages/api/streaming.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/streaming.ts
@@ -11,7 +11,7 @@ export const config = {
   ],
 };
 
-export default async (request: NextRequest) => {
+export default async function handler(request: NextRequest) {
   const openai = new OpenAI();
 
   const text: string[] = [];
@@ -27,4 +27,4 @@ export default async (request: NextRequest) => {
   }
 
   return NextResponse.json({ text: text.join('') });
-};
+}

--- a/ecosystem-tests/vercel-edge/src/pages/api/transcribe.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/transcribe.ts
@@ -12,7 +12,7 @@ export const config = {
   ],
 };
 
-export default async (request: NextRequest) => {
+export default async function handler(request: NextRequest) {
   const openai = new OpenAI();
 
   async function typeTests() {
@@ -33,4 +33,4 @@ export default async (request: NextRequest) => {
   const transcription = await openai.audio.transcriptions.create(params);
 
   return NextResponse.json(transcription);
-};
+}

--- a/ecosystem-tests/vercel-edge/src/pages/api/vercel-ai-streaming.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/vercel-ai-streaming.ts
@@ -10,7 +10,7 @@ export const config = {
   ],
 };
 
-export default async (request: NextRequest) => {
+export default async function handler(request: NextRequest) {
   const openai = new OpenAI();
 
   const { messages }: { messages: UIMessage[] } = await request.json();
@@ -53,4 +53,4 @@ export default async (request: NextRequest) => {
   });
 
   return createUIMessageStreamResponse({ stream });
-};
+}

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -72,7 +72,6 @@ const compatibilityRules = [
   'unicorn/consistent-function-scoping',
   'unicorn/filename-case',
   'unicorn/import-style',
-  'unicorn/no-anonymous-default-export',
   'unicorn/no-array-for-each',
   'unicorn/no-array-reduce',
   'unicorn/no-array-sort',


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/no-anonymous-default-export` compatibility exception from `oxlint.config.ts`.
- Resolve the existing violations while preserving behavior.
- Baseline count: 7 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 98; stacked on https://github.com/openai/openai-node/pull/2190.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188
https://github.com/openai/openai-node/pull/2190
https://github.com/openai/openai-node/pull/2191 :point_left: this PR
https://github.com/openai/openai-node/pull/2189
https://github.com/openai/openai-node/pull/2192
https://github.com/openai/openai-node/pull/2193
https://github.com/openai/openai-node/pull/2195
https://github.com/openai/openai-node/pull/2194
https://github.com/openai/openai-node/pull/2204
https://github.com/openai/openai-node/pull/2196
https://github.com/openai/openai-node/pull/2197
https://github.com/openai/openai-node/pull/2198
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201
https://github.com/openai/openai-node/pull/2202
https://github.com/openai/openai-node/pull/2203
https://github.com/openai/openai-node/pull/2205
https://github.com/openai/openai-node/pull/2206
https://github.com/openai/openai-node/pull/2207