### PR TITLE
chore(lint): enable unicorn/no-array-for-each

### DIFF
--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -258,16 +258,16 @@ async function main() {
   // Some projects, e.g. Deno can be slow to run, so offer the option to skip them. Example:
   //   --skip=deno node-ts-cjs
   if (args.skip.length > 0) {
-    args.skip.forEach((projectName, idx) => {
+    for (const [idx, projectName] of args.skip.entries()) {
       // Ensure the inputted project name is lower case
       args.skip[idx] = (projectName + '').toLowerCase();
-    });
+    }
 
     projectNames = projectNames.filter((projectName) => !(args.skip as string[]).includes(projectName));
 
-    args.skip.forEach((projectName) => {
+    for (const projectName of args.skip) {
       projectNamesSet.delete(projectName as any);
-    });
+    }
   }
 
   const tmpFolderPath = path.resolve(process.cwd(), 'tmp');

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -62,7 +62,6 @@ const compatibilityRules = [
   'unicorn/consistent-assert',
   'unicorn/consistent-function-scoping',
   'unicorn/filename-case',
-  'unicorn/no-array-for-each',
   'unicorn/no-array-reduce',
   'unicorn/no-await-expression-member',
   'unicorn/no-console-spaces',

--- a/src/_vendor/zod-to-json-schema/parsers/intersection.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/intersection.ts
@@ -35,7 +35,7 @@ export function parseIntersectionDef(
 
   const mergedAllOf: JsonSchema7Type[] = [];
   // If either of the schemas is an allOf, merge them into a single allOf
-  allOf.forEach((schema) => {
+  for (const schema of allOf) {
     if (isJsonSchema7AllOfType(schema)) {
       mergedAllOf.push(...schema.allOf);
       if (schema.unevaluatedProperties === undefined) {
@@ -54,7 +54,7 @@ export function parseIntersectionDef(
       }
       mergedAllOf.push(nestedSchema);
     }
-  });
+  }
   return mergedAllOf.length
     ? {
         allOf: mergedAllOf,

--- a/src/core/EventEmitter.ts
+++ b/src/core/EventEmitter.ts
@@ -87,7 +87,9 @@ export class EventEmitter<EventTypes extends Record<string, (...args: any) => an
     const listeners: EventListeners<EventTypes, Event> | undefined = this.#listeners[event];
     if (listeners) {
       this.#listeners[event] = listeners.filter((l) => !l.once) as any;
-      listeners.forEach(({ listener }: any) => listener(...(args as any)));
+      for (const { listener } of listeners as any) {
+        listener(...(args as any));
+      }
     }
   }
 

--- a/src/internal/qs/utils.ts
+++ b/src/internal/qs/utils.ts
@@ -87,18 +87,22 @@ export function merge(
   }
 
   if (isArray(target) && isArray(source)) {
-    source.forEach(function (item, i) {
-      if (has(target, i)) {
-        const targetItem = target[i];
-        if (targetItem && typeof targetItem === 'object' && item && typeof item === 'object') {
-          target[i] = merge(targetItem, item, options);
+    const sourceLength = source.length;
+    for (let i = 0; i < sourceLength; i += 1) {
+      if (i in source) {
+        const item = source[i];
+        if (has(target, i)) {
+          const targetItem = target[i];
+          if (targetItem && typeof targetItem === 'object' && item && typeof item === 'object') {
+            target[i] = merge(targetItem, item, options);
+          } else {
+            target.push(item);
+          }
         } else {
-          target.push(item);
+          target[i] = item;
         }
-      } else {
-        target[i] = item;
       }
-    });
+    }
     return target;
   }
 

--- a/src/lib/EventEmitter.ts
+++ b/src/lib/EventEmitter.ts
@@ -96,7 +96,9 @@ export class EventEmitter<EventTypes extends Record<string, (...args: any) => an
     const listeners: EventListeners<EventTypes, Event> | undefined = this.#listeners[event];
     if (listeners) {
       this.#listeners[event] = listeners.filter((l) => !l.once) as any;
-      listeners.forEach(({ listener }: any) => listener(...(args as any)));
+      for (const { listener } of listeners as any) {
+        listener(...(args as any));
+      }
     }
   }
 

--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -322,7 +322,9 @@ export class EventStream<EventTypes extends BaseEvents> {
     const listeners: EventListeners<EventTypes, Event> | undefined = this.#listeners[event];
     if (listeners) {
       this.#listeners[event] = listeners.filter((l) => !l.once) as any;
-      listeners.forEach(({ listener }: any) => listener(...(args as any)));
+      for (const { listener } of listeners as any) {
+        listener(...(args as any));
+      }
     }
 
     if (event === 'abort') {

--- a/tests/base64.test.ts
+++ b/tests/base64.test.ts
@@ -45,9 +45,9 @@ describe.each(['Buffer', 'atob'])('with %s', (mode) => {
       },
     ];
 
-    testCases.forEach(({ input, expected }) => {
+    for (const { input, expected } of testCases) {
       expect(toBase64(input)).toBe(expected);
-    });
+    }
   });
 
   test('fromBase64', () => {
@@ -73,8 +73,8 @@ describe.each(['Buffer', 'atob'])('with %s', (mode) => {
       },
     ];
 
-    testCases.forEach(({ input, expected }) => {
+    for (const { input, expected } of testCases) {
       expect(fromBase64(input)).toEqual(expected);
-    });
+    }
   });
 });

--- a/tests/qs/stringify.test.ts
+++ b/tests/qs/stringify.test.ts
@@ -1785,7 +1785,7 @@ describe('stringify()', function () {
   });
 
   test('Edge cases and unknown formats', function () {
-    ['UFO1234', false, 1234, null, {}, []].forEach(function (format) {
+    for (const format of ['UFO1234', false, 1234, null, {}, []]) {
       // st['throws'](function () {
       // 	stringify({ a: 'b c' }, { format: format });
       // }, new TypeError('Unknown format option provided.'));
@@ -1793,7 +1793,7 @@ describe('stringify()', function () {
         // @ts-expect-error
         stringify({ a: 'b c' }, { format: format });
       }).toThrow(TypeError);
-    });
+    }
   });
 
   test('encodeValuesOnly', function () {
@@ -2175,7 +2175,7 @@ describe('stringify()', function () {
 });
 
 describe('stringifies empty keys', function () {
-  empty_test_cases.forEach(function (testCase) {
+  for (const testCase of empty_test_cases) {
     test('stringifies an object with empty string key with ' + testCase.input, function () {
       // st.deepEqual(
       // 	stringify(testCase.withEmptyKeys, { encode: false, arrayFormat: 'indices' }),
@@ -2202,7 +2202,7 @@ describe('stringifies empty keys', function () {
         testCase.stringify_output.repeat,
       );
     });
-  });
+  }
 
   test('edge case with object/arrays', function () {
     // st.deepEqual(stringify({ '': { '': [2, 3] } }, { encode: false }), '[][0]=2&[][1]=3');


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/no-array-for-each` compatibility exception from `oxlint.config.ts`.
- Resolve the existing violations while preserving behavior.
- Baseline count: 11 diagnostics.

## Additional context & links

- Oxlint cleanup stack, part 114; stacked on https://github.com/openai/openai-node/pull/2205.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188
https://github.com/openai/openai-node/pull/2190
https://github.com/openai/openai-node/pull/2191
https://github.com/openai/openai-node/pull/2189
https://github.com/openai/openai-node/pull/2192
https://github.com/openai/openai-node/pull/2193
https://github.com/openai/openai-node/pull/2195
https://github.com/openai/openai-node/pull/2194
https://github.com/openai/openai-node/pull/2204
https://github.com/openai/openai-node/pull/2196
https://github.com/openai/openai-node/pull/2197
https://github.com/openai/openai-node/pull/2198
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201
https://github.com/openai/openai-node/pull/2202
https://github.com/openai/openai-node/pull/2203
https://github.com/openai/openai-node/pull/2205
https://github.com/openai/openai-node/pull/2206 :point_left: this PR
https://github.com/openai/openai-node/pull/2207