### PR TITLE
chore(lint): enable typescript/parameter-properties

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -63,7 +63,6 @@ const compatibilityRules = [
   'typescript/no-import-type-side-effects',
   'typescript/no-namespace',
   'typescript/no-non-null-assertion',
-  'typescript/parameter-properties',
   'typescript/prefer-for-of',
   'typescript/prefer-ts-expect-error',
   'unicorn/catch-error-name',

--- a/scripts/_vendor/tsc-multi/src/worker/worker.ts
+++ b/scripts/_vendor/tsc-multi/src/worker/worker.ts
@@ -28,14 +28,13 @@ function loadCompiler(cwd: string, name = 'typescript'): TS {
 }
 
 export class Worker {
+  private readonly data: WorkerOptions;
   private readonly ts: TS;
   private readonly system: ts.System;
   private readonly reporter: Reporter;
 
-  constructor(
-    private readonly data: WorkerOptions,
-    system?: ts.System,
-  ) {
+  constructor(data: WorkerOptions, system?: ts.System) {
+    this.data = data;
     this.ts = loadCompiler(data.cwd, data.compiler);
     this.system = this.createSystem(system || this.ts.sys);
     this.reporter = createReporter({

--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -18,12 +18,10 @@ export type ServerSentEvent = {
 export class Stream<Item> implements AsyncIterable<Item> {
   controller: AbortController;
   #client: OpenAI | undefined;
+  private iterator: () => AsyncIterator<Item>;
 
-  constructor(
-    private iterator: () => AsyncIterator<Item>,
-    controller: AbortController,
-    client?: OpenAI,
-  ) {
+  constructor(iterator: () => AsyncIterator<Item>, controller: AbortController, client?: OpenAI) {
+    this.iterator = iterator;
     this.controller = controller;
     this.#client = client;
   }

--- a/src/internal/bedrock.ts
+++ b/src/internal/bedrock.ts
@@ -90,7 +90,11 @@ export function assertProviderOwnsAuthorization(headers: Headers): void {
 }
 
 class BedrockBearerAuth implements BedrockRequestAuth {
-  constructor(private readonly tokenProvider: ApiKeySetter) {}
+  private readonly tokenProvider: ApiKeySetter;
+
+  constructor(tokenProvider: ApiKeySetter) {
+    this.tokenProvider = tokenProvider;
+  }
 
   async prepareRequest(request: FinalizedRequestInit, _context: ProviderRequestContext): Promise<void> {
     const headers = new Headers(request.headers);

--- a/src/providers/bedrock/aws.ts
+++ b/src/providers/bedrock/aws.ts
@@ -117,19 +117,22 @@ function validateCredentialIdentity(identity: AwsCredentialIdentity): AwsCredent
   return identity;
 }
 
+type BedrockSigV4AuthOptions = {
+  region: string;
+  staticCredentials?: AwsCredentialIdentity | undefined;
+  profile?: string | undefined;
+  credentialProvider?: AwsCredentialsProvider | undefined;
+  usesDefaultChain: boolean;
+};
+
 class BedrockSigV4Auth implements BedrockRequestAuth {
   private signer: SignatureV4 | undefined;
   private resolvedCredentialsProvider: (() => Promise<AwsCredentialIdentity>) | undefined;
+  private readonly options: BedrockSigV4AuthOptions;
 
-  constructor(
-    private readonly options: {
-      region: string;
-      staticCredentials?: AwsCredentialIdentity | undefined;
-      profile?: string | undefined;
-      credentialProvider?: AwsCredentialsProvider | undefined;
-      usesDefaultChain: boolean;
-    },
-  ) {}
+  constructor(options: BedrockSigV4AuthOptions) {
+    this.options = options;
+  }
 
   private credentialsProvider(): () => Promise<AwsCredentialIdentity> {
     if (this.resolvedCredentialsProvider) return this.resolvedCredentialsProvider;

--- a/tests/internal/uploads-branches.test.ts
+++ b/tests/internal/uploads-branches.test.ts
@@ -132,7 +132,11 @@ describe('buffered multipart forms', () => {
 
   test('rejects fetch implementations that stringify FormData objects', async () => {
     class UnsupportedResponse {
-      constructor(private readonly body: FormData) {}
+      private readonly body: FormData;
+
+      constructor(body: FormData) {
+        this.body = body;
+      }
 
       async text() {
         return this.body.toString();

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -154,8 +154,10 @@ class RunnerListener {
   gotEnd = false;
 
   onceMessageCallCount = 0;
+  public runner: ChatCompletionRunner<any>;
 
-  constructor(public runner: ChatCompletionRunner<any>) {
+  constructor(runner: ChatCompletionRunner<any>) {
+    this.runner = runner;
     runner
       .on('connect', () => (this.gotConnect = true))
       .on('content', (content) => this.contents.push(content))
@@ -278,8 +280,10 @@ class StreamingRunnerListener {
   error: OpenAIError | undefined;
   gotConnect = false;
   gotEnd = false;
+  public runner: ChatCompletionStreamingRunner<any>;
 
-  constructor(public runner: ChatCompletionStreamingRunner<any>) {
+  constructor(runner: ChatCompletionStreamingRunner<any>) {
+    this.runner = runner;
     runner
       .on('connect', () => (this.gotConnect = true))
       .on('chunk', (chunk) => this.eventChunks.push(chunk))

--- a/tests/realtime-websocket.test.ts
+++ b/tests/realtime-websocket.test.ts
@@ -39,11 +39,12 @@ class FakeBrowserSocket {
   readonly listeners = new Map<string, Listener>();
   readonly send = vi.fn();
   readonly close = vi.fn();
+  readonly url: string;
+  readonly protocols: string[];
 
-  constructor(
-    readonly url: string,
-    readonly protocols: string[],
-  ) {
+  constructor(url: string, protocols: string[]) {
+    this.url = url;
+    this.protocols = protocols;
     FakeBrowserSocket.instances.push(this);
   }
 


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `typescript/parameter-properties` compatibility exception from `oxlint.config.ts`.
- Resolve the existing violations while preserving behavior.
- Baseline count: 9 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 102; stacked on https://github.com/openai/openai-node/pull/2193.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188
https://github.com/openai/openai-node/pull/2190
https://github.com/openai/openai-node/pull/2191
https://github.com/openai/openai-node/pull/2189
https://github.com/openai/openai-node/pull/2192
https://github.com/openai/openai-node/pull/2193
https://github.com/openai/openai-node/pull/2195 :point_left: this PR
https://github.com/openai/openai-node/pull/2194
https://github.com/openai/openai-node/pull/2204
https://github.com/openai/openai-node/pull/2196
https://github.com/openai/openai-node/pull/2197
https://github.com/openai/openai-node/pull/2198
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201
https://github.com/openai/openai-node/pull/2202
https://github.com/openai/openai-node/pull/2203
https://github.com/openai/openai-node/pull/2205
https://github.com/openai/openai-node/pull/2206
https://github.com/openai/openai-node/pull/2207