### PR TITLE
chore(lint): enable class-methods-use-this

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -7,7 +7,6 @@ const stainlessGeneratedFiles = requireConfig('./scripts/stainless-generated-fil
 // Existing handwritten SDK patterns predate these preset rules.
 const compatibilityRules = [
   'arrow-body-style',
-  'class-methods-use-this',
   'complexity',
   'curly',
   'default-case',

--- a/src/auth/workload-identity-auth.ts
+++ b/src/auth/workload-identity-auth.ts
@@ -28,7 +28,7 @@ export class WorkloadIdentityAuth {
   }
 
   async getToken(): Promise<string> {
-    if (!this.cachedToken || this.isTokenExpired(this.cachedToken)) {
+    if (!this.cachedToken || WorkloadIdentityAuth.isTokenExpired(this.cachedToken)) {
       if (this.refreshPromise) {
         return await this.refreshPromise;
       }
@@ -118,7 +118,7 @@ export class WorkloadIdentityAuth {
     return accessToken;
   }
 
-  private isTokenExpired(cachedToken: CachedToken): boolean {
+  private static isTokenExpired(cachedToken: CachedToken): boolean {
     return Date.now() >= cachedToken.expiresAt;
   }
 

--- a/src/internal/ws-adapter-browser.ts
+++ b/src/internal/ws-adapter-browser.ts
@@ -52,7 +52,7 @@ export class BrowserWebSocket implements WebSocketLike {
   }
 
   on(event: string, listener: Listener): void {
-    const wrapped = this._wrapListener(event, listener);
+    const wrapped = BrowserWebSocket._wrapListener(event, listener);
     this._listenersFor(event).set(listener, wrapped);
     this._ws.addEventListener(event, wrapped);
   }
@@ -72,7 +72,7 @@ export class BrowserWebSocket implements WebSocketLike {
       this.off(event, listener);
       listener(...args);
     };
-    const wrapped = this._wrapListener(event, onceListener);
+    const wrapped = BrowserWebSocket._wrapListener(event, onceListener);
     this._listenersFor(event).set(listener, wrapped);
     this._ws.addEventListener(event, wrapped);
   }
@@ -90,7 +90,7 @@ export class BrowserWebSocket implements WebSocketLike {
    * Converts browser event objects to positional arguments matching the
    * {@link WebSocketLike} interface.
    */
-  private _wrapListener(event: string, listener: Listener): DOMEventHandler {
+  private static _wrapListener(event: string, listener: Listener): DOMEventHandler {
     switch (event) {
       case 'message':
         return (ev: MessageEvent) => {

--- a/src/internal/ws-adapter-node.ts
+++ b/src/internal/ws-adapter-node.ts
@@ -32,7 +32,7 @@ export class NodeWebSocket implements WebSocketLike {
   }
 
   on(event: string, listener: Listener): void {
-    const wrapped = this._wrapListener(event, listener);
+    const wrapped = NodeWebSocket._wrapListener(event, listener);
     this._listenersFor(event).set(listener, wrapped);
     this._ws.on(event, wrapped);
   }
@@ -52,7 +52,7 @@ export class NodeWebSocket implements WebSocketLike {
       this.off(event, listener);
       listener(...args);
     };
-    const wrapped = this._wrapListener(event, onceListener);
+    const wrapped = NodeWebSocket._wrapListener(event, onceListener);
     this._listenersFor(event).set(listener, wrapped);
     this._ws.on(event, wrapped);
   }
@@ -85,7 +85,7 @@ export class NodeWebSocket implements WebSocketLike {
     return data;
   }
 
-  private _wrapListener(event: string, listener: Listener): Listener {
+  private static _wrapListener(event: string, listener: Listener): Listener {
     switch (event) {
       case 'message':
         return (data: Buffer | ArrayBuffer | Buffer[], isBinary: boolean) => {

--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -297,7 +297,7 @@ export class AbstractChatCompletionRunner<
     }
   }
 
-  #validateParams(params: ChatCompletionCreateParams): void {
+  static #validateParams(params: ChatCompletionCreateParams): void {
     if (params.n != null && params.n > 1) {
       throw new OpenAIError(
         'ChatCompletion convenience helpers only support n=1 at this time. To use n>1, please use chat.completions.create() directly.',
@@ -311,7 +311,7 @@ export class AbstractChatCompletionRunner<
     options?: RequestOptions,
   ): Promise<ParsedChatCompletion<ParsedT>> {
     this._listenForAbort(options?.signal);
-    this.#validateParams(params);
+    AbstractChatCompletionRunner.#validateParams(params);
 
     const chatCompletion = await client.chat.completions.create(
       { ...params, stream: false },
@@ -444,7 +444,7 @@ export class AbstractChatCompletionRunner<
         rawContent = await fn.function(args, runner, toolContext);
       }
 
-      const content = this.#stringifyFunctionCallResult(rawContent);
+      const content = AbstractChatCompletionRunner.#stringifyFunctionCallResult(rawContent);
       return { message: { role, tool_call_id, content }, functionCalled: true };
     };
 
@@ -500,7 +500,7 @@ export class AbstractChatCompletionRunner<
     }
   }
 
-  #stringifyFunctionCallResult(rawContent: unknown): string {
+  static #stringifyFunctionCallResult(rawContent: unknown): string {
     return typeof rawContent === 'string'
       ? rawContent
       : rawContent === undefined

--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -630,6 +630,7 @@ export class AssistantStream
     throw new Error('Tried to accumulate a non-message event');
   }
 
+  // oxlint-disable-next-line class-methods-use-this -- Keeping this helper on the instance preserves nearby accumulator method structure.
   #accumulateContent(
     contentElement: MessageContentDelta,
     currentContent: MessageContent | undefined,
@@ -730,6 +731,7 @@ export class AssistantStream
     }
   }
 
+  // oxlint-disable-next-line class-methods-use-this -- Subclasses can override this instance hook.
   protected _addRun(run: Run): Run {
     return run;
   }

--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -4,12 +4,14 @@ export class EventStream<EventTypes extends BaseEvents> {
   controller: AbortController = new AbortController();
 
   #connectedPromise: Promise<void>;
+  // oxlint-disable class-methods-use-this -- Deferred promise resolvers are intentionally per-instance mutable callbacks.
   #resolveConnectedPromise: () => void = () => undefined;
   #rejectConnectedPromise: (error: OpenAIError) => void = () => undefined;
 
   #endPromise: Promise<void>;
   #resolveEndPromise: () => void = () => undefined;
   #rejectEndPromise: (error: OpenAIError) => void = () => undefined;
+  // oxlint-enable class-methods-use-this
 
   #listeners: {
     [Event in keyof EventTypes]?: EventListeners<EventTypes, Event>;
@@ -357,6 +359,7 @@ export class EventStream<EventTypes extends BaseEvents> {
     }
   }
 
+  // oxlint-disable-next-line class-methods-use-this -- Subclasses override this instance hook.
   protected _emitFinal(): void {
     // Hook for subclasses.
   }

--- a/tests/lib/provider.test.ts
+++ b/tests/lib/provider.test.ts
@@ -164,6 +164,7 @@ describe('provider', () => {
     let attempt = 0;
 
     class TestClient extends OpenAI {
+      // oxlint-disable-next-line class-methods-use-this -- This fixture exercises an overridable instance hook.
       protected override async prepareRequest(request: RequestInit): Promise<void> {
         order.push('subclass');
         (request.headers as Headers).set('x-prepared-by', 'subclass');

--- a/tests/path.test.ts
+++ b/tests/path.test.ts
@@ -46,6 +46,7 @@ describe('path template tag function', () => {
       readonly kind = 'class';
     })();
     const classWithToString = new (class {
+      // oxlint-disable-next-line class-methods-use-this -- This fixture intentionally exercises an instance toString protocol.
       toString() {
         return 'ok';
       }
@@ -115,6 +116,7 @@ describe('path template tag function', () => {
     const crossRealmString = new newRealm.String();
     const crossRealmClass = new (class extends newRealm.Object {})();
     const crossRealmClassWithToString = new (class extends newRealm.Object {
+      // oxlint-disable-next-line class-methods-use-this -- This fixture intentionally exercises an instance toString protocol.
       toString() {
         return 'ok';
       }


### PR DESCRIPTION
## Summary

- Removes `class-methods-use-this` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 123 of 185.
- Base: `dev/hayden/ultracite-122-typescript-no-namespace`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`