### PR TITLE
chore(lint): enable no-inner-declarations

### DIFF
--- a/ecosystem-tests/browser-direct-import/src/test.ts
+++ b/ecosystem-tests/browser-direct-import/src/test.ts
@@ -7,9 +7,9 @@ import puppeteer from 'puppeteer';
   let page;
   try {
     page = await browser.newPage();
-    function debugEvent(subj: string) {
+    const debugEvent = (subj: string) => {
       return subj.padEnd('requestfailed'.length);
-    }
+    };
     page
       .on('console', (message) =>
         console.error(

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -366,15 +366,15 @@ async function main() {
       const eraseLine = '\u001B[2K';
 
       let progressDisplayed = false;
-      function clearProgress() {
+      const clearProgress = () => {
         if (progressDisplayed) {
           process.stderr.write(cursorLeft + eraseLine);
           progressDisplayed = false;
         }
-      }
+      };
       const spinner = ['|', '/', '-', '\\'];
 
-      function showProgress() {
+      const showProgress = () => {
         clearProgress();
         progressDisplayed = true;
         const spin = spinner[Math.floor(Date.now() / 500) % spinner.length];
@@ -382,7 +382,7 @@ async function main() {
           `${spin} Running ${[...runningProjects].join(', ')}`.substring(0, process.stdout.columns - 3) +
             '...',
         );
-      }
+      };
 
       const progressInterval = setInterval(showProgress, process.stdout.isTTY ? 500 : 5000);
       showProgress();

--- a/ecosystem-tests/cloudflare-worker/src/worker.ts
+++ b/ecosystem-tests/cloudflare-worker/src/worker.ts
@@ -48,15 +48,15 @@ export default {
 			console.error('created client');
 
 			const tests: Test[] = [];
-			function it(description: string, handler: () => Promise<void>) {
+			const it = (description: string, handler: () => Promise<void>) => {
 				tests.push({ description, handler });
-			}
-			function expectEqual(a: any, b: any) {
+			};
+			const expectEqual = (a: any, b: any) => {
 				if (!Object.is(a, b)) {
 					throw new Error(`expected values to be equal: ${JSON.stringify({ a, b })}`);
 				}
-			}
-			function expectSimilar(received: string, expected: string, maxDistance: number) {
+			};
+			const expectSimilar = (received: string, expected: string, maxDistance: number) => {
 				const receivedDistance = distance(received, expected);
 				if (receivedDistance < maxDistance) {
 					return;
@@ -70,7 +70,7 @@ export default {
 				].join('\n');
 
 				throw new Error(message);
-			}
+			};
 
 			uploadWebApiTestCases({
 				client: client as any,

--- a/ecosystem-tests/ts-browser-webpack/src/test.ts
+++ b/ecosystem-tests/ts-browser-webpack/src/test.ts
@@ -7,9 +7,9 @@ import puppeteer from 'puppeteer';
   let page;
   try {
     page = await browser.newPage();
-    function debugEvent(subj: string) {
+    const debugEvent = (subj: string) => {
       return subj.padEnd('requestfailed'.length);
-    }
+    };
     page
       .on('console', (message) =>
         console.error(

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -24,7 +24,6 @@ const compatibilityRules = [
   'no-empty-function',
   'no-eq-null',
   'no-inline-comments',
-  'no-inner-declarations',
   'no-negated-condition',
   'no-nested-ternary',
   'no-param-reassign',

--- a/src/helpers/audio.ts
+++ b/src/helpers/audio.ts
@@ -112,6 +112,12 @@ function nodejsRecordAudio({ signal, device, timeout }: RecordAudioOptions = {})
         },
       );
 
+      const returnData = () => {
+        const audioBuffer = Buffer.concat(data);
+        const audioFile = new File([audioBuffer], 'audio.wav', { type: 'audio/wav' });
+        resolve(audioFile);
+      };
+
       ffmpeg.stdout.on('data', (chunk) => {
         data.push(chunk);
       });
@@ -124,12 +130,6 @@ function nodejsRecordAudio({ signal, device, timeout }: RecordAudioOptions = {})
       ffmpeg.on('close', (code) => {
         returnData();
       });
-
-      function returnData() {
-        const audioBuffer = Buffer.concat(data);
-        const audioFile = new File([audioBuffer], 'audio.wav', { type: 'audio/wav' });
-        resolve(audioFile);
-      }
 
       if (typeof timeout === 'number' && timeout > 0) {
         const internalSignal = AbortSignal.timeout(timeout);

--- a/tests/utils/mock-snapshots.ts
+++ b/tests/utils/mock-snapshots.ts
@@ -12,13 +12,13 @@ export async function makeSnapshotRequest<T>(
   if (process.env['UPDATE_API_SNAPSHOTS'] === '1') {
     var capturedResponseContent: string | null = null;
 
-    async function fetch(url: RequestInfo, init?: RequestInit) {
+    const snapshotFetch = async (url: RequestInfo, init?: RequestInit) => {
       const response = await defaultFetch(url, init);
       capturedResponseContent = await response.text();
       return new Response(capturedResponseContent, response);
-    }
+    };
 
-    const openai = new OpenAI({ fetch });
+    const openai = new OpenAI({ fetch: snapshotFetch });
 
     const result = await requestFn(openai);
     if (!capturedResponseContent) {
@@ -71,13 +71,13 @@ export async function makeStreamSnapshotRequest<T extends AsyncIterable<any>>(
   if (process.env['UPDATE_API_SNAPSHOTS'] === '1') {
     var capturedResponseContent: string | null = null;
 
-    async function fetch(url: RequestInfo, init?: RequestInit) {
+    const snapshotFetch = async (url: RequestInfo, init?: RequestInit) => {
       const response = await defaultFetch(url, init);
       capturedResponseContent = await response.text();
       return new Response(Readable.from(capturedResponseContent), response);
-    }
+    };
 
-    const openai = new OpenAI({ fetch });
+    const openai = new OpenAI({ fetch: snapshotFetch });
 
     const iterator = requestFn(openai);
     for await (const _ of iterator) {


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `no-inner-declarations` compatibility exception from `oxlint.config.ts`.
- Resolve or narrowly account for the existing violations while preserving behavior.
- Baseline count: 10 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 107; stacked on https://github.com/openai/openai-node/pull/2197.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188
https://github.com/openai/openai-node/pull/2190
https://github.com/openai/openai-node/pull/2191
https://github.com/openai/openai-node/pull/2189
https://github.com/openai/openai-node/pull/2192
https://github.com/openai/openai-node/pull/2193
https://github.com/openai/openai-node/pull/2195
https://github.com/openai/openai-node/pull/2194
https://github.com/openai/openai-node/pull/2204
https://github.com/openai/openai-node/pull/2196
https://github.com/openai/openai-node/pull/2197
https://github.com/openai/openai-node/pull/2198 :point_left: this PR
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201
https://github.com/openai/openai-node/pull/2202
https://github.com/openai/openai-node/pull/2203
https://github.com/openai/openai-node/pull/2205
https://github.com/openai/openai-node/pull/2206
https://github.com/openai/openai-node/pull/2207