### PR TITLE
chore(lint): enable unicorn/no-await-expression-member

### DIFF
--- a/ecosystem-tests/cloudflare-worker/tests/test.js
+++ b/ecosystem-tests/cloudflare-worker/tests/test.js
@@ -1,7 +1,8 @@
 it(
 	'works',
 	async () => {
-		expect(await (await fetch('http://localhost:8787/test')).text()).toEqual('Passed!');
+		const response = await fetch('http://localhost:8787/test');
+		expect(await response.text()).toEqual('Passed!');
 	},
 	3 * 60000
 );

--- a/ecosystem-tests/vercel-edge/tests/test.ts
+++ b/ecosystem-tests/vercel-edge/tests/test.ts
@@ -4,7 +4,8 @@ console.log(baseUrl);
 it(
   'node runtime',
   async () => {
-    expect(await (await fetch(`${baseUrl}/api/node-test`)).text()).toEqual('Passed!');
+    const response = await fetch(`${baseUrl}/api/node-test`);
+    expect(await response.text()).toEqual('Passed!');
   },
   3 * 60000,
 );
@@ -12,7 +13,8 @@ it(
 it(
   'edge runtime',
   async () => {
-    expect(await (await fetch(`${baseUrl}/api/edge-test`)).text()).toEqual('Passed!');
+    const response = await fetch(`${baseUrl}/api/edge-test`);
+    expect(await response.text()).toEqual('Passed!');
   },
   3 * 60000,
 );

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -53,7 +53,6 @@ const compatibilityRules = [
   'unicorn/consistent-assert',
   'unicorn/consistent-function-scoping',
   'unicorn/filename-case',
-  'unicorn/no-await-expression-member',
   'unicorn/no-console-spaces',
   'unicorn/no-nested-ternary',
   'unicorn/no-typeof-undefined',

--- a/src/auth/subject-token-providers.ts
+++ b/src/auth/subject-token-providers.ts
@@ -163,7 +163,8 @@ export function gcpIDTokenProvider(
           throw new Error(`GCP Metadata Server returned ${response.status}: ${errorText}`);
         }
 
-        const token = (await response.text()).trim();
+        const tokenText = await response.text();
+        const token = tokenText.trim();
         if (!token) {
           throw new Error('GCP metadata server returned an empty token');
         }

--- a/tests/lib/ChatCompletionStream.test.ts
+++ b/tests/lib/ChatCompletionStream.test.ts
@@ -349,7 +349,8 @@ describe('.stream()', () => {
       }),
     );
 
-    expect((await stream.finalChatCompletion()).choices[0]).toMatchInlineSnapshot(`
+    const completion = await stream.finalChatCompletion();
+    expect(completion.choices[0]).toMatchInlineSnapshot(`
       {
         "finish_reason": "stop",
         "index": 0,
@@ -387,7 +388,8 @@ describe('.stream()', () => {
       }),
     );
 
-    expect((await stream.finalChatCompletion()).choices[0]).toMatchInlineSnapshot(`
+    const completion = await stream.finalChatCompletion();
+    expect(completion.choices[0]).toMatchInlineSnapshot(`
       {
         "finish_reason": "stop",
         "index": 0,
@@ -410,33 +412,33 @@ describe('.stream()', () => {
   it('emits content logprobs events', async () => {
     var capturedLogProbs: ChatCompletionTokenLogprob[] | undefined;
 
-    const stream = (
-      await makeStreamSnapshotRequest((openai) =>
-        openai.chat.completions.stream({
-          model: 'gpt-4o-2024-08-06',
-          messages: [
-            {
-              role: 'user',
-              content: "What's the weather like in SF?",
-            },
-          ],
-          logprobs: true,
-          response_format: zodResponseFormat(
-            z.object({
-              city: z.string(),
-              units: z.enum(['c', 'f']).default('f'),
-            }),
-            'location',
-          ),
-        }),
-      )
-    ).on('logprobs.content.done', (props) => {
+    const request = await makeStreamSnapshotRequest((openai) =>
+      openai.chat.completions.stream({
+        model: 'gpt-4o-2024-08-06',
+        messages: [
+          {
+            role: 'user',
+            content: "What's the weather like in SF?",
+          },
+        ],
+        logprobs: true,
+        response_format: zodResponseFormat(
+          z.object({
+            city: z.string(),
+            units: z.enum(['c', 'f']).default('f'),
+          }),
+          'location',
+        ),
+      }),
+    );
+    const stream = request.on('logprobs.content.done', (props) => {
       if (!capturedLogProbs?.length) {
         capturedLogProbs = props.content;
       }
     });
 
-    const choice = (await stream.finalChatCompletion()).choices[0];
+    const completion = await stream.finalChatCompletion();
+    const choice = completion.choices[0];
     expect(choice).toMatchInlineSnapshot(`
       {
         "finish_reason": "stop",
@@ -569,33 +571,33 @@ describe('.stream()', () => {
   it('emits refusal logprobs events', async () => {
     var capturedLogProbs: ChatCompletionTokenLogprob[] | undefined;
 
-    const stream = (
-      await makeStreamSnapshotRequest((openai) =>
-        openai.chat.completions.stream({
-          model: 'gpt-4o-2024-08-06',
-          messages: [
-            {
-              role: 'user',
-              content: 'a bad question',
-            },
-          ],
-          logprobs: true,
-          response_format: zodResponseFormat(
-            z.object({
-              city: z.string(),
-              units: z.enum(['c', 'f']).default('f'),
-            }),
-            'location',
-          ),
-        }),
-      )
-    ).on('logprobs.refusal.done', (props) => {
+    const request = await makeStreamSnapshotRequest((openai) =>
+      openai.chat.completions.stream({
+        model: 'gpt-4o-2024-08-06',
+        messages: [
+          {
+            role: 'user',
+            content: 'a bad question',
+          },
+        ],
+        logprobs: true,
+        response_format: zodResponseFormat(
+          z.object({
+            city: z.string(),
+            units: z.enum(['c', 'f']).default('f'),
+          }),
+          'location',
+        ),
+      }),
+    );
+    const stream = request.on('logprobs.refusal.done', (props) => {
       if (!capturedLogProbs?.length) {
         capturedLogProbs = props.refusal;
       }
     });
 
-    const choice = (await stream.finalChatCompletion()).choices[0];
+    const completion = await stream.finalChatCompletion();
+    const choice = completion.choices[0];
     expect(choice).toMatchInlineSnapshot(`
       {
         "finish_reason": "stop",

--- a/tests/lib/ResponseStream.test.ts
+++ b/tests/lib/ResponseStream.test.ts
@@ -201,14 +201,13 @@ describe('.stream()', () => {
   it('standard text works', async () => {
     const deltas: string[] = [];
 
-    const stream = (
-      await makeStreamSnapshotRequest((openai) =>
-        openai.responses.stream({
-          model: 'gpt-4o-2024-08-06',
-          input: 'Say hello world',
-        }),
-      )
-    ).on('response.output_text.delta', (e) => {
+    const request = await makeStreamSnapshotRequest((openai) =>
+      openai.responses.stream({
+        model: 'gpt-4o-2024-08-06',
+        input: 'Say hello world',
+      }),
+    );
+    const stream = request.on('response.output_text.delta', (e) => {
       deltas.push(e.snapshot);
     });
 

--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -256,11 +256,8 @@ describe('instantiate azure client', () => {
         apiVersion,
         fetch: testFetch,
       });
-      expect(
-        (await client.request({ method: 'post', path: 'https://example.com' }).asResponse()).headers.get(
-          'authorization',
-        ),
-      ).toEqual('Bearer my token');
+      const response = await client.request({ method: 'post', path: 'https://example.com' }).asResponse();
+      expect(response.headers.get('authorization')).toEqual('Bearer my token');
     });
 
     test('apiKey and azureADTokenProvider cant be combined', () => {
@@ -303,16 +300,13 @@ describe('instantiate azure client', () => {
         apiVersion,
         fetch: testFetch,
       });
-      expect(
-        (
-          await client.chat.completions
-            .create({
-              model,
-              messages: [{ role: 'system', content: 'Hello' }],
-            })
-            .asResponse()
-        ).headers.get('authorization'),
-      ).toEqual('Bearer token-1');
+      const response = await client.chat.completions
+        .create({
+          model,
+          messages: [{ role: 'system', content: 'Hello' }],
+        })
+        .asResponse();
+      expect(response.headers.get('authorization')).toEqual('Bearer token-1');
     });
   });
 
@@ -442,15 +436,12 @@ describe('azure request building', () => {
       });
 
       test('handles text to speech', async () => {
-        expect(
-          await (
-            await client.audio.speech.create({
-              model,
-              input: '',
-              voice: 'alloy',
-            })
-          ).json(),
-        ).toMatchObject({
+        const response = await client.audio.speech.create({
+          model,
+          input: '',
+          voice: 'alloy',
+        });
+        expect(await response.json()).toMatchObject({
           url: `https://example.com/openai/deployments/${deployment}/audio/speech?api-version=${apiVersion}`,
         });
       });
@@ -569,15 +560,12 @@ describe('azure request building', () => {
       });
 
       test('handles text to speech', async () => {
-        expect(
-          await (
-            await client.audio.speech.create({
-              model: deployment,
-              input: '',
-              voice: 'alloy',
-            })
-          ).json(),
-        ).toMatchObject({
+        const response = await client.audio.speech.create({
+          model: deployment,
+          input: '',
+          voice: 'alloy',
+        });
+        expect(await response.json()).toMatchObject({
           url: `https://example.com/openai/deployments/${deployment}/audio/speech?api-version=${apiVersion}`,
         });
       });


### PR DESCRIPTION
## Summary

- Removes `unicorn/no-await-expression-member` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 126 of 185.
- Base: `dev/hayden/ultracite-125-typescript-no-dynamic-delete`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`