### PR TITLE
chore(lint): enable unicorn/prefer-spread

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -68,7 +68,6 @@ const compatibilityRules = [
   'unicorn/prefer-module',
   'unicorn/prefer-node-protocol',
   'unicorn/prefer-response-static-json',
-  'unicorn/prefer-spread',
   'unicorn/prefer-string-replace-all',
   'unicorn/prefer-string-slice',
   'unicorn/switch-case-braces',

--- a/scripts/test-packed-package.ts
+++ b/scripts/test-packed-package.ts
@@ -228,7 +228,7 @@
 
     // Zod/AWS helpers require optional peers; Node-only helpers require @types/node.
     // Validate every other mapped source without installing either in this consumer.
-    const browserSafeSources = Array.from(mappedSources.entries())
+    const browserSafeSources = [...mappedSources.entries()]
       .filter(([source]) => !requiresOptionalPeer(source))
       .map(([, source]) => source);
     browserSafeSources.sort();

--- a/src/_vendor/zod-to-json-schema/parsers/nativeEnum.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/nativeEnum.ts
@@ -13,7 +13,7 @@ export function parseNativeEnumDef(def: ZodNativeEnumDef): JsonSchema7NativeEnum
 
   const actualValues = actualKeys.map((key: string) => object[key]!);
 
-  const parsedTypes = Array.from(new Set(actualValues.map((values: string | number) => typeof values)));
+  const parsedTypes = [...new Set(actualValues.map((values: string | number) => typeof values))];
 
   return {
     type:

--- a/src/_vendor/zod-to-json-schema/parsers/string.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/string.ts
@@ -236,9 +236,7 @@ export function parseStringDef(def: ZodStringDef, refs: Refs): JsonSchema7String
 }
 
 const escapeNonAlphaNumeric = (value: string) =>
-  Array.from(value)
-    .map((c) => (/[a-zA-Z0-9]/.test(c) ? c : `\\${c}`))
-    .join('');
+  [...value].map((c) => (/[a-zA-Z0-9]/.test(c) ? c : `\\${c}`)).join('');
 
 const addFormat = (
   schema: JsonSchema7StringType,

--- a/src/_vendor/zod-to-json-schema/parsers/union.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/union.ts
@@ -33,8 +33,7 @@ export function parseUnionDef(
 ): JsonSchema7PrimitiveUnionType | JsonSchema7AnyOfType | undefined {
   if (refs.target === 'openApi3') return asAnyOf(def, refs);
 
-  const options: readonly ZodTypeAny[] =
-    def.options instanceof Map ? Array.from(def.options.values()) : def.options;
+  const options: readonly ZodTypeAny[] = def.options instanceof Map ? [...def.options.values()] : def.options;
 
   // This blocks tries to look ahead a bit to produce nicer looking schemas with type array instead of anyOf.
   if (
@@ -111,7 +110,7 @@ const asAnyOf = (
   def: ZodUnionDef | ZodDiscriminatedUnionDef<any, any>,
   refs: Refs,
 ): JsonSchema7PrimitiveUnionType | JsonSchema7AnyOfType | undefined => {
-  const anyOf = ((def.options instanceof Map ? Array.from(def.options.values()) : def.options) as any[])
+  const anyOf = ((def.options instanceof Map ? [...def.options.values()] : def.options) as any[])
     .map((x, i) =>
       parseDef(x._def, {
         ...refs,

--- a/src/internal/qs/utils.ts
+++ b/src/internal/qs/utils.ts
@@ -77,6 +77,7 @@ export function merge(
   }
 
   if (!target || typeof target !== 'object') {
+    // oxlint-disable-next-line unicorn/prefer-spread -- concat intentionally preserves one-level flattening and sparse-array behavior.
     return [target].concat(source);
   }
 
@@ -254,6 +255,7 @@ export function is_buffer(obj: any) {
 }
 
 export function combine(a: any, b: any) {
+  // oxlint-disable-next-line unicorn/prefer-spread -- concat intentionally preserves one-level flattening and sparse-array behavior.
   return [].concat(a, b);
 }
 

--- a/src/internal/ws.ts
+++ b/src/internal/ws.ts
@@ -66,6 +66,7 @@ function snapshotRawData(data: RawWebSocketData): Exclude<RawWebSocketData, Arra
     copy.set(toUint8Array(data));
     return copy;
   }
+  // oxlint-disable-next-line unicorn/prefer-spread -- ArrayBufferLike.slice copies bytes while spread changes the return type.
   return data.slice(0);
 }
 
@@ -134,7 +135,7 @@ export class SendQueue<T = unknown> {
         send(pending[i]!.data);
       } catch (err) {
         const remaining = pending.slice(i);
-        this._queue = remaining.concat(this._queue);
+        this._queue = [...remaining, ...this._queue];
         this._bytes = this._queue.reduce((sum, item) => sum + item.byteLength, 0);
         throw err;
       }

--- a/tests/form.test.ts
+++ b/tests/form.test.ts
@@ -52,7 +52,7 @@ describe('form data validation', () => {
       },
       fetch,
     );
-    expect(Array.from(form.entries())).toEqual([]);
+    expect([...form.entries()]).toEqual([]);
 
     const form2 = await createForm(
       {
@@ -63,7 +63,7 @@ describe('form data validation', () => {
       },
       fetch,
     );
-    expect(Array.from(form2.entries())).toEqual([['bar[foo]', 'string']]);
+    expect([...form2.entries()]).toEqual([['bar[foo]', 'string']]);
   });
 
   test('nested undefined array item is stripped', async () => {
@@ -73,7 +73,7 @@ describe('form data validation', () => {
       },
       fetch,
     );
-    expect(Array.from(form.entries())).toEqual([]);
+    expect([...form.entries()]).toEqual([]);
 
     const form2 = await createForm(
       {
@@ -81,7 +81,7 @@ describe('form data validation', () => {
       },
       fetch,
     );
-    expect(Array.from(form2.entries())).toEqual([['bar[]', 'foo']]);
+    expect([...form2.entries()]).toEqual([['bar[]', 'foo']]);
   });
 
   test('streams multipart file content lazily', async () => {


### PR DESCRIPTION
## Summary

- Removes `unicorn/prefer-spread` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 120 of 185.
- Base: `dev/hayden/ultracite-119-typescript-ban-types`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`