### PR TITLE
chore(lint): enable import/first

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -16,7 +16,6 @@ const compatibilityRules = [
   'func-names',
   'func-style',
   'import/consistent-type-specifier-style',
-  'import/first',
   'import/no-cycle',
   'jsdoc/no-defaults',
   'jsdoc/require-param-description',

--- a/src/_vendor/zod-to-json-schema/index.ts
+++ b/src/_vendor/zod-to-json-schema/index.ts
@@ -1,3 +1,5 @@
+import { zodToJsonSchema } from './zodToJsonSchema';
+
 export * from './Options';
 export * from './Refs';
 export * from './errorMessages';
@@ -33,6 +35,5 @@ export * from './parsers/undefined';
 export * from './parsers/union';
 export * from './parsers/unknown';
 export * from './zodToJsonSchema';
-import { zodToJsonSchema } from './zodToJsonSchema';
 
 export default zodToJsonSchema;

--- a/tests/helpers/audio-recording.test.ts
+++ b/tests/helpers/audio-recording.test.ts
@@ -1,11 +1,10 @@
 import { vi, type MockedFunction } from 'vitest';
-
-vi.mock('node:child_process', () => ({ spawn: vi.fn() }));
-
 import { spawn } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { PassThrough, Readable, Writable } from 'node:stream';
 import { playAudio, recordAudio } from 'openai/helpers/audio';
+
+vi.mock('node:child_process', () => ({ spawn: vi.fn() }));
 
 const spawnMock = spawn as MockedFunction<typeof spawn>;
 

--- a/tests/helpers/audio.test.ts
+++ b/tests/helpers/audio.test.ts
@@ -1,10 +1,9 @@
 import { vi, type MockedFunction } from 'vitest';
-
-vi.mock('node:child_process', () => ({ spawn: vi.fn() }));
-
 import { spawn } from 'node:child_process';
 import { Readable, Writable } from 'node:stream';
 import { playAudio } from 'openai/helpers/audio';
+
+vi.mock('node:child_process', () => ({ spawn: vi.fn() }));
 
 const spawnMock = spawn as MockedFunction<typeof spawn>;
 


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `import/first` compatibility exception from `oxlint.config.ts`.
- Resolve the existing violations while preserving behavior.
- Baseline count: 8 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 100; stacked on https://github.com/openai/openai-node/pull/2189.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188
https://github.com/openai/openai-node/pull/2190
https://github.com/openai/openai-node/pull/2191
https://github.com/openai/openai-node/pull/2189
https://github.com/openai/openai-node/pull/2192 :point_left: this PR
https://github.com/openai/openai-node/pull/2193
https://github.com/openai/openai-node/pull/2195
https://github.com/openai/openai-node/pull/2194
https://github.com/openai/openai-node/pull/2204
https://github.com/openai/openai-node/pull/2196
https://github.com/openai/openai-node/pull/2197
https://github.com/openai/openai-node/pull/2198
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201
https://github.com/openai/openai-node/pull/2202
https://github.com/openai/openai-node/pull/2203
https://github.com/openai/openai-node/pull/2205
https://github.com/openai/openai-node/pull/2206
https://github.com/openai/openai-node/pull/2207