### PR TITLE
chore(lint): enable prefer-object-has-own

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -35,7 +35,6 @@ const compatibilityRules = [
   'prefer-arrow-callback',
   'prefer-destructuring',
   'prefer-named-capture-group',
-  'prefer-object-has-own',
   'prefer-template',
   'promise/avoid-new',
   'promise/prefer-await-to-callbacks',

--- a/src/helpers/zod.ts
+++ b/src/helpers/zod.ts
@@ -16,6 +16,7 @@ import { type ResponseFormatTextJSONSchemaConfig } from '../resources/responses/
 import { type RealtimeFunctionTool } from '../resources/realtime/realtime';
 import { toStrictJsonSchema } from '../lib/transform';
 import { JSONSchema } from '../lib/jsonschema';
+import { hasOwn } from '../internal/utils/values';
 
 type ZodV4Schema = z4.ZodType | z4Mini.ZodMiniType;
 type ZodSchema = z3.ZodType | ZodV4Schema;
@@ -54,7 +55,7 @@ function encodeSchemaDefinitionRefToken(token: string): string {
 }
 
 function validateSchemaDefinitions(schemaDefinitions: ZodSchemaDefinitions | undefined): void {
-  if (schemaDefinitions && Object.prototype.hasOwnProperty.call(schemaDefinitions, '__proto__')) {
+  if (schemaDefinitions && hasOwn(schemaDefinitions, '__proto__')) {
     throw new Error('schemaDefinitions cannot include "__proto__" as a definition name');
   }
 }
@@ -95,7 +96,7 @@ function getZodV3RootName(name: string, schemaDefinitions: ZodSchemaDefinitions 
   if (!schemaDefinitions) return name;
 
   let rootName = name;
-  while (Object.prototype.hasOwnProperty.call(schemaDefinitions, rootName)) {
+  while (hasOwn(schemaDefinitions, rootName)) {
     rootName = `${rootName}_root`;
   }
   return rootName;

--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -30,7 +30,7 @@ import {
 import { RunStep, RunStepDelta, ToolCall, ToolCallDelta } from '../resources/beta/threads/runs/steps';
 import { ThreadCreateAndRunParamsBase, Threads } from '../resources/beta/threads/threads';
 import { BaseEvents, EventStream } from './EventStream';
-import { isObj } from '../internal/utils';
+import { hasOwn, isObj } from '../internal/utils';
 
 export interface AssistantStreamEvents extends BaseEvents {
   run: (run: Run) => void;
@@ -641,7 +641,7 @@ export class AssistantStream
 
   static accumulateDelta(acc: Record<string, any>, delta: Record<string, any>): Record<string, any> {
     for (const [key, deltaValue] of Object.entries(delta)) {
-      if (!Object.prototype.hasOwnProperty.call(acc, key)) {
+      if (!hasOwn(acc, key)) {
         acc[key] = deltaValue;
         continue;
       }

--- a/src/lib/transform.ts
+++ b/src/lib/transform.ts
@@ -1,4 +1,5 @@
 import type { JSONSchema, JSONSchemaDefinition } from './jsonschema';
+import { hasOwn } from '../internal/utils';
 
 const JSON_SCHEMA_ANNOTATION_KEYWORDS = new Set([
   '$comment',
@@ -442,10 +443,7 @@ function planPromotedRootAnyOfDefinitionRenames(
     let aliasIndex = 0;
 
     for (const [name, definition] of Object.entries(branchDefinitions)) {
-      if (
-        !Object.prototype.hasOwnProperty.call(rootDefinitions, name) ||
-        schemasEqual(rootDefinitions[name], definition)
-      ) {
+      if (!hasOwn(rootDefinitions, name) || schemasEqual(rootDefinitions[name], definition)) {
         continue;
       }
 
@@ -695,7 +693,7 @@ function ensureStrictJsonSchema(
   const properties = jsonSchema.properties;
   if (hasObjectShape(jsonSchema)) {
     for (const key of required) {
-      if (!isObject(properties) || !Object.prototype.hasOwnProperty.call(properties, key)) {
+      if (!isObject(properties) || !hasOwn(properties, key)) {
         throw new Error(
           `Object schema at \`${
             path.join('/') || '<root>'
@@ -850,13 +848,13 @@ function resolvePointerPart(resolved: unknown, part: string): unknown | undefine
     }
 
     const index = Number(part);
-    if (!Object.prototype.hasOwnProperty.call(resolved, index)) {
+    if (!hasOwn(resolved, index)) {
       return undefined;
     }
     return resolved[index];
   }
 
-  if (!isObject(resolved) || !Object.prototype.hasOwnProperty.call(resolved, part)) {
+  if (!isObject(resolved) || !hasOwn(resolved, part)) {
     return undefined;
   }
   return resolved[part];
@@ -1296,7 +1294,7 @@ function rewriteLocalRefsIntoFilteredAnyOfBranches(root: JSONSchema): void {
         }
 
         const branchIndex = Number(branchIndexPart);
-        if (!Object.prototype.hasOwnProperty.call(branches, branchIndex)) {
+        if (!hasOwn(branches, branchIndex)) {
           return ref;
         }
 
@@ -1390,7 +1388,7 @@ function preserveAllOfRefTargets(root: JSONSchema, rootOnly = false): void {
     }
 
     let alias = '__openai_strict_allOf_ref_' + aliasIndex++;
-    while (Object.prototype.hasOwnProperty.call(definitions, alias)) {
+    while (hasOwn(definitions, alias)) {
       alias = '__openai_strict_allOf_ref_' + aliasIndex++;
     }
     definitions[alias] = structuredClone(target);
@@ -1467,7 +1465,7 @@ function preserveDiscardedAllOfPropertyRefTargets(root: JSONSchema, discardedPat
     }
 
     let alias = '__openai_strict_allOf_property_ref_' + aliasIndex++;
-    while (Object.prototype.hasOwnProperty.call(definitions, alias)) {
+    while (hasOwn(definitions, alias)) {
       alias = '__openai_strict_allOf_property_ref_' + aliasIndex++;
     }
     definitions[alias] = structuredClone(target);
@@ -1935,10 +1933,7 @@ function mergeObjectAllOf(
     if (allowedClosedProperties !== undefined && !allowedClosedProperties.has(key)) {
       continue;
     }
-    if (
-      Object.prototype.hasOwnProperty.call(mergedProperties, key) &&
-      !schemasEqual(mergedProperties[key], propertySchema)
-    ) {
+    if (hasOwn(mergedProperties, key) && !schemasEqual(mergedProperties[key], propertySchema)) {
       fail();
     }
     mergedProperties[key] = propertySchema;

--- a/tests/helpers/zod.test.ts
+++ b/tests/helpers/zod.test.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest';
+import { hasOwn } from 'openai/internal/utils/values';
 
 import {
   zodFunction,
@@ -55,7 +56,7 @@ function resolveJsonPointer(root: Record<string, unknown>, pointer: string): unk
   for (const token of tokens) {
     expect(value).not.toBeNull();
     expect(typeof value).toBe('object');
-    expect(Object.prototype.hasOwnProperty.call(value, token)).toBe(true);
+    expect(hasOwn(value as object, token)).toBe(true);
     value = (value as Record<string, unknown>)[token];
   }
   return value;

--- a/tests/lib/transform.test.ts
+++ b/tests/lib/transform.test.ts
@@ -1,6 +1,7 @@
 import { toStrictJsonSchema } from 'openai/lib/transform';
 import { detailedDiff } from 'deep-object-diff';
 import { JSONSchema } from 'openai/lib/jsonschema';
+import { hasOwn } from 'openai/internal/utils/values';
 
 describe('toStrictJsonSchema', () => {
   describe('Root Schema Validation', () => {
@@ -2564,7 +2565,7 @@ describe('toStrictJsonSchema', () => {
           ['other', { type: 'number' }],
         ]),
       );
-      expect(Object.prototype.hasOwnProperty.call(properties, '__proto__')).toBe(true);
+      expect(hasOwn(properties as object, '__proto__')).toBe(true);
     });
 
     test('merges matching object allOf properties with reordered schema keys', () => {


### PR DESCRIPTION
## Summary

- Removes `prefer-object-has-own` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 118 of 185.
- Base: `dev/hayden/ultracite-117-jsdoc-require-param-description`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`