### PR TITLE
chore(lint): enable typescript/ban-types

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -44,7 +44,6 @@ const compatibilityRules = [
   'sort-keys',
   'typescript/array-type',
   'typescript/ban-ts-comment',
-  'typescript/ban-types',
   'typescript/consistent-indexed-object-style',
   'typescript/consistent-type-definitions',
   'typescript/consistent-type-imports',
@@ -137,6 +136,7 @@ module.exports = defineConfig({
         'src/_vendor/zod-to-json-schema/parsers/unknown.ts',
       ],
       rules: {
+        'typescript/ban-types': 'off',
         'typescript/no-empty-object-type': 'off',
       },
     },

--- a/src/beta/realtime/internal-base.ts
+++ b/src/beta/realtime/internal-base.ts
@@ -24,6 +24,7 @@ export class OpenAIRealtimeError extends OpenAIError {
   }
 }
 
+// oxlint-disable-next-line typescript/ban-types -- The empty intersection materializes the mapped event shape without changing its public type.
 type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {};
 
 type RealtimeEvents = Simplify<

--- a/src/helpers/standard-schema.ts
+++ b/src/helpers/standard-schema.ts
@@ -105,11 +105,11 @@ type StandardToolOptions<Parameters extends StandardSchemaLike> = {
 
 type StandardToolReturnOptions<
   Parameters extends StandardSchemaLike,
-  Function extends StandardToolFunction<Parameters> | undefined,
+  ToolFunction extends StandardToolFunction<Parameters> | undefined,
 > = {
   arguments: InferStandardOutput<Parameters>;
   name: string;
-  function: Function;
+  function: ToolFunction;
 };
 
 function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
@@ -507,10 +507,10 @@ export function standardTextFormat<Schema extends StandardSchemaLike>(
  */
 export function standardFunction<
   Parameters extends StandardSchemaLike,
-  Function extends StandardToolFunction<Parameters>,
+  ToolFunction extends StandardToolFunction<Parameters>,
 >(
-  options: StandardToolOptions<Parameters> & { function: Function },
-): AutoParseableTool<StandardToolReturnOptions<Parameters, Function>>;
+  options: StandardToolOptions<Parameters> & { function: ToolFunction },
+): AutoParseableTool<StandardToolReturnOptions<Parameters, ToolFunction>>;
 export function standardFunction<Parameters extends StandardSchemaLike>(
   options: StandardToolOptions<Parameters> & { function?: undefined },
 ): AutoParseableTool<StandardToolReturnOptions<Parameters, undefined>>;
@@ -542,10 +542,10 @@ export function standardFunction<Parameters extends StandardSchemaLike>(
  */
 export function standardResponsesFunction<
   Parameters extends StandardSchemaLike,
-  Function extends StandardToolFunction<Parameters>,
+  ToolFunction extends StandardToolFunction<Parameters>,
 >(
-  options: StandardToolOptions<Parameters> & { function: Function },
-): AutoParseableResponseTool<StandardToolReturnOptions<Parameters, Function>>;
+  options: StandardToolOptions<Parameters> & { function: ToolFunction },
+): AutoParseableResponseTool<StandardToolReturnOptions<Parameters, ToolFunction>>;
 export function standardResponsesFunction<Parameters extends StandardSchemaLike>(
   options: StandardToolOptions<Parameters> & { function?: undefined },
 ): AutoParseableResponseTool<StandardToolReturnOptions<Parameters, undefined>>;

--- a/src/lib/jsonschema.ts
+++ b/src/lib/jsonschema.ts
@@ -12,14 +12,8 @@
  * @see https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.1.1
  */
 export type JSONSchemaTypeName =
-  | ({} & string)
-  | 'string'
-  | 'number'
-  | 'integer'
-  | 'boolean'
-  | 'object'
-  | 'array'
-  | 'null';
+  // oxlint-disable-next-line typescript/ban-types -- The empty intersection preserves literal-union widening for arbitrary JSON Schema type names.
+  ({} & string) | 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array' | 'null';
 
 /**
  * Primitive type

--- a/src/realtime/internal-base.ts
+++ b/src/realtime/internal-base.ts
@@ -29,6 +29,7 @@ export class OpenAIRealtimeError extends OpenAIError {
   }
 }
 
+// oxlint-disable-next-line typescript/ban-types -- The empty intersection materializes the mapped event shape without changing its public type.
 type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {};
 
 type RealtimeEvents = Simplify<


### PR DESCRIPTION
## Summary

- Removes `typescript/ban-types` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 119 of 185.
- Base: `dev/hayden/ultracite-118-prefer-object-has-own`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`