### PR TITLE
chore(lint): enable unicorn/import-style

### DIFF
--- a/examples/chat-completions/function-call-stream-raw.ts
+++ b/examples/chat-completions/function-call-stream-raw.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S npm run tsn -- -T
 
-import util from 'util';
+import { formatWithOptions } from 'util';
 import OpenAI from 'openai';
 import {
   ChatCompletionMessage,
@@ -142,8 +142,8 @@ function lineRewriter() {
   return function write(value: any) {
     process.stdout.cursorTo(0);
     process.stdout.moveCursor(0, -Math.floor((lastMessageLength - 1) / process.stdout.columns));
-    lastMessageLength = util.formatWithOptions({ colors: false, breakLength: Infinity }, value).length;
-    process.stdout.write(util.formatWithOptions({ colors: true, breakLength: Infinity }, value));
+    lastMessageLength = formatWithOptions({ colors: false, breakLength: Infinity }, value).length;
+    process.stdout.write(formatWithOptions({ colors: true, breakLength: Infinity }, value));
   };
 }
 

--- a/examples/chat-completions/function-call-stream.ts
+++ b/examples/chat-completions/function-call-stream.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S npm run tsn -- -T
 
-import util from 'util';
+import { formatWithOptions } from 'util';
 import OpenAI from 'openai';
 import {
   ChatCompletionMessage,
@@ -142,8 +142,8 @@ function lineRewriter() {
   return function write(value: any) {
     process.stdout.cursorTo(0);
     process.stdout.moveCursor(0, -Math.floor((lastMessageLength - 1) / process.stdout.columns));
-    lastMessageLength = util.formatWithOptions({ colors: false, breakLength: Infinity }, value).length;
-    process.stdout.write(util.formatWithOptions({ colors: true, breakLength: Infinity }, value));
+    lastMessageLength = formatWithOptions({ colors: false, breakLength: Infinity }, value).length;
+    process.stdout.write(formatWithOptions({ colors: true, breakLength: Infinity }, value));
   };
 }
 

--- a/examples/chat-completions/tool-calls-stream.ts
+++ b/examples/chat-completions/tool-calls-stream.ts
@@ -19,7 +19,7 @@
 //
 //
 
-import util from 'util';
+import { formatWithOptions } from 'util';
 import OpenAI from 'openai';
 import {
   ChatCompletionMessage,
@@ -209,7 +209,7 @@ function lineRewriter() {
     process.stdout.moveCursor(0, -lastMessageLines);
 
     // calculate where to move cursor back for the next move.
-    const text = util.formatWithOptions({ colors: false, breakLength: Infinity, depth: 4 }, value);
+    const text = formatWithOptions({ colors: false, breakLength: Infinity, depth: 4 }, value);
     const __LINE_BREAK_PLACE_HOLDER__ = '__LINE_BREAK_PLACE_HOLDER__';
     const lines = text
       // @ts-ignore-error this requires es2021
@@ -225,7 +225,7 @@ function lineRewriter() {
     lastMessageLines = Math.max(lastMessageLines, 0);
 
     process.stdout.clearScreenDown();
-    process.stdout.write(util.formatWithOptions({ colors: true, breakLength: Infinity, depth: 4 }, value));
+    process.stdout.write(formatWithOptions({ colors: true, breakLength: Infinity, depth: 4 }, value));
   };
 }
 const db: { id: string; name: string; genre: string; description: string }[] = [

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -62,7 +62,6 @@ const compatibilityRules = [
   'unicorn/consistent-assert',
   'unicorn/consistent-function-scoping',
   'unicorn/filename-case',
-  'unicorn/import-style',
   'unicorn/no-array-for-each',
   'unicorn/no-array-reduce',
   'unicorn/no-await-expression-member',

--- a/scripts/_vendor/tsc-multi/src/build.ts
+++ b/scripts/_vendor/tsc-multi/src/build.ts
@@ -1,5 +1,5 @@
 import { fork } from 'child_process';
-import { join } from 'path';
+import path = require('path');
 import { Config, Target } from './config';
 import { WorkerOptions } from './worker/types';
 import { Stream } from 'stream';
@@ -9,7 +9,7 @@ import onExit from 'signal-exit';
 import pAll from 'p-all';
 import debug from './debug';
 
-const WORKER_PATH = join(__dirname, 'worker/entry.ts');
+const WORKER_PATH = path.join(__dirname, 'worker/entry.ts');
 const TS_NODE_REGISTER = require.resolve('ts-node/register/transpile-only');
 const WORKER_TS_NODE_ENV = {
   TS_NODE_SKIP_PROJECT: 'true',

--- a/scripts/_vendor/tsc-multi/src/config.ts
+++ b/scripts/_vendor/tsc-multi/src/config.ts
@@ -1,4 +1,4 @@
-import { dirname, resolve } from 'path';
+import nodePath = require('path');
 import { object, string, array, Infer, validate, optional, type, integer, min, boolean } from 'superstruct';
 import Debug from './debug';
 import { readJSON, tryReadJSON } from './utils';
@@ -41,7 +41,7 @@ export interface LoadConfigOptions {
 
 export async function loadConfig({ cwd = process.cwd(), path }: LoadConfigOptions): Promise<Config> {
   const mustLoadConfig = !!path;
-  const configPath = resolve(cwd, path || 'tsc-multi.json');
+  const configPath = nodePath.resolve(cwd, path || 'tsc-multi.json');
 
   debug('Read config from %s', configPath);
 
@@ -61,6 +61,6 @@ export async function loadConfig({ cwd = process.cwd(), path }: LoadConfigOption
   return {
     ...config,
     cwd,
-    projects: await resolveProjectPath(dirname(configPath), config.projects || []),
+    projects: await resolveProjectPath(nodePath.dirname(configPath), config.projects || []),
   };
 }

--- a/scripts/_vendor/tsc-multi/src/transformer.ts
+++ b/scripts/_vendor/tsc-multi/src/transformer.ts
@@ -1,4 +1,4 @@
-import { resolve, dirname, extname, relative } from 'path';
+import nodePath = require('path');
 import type ts from 'typescript';
 import { trimSuffix } from './utils';
 import assert from 'assert';
@@ -53,14 +53,14 @@ export function createTransformer<T extends ts.SourceFile | ts.Bundle>(
 
   function isDirectory(sourceFile: ts.SourceFile, path: string): boolean {
     const sourcePath = sourceFile.fileName;
-    const fullPath = resolve(dirname(sourcePath), path);
+    const fullPath = nodePath.resolve(nodePath.dirname(sourcePath), path);
 
     return sys.directoryExists(fullPath);
   }
 
   function fileExists(sourceFile: ts.SourceFile, path: string): boolean {
     const sourcePath = sourceFile.fileName;
-    const fullPath = resolve(dirname(sourcePath), path);
+    const fullPath = nodePath.resolve(nodePath.dirname(sourcePath), path);
 
     return sys.fileExists(fullPath);
   }
@@ -72,7 +72,7 @@ export function createTransformer<T extends ts.SourceFile | ts.Bundle>(
   ): ts.LiteralExpression | T {
     if (!isStringLiteral(node) || !isRelativePath(node.text)) return node;
 
-    const ext = extname(node.text);
+    const ext = nodePath.extname(node.text);
 
     if (ext === MJS_EXT || ext === CJS_EXT) {
       return node;
@@ -101,7 +101,7 @@ export function createTransformer<T extends ts.SourceFile | ts.Bundle>(
     let sourceFile: ts.SourceFile;
 
     function getRelativeImport(mod: string) {
-      const r = relative(dirname(sourceFile.fileName), mod);
+      const r = nodePath.relative(nodePath.dirname(sourceFile.fileName), mod);
       return /^\.?\.?\//.test(r) ? r : './' + r;
     }
 

--- a/scripts/_vendor/tsc-multi/src/worker/worker.ts
+++ b/scripts/_vendor/tsc-multi/src/worker/worker.ts
@@ -4,7 +4,7 @@ import { createReporter, Reporter } from '../report';
 import { mergeCustomTransformers, trimSuffix, isIncrementalCompilation } from '../utils';
 import { createTransformer } from '../transformer';
 import { WorkerOptions } from './types';
-import { dirname, extname, join, resolve } from 'path';
+import nodePath = require('path');
 import assert from 'assert';
 import { helpers } from '../helpers';
 
@@ -265,8 +265,12 @@ export class Worker {
     };
 
     host.getParsedCommandLine = (path: string) => {
-      const basePath = trimSuffix(path, extname(path));
-      const { options } = this.ts.convertCompilerOptionsFromJson(this.data.target, dirname(path), path);
+      const basePath = trimSuffix(path, nodePath.extname(path));
+      const { options } = this.ts.convertCompilerOptionsFromJson(
+        this.data.target,
+        nodePath.dirname(path),
+        path,
+      );
 
       const config = this.ts.getParsedCommandLineOfConfigFile(path, options, parseConfigFileHost);
       if (!config) return;
@@ -274,7 +278,7 @@ export class Worker {
       if (this.data.shareHelpers) {
         const root = (this.ts as any).getCommonSourceDirectoryOfConfig(config);
         config.options.importHelpers = true;
-        resolvedShareHelpers = resolve(root, this.data.shareHelpers);
+        resolvedShareHelpers = nodePath.resolve(root, this.data.shareHelpers);
       }
 
       // Set separated tsbuildinfo paths to avoid that multiple workers to
@@ -340,7 +344,7 @@ export class Worker {
       }
     }
     write(
-      resolve(out, this.data.shareHelpers),
+      nodePath.resolve(out, this.data.shareHelpers),
       this.ts.transpileModule(
         helperDeps.map((name) => helpers[name].code).join('\n\n') +
           `\n\nexport { ${[...helpersNeeded].join(', ')} };\n`,
@@ -365,7 +369,7 @@ export class Worker {
   private transpileProject(projectPath: string) {
     const tsConfigPath = this.system.fileExists(projectPath)
       ? projectPath
-      : join(projectPath, 'tsconfig.json');
+      : nodePath.join(projectPath, 'tsconfig.json');
     const { options } = this.ts.convertCompilerOptionsFromJson(this.data.target, projectPath, tsConfigPath);
 
     const parseConfigFileHost: ts.ParseConfigFileHost = {
@@ -380,7 +384,7 @@ export class Worker {
     if (this.data.shareHelpers) {
       const root = (this.ts as any).getCommonSourceDirectoryOfConfig(config);
       config.options.importHelpers = true;
-      resolvedShareHelpers = resolve(root, this.data.shareHelpers);
+      resolvedShareHelpers = nodePath.resolve(root, this.data.shareHelpers);
     }
 
     const helpersNeeded = new Set<string>();

--- a/tests/oxlint-config.test.ts
+++ b/tests/oxlint-config.test.ts
@@ -1,11 +1,11 @@
 import { spawnSync } from 'node:child_process';
 import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import path from 'node:path';
 
 const repoRoot = process.cwd();
-const oxlint = join(repoRoot, 'node_modules/oxlint/bin/oxlint');
-const oxfmt = join(repoRoot, 'node_modules/oxfmt/bin/oxfmt');
+const oxlint = path.join(repoRoot, 'node_modules/oxlint/bin/oxlint');
+const oxfmt = path.join(repoRoot, 'node_modules/oxfmt/bin/oxfmt');
 
 test('inherits Ultracite native plugins and enforces their rules', () => {
   const printed = spawnSync(process.execPath, [oxlint, '--print-config', 'src/internal/uploads.ts'], {
@@ -26,15 +26,15 @@ test('inherits Ultracite native plugins and enforces their rules', () => {
   );
   expect(configuration.rules['unicorn/no-instanceof-array']).toBe('deny');
 
-  const fixtureRoot = mkdtempSync(join(tmpdir(), 'openai-node-oxlint-config-'));
+  const fixtureRoot = mkdtempSync(path.join(tmpdir(), 'openai-node-oxlint-config-'));
 
   try {
-    const fixturePath = join(fixtureRoot, 'native-plugin.ts');
+    const fixturePath = path.join(fixtureRoot, 'native-plugin.ts');
     writeFileSync(fixturePath, 'const values = [];\nconsole.log(values instanceof Array);\n');
 
     const linted = spawnSync(
       process.execPath,
-      [oxlint, '--config', join(repoRoot, 'oxlint.config.ts'), '--format', 'json', fixturePath],
+      [oxlint, '--config', path.join(repoRoot, 'oxlint.config.ts'), '--format', 'json', fixturePath],
       { cwd: repoRoot, encoding: 'utf8' },
     );
 
@@ -45,7 +45,7 @@ test('inherits Ultracite native plugins and enforces their rules', () => {
 
     const formatted = spawnSync(
       process.execPath,
-      [oxfmt, '--config', join(repoRoot, 'oxfmt.config.ts'), '--check', fixturePath],
+      [oxfmt, '--config', path.join(repoRoot, 'oxfmt.config.ts'), '--check', fixturePath],
       { cwd: repoRoot, encoding: 'utf8' },
     );
 
@@ -56,21 +56,21 @@ test('inherits Ultracite native plugins and enforces their rules', () => {
 });
 
 test('recognizes both Stainless and Castiron generated SDK files', () => {
-  const fixtureRoot = mkdtempSync(join(tmpdir(), 'openai-node-generated-files-'));
+  const fixtureRoot = mkdtempSync(path.join(tmpdir(), 'openai-node-generated-files-'));
 
   try {
-    const scriptsDirectory = join(fixtureRoot, 'scripts');
+    const scriptsDirectory = path.join(fixtureRoot, 'scripts');
     mkdirSync(scriptsDirectory);
-    const generatedFilesScript = join(scriptsDirectory, 'stainless-generated-files.cjs');
-    copyFileSync(join(repoRoot, 'scripts/stainless-generated-files.cjs'), generatedFilesScript);
+    const generatedFilesScript = path.join(scriptsDirectory, 'stainless-generated-files.cjs');
+    copyFileSync(path.join(repoRoot, 'scripts/stainless-generated-files.cjs'), generatedFilesScript);
 
     for (const generator of ['Stainless', 'Castiron']) {
       writeFileSync(
-        join(fixtureRoot, `${generator.toLowerCase()}.ts`),
+        path.join(fixtureRoot, `${generator.toLowerCase()}.ts`),
         `// File generated from our OpenAPI spec by ${generator}. See CONTRIBUTING.md for details.\n`,
       );
     }
-    writeFileSync(join(fixtureRoot, 'handwritten.ts'), 'export const handwritten = true;\n');
+    writeFileSync(path.join(fixtureRoot, 'handwritten.ts'), 'export const handwritten = true;\n');
 
     const generatedFiles = require(generatedFilesScript) as string[];
     expect(generatedFiles).toEqual(['castiron.ts', 'stainless.ts']);
@@ -110,15 +110,15 @@ test('formats generated SDK files without linting them', () => {
 });
 
 test('removes adjacent unused imports from generated files until fixes stabilize', () => {
-  const fixtureRoot = mkdtempSync(join(repoRoot, '.oxlint-generated-imports-'));
+  const fixtureRoot = mkdtempSync(path.join(repoRoot, '.oxlint-generated-imports-'));
 
   try {
-    const handwrittenPath = join(fixtureRoot, 'handwritten.ts');
+    const handwrittenPath = path.join(fixtureRoot, 'handwritten.ts');
     const handwritten = "import { HandwrittenUnused } from './dependency';\nexport const value = 1;\n";
     writeFileSync(handwrittenPath, handwritten);
 
     for (const generator of ['Stainless', 'Castiron']) {
-      const generatedPath = join(fixtureRoot, `${generator.toLowerCase()}.ts`);
+      const generatedPath = path.join(fixtureRoot, `${generator.toLowerCase()}.ts`);
       const imports = Array.from(
         { length: 20 },
         (_, index) => `import { Unused${index} } from './dependency-${index}';`,
@@ -140,7 +140,7 @@ test('removes adjacent unused imports from generated files until fixes stabilize
 
       const fixed = spawnSync(
         process.execPath,
-        [join(repoRoot, 'scripts/lint-generated.cjs'), '--fix', generatedPath, handwrittenPath],
+        [path.join(repoRoot, 'scripts/lint-generated.cjs'), '--fix', generatedPath, handwrittenPath],
         { cwd: repoRoot, encoding: 'utf8' },
       );
 
@@ -160,22 +160,22 @@ test('removes adjacent unused imports from generated files until fixes stabilize
 });
 
 test('limits generated import cleanup to paths supplied through a fast-format file list', () => {
-  const fixtureRoot = mkdtempSync(join(repoRoot, '.oxlint-generated-file-list-'));
+  const fixtureRoot = mkdtempSync(path.join(repoRoot, '.oxlint-generated-file-list-'));
 
   try {
     const header = '// File generated from our OpenAPI spec by Castiron. See CONTRIBUTING.md for details.';
-    const selectedPath = join(fixtureRoot, 'selected.ts');
-    const untouchedPath = join(fixtureRoot, 'untouched.ts');
+    const selectedPath = path.join(fixtureRoot, 'selected.ts');
+    const untouchedPath = path.join(fixtureRoot, 'untouched.ts');
     const source = `${header}\nimport { Unused } from './dependency';\nexport const value = 1;\n`;
     writeFileSync(selectedPath, source);
     writeFileSync(untouchedPath, source);
 
-    const fileList = join(fixtureRoot, 'files.txt');
+    const fileList = path.join(fixtureRoot, 'files.txt');
     writeFileSync(fileList, `${selectedPath}\n`);
 
     const fixed = spawnSync(
       process.execPath,
-      [join(repoRoot, 'scripts/lint-generated.cjs'), '--fix', '--file-list', fileList],
+      [path.join(repoRoot, 'scripts/lint-generated.cjs'), '--fix', '--file-list', fileList],
       { cwd: repoRoot, encoding: 'utf8' },
     );
 
@@ -188,10 +188,10 @@ test('limits generated import cleanup to paths supplied through a fast-format fi
 });
 
 test('checks unused generated imports without rejecting intentionally unused variables', () => {
-  const fixtureRoot = mkdtempSync(join(repoRoot, '.oxlint-generated-check-'));
+  const fixtureRoot = mkdtempSync(path.join(repoRoot, '.oxlint-generated-check-'));
 
   try {
-    const generatedPath = join(fixtureRoot, 'generated.ts');
+    const generatedPath = path.join(fixtureRoot, 'generated.ts');
     const source = [
       '// File generated from our OpenAPI spec by Castiron. See CONTRIBUTING.md for details.',
       "import { Unused } from './dependency';",
@@ -203,7 +203,7 @@ test('checks unused generated imports without rejecting intentionally unused var
 
     const checked = spawnSync(
       process.execPath,
-      [join(repoRoot, 'scripts/lint-generated.cjs'), '--check', generatedPath],
+      [path.join(repoRoot, 'scripts/lint-generated.cjs'), '--check', generatedPath],
       { cwd: repoRoot, encoding: 'utf8' },
     );
 
@@ -215,7 +215,7 @@ test('checks unused generated imports without rejecting intentionally unused var
 
     const fixed = spawnSync(
       process.execPath,
-      [join(repoRoot, 'scripts/lint-generated.cjs'), '--fix', generatedPath],
+      [path.join(repoRoot, 'scripts/lint-generated.cjs'), '--fix', generatedPath],
       { cwd: repoRoot, encoding: 'utf8' },
     );
 
@@ -224,7 +224,7 @@ test('checks unused generated imports without rejecting intentionally unused var
 
     const rechecked = spawnSync(
       process.execPath,
-      [join(repoRoot, 'scripts/lint-generated.cjs'), '--check', generatedPath],
+      [path.join(repoRoot, 'scripts/lint-generated.cjs'), '--check', generatedPath],
       { cwd: repoRoot, encoding: 'utf8' },
     );
 
@@ -236,20 +236,20 @@ test('checks unused generated imports without rejecting intentionally unused var
 });
 
 test('rejects SDK package imports in generated source but allows them in generated tests', () => {
-  const sourceRoot = mkdtempSync(join(repoRoot, 'src', '.oxlint-generated-source-'));
-  const testsRoot = mkdtempSync(join(repoRoot, 'tests', '.oxlint-generated-tests-'));
+  const sourceRoot = mkdtempSync(path.join(repoRoot, 'src', '.oxlint-generated-source-'));
+  const testsRoot = mkdtempSync(path.join(repoRoot, 'tests', '.oxlint-generated-tests-'));
 
   try {
     const header = '// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.';
-    const sourcePath = join(sourceRoot, 'client.ts');
-    const testPath = join(testsRoot, 'client.test.ts');
+    const sourcePath = path.join(sourceRoot, 'client.ts');
+    const testPath = path.join(testsRoot, 'client.test.ts');
     const source = `${header}\nimport OpenAI from 'openai';\nexport const client = OpenAI;\n`;
     writeFileSync(sourcePath, source);
     writeFileSync(testPath, source);
 
     const checkedSource = spawnSync(
       process.execPath,
-      [join(repoRoot, 'scripts/lint-generated.cjs'), '--check', sourcePath],
+      [path.join(repoRoot, 'scripts/lint-generated.cjs'), '--check', sourcePath],
       { cwd: repoRoot, encoding: 'utf8' },
     );
 
@@ -259,7 +259,7 @@ test('rejects SDK package imports in generated source but allows them in generat
 
     const fixedSource = spawnSync(
       process.execPath,
-      [join(repoRoot, 'scripts/lint-generated.cjs'), '--fix', sourcePath],
+      [path.join(repoRoot, 'scripts/lint-generated.cjs'), '--fix', sourcePath],
       { cwd: repoRoot, encoding: 'utf8' },
     );
 
@@ -269,7 +269,7 @@ test('rejects SDK package imports in generated source but allows them in generat
     for (const mode of ['--check', '--fix']) {
       const generatedTest = spawnSync(
         process.execPath,
-        [join(repoRoot, 'scripts/lint-generated.cjs'), mode, testPath],
+        [path.join(repoRoot, 'scripts/lint-generated.cjs'), mode, testPath],
         { cwd: repoRoot, encoding: 'utf8' },
       );
 
@@ -283,10 +283,10 @@ test('rejects SDK package imports in generated source but allows them in generat
 });
 
 test('checks and fixes generated imports through the public package commands', () => {
-  const fixtureRoot = mkdtempSync(join(repoRoot, '.oxlint-public-entrypoints-'));
+  const fixtureRoot = mkdtempSync(path.join(repoRoot, '.oxlint-public-entrypoints-'));
 
   try {
-    const generatedPath = join(fixtureRoot, 'generated.ts');
+    const generatedPath = path.join(fixtureRoot, 'generated.ts');
     writeFileSync(
       generatedPath,
       [

--- a/tests/resource-exports.test.ts
+++ b/tests/resource-exports.test.ts
@@ -1,12 +1,12 @@
 import { readdirSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import nodePath from 'node:path';
 
-const repositoryRoot = join(__dirname, '..');
-const resourcesDirectory = join(repositoryRoot, 'src', 'resources');
+const repositoryRoot = nodePath.join(__dirname, '..');
+const resourcesDirectory = nodePath.join(repositoryRoot, 'src', 'resources');
 
 function findResourceIndexes(directory: string): string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-    const path = join(directory, entry.name);
+    const path = nodePath.join(directory, entry.name);
 
     if (entry.isDirectory()) return findResourceIndexes(path);
     return entry.name === 'index.ts' ? [path] : [];
@@ -14,16 +14,16 @@ function findResourceIndexes(directory: string): string[] {
 }
 
 const realtimeModules = ['realtime', 'beta/realtime'].flatMap((directory) => {
-  const moduleDirectory = join(repositoryRoot, 'src', directory);
+  const moduleDirectory = nodePath.join(repositoryRoot, 'src', directory);
 
   return readdirSync(moduleDirectory)
     .filter((name) => name.endsWith('.ts'))
-    .map((name) => join(moduleDirectory, name));
+    .map((name) => nodePath.join(moduleDirectory, name));
 });
 
 const resourceIndexes = [...findResourceIndexes(resourcesDirectory), ...realtimeModules].map(
   (modulePath) => ({
-    path: relative(repositoryRoot, modulePath),
+    path: nodePath.relative(repositoryRoot, modulePath),
     modulePath,
   }),
 );

--- a/tests/test-script.test.ts
+++ b/tests/test-script.test.ts
@@ -10,18 +10,18 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
 import jestConfig from '../jest.config';
 import generatedTestPatterns from '../scripts/generated-test-patterns.json';
 
-const testScriptPath = join(process.cwd(), 'scripts/test');
-const generatedTestPatternsPath = join(process.cwd(), 'scripts/generated-test-patterns.json');
-const generatedTopLevelTests = readdirSync(join(process.cwd(), 'tests')).filter(
+const testScriptPath = path.join(process.cwd(), 'scripts/test');
+const generatedTestPatternsPath = path.join(process.cwd(), 'scripts/generated-test-patterns.json');
+const generatedTopLevelTests = readdirSync(path.join(process.cwd(), 'tests')).filter(
   (file) =>
     file.endsWith('.test.ts') &&
-    readFileSync(join(process.cwd(), 'tests', file), 'utf8').startsWith(
+    readFileSync(path.join(process.cwd(), 'tests', file), 'utf8').startsWith(
       '// File generated from our OpenAPI spec by Stainless.',
     ),
 );
@@ -30,30 +30,30 @@ describe('scripts/test', () => {
   let fixtureDir: string;
 
   beforeEach(() => {
-    fixtureDir = mkdtempSync(join(tmpdir(), 'openai-node-test-script-'));
+    fixtureDir = mkdtempSync(path.join(tmpdir(), 'openai-node-test-script-'));
 
-    mkdirSync(join(fixtureDir, 'scripts'), { recursive: true });
-    mkdirSync(join(fixtureDir, 'node_modules/.bin'), { recursive: true });
-    mkdirSync(join(fixtureDir, 'bin'), { recursive: true });
+    mkdirSync(path.join(fixtureDir, 'scripts'), { recursive: true });
+    mkdirSync(path.join(fixtureDir, 'node_modules/.bin'), { recursive: true });
+    mkdirSync(path.join(fixtureDir, 'bin'), { recursive: true });
 
-    copyFileSync(testScriptPath, join(fixtureDir, 'scripts/test'));
-    copyFileSync(generatedTestPatternsPath, join(fixtureDir, 'scripts/generated-test-patterns.json'));
-    chmodSync(join(fixtureDir, 'scripts/test'), 0o755);
+    copyFileSync(testScriptPath, path.join(fixtureDir, 'scripts/test'));
+    copyFileSync(generatedTestPatternsPath, path.join(fixtureDir, 'scripts/generated-test-patterns.json'));
+    chmodSync(path.join(fixtureDir, 'scripts/test'), 0o755);
 
     writeExecutable(
-      join(fixtureDir, 'bin/curl'),
+      path.join(fixtureDir, 'bin/curl'),
       `#!/usr/bin/env bash
 exit 0
 `,
     );
     writeExecutable(
-      join(fixtureDir, 'node_modules/.bin/jest'),
+      path.join(fixtureDir, 'node_modules/.bin/jest'),
       `#!/usr/bin/env bash
 printf '%s\\0' "$@" > "$JEST_ARGS_FILE"
 `,
     );
     writeExecutable(
-      join(fixtureDir, 'node_modules/.bin/vitest'),
+      path.join(fixtureDir, 'node_modules/.bin/vitest'),
       `#!/usr/bin/env bash
 printf '%s\\0' "$@" > "$VITEST_ARGS_FILE"
 `,
@@ -70,15 +70,15 @@ printf '%s\\0' "$@" > "$VITEST_ARGS_FILE"
   }
 
   function runTestScript(args: string[], suite = 'all'): { jestArgs: string[]; vitestArgs: string[] } {
-    const jestArgsFile = join(fixtureDir, 'jest-args');
-    const vitestArgsFile = join(fixtureDir, 'vitest-args');
-    const result = spawnSync(join(fixtureDir, 'scripts/test'), args, {
+    const jestArgsFile = path.join(fixtureDir, 'jest-args');
+    const vitestArgsFile = path.join(fixtureDir, 'vitest-args');
+    const result = spawnSync(path.join(fixtureDir, 'scripts/test'), args, {
       encoding: 'utf8',
       env: {
         ...process.env,
         JEST_ARGS_FILE: jestArgsFile,
         OPENAI_TEST_SUITE: suite,
-        PATH: `${join(fixtureDir, 'bin')}:${process.env['PATH']}`,
+        PATH: `${path.join(fixtureDir, 'bin')}:${process.env['PATH']}`,
         VITEST_ARGS_FILE: vitestArgsFile,
       },
     });
@@ -164,7 +164,7 @@ printf '%s\\0' "$@" > "$VITEST_ARGS_FILE"
 
   test.each([
     { label: 'relative', testPath: './tests/index.test.ts' },
-    { label: 'absolute', testPath: join(process.cwd(), 'tests/index.test.ts') },
+    { label: 'absolute', testPath: path.join(process.cwd(), 'tests/index.test.ts') },
   ])('routes $label generated path filters only to Jest', ({ testPath }) => {
     expect(runTestScript([testPath])).toEqual({
       jestArgs: ['--runInBand', testPath],

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,12 +1,12 @@
-import { resolve } from 'node:path';
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 import generatedTestPatterns from './scripts/generated-test-patterns.json';
 
 export default defineConfig({
   resolve: {
     alias: [
-      { find: /^openai$/, replacement: resolve(__dirname, 'src/index.ts') },
-      { find: /^openai\/(.*)$/, replacement: resolve(__dirname, 'src/$1') },
+      { find: /^openai$/, replacement: path.resolve(__dirname, 'src/index.ts') },
+      { find: /^openai\/(.*)$/, replacement: path.resolve(__dirname, 'src/$1') },
     ],
   },
   test: {


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/import-style` compatibility exception from `oxlint.config.ts`.
- Resolve the existing violations while preserving behavior.
- Baseline count: 11 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 113; stacked on https://github.com/openai/openai-node/pull/2203.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188
https://github.com/openai/openai-node/pull/2190
https://github.com/openai/openai-node/pull/2191
https://github.com/openai/openai-node/pull/2189
https://github.com/openai/openai-node/pull/2192
https://github.com/openai/openai-node/pull/2193
https://github.com/openai/openai-node/pull/2195
https://github.com/openai/openai-node/pull/2194
https://github.com/openai/openai-node/pull/2204
https://github.com/openai/openai-node/pull/2196
https://github.com/openai/openai-node/pull/2197
https://github.com/openai/openai-node/pull/2198
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201
https://github.com/openai/openai-node/pull/2202
https://github.com/openai/openai-node/pull/2203
https://github.com/openai/openai-node/pull/2205 :point_left: this PR
https://github.com/openai/openai-node/pull/2206
https://github.com/openai/openai-node/pull/2207