### PR TITLE
chore(lint): enable unicorn/prefer-event-target

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -79,7 +79,6 @@ const compatibilityRules = [
   'unicorn/no-useless-undefined',
   'unicorn/numeric-separators-style',
   'unicorn/prefer-at',
-  'unicorn/prefer-event-target',
   'unicorn/prefer-module',
   'unicorn/prefer-node-protocol',
   'unicorn/prefer-optional-catch-binding',
@@ -153,6 +152,23 @@ module.exports = defineConfig({
       ],
       rules: {
         'typescript/no-empty-object-type': 'off',
+      },
+    },
+    {
+      // These SDK and test helpers intentionally use typed or Node EventEmitter APIs;
+      // EventTarget would lose multi-argument events, emit chaining, or public behavior.
+      files: [
+        'src/beta/realtime/internal-base.ts',
+        'src/core/EventEmitter.ts',
+        'src/realtime/internal-base.ts',
+        'tests/helpers/audio-recording.test.ts',
+        'tests/internal/websocket-adapters.test.ts',
+        'tests/lib/core-event-emitter.test.ts',
+        'tests/lib/eventEmitter.test.ts',
+        'tests/lib/responsesWebSocket.test.ts',
+      ],
+      rules: {
+        'unicorn/prefer-event-target': 'off',
       },
     },
     {


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/prefer-event-target` compatibility exception from `oxlint.config.ts`.
- Keep intentional Node-style SDK event emitters through narrow file overrides.
- Baseline count: 9 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 104; stacked on https://github.com/openai/openai-node/pull/2194.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188
https://github.com/openai/openai-node/pull/2190
https://github.com/openai/openai-node/pull/2191
https://github.com/openai/openai-node/pull/2189
https://github.com/openai/openai-node/pull/2192
https://github.com/openai/openai-node/pull/2193
https://github.com/openai/openai-node/pull/2195
https://github.com/openai/openai-node/pull/2194
https://github.com/openai/openai-node/pull/2204 :point_left: this PR
https://github.com/openai/openai-node/pull/2196
https://github.com/openai/openai-node/pull/2197
https://github.com/openai/openai-node/pull/2198
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201
https://github.com/openai/openai-node/pull/2202
https://github.com/openai/openai-node/pull/2203
https://github.com/openai/openai-node/pull/2205
https://github.com/openai/openai-node/pull/2206
https://github.com/openai/openai-node/pull/2207