### PR TITLE
chore(lint): enable node/global-require

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -30,7 +30,6 @@ const compatibilityRules = [
   'no-unused-vars',
   'no-use-before-define',
   'no-var',
-  'node/global-require',
   'object-shorthand',
   'prefer-arrow-callback',
   'prefer-destructuring',

--- a/scripts/_vendor/tsc-multi/src/worker/worker.ts
+++ b/scripts/_vendor/tsc-multi/src/worker/worker.ts
@@ -24,6 +24,7 @@ type TS = typeof ts;
 
 function loadCompiler(cwd: string, name = 'typescript'): TS {
   const path = require.resolve(name, { paths: [cwd, __dirname] });
+  // oxlint-disable-next-line node/global-require -- The compiler package is selected at runtime from worker options.
   return require(path);
 }
 

--- a/scripts/check-node-version-policy.ts
+++ b/scripts/check-node-version-policy.ts
@@ -1,8 +1,11 @@
-(() => {
-  const assert = require('node:assert/strict');
-  const fs = require('node:fs');
-  const path = require('node:path');
+const nodeVersionPolicyAssert = require('node:assert/strict');
+const nodeVersionPolicyFs = require('node:fs');
+const nodeVersionPolicyPath = require('node:path');
 
+(() => {
+  const assert = nodeVersionPolicyAssert;
+  const fs = nodeVersionPolicyFs;
+  const path = nodeVersionPolicyPath;
   interface PackageMetadata {
     engines?: {
       node?: string;

--- a/scripts/test-packed-package.ts
+++ b/scripts/test-packed-package.ts
@@ -1,10 +1,15 @@
-(() => {
-  const assert = require('node:assert/strict');
-  const childProcess = require('node:child_process');
-  const fs = require('node:fs');
-  const os = require('node:os');
-  const path = require('node:path');
+const packedPackageAssert = require('node:assert/strict');
+const packedPackageChildProcess = require('node:child_process');
+const packedPackageFs = require('node:fs');
+const packedPackageOs = require('node:os');
+const packedPackagePath = require('node:path');
 
+(() => {
+  const assert = packedPackageAssert;
+  const childProcess = packedPackageChildProcess;
+  const fs = packedPackageFs;
+  const os = packedPackageOs;
+  const path = packedPackagePath;
   interface PackageMetadata {
     engines?: {
       node?: string;

--- a/scripts/utils/check-version.cjs
+++ b/scripts/utils/check-version.cjs
@@ -1,8 +1,8 @@
 const fs = require('fs');
 const path = require('path');
+const pkg = require('../../package.json');
 
 const main = () => {
-  const pkg = require('../../package.json');
   const version = pkg['version'];
   if (!version) throw new Error('The version property is not set in the package.json file');
   if (typeof version !== 'string') {

--- a/tests/oxlint-config.test.ts
+++ b/tests/oxlint-config.test.ts
@@ -19,6 +19,7 @@ test('inherits Ultracite native plugins and enforces their rules', () => {
     plugins: string[];
     rules: Record<string, string>;
   };
+  // oxlint-disable-next-line node/global-require -- This test verifies the CommonJS config dependency used by oxlint.config.ts.
   const preset = require('ultracite/oxlint/core').default as { plugins: string[] };
 
   expect(configuration.plugins).toEqual(
@@ -72,6 +73,7 @@ test('recognizes both Stainless and Castiron generated SDK files', () => {
     }
     writeFileSync(path.join(fixtureRoot, 'handwritten.ts'), 'export const handwritten = true;\n');
 
+    // oxlint-disable-next-line node/global-require -- The fixture module path is created dynamically for this test.
     const generatedFiles = require(generatedFilesScript) as string[];
     expect(generatedFiles).toEqual(['castiron.ts', 'stainless.ts']);
   } finally {

--- a/tests/uploads.test.ts
+++ b/tests/uploads.test.ts
@@ -78,6 +78,7 @@ describe('missing File error message', () => {
     // The file shim captures the global File object when it's first imported.
     // Reset modules before each test so we can test the error thrown when it's undefined.
     vi.resetModules();
+    // oxlint-disable-next-line node/global-require -- Resetting modules requires loading this fresh for each test.
     const buffer = require('node:buffer');
     // @ts-ignore
     prevGlobalFile = globalThis.File;
@@ -90,6 +91,7 @@ describe('missing File error message', () => {
     // Clean up
     // @ts-ignore
     globalThis.File = prevGlobalFile;
+    // oxlint-disable-next-line node/global-require -- Resetting modules requires restoring the freshly loaded module.
     require('node:buffer').File = prevNodeFile;
     vi.resetModules();
   });


### PR DESCRIPTION
## Summary

- Removes `node/global-require` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 121 of 185.
- Base: `dev/hayden/ultracite-120-unicorn-prefer-spread`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`