### PR TITLE
chore(lint): enable jsdoc/require-param-description

### DIFF
--- a/ecosystem-tests/browser-direct-import/public/index.js
+++ b/ecosystem-tests/browser-direct-import/public/index.js
@@ -47,8 +47,8 @@ async function runTests() {
 const testPath = [];
 
 /**
- * @param {string} description 
- * @param {() => void} handler 
+ * @param {string} description - Test suite description.
+ * @param {() => void} handler - Test suite callback.
  */
 function describe(description, handler) {
   testPath.push(description);
@@ -60,8 +60,8 @@ function describe(description, handler) {
 }
 
 /**
- * @param {string} description
- * @param {() => any} run
+ * @param {string} description - Test case description.
+ * @param {() => any} run - Test case callback.
  * @param {number} [timeout] - Defaults to `60000`.
  */
 function it(description, run, timeout = 60000) {
@@ -69,7 +69,7 @@ function it(description, run, timeout = 60000) {
 }
 
 /**
- * @param {any} received
+ * @param {any} received - Value being asserted.
  * @returns {{
  *   toEqual: (expected: any) => void;
  *   toBeSimilarTo: (comparedTo: string, expectedDistance: number) => void;

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -17,7 +17,6 @@ const compatibilityRules = [
   'func-style',
   'import/consistent-type-specifier-style',
   'import/no-cycle',
-  'jsdoc/require-param-description',
   'no-await-in-loop',
   'no-bitwise',
   'no-eq-null',


### PR DESCRIPTION
## Summary

- Removes `jsdoc/require-param-description` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 117 of 185.
- Base: `dev/hayden/ultracite-116-jsdoc-no-defaults`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`