### PR TITLE
chore(lint): enable unicorn/no-negated-condition

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -68,7 +68,6 @@ const compatibilityRules = [
   'unicorn/no-array-reduce',
   'unicorn/no-await-expression-member',
   'unicorn/no-console-spaces',
-  'unicorn/no-negated-condition',
   'unicorn/no-nested-ternary',
   'unicorn/no-typeof-undefined',
   'unicorn/no-useless-undefined',


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/no-negated-condition` compatibility exception from `oxlint.config.ts`.
- The overlapping core-rule cleanup in part 108 already resolves these sites.
- Baseline count: 10 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 111; stacked on https://github.com/openai/openai-node/pull/2201.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188
https://github.com/openai/openai-node/pull/2190
https://github.com/openai/openai-node/pull/2191
https://github.com/openai/openai-node/pull/2189
https://github.com/openai/openai-node/pull/2192
https://github.com/openai/openai-node/pull/2193
https://github.com/openai/openai-node/pull/2195
https://github.com/openai/openai-node/pull/2194
https://github.com/openai/openai-node/pull/2204
https://github.com/openai/openai-node/pull/2196
https://github.com/openai/openai-node/pull/2197
https://github.com/openai/openai-node/pull/2198
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201
https://github.com/openai/openai-node/pull/2202 :point_left: this PR
https://github.com/openai/openai-node/pull/2203
https://github.com/openai/openai-node/pull/2205
https://github.com/openai/openai-node/pull/2206
https://github.com/openai/openai-node/pull/2207