### PR TITLE
chore(lint): enable typescript/consistent-indexed-object-style

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -42,7 +42,6 @@ const compatibilityRules = [
   'sort-keys',
   'typescript/array-type',
   'typescript/ban-ts-comment',
-  'typescript/consistent-indexed-object-style',
   'typescript/consistent-type-definitions',
   'typescript/consistent-type-imports',
   'typescript/method-signature-style',

--- a/scripts/_vendor/tsc-multi/src/config.ts
+++ b/scripts/_vendor/tsc-multi/src/config.ts
@@ -13,7 +13,7 @@ const targetSchema = type({
   transpileOnly: optional(boolean()),
 });
 
-export type Target = Infer<typeof targetSchema> & { [key: string]: unknown };
+export type Target = Infer<typeof targetSchema> & Record<string, unknown>;
 
 const configSchema = object({
   projects: optional(array(string())),

--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -9,13 +9,14 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
   options?: Partial<Options<Target>> | string,
 ): (Target extends 'jsonSchema7' ? JsonSchema7Type : object) & {
   $schema?: string;
-  definitions?: {
-    [key: string]: Target extends 'jsonSchema7'
+  definitions?: Record<
+    string,
+    Target extends 'jsonSchema7'
       ? JsonSchema7Type
       : Target extends 'jsonSchema2019-09'
         ? JsonSchema7Type
-        : object;
-  };
+        : object
+  >;
 } => {
   const refs = getRefs(options);
 

--- a/src/core/EventEmitter.ts
+++ b/src/core/EventEmitter.ts
@@ -5,9 +5,10 @@ type EventListeners<Events, EventType extends keyof Events> = Array<{
   once?: boolean;
 }>;
 
-export type EventParameters<Events, EventType extends keyof Events> = {
-  [Event in EventType]: EventListener<Events, EventType> extends (...args: infer P) => any ? P : never;
-}[EventType];
+export type EventParameters<Events, EventType extends keyof Events> = Record<
+  EventType,
+  EventListener<Events, EventType> extends (...args: infer P) => any ? P : never
+>[EventType];
 
 export class EventEmitter<EventTypes extends Record<string, (...args: any) => any>> {
   #listeners: {

--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -79,8 +79,8 @@ export class AssistantStream
 
   //Used to accumulate deltas
   //We are accumulating many types so the value here is not strict
-  #runStepSnapshots: { [id: string]: Runs.RunStep } = {};
-  #messageSnapshots: { [id: string]: Message } = {};
+  #runStepSnapshots: Record<string, Runs.RunStep> = {};
+  #messageSnapshots: Record<string, Message> = {};
   #messageSnapshot: Message | undefined;
   #finalRun: Run | undefined;
   #currentContentIndex: number | undefined;

--- a/src/lib/EventEmitter.ts
+++ b/src/lib/EventEmitter.ts
@@ -5,9 +5,10 @@ type EventListeners<Events, EventType extends keyof Events> = Array<{
   once?: boolean;
 }>;
 
-export type EventParameters<Events, EventType extends keyof Events> = {
-  [Event in EventType]: EventListener<Events, EventType> extends (...args: infer P) => any ? P : never;
-}[EventType];
+export type EventParameters<Events, EventType extends keyof Events> = Record<
+  EventType,
+  EventListener<Events, EventType> extends (...args: infer P) => any ? P : never
+>[EventType];
 
 export class EventEmitter<EventTypes extends Record<string, (...args: any) => any>> {
   #listeners: {

--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -372,9 +372,10 @@ type EventListeners<Events, EventType extends keyof Events> = Array<{
   once?: boolean;
 }>;
 
-export type EventParameters<Events, EventType extends keyof Events> = {
-  [Event in EventType]: EventListener<Events, EventType> extends (...args: infer P) => any ? P : never;
-}[EventType];
+export type EventParameters<Events, EventType extends keyof Events> = Record<
+  EventType,
+  EventListener<Events, EventType> extends (...args: infer P) => any ? P : never
+>[EventType];
 
 export interface BaseEvents {
   connect: () => void;

--- a/src/lib/jsonschema.ts
+++ b/src/lib/jsonschema.ts
@@ -102,16 +102,8 @@ export interface JSONSchema {
   maxProperties?: number | undefined;
   minProperties?: number | undefined;
   required?: string[] | undefined;
-  properties?:
-    | {
-        [key: string]: JSONSchemaDefinition;
-      }
-    | undefined;
-  patternProperties?:
-    | {
-        [key: string]: JSONSchemaDefinition;
-      }
-    | undefined;
+  properties?: Record<string, JSONSchemaDefinition> | undefined;
+  patternProperties?: Record<string, JSONSchemaDefinition> | undefined;
   additionalProperties?: JSONSchemaDefinition | undefined;
   propertyNames?: JSONSchemaDefinition | undefined;
 
@@ -133,21 +125,13 @@ export interface JSONSchema {
   /**
    * @see https://json-schema.org/draft/2020-12/json-schema-core.html#section-8.2.4
    */
-  $defs?:
-    | {
-        [key: string]: JSONSchemaDefinition;
-      }
-    | undefined;
+  $defs?: Record<string, JSONSchemaDefinition> | undefined;
 
   /**
    * @deprecated Use $defs instead (draft 2019-09+)
    * @see https://tools.ietf.org/doc/html/draft-handrews-json-schema-validation-01#page-22
    */
-  definitions?:
-    | {
-        [key: string]: JSONSchemaDefinition;
-      }
-    | undefined;
+  definitions?: Record<string, JSONSchemaDefinition> | undefined;
 
   /**
    * @see https://json-schema.org/draft/2020-12/json-schema-core#ref

--- a/tests/path.test.ts
+++ b/tests/path.test.ts
@@ -147,11 +147,7 @@ describe('path template tag function', () => {
     expect(rawPath`${crossRealmString}/`).toBe('/');
     expect(rawPath`/${crossRealmClassWithToString}`).toBe('/ok');
 
-    const results: {
-      [pathParts: string]: {
-        [params: string]: { valid: boolean; result?: string; error?: string };
-      };
-    } = {};
+    const results: Record<string, Record<string, { valid: boolean; result?: string; error?: string }>> = {};
 
     for (const pathParts of testCases) {
       const pathResults: Record<string, { valid: boolean; result?: string; error?: string }> = {};

--- a/tests/responsesTools.test.ts
+++ b/tests/responsesTools.test.ts
@@ -69,7 +69,7 @@ type _StableFunctionToolMayOmitOutputSchema = Assert<
   IsAssignable<
     {
       name: string;
-      parameters: { [key: string]: unknown } | null;
+      parameters: Record<string, unknown> | null;
       strict: boolean | null;
       type: 'function';
     },
@@ -87,7 +87,7 @@ type _BetaFunctionToolMayOmitOutputSchema = Assert<
   IsAssignable<
     {
       name: string;
-      parameters: { [key: string]: unknown } | null;
+      parameters: Record<string, unknown> | null;
       strict: boolean | null;
       type: 'function';
     },

--- a/tsconfig.dist-src.d.ts
+++ b/tsconfig.dist-src.d.ts
@@ -4,9 +4,7 @@ export {};
 
 declare global {
   namespace NodeJS {
-    interface ProcessEnv {
-      [key: string]: string | undefined;
-    }
+    type ProcessEnv = Record<string, string | undefined>;
 
     interface Process {
       env: ProcessEnv;


### PR DESCRIPTION
## Summary

- Removes `typescript/consistent-indexed-object-style` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 124 of 185.
- Base: `dev/hayden/ultracite-123-class-methods-use-this`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`