### PR TITLE
chore(lint): enable unicorn/no-array-reduce

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -62,7 +62,6 @@ const compatibilityRules = [
   'unicorn/consistent-assert',
   'unicorn/consistent-function-scoping',
   'unicorn/filename-case',
-  'unicorn/no-array-reduce',
   'unicorn/no-await-expression-member',
   'unicorn/no-console-spaces',
   'unicorn/no-nested-ternary',

--- a/scripts/_vendor/tsc-multi/src/worker/worker.ts
+++ b/scripts/_vendor/tsc-multi/src/worker/worker.ts
@@ -149,18 +149,17 @@ export class Worker {
     return {
       ...sys,
       fileExists: (inputPath) => {
-        return getReadPaths(inputPath).reduce<boolean>(
-          (result, path) => result || sys.fileExists(path),
-          false,
-        );
+        for (const path of getReadPaths(inputPath)) {
+          if (sys.fileExists(path)) return true;
+        }
+        return false;
       },
       readFile: (inputPath, encoding) => {
-        return (
-          getReadPaths(inputPath).reduce<string | undefined | null>(
-            (result, path) => result ?? sys.readFile(path, encoding),
-            null,
-          ) ?? undefined
-        );
+        for (const path of getReadPaths(inputPath)) {
+          const result = sys.readFile(path, encoding);
+          if (result !== undefined && result !== null) return result;
+        }
+        return undefined;
       },
       writeFile: (path, data, writeByteOrderMark) => {
         const newPath = this.rewritePath(path);

--- a/src/_vendor/zod-to-json-schema/parsers/object.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/object.ts
@@ -27,47 +27,37 @@ export type JsonSchema7ObjectType = {
 };
 
 export function parseObjectDef(def: ZodObjectDef, refs: Refs) {
+  const properties: Record<string, JsonSchema7Type> = {};
+  const required: string[] = [];
+  for (const [propName, propDef] of Object.entries(def.shape())) {
+    if (propDef === undefined || propDef._def === undefined) continue;
+    const propertyPath = [...refs.currentPath, 'properties', propName];
+    const parsedDef = parseDef(propDef._def, {
+      ...refs,
+      currentPath: propertyPath,
+      propertyPath,
+    });
+    if (parsedDef === undefined) continue;
+    if (
+      refs.openaiStrictMode &&
+      propDef.isOptional() &&
+      !propDef.isNullable() &&
+      typeof propDef._def?.defaultValue === 'undefined'
+    ) {
+      throw new Error(
+        `Zod field at \`${propertyPath.join(
+          '/',
+        )}\` uses \`.optional()\` without \`.nullable()\` which is not supported by the API. See: https://platform.openai.com/docs/guides/structured-outputs?api-mode=responses#all-fields-must-be-required`,
+      );
+    }
+    properties[propName] = parsedDef;
+    if (!propDef.isOptional() || refs.openaiStrictMode) required.push(propName);
+  }
+
   const result: JsonSchema7ObjectType = {
     type: 'object',
-    ...Object.entries(def.shape()).reduce(
-      (
-        acc: {
-          properties: Record<string, JsonSchema7Type>;
-          required: string[];
-        },
-        [propName, propDef],
-      ) => {
-        if (propDef === undefined || propDef._def === undefined) return acc;
-        const propertyPath = [...refs.currentPath, 'properties', propName];
-        const parsedDef = parseDef(propDef._def, {
-          ...refs,
-          currentPath: propertyPath,
-          propertyPath,
-        });
-        if (parsedDef === undefined) return acc;
-        if (
-          refs.openaiStrictMode &&
-          propDef.isOptional() &&
-          !propDef.isNullable() &&
-          typeof propDef._def?.defaultValue === 'undefined'
-        ) {
-          throw new Error(
-            `Zod field at \`${propertyPath.join(
-              '/',
-            )}\` uses \`.optional()\` without \`.nullable()\` which is not supported by the API. See: https://platform.openai.com/docs/guides/structured-outputs?api-mode=responses#all-fields-must-be-required`,
-          );
-        }
-        return {
-          properties: {
-            ...acc.properties,
-            [propName]: parsedDef,
-          },
-          required:
-            propDef.isOptional() && !refs.openaiStrictMode ? acc.required : [...acc.required, propName],
-        };
-      },
-      { properties: {}, required: [] },
-    ),
+    properties,
+    required,
     additionalProperties: decideAdditionalProperties(def, refs),
   };
   if (!result.required!.length) delete result.required;

--- a/src/internal/qs/utils.ts
+++ b/src/internal/qs/utils.ts
@@ -106,19 +106,19 @@ export function merge(
     return target;
   }
 
-  return Object.keys(source).reduce(function (acc, key) {
+  for (const key of Object.keys(source)) {
     const value = source[key];
 
-    acc[key] = has(acc, key) ? merge(acc[key], value, options) : value;
-    return acc;
-  }, mergeTarget);
+    mergeTarget[key] = has(mergeTarget, key) ? merge(mergeTarget[key], value, options) : value;
+  }
+  return mergeTarget;
 }
 
 export function assign_single_source(target: any, source: any) {
-  return Object.keys(source).reduce(function (acc, key) {
-    acc[key] = source[key];
-    return acc;
-  }, target);
+  for (const key of Object.keys(source)) {
+    target[key] = source[key];
+  }
+  return target;
 }
 
 export function decode(str: string, _: any, charset: string) {

--- a/src/internal/utils/path.ts
+++ b/src/internal/utils/path.ts
@@ -21,32 +21,36 @@ export const createPathTagFunction = (pathEncoder = encodeURIPath) =>
 
     let postPath = false;
     const invalidSegments = [];
-    const path = statics.reduce((previousValue, currentValue, index) => {
-      if (/[?#]/.test(currentValue)) {
-        postPath = true;
+    let path = '';
+    for (let index = 0; index < statics.length; index += 1) {
+      if (index in statics) {
+        const currentValue = statics[index]!;
+        if (/[?#]/.test(currentValue)) {
+          postPath = true;
+        }
+        const value = params[index];
+        let encoded = (postPath ? encodeURIComponent : pathEncoder)('' + value);
+        if (
+          index !== params.length &&
+          (value == null ||
+            (typeof value === 'object' &&
+              // handle values from other realms
+              value.toString ===
+                Object.getPrototypeOf(Object.getPrototypeOf((value as any).hasOwnProperty ?? EMPTY) ?? EMPTY)
+                  ?.toString))
+        ) {
+          encoded = value + '';
+          invalidSegments.push({
+            start: path.length + currentValue.length,
+            length: encoded.length,
+            error: `Value of type ${Object.prototype.toString
+              .call(value)
+              .slice(8, -1)} is not a valid path parameter`,
+          });
+        }
+        path += currentValue + (index === params.length ? '' : encoded);
       }
-      const value = params[index];
-      let encoded = (postPath ? encodeURIComponent : pathEncoder)('' + value);
-      if (
-        index !== params.length &&
-        (value == null ||
-          (typeof value === 'object' &&
-            // handle values from other realms
-            value.toString ===
-              Object.getPrototypeOf(Object.getPrototypeOf((value as any).hasOwnProperty ?? EMPTY) ?? EMPTY)
-                ?.toString))
-      ) {
-        encoded = value + '';
-        invalidSegments.push({
-          start: previousValue.length + currentValue.length,
-          length: encoded.length,
-          error: `Value of type ${Object.prototype.toString
-            .call(value)
-            .slice(8, -1)} is not a valid path parameter`,
-        });
-      }
-      return previousValue + currentValue + (index === params.length ? '' : encoded);
-    }, '');
+    }
 
     const pathOnly = path.split(/[?#]/, 1)[0]!;
     const invalidSegmentPattern = /(?<=^|\/)(?:\.|%2e){1,2}(?=\/|$)/gi;
@@ -65,12 +69,13 @@ export const createPathTagFunction = (pathEncoder = encodeURIPath) =>
 
     if (invalidSegments.length > 0) {
       let lastEnd = 0;
-      const underline = invalidSegments.reduce((acc, segment) => {
+      let underline = '';
+      for (const segment of invalidSegments) {
         const spaces = ' '.repeat(segment.start - lastEnd);
         const arrows = '^'.repeat(segment.length);
         lastEnd = segment.start + segment.length;
-        return acc + spaces + arrows;
-      }, '');
+        underline += spaces + arrows;
+      }
 
       throw new OpenAIError(
         `Path parameters result in path with invalid segments:\n${invalidSegments

--- a/tests/helpers/zod.test.ts
+++ b/tests/helpers/zod.test.ts
@@ -28,14 +28,20 @@ function collectRefs(value: unknown, refs: string[] = []): string[] {
 function countEnumValues(value: unknown): number {
   if (!value || typeof value !== 'object') return 0;
   if (Array.isArray(value)) {
-    return value.reduce((total, child) => total + countEnumValues(child), 0);
+    let total = 0;
+    for (const child of value) {
+      total += countEnumValues(child);
+    }
+    return total;
   }
 
   const record = value as Record<string, unknown>;
   const enumValues = Array.isArray(record['enum']) ? record['enum'].length : 0;
-  return (
-    enumValues + Object.values(record).reduce<number>((total, child) => total + countEnumValues(child), 0)
-  );
+  let nestedEnumValues = 0;
+  for (const child of Object.values(record)) {
+    nestedEnumValues += countEnumValues(child);
+  }
+  return enumValues + nestedEnumValues;
 }
 
 function resolveJsonPointer(root: Record<string, unknown>, pointer: string): unknown {
@@ -45,12 +51,14 @@ function resolveJsonPointer(root: Record<string, unknown>, pointer: string): unk
     .split('/')
     .map((token) => token.replace(/~1/g, '/').replace(/~0/g, '~'));
 
-  return tokens.reduce<unknown>((value, token) => {
+  let value: unknown = root;
+  for (const token of tokens) {
     expect(value).not.toBeNull();
     expect(typeof value).toBe('object');
     expect(Object.prototype.hasOwnProperty.call(value, token)).toBe(true);
-    return (value as Record<string, unknown>)[token];
-  }, root);
+    value = (value as Record<string, unknown>)[token];
+  }
+  return value;
 }
 
 function expectDefinitionRefsToResolve(schema: Record<string, unknown>) {


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Remove the `unicorn/no-array-reduce` compatibility exception from `oxlint.config.ts`.
- Replace the remaining array reductions with explicit loops while preserving short-circuit and sparse-array behavior.
- Baseline count: 8 diagnostics after the preceding cleanup commits.

## Additional context & links

- Oxlint cleanup stack, part 115; stacked on https://github.com/openai/openai-node/pull/2206.
- No exported SDK API behavior is intended to change.
- Preserves generated-file exclusions and repository-specific lint policy.

### Validation

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`

## Stack

https://github.com/openai/openai-node/pull/2188
https://github.com/openai/openai-node/pull/2190
https://github.com/openai/openai-node/pull/2191
https://github.com/openai/openai-node/pull/2189
https://github.com/openai/openai-node/pull/2192
https://github.com/openai/openai-node/pull/2193
https://github.com/openai/openai-node/pull/2195
https://github.com/openai/openai-node/pull/2194
https://github.com/openai/openai-node/pull/2204
https://github.com/openai/openai-node/pull/2196
https://github.com/openai/openai-node/pull/2197
https://github.com/openai/openai-node/pull/2198
https://github.com/openai/openai-node/pull/2199
https://github.com/openai/openai-node/pull/2200
https://github.com/openai/openai-node/pull/2201
https://github.com/openai/openai-node/pull/2202
https://github.com/openai/openai-node/pull/2203
https://github.com/openai/openai-node/pull/2205
https://github.com/openai/openai-node/pull/2206
https://github.com/openai/openai-node/pull/2207 :point_left: this PR