### PR TITLE
chore(lint): enable oxc/no-accumulating-spread

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -35,7 +35,6 @@ const compatibilityRules = [
   'no-var',
   'node/global-require',
   'object-shorthand',
-  'oxc/no-accumulating-spread',
   'prefer-arrow-callback',
   'prefer-destructuring',
   'prefer-named-capture-group',

--- a/src/_vendor/zod-to-json-schema/parsers/record.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/record.ts
@@ -50,9 +50,9 @@ export function parseRecordDef(
   }
 
   if (def.keyType?._def.typeName === ZodFirstPartyTypeKind.ZodString && def.keyType._def.checks?.length) {
-    const keyType: JsonSchema7RecordPropertyNamesType = Object.entries(
-      parseStringDef(def.keyType._def, refs),
-    ).reduce((acc, [key, value]) => (key === 'type' ? acc : { ...acc, [key]: value }), {});
+    const keyType = Object.fromEntries(
+      Object.entries(parseStringDef(def.keyType._def, refs)).filter(([key]) => key !== 'type'),
+    ) as JsonSchema7RecordPropertyNamesType;
 
     return {
       ...schema,

--- a/src/_vendor/zod-to-json-schema/parsers/tuple.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/tuple.ts
@@ -30,7 +30,7 @@ export function parseTupleDef(
             currentPath: [...refs.currentPath, 'items', `${i}`],
           }),
         )
-        .reduce((acc: JsonSchema7Type[], x) => (x === undefined ? acc : [...acc, x]), []),
+        .filter((x): x is JsonSchema7Type => x !== undefined),
       additionalItems: parseDef(def.rest._def, {
         ...refs,
         currentPath: [...refs.currentPath, 'additionalItems'],
@@ -48,6 +48,6 @@ export function parseTupleDef(
           currentPath: [...refs.currentPath, 'items', `${i}`],
         }),
       )
-      .reduce((acc: JsonSchema7Type[], x) => (x === undefined ? acc : [...acc, x]), []),
+      .filter((x): x is JsonSchema7Type => x !== undefined),
   };
 }

--- a/src/_vendor/zod-to-json-schema/parsers/union.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/union.ts
@@ -42,10 +42,13 @@ export function parseUnionDef(
   ) {
     // all types in union are primitive and lack checks, so might as well squash into {type: [...]}
 
-    const types = options.reduce((types: JsonSchema7Primitive[], x) => {
+    const types: JsonSchema7Primitive[] = [];
+    for (const x of options) {
       const type = primitiveMappings[x._def.typeName as ZodPrimitive]; //Can be safely casted due to row 43
-      return type && !types.includes(type) ? [...types, type] : types;
-    }, []);
+      if (type && !types.includes(type)) {
+        types.push(type);
+      }
+    }
 
     return {
       type: types.length > 1 ? types : types[0]!,
@@ -53,44 +56,51 @@ export function parseUnionDef(
   } else if (options.every((x) => x._def.typeName === 'ZodLiteral' && !x.description)) {
     // all options literals
 
-    const types = options.reduce((acc: JsonSchema7Primitive[], x: { _def: ZodLiteralDef }) => {
+    const types: JsonSchema7Primitive[] = [];
+    for (const x of options as readonly { _def: ZodLiteralDef }[]) {
       const type = typeof x._def.value;
       switch (type) {
         case 'string':
         case 'number':
         case 'boolean':
-          return [...acc, type];
+          types.push(type);
+          break;
         case 'bigint':
-          return [...acc, 'integer' as const];
+          types.push('integer');
+          break;
         case 'object':
-          if (x._def.value === null) return [...acc, 'null' as const];
-          return acc;
-        default:
-          return acc;
+          if (x._def.value === null) types.push('null');
+          break;
       }
-    }, []);
+    }
 
     if (types.length === options.length) {
       // all the literals are primitive, as far as null can be considered primitive
 
       const uniqueTypes = types.filter((x, i, a) => a.indexOf(x) === i);
+      const enumValues: (string | number | bigint | boolean | null)[] = [];
+      for (const x of options) {
+        if (!enumValues.includes(x._def.value)) {
+          enumValues.push(x._def.value);
+        }
+      }
       return {
         type: uniqueTypes.length > 1 ? uniqueTypes : uniqueTypes[0]!,
-        enum: options.reduce(
-          (acc, x) => {
-            return acc.includes(x._def.value) ? acc : [...acc, x._def.value];
-          },
-          [] as (string | number | bigint | boolean | null)[],
-        ),
+        enum: enumValues,
       };
     }
   } else if (options.every((x) => x._def.typeName === 'ZodEnum')) {
+    const enumValues: string[] = [];
+    for (const x of options) {
+      for (const value of x._def.values) {
+        if (!enumValues.includes(value)) {
+          enumValues.push(value);
+        }
+      }
+    }
     return {
       type: 'string',
-      enum: options.reduce(
-        (acc: string[], x) => [...acc, ...x._def.values.filter((x: string) => !acc.includes(x))],
-        [],
-      ),
+      enum: enumValues,
     };
   }
 

--- a/src/lib/transform.ts
+++ b/src/lib/transform.ts
@@ -1889,18 +1889,20 @@ function mergeObjectAllOf(
   // closed property sets before merging schemas so optional declarations
   // excluded by another closed branch are discarded, while required excluded
   // properties remain unrepresentable and fail closed.
-  const allowedClosedProperties =
-    closedPropertySets.length === 0
-      ? undefined
-      : closedPropertySets
-          .slice(1)
-          .reduce(
-            (allowed, keys) => new Set([...allowed].filter((key) => keys.has(key))),
-            new Set(closedPropertySets[0]),
-          );
+  let allowedClosedProperties: Set<string> | undefined;
+  if (closedPropertySets.length > 0) {
+    allowedClosedProperties = new Set(closedPropertySets[0]);
+    for (const keys of closedPropertySets.slice(1)) {
+      for (const key of allowedClosedProperties) {
+        if (!keys.has(key)) {
+          allowedClosedProperties.delete(key);
+        }
+      }
+    }
+  }
+  const closedProperties = allowedClosedProperties;
   const excludesRequiredProperty =
-    allowedClosedProperties !== undefined &&
-    [...mergedRequired].some((key) => !allowedClosedProperties.has(key));
+    closedProperties !== undefined && [...mergedRequired].some((key) => !closedProperties.has(key));
   const collapsesToNull = excludesRequiredProperty && !hasExplicitObjectType && hasExplicitNullableObjectType;
   const discardedPropertyPaths = propertyEntries
     .filter(


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `oxc/no-accumulating-spread` compatibility exception from `oxlint.config.ts`.
- Resolve or narrowly account for the existing violations while preserving behavior.
- Baseline count: 10 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 110; stacked on https://github.com/openai/openai-node/pull/2200.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188
https://github.com/openai/openai-node/pull/2190
https://github.com/openai/openai-node/pull/2191
https://github.com/openai/openai-node/pull/2189
https://github.com/openai/openai-node/pull/2192
https://github.com/openai/openai-node/pull/2193
https://github.com/openai/openai-node/pull/2195
https://github.com/openai/openai-node/pull/2194
https://github.com/openai/openai-node/pull/2204
https://github.com/openai/openai-node/pull/2196
https://github.com/openai/openai-node/pull/2197
https://github.com/openai/openai-node/pull/2198
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201 :point_left: this PR
https://github.com/openai/openai-node/pull/2202
https://github.com/openai/openai-node/pull/2203
https://github.com/openai/openai-node/pull/2205
https://github.com/openai/openai-node/pull/2206
https://github.com/openai/openai-node/pull/2207