### PR TITLE
chore(lint): enable typescript/no-dynamic-delete

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -45,7 +45,6 @@ const compatibilityRules = [
   'typescript/consistent-type-definitions',
   'typescript/consistent-type-imports',
   'typescript/method-signature-style',
-  'typescript/no-dynamic-delete',
   'typescript/no-explicit-any',
   'typescript/no-import-type-side-effects',
   'typescript/no-non-null-assertion',
@@ -193,6 +192,19 @@ module.exports = defineConfig({
       ],
       rules: {
         'typescript/no-namespace': 'off',
+      },
+    },
+    {
+      // Schema normalization intentionally deletes dynamic keys in place, and these
+      // tests exercise deletion/restoration behavior directly.
+      files: [
+        'src/lib/transform.ts',
+        'tests/internal/detect-platform.test.ts',
+        'tests/internal/utils.test.ts',
+        'tests/lib/bedrock-provider.test.ts',
+      ],
+      rules: {
+        'typescript/no-dynamic-delete': 'off',
       },
     },
     {


### PR DESCRIPTION
## Summary

- Removes `typescript/no-dynamic-delete` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 125 of 185.
- Base: `dev/hayden/ultracite-124-typescript-consistent-indexed-object-style`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`