### PR TITLE
chore(lint): enable no-empty-function

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -21,7 +21,6 @@ const compatibilityRules = [
   'jsdoc/require-param-description',
   'no-await-in-loop',
   'no-bitwise',
-  'no-empty-function',
   'no-eq-null',
   'no-inline-comments',
   'no-nested-ternary',

--- a/src/_vendor/zod-to-json-schema/parsers/string.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/string.ts
@@ -227,7 +227,7 @@ export function parseStringDef(def: ZodStringDef, refs: Refs): JsonSchema7String
         case 'trim':
           break;
         default:
-          ((_: never) => {})(check);
+          ((_: never) => undefined)(check);
       }
     }
   }

--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -114,7 +114,7 @@ export class Stream<Item> implements AsyncIterable<Item> {
       let cancelPromise: Promise<void> | undefined;
       const cancel = () => {
         cancelPromise ??= reader.cancel();
-        cancelPromise.catch(() => {});
+        cancelPromise.catch(() => undefined);
       };
 
       controller.signal.addEventListener('abort', cancel, { once: true });

--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -761,4 +761,6 @@ export class AssistantStream
   }
 }
 
-function assertNever(_x: never) {}
+function assertNever(_x: never) {
+  return _x;
+}

--- a/src/lib/ChatCompletionStream.ts
+++ b/src/lib/ChatCompletionStream.ts
@@ -1012,4 +1012,6 @@ function assertIsEmpty<T extends object>(obj: AssertIsEmpty<T>): asserts obj is 
   void obj;
 }
 
-function assertNever(_x: never) {}
+function assertNever(_x: never) {
+  return _x;
+}

--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -4,12 +4,12 @@ export class EventStream<EventTypes extends BaseEvents> {
   controller: AbortController = new AbortController();
 
   #connectedPromise: Promise<void>;
-  #resolveConnectedPromise: () => void = () => {};
-  #rejectConnectedPromise: (error: OpenAIError) => void = () => {};
+  #resolveConnectedPromise: () => void = () => undefined;
+  #rejectConnectedPromise: (error: OpenAIError) => void = () => undefined;
 
   #endPromise: Promise<void>;
-  #resolveEndPromise: () => void = () => {};
-  #rejectEndPromise: (error: OpenAIError) => void = () => {};
+  #resolveEndPromise: () => void = () => undefined;
+  #rejectEndPromise: (error: OpenAIError) => void = () => undefined;
 
   #listeners: {
     [Event in keyof EventTypes]?: EventListeners<EventTypes, Event>;
@@ -36,8 +36,8 @@ export class EventStream<EventTypes extends BaseEvents> {
     // we will manually cause an unhandled rejection error later
     // if the user hasn't registered any error listener or called
     // any promise-returning method.
-    this.#connectedPromise.catch(() => {});
-    this.#endPromise.catch(() => {});
+    this.#connectedPromise.catch(() => undefined);
+    this.#endPromise.catch(() => undefined);
   }
 
   protected _run(this: EventStream<EventTypes>, executor: () => Promise<any>) {
@@ -355,7 +355,9 @@ export class EventStream<EventTypes extends BaseEvents> {
     }
   }
 
-  protected _emitFinal(): void {}
+  protected _emitFinal(): void {
+    // Hook for subclasses.
+  }
 }
 
 type EventListener<Events, EventType extends keyof Events> = Events[EventType];


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `no-empty-function` compatibility exception from `oxlint.config.ts`.
- Resolve the existing violations while preserving behavior.
- Baseline count: 11 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 112; stacked on https://github.com/openai/openai-node/pull/2202.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188
https://github.com/openai/openai-node/pull/2190
https://github.com/openai/openai-node/pull/2191
https://github.com/openai/openai-node/pull/2189
https://github.com/openai/openai-node/pull/2192
https://github.com/openai/openai-node/pull/2193
https://github.com/openai/openai-node/pull/2195
https://github.com/openai/openai-node/pull/2194
https://github.com/openai/openai-node/pull/2204
https://github.com/openai/openai-node/pull/2196
https://github.com/openai/openai-node/pull/2197
https://github.com/openai/openai-node/pull/2198
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201
https://github.com/openai/openai-node/pull/2202
https://github.com/openai/openai-node/pull/2203 :point_left: this PR
https://github.com/openai/openai-node/pull/2205
https://github.com/openai/openai-node/pull/2206
https://github.com/openai/openai-node/pull/2207