### PR TITLE
chore(lint): enable typescript/prefer-for-of

### DIFF
--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -679,13 +679,10 @@ const fileCache = (() => {
   return {
     // Copy existing files from each ecosystem-tests project folder to the ./tmp folder
     cacheFiles: async (tmpFolderPath: string) => {
-      for (let i = 0; i < projectNames.length; i++) {
-        const projectName = (projectNames as any)[i] as string;
+      for (const projectName of projectNames) {
         const projectPath = path.resolve(process.cwd(), 'ecosystem-tests', projectName);
 
-        for (let j = 0; j < filesToCache.length; j++) {
-          const fileName = filesToCache[j] || '';
-
+        for (const fileName of filesToCache) {
           const filePath = path.resolve(projectPath, fileName);
           if (await fileExists(filePath)) {
             const tmpProjectPath = path.resolve(tmpFolderPath, projectName);
@@ -701,15 +698,11 @@ const fileCache = (() => {
 
     // Restore the original files to each ecosystem-tests project folder from the ./tmp folder
     restoreFiles: async (tmpFolderPath: string) => {
-      for (let i = 0; i < projectNames.length; i++) {
-        const projectName = (projectNames as any)[i] as string;
-
+      for (const projectName of projectNames) {
         const projectPath = path.resolve(process.cwd(), 'ecosystem-tests', projectName);
         const tmpProjectPath = path.resolve(tmpFolderPath, projectName);
 
-        for (let j = 0; j < filesToCache.length; j++) {
-          const fileName = filesToCache[j] || '';
-
+        for (const fileName of filesToCache) {
           const cachedFilePath = path.resolve(tmpProjectPath, fileName);
           const projectFilePath = path.resolve(projectPath, fileName);
           if (await fileExists(cachedFilePath)) {

--- a/examples/chat-completions/tool-calls-stream.ts
+++ b/examples/chat-completions/tool-calls-stream.ts
@@ -179,8 +179,7 @@ function messageReducer(previous: ChatCompletionMessage, item: ChatCompletionChu
         acc[key] = value;
       } else if (Array.isArray(acc[key]) && Array.isArray(value)) {
         const accArray = acc[key];
-        for (let i = 0; i < value.length; i++) {
-          const { index, ...chunkTool } = value[i];
+        for (const { index, ...chunkTool } of value) {
           if (index - accArray.length > 1) {
             throw new Error(
               `Error: An array has an empty value when tool_calls are constructed. tool_calls: ${accArray}; tool: ${value}`,

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -63,7 +63,6 @@ const compatibilityRules = [
   'typescript/no-import-type-side-effects',
   'typescript/no-namespace',
   'typescript/no-non-null-assertion',
-  'typescript/prefer-for-of',
   'typescript/prefer-ts-expect-error',
   'unicorn/catch-error-name',
   'unicorn/consistent-assert',

--- a/src/internal/qs/stringify.ts
+++ b/src/internal/qs/stringify.ts
@@ -171,8 +171,7 @@ function inner_stringify(
     return adjusted_prefix + '[]';
   }
 
-  for (let j = 0; j < obj_keys.length; ++j) {
-    const key = obj_keys[j];
+  for (const key of obj_keys) {
     const value =
       // @ts-ignore
       typeof key === 'object' && typeof key.value !== 'undefined' ? key.value : obj[key as any];
@@ -337,9 +336,7 @@ export function stringify(object: any, opts: StringifyOptions = {}) {
   }
 
   const sideChannel = new WeakMap();
-  for (let i = 0; i < obj_keys.length; ++i) {
-    const key = obj_keys[i]!;
-
+  for (const key of obj_keys) {
     if (options.skipNulls && obj[key] === null) {
       continue;
     }

--- a/src/internal/qs/utils.ts
+++ b/src/internal/qs/utils.ts
@@ -30,9 +30,9 @@ function compact_queue<T extends Record<string, any>>(queue: Array<{ obj: T; pro
     if (isArray(obj)) {
       const compacted: unknown[] = [];
 
-      for (let j = 0; j < obj.length; ++j) {
-        if (typeof obj[j] !== 'undefined') {
-          compacted.push(obj[j]);
+      for (const value of obj) {
+        if (typeof value !== 'undefined') {
+          compacted.push(value);
         }
       }
 
@@ -218,14 +218,12 @@ export function compact(value: any) {
   const queue = [{ obj: { o: value }, prop: 'o' }];
   const refs: object[] = [];
 
-  for (let i = 0; i < queue.length; ++i) {
-    const item = queue[i];
+  for (const item of queue) {
     // @ts-ignore
     const obj = item.obj[item.prop];
 
     const keys = Object.keys(obj);
-    for (let j = 0; j < keys.length; ++j) {
-      const key = keys[j]!;
+    for (const key of keys) {
       const val = obj[key];
       if (typeof val === 'object' && val !== null && !refs.includes(val)) {
         queue.push({ obj: obj, prop: key });
@@ -258,8 +256,8 @@ export function combine(a: any, b: any) {
 export function maybe_map<T>(val: T[], fn: (v: T) => T) {
   if (isArray(val)) {
     const mapped = [];
-    for (let i = 0; i < val.length; i += 1) {
-      mapped.push(fn(val[i]!));
+    for (const item of val) {
+      mapped.push(fn(item));
     }
     return mapped;
   }


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `typescript/prefer-for-of` compatibility exception from `oxlint.config.ts`.
- Resolve the existing violations while preserving behavior.
- Baseline count: 9 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 103; stacked on https://github.com/openai/openai-node/pull/2195.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188
https://github.com/openai/openai-node/pull/2190
https://github.com/openai/openai-node/pull/2191
https://github.com/openai/openai-node/pull/2189
https://github.com/openai/openai-node/pull/2192
https://github.com/openai/openai-node/pull/2193
https://github.com/openai/openai-node/pull/2195
https://github.com/openai/openai-node/pull/2194 :point_left: this PR
https://github.com/openai/openai-node/pull/2204
https://github.com/openai/openai-node/pull/2196
https://github.com/openai/openai-node/pull/2197
https://github.com/openai/openai-node/pull/2198
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201
https://github.com/openai/openai-node/pull/2202
https://github.com/openai/openai-node/pull/2203
https://github.com/openai/openai-node/pull/2205
https://github.com/openai/openai-node/pull/2206
https://github.com/openai/openai-node/pull/2207