### PR TITLE
chore(lint): enable max-classes-per-file

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -19,7 +19,6 @@ const compatibilityRules = [
   'import/no-cycle',
   'jsdoc/no-defaults',
   'jsdoc/require-param-description',
-  'max-classes-per-file',
   'no-await-in-loop',
   'no-bitwise',
   'no-empty-function',
@@ -168,6 +167,29 @@ module.exports = defineConfig({
       ],
       rules: {
         'unicorn/prefer-event-target': 'off',
+      },
+    },
+    {
+      // These files intentionally colocate one closely related class pair.
+      files: [
+        'src/_vendor/partial-json-parser/parser.ts',
+        'src/beta/realtime/internal-base.ts',
+        'src/core/EventEmitter.ts',
+        'src/core/streaming.ts',
+        'src/realtime/internal-base.ts',
+        'tests/internal/websocket-adapters.test.ts',
+        'tests/lib/ChatCompletionRunFunctions.test.ts',
+        'tests/lib/responsesWebSocket.test.ts',
+      ],
+      rules: {
+        'max-classes-per-file': ['error', { max: 2 }],
+      },
+    },
+    {
+      // Path validation deliberately creates anonymous class-expression fixtures.
+      files: ['tests/path.test.ts'],
+      rules: {
+        'max-classes-per-file': ['error', { ignoreExpressions: true }],
       },
     },
     {

--- a/src/internal/ws-adapter-browser.ts
+++ b/src/internal/ws-adapter-browser.ts
@@ -7,7 +7,7 @@ type Listener = (...args: any[]) => void;
 type DOMEventHandler = (ev: any) => void;
 
 // Minimal browser API type declarations.
-declare class WebSocket {
+interface WebSocket {
   readonly readyState: number;
   binaryType: string;
   send(data: string | ArrayBufferLike | ArrayBufferView): void;


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `max-classes-per-file` compatibility exception from `oxlint.config.ts`.
- Resolve or narrowly account for the existing violations while preserving behavior.
- Baseline count: 10 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 106; stacked on https://github.com/openai/openai-node/pull/2196.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188
https://github.com/openai/openai-node/pull/2190
https://github.com/openai/openai-node/pull/2191
https://github.com/openai/openai-node/pull/2189
https://github.com/openai/openai-node/pull/2192
https://github.com/openai/openai-node/pull/2193
https://github.com/openai/openai-node/pull/2195
https://github.com/openai/openai-node/pull/2194
https://github.com/openai/openai-node/pull/2204
https://github.com/openai/openai-node/pull/2196
https://github.com/openai/openai-node/pull/2197 :point_left: this PR
https://github.com/openai/openai-node/pull/2198
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201
https://github.com/openai/openai-node/pull/2202
https://github.com/openai/openai-node/pull/2203
https://github.com/openai/openai-node/pull/2205
https://github.com/openai/openai-node/pull/2206
https://github.com/openai/openai-node/pull/2207