### PR TITLE
chore(lint): enable unicorn/prefer-type-error

### DIFF
--- a/ecosystem-tests/browser-direct-import/src/test.ts
+++ b/ecosystem-tests/browser-direct-import/src/test.ts
@@ -50,7 +50,7 @@ import puppeteer from 'puppeteer';
     }
 
     if (!Array.isArray(results)) {
-      throw new Error(`failed to get test results from page`);
+      throw new TypeError(`failed to get test results from page`);
     }
     const failed = results.filter((r) => !r.passed);
     if (failed.length) {

--- a/ecosystem-tests/ts-browser-webpack/src/test.ts
+++ b/ecosystem-tests/ts-browser-webpack/src/test.ts
@@ -50,7 +50,7 @@ import puppeteer from 'puppeteer';
     }
 
     if (!Array.isArray(results)) {
-      throw new Error(`failed to get test results from page`);
+      throw new TypeError(`failed to get test results from page`);
     }
     const failed = results.filter((r) => !r.passed);
     if (failed.length) {

--- a/examples/responses/websocket.ts
+++ b/examples/responses/websocket.ts
@@ -171,7 +171,7 @@ const parseArgs = (argv: Array<string>): CLIArgs => {
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (typeof arg !== 'string') {
-      throw new Error('Unexpected missing CLI argument');
+      throw new TypeError('Unexpected missing CLI argument');
     }
 
     if (arg === '--model') {
@@ -229,7 +229,7 @@ const parseSKUArguments = (rawArguments: string): SKUArguments => {
 
   const skuValue = parsed['sku'];
   if (typeof skuValue !== 'string') {
-    throw new Error(`Tool arguments must include a string \`sku\`: ${rawArguments}`);
+    throw new TypeError(`Tool arguments must include a string \`sku\`: ${rawArguments}`);
   }
 
   return { sku: skuValue };

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -89,7 +89,6 @@ const compatibilityRules = [
   'unicorn/prefer-spread',
   'unicorn/prefer-string-replace-all',
   'unicorn/prefer-string-slice',
-  'unicorn/prefer-type-error',
   'unicorn/switch-case-braces',
   'unicorn/text-encoding-identifier-case',
   'vars-on-top',

--- a/scripts/utils/check-version.cjs
+++ b/scripts/utils/check-version.cjs
@@ -6,7 +6,7 @@ const main = () => {
   const version = pkg['version'];
   if (!version) throw new Error('The version property is not set in the package.json file');
   if (typeof version !== 'string') {
-    throw new Error(
+    throw new TypeError(
       `Unexpected type for the package.json version field; got ${typeof version}, expected string`,
     );
   }

--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -683,7 +683,9 @@ export class AssistantStream
           }
 
           if (typeof index !== 'number') {
-            throw new Error(`Expected array delta entry \`index\` property to be a number but got ${index}`);
+            throw new TypeError(
+              `Expected array delta entry \`index\` property to be a number but got ${index}`,
+            );
           }
 
           const accEntry = accValue[index];
@@ -691,7 +693,9 @@ export class AssistantStream
         }
         continue;
       } else {
-        throw new Error(`Unhandled record type: ${key}, deltaValue: ${deltaValue}, accValue: ${accValue}`);
+        throw new TypeError(
+          `Unhandled record type: ${key}, deltaValue: ${deltaValue}, accValue: ${accValue}`,
+        );
       }
       acc[key] = accValue;
     }

--- a/src/lib/transform.ts
+++ b/src/lib/transform.ts
@@ -723,7 +723,7 @@ function ensureStrictJsonSchema(
   const items = jsonSchema.items;
   const additionalItems = jsonSchema.additionalItems;
   if (Array.isArray(items)) {
-    throw new Error(
+    throw new TypeError(
       `Schema at \`${
         path.join('/') || '<root>'
       }\` uses tuple-form \`items\`, which cannot be represented in strict Structured Outputs.`,


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/prefer-type-error` compatibility exception from `oxlint.config.ts`.
- Resolve the existing violations while preserving behavior.
- Baseline count: 8 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 101; stacked on https://github.com/openai/openai-node/pull/2192.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188
https://github.com/openai/openai-node/pull/2190
https://github.com/openai/openai-node/pull/2191
https://github.com/openai/openai-node/pull/2189
https://github.com/openai/openai-node/pull/2192
https://github.com/openai/openai-node/pull/2193 :point_left: this PR
https://github.com/openai/openai-node/pull/2195
https://github.com/openai/openai-node/pull/2194
https://github.com/openai/openai-node/pull/2204
https://github.com/openai/openai-node/pull/2196
https://github.com/openai/openai-node/pull/2197
https://github.com/openai/openai-node/pull/2198
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201
https://github.com/openai/openai-node/pull/2202
https://github.com/openai/openai-node/pull/2203
https://github.com/openai/openai-node/pull/2205
https://github.com/openai/openai-node/pull/2206
https://github.com/openai/openai-node/pull/2207