### PR TITLE
chore(lint): enable unicorn/prefer-optional-catch-binding

### DIFF
--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -433,7 +433,7 @@ async function main() {
                 args.retryDelay,
                 isLikelyNodeCrash,
               );
-            } catch (error) {
+            } catch {
               failed.push(project);
             } finally {
               runningProjects.delete(project);
@@ -595,7 +595,7 @@ async function installPackage() {
   try {
     // Ensure that there is a clean node_modules folder.
     await run('rm', ['-rf', `./node_modules`]);
-  } catch (err) {
+  } catch {
     // Best-effort cleanup; installation below can continue.
   }
 
@@ -647,7 +647,7 @@ async function pathExists(path: string) {
   try {
     await fs.access(path);
     return true;
-  } catch (error) {
+  } catch {
     return false;
   }
 }

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -81,7 +81,6 @@ const compatibilityRules = [
   'unicorn/prefer-at',
   'unicorn/prefer-module',
   'unicorn/prefer-node-protocol',
-  'unicorn/prefer-optional-catch-binding',
   'unicorn/prefer-response-static-json',
   'unicorn/prefer-spread',
   'unicorn/prefer-string-replace-all',

--- a/src/_vendor/partial-json-parser/parser.ts
+++ b/src/_vendor/partial-json-parser/parser.ts
@@ -139,7 +139,7 @@ const _parseJSON = (jsonString: string, allow: number) => {
     } else if (Allow.STR & allow) {
       try {
         return JSON.parse(jsonString.substring(start, index - Number(escape)) + '"');
-      } catch (e) {
+      } catch {
         // SyntaxError: Invalid escape sequence
         return JSON.parse(jsonString.substring(start, jsonString.lastIndexOf('\\')) + '"');
       }
@@ -168,7 +168,7 @@ const _parseJSON = (jsonString: string, allow: number) => {
         skipBlank();
         if (jsonString[index] === ',') index++; // skip comma
       }
-    } catch (e) {
+    } catch {
       if (Allow.OBJ & allow) return obj;
       markPartialJSON("Expected '}' at end of object");
     }
@@ -187,7 +187,7 @@ const _parseJSON = (jsonString: string, allow: number) => {
           index++; // skip comma
         }
       }
-    } catch (e) {
+    } catch {
       if (Allow.ARR & allow) {
         return arr;
       }
@@ -208,7 +208,7 @@ const _parseJSON = (jsonString: string, allow: number) => {
             if (jsonString[jsonString.length - 1] === '.')
               return JSON.parse(jsonString.substring(0, jsonString.lastIndexOf('.')));
             return JSON.parse(jsonString.substring(0, jsonString.lastIndexOf('e')));
-          } catch (e) {
+          } catch {
             // Fall through to report malformed input below.
           }
         }
@@ -225,7 +225,7 @@ const _parseJSON = (jsonString: string, allow: number) => {
 
     try {
       return JSON.parse(jsonString.substring(start, index));
-    } catch (e) {
+    } catch {
       if (jsonString.substring(start, index) === '-' && Allow.NUM & allow)
         markPartialJSON("Not sure what '-' is");
       try {

--- a/src/internal/qs/utils.ts
+++ b/src/internal/qs/utils.ts
@@ -126,7 +126,7 @@ export function decode(str: string, _: any, charset: string) {
   // utf-8
   try {
     return decodeURIComponent(strWithoutPlus);
-  } catch (e) {
+  } catch {
     return strWithoutPlus;
   }
 }


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/prefer-optional-catch-binding` compatibility exception from `oxlint.config.ts`.
- Resolve the existing violations while preserving behavior.
- Baseline count: 9 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 105; stacked on https://github.com/openai/openai-node/pull/2204.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188
https://github.com/openai/openai-node/pull/2190
https://github.com/openai/openai-node/pull/2191
https://github.com/openai/openai-node/pull/2189
https://github.com/openai/openai-node/pull/2192
https://github.com/openai/openai-node/pull/2193
https://github.com/openai/openai-node/pull/2195
https://github.com/openai/openai-node/pull/2194
https://github.com/openai/openai-node/pull/2204
https://github.com/openai/openai-node/pull/2196 :point_left: this PR
https://github.com/openai/openai-node/pull/2197
https://github.com/openai/openai-node/pull/2198
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201
https://github.com/openai/openai-node/pull/2202
https://github.com/openai/openai-node/pull/2203
https://github.com/openai/openai-node/pull/2205
https://github.com/openai/openai-node/pull/2206
https://github.com/openai/openai-node/pull/2207