### PR TITLE
chore(lint): enable unicorn/no-nested-ternary

### DIFF
--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -286,13 +286,16 @@ async function main() {
   const positionalArgs = args._.filter(Boolean);
 
   // For some reason `yargs` doesn't pick up the positional args correctly
-  const projectsToRun = (
-    args.projects?.length
-      ? args.projects
-      : positionalArgs.length
-        ? positionalArgs.filter((n) => typeof n === 'string' && (projectNamesSet as Set<string>).has(n))
-        : projectNames
-  ) as typeof projectNames;
+  let projectsToRun: typeof projectNames;
+  if (args.projects?.length) {
+    projectsToRun = args.projects as typeof projectNames;
+  } else if (positionalArgs.length) {
+    projectsToRun = positionalArgs.filter(
+      (n) => typeof n === 'string' && (projectNamesSet as Set<string>).has(n),
+    ) as typeof projectNames;
+  } else {
+    projectsToRun = projectNames;
+  }
   console.error(`running projects: ${projectsToRun}`);
 
   const failed: typeof projectNames = [];

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -54,7 +54,6 @@ const compatibilityRules = [
   'unicorn/consistent-function-scoping',
   'unicorn/filename-case',
   'unicorn/no-console-spaces',
-  'unicorn/no-nested-ternary',
   'unicorn/no-typeof-undefined',
   'unicorn/no-useless-undefined',
   'unicorn/numeric-separators-style',

--- a/scripts/_vendor/tsc-multi/src/transformer.ts
+++ b/scripts/_vendor/tsc-multi/src/transformer.ts
@@ -271,6 +271,7 @@ export function createTransformer<T extends ts.SourceFile | ts.Bundle>(
       }
       return ctx.factory.updateSourceFile(
         sourceFile,
+        // oxlint-disable unicorn/no-nested-ternary, no-nested-ternary -- Preserve the vendored transformer AST construction shape.
         newStatements.map((group) =>
           Array.isArray(group)
             ? group.length === 1 &&
@@ -312,6 +313,7 @@ export function createTransformer<T extends ts.SourceFile | ts.Bundle>(
                 ])
             : group,
         ),
+        // oxlint-enable unicorn/no-nested-ternary, no-nested-ternary
       );
     };
 

--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -20,8 +20,12 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
 } => {
   const refs = getRefs(options);
 
-  const name =
-    typeof options === 'string' ? options : options?.nameStrategy === 'title' ? undefined : options?.name;
+  let name: string | undefined;
+  if (typeof options === 'string') {
+    name = options;
+  } else if (options?.nameStrategy !== 'title') {
+    name = options?.name;
+  }
 
   const main =
     parseDef(
@@ -77,39 +81,37 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
     return definitions;
   })();
 
-  const combined: ReturnType<typeof zodToJsonSchema<Target>> =
-    name === undefined
-      ? definitions
+  let combined: ReturnType<typeof zodToJsonSchema<Target>>;
+  if (name === undefined) {
+    combined = definitions
+      ? {
+          ...main,
+          [refs.definitionPath]: definitions,
+        }
+      : main;
+  } else if (refs.nameStrategy === 'duplicate-ref') {
+    combined = {
+      ...main,
+      ...(definitions || refs.seenRefs.size
         ? {
-            ...main,
-            [refs.definitionPath]: definitions,
-          }
-        : main
-      : refs.nameStrategy === 'duplicate-ref'
-        ? {
-            ...main,
-            ...(definitions || refs.seenRefs.size
-              ? {
-                  [refs.definitionPath]: {
-                    ...definitions,
-                    // only actually duplicate the schema definition if it was ever referenced
-                    // otherwise the duplication is completely pointless
-                    ...(refs.seenRefs.size ? { [name]: main } : undefined),
-                  },
-                }
-              : undefined),
-          }
-        : {
-            $ref: [
-              ...(refs.$refStrategy === 'relative' ? [] : refs.basePath),
-              refs.definitionPath,
-              name,
-            ].join('/'),
             [refs.definitionPath]: {
               ...definitions,
-              [name]: main,
+              // only actually duplicate the schema definition if it was ever referenced
+              // otherwise the duplication is completely pointless
+              ...(refs.seenRefs.size ? { [name]: main } : undefined),
             },
-          };
+          }
+        : undefined),
+    };
+  } else {
+    combined = {
+      $ref: [...(refs.$refStrategy === 'relative' ? [] : refs.basePath), refs.definitionPath, name].join('/'),
+      [refs.definitionPath]: {
+        ...definitions,
+        [name]: main,
+      },
+    };
+  }
 
   if (refs.target === 'jsonSchema7') {
     combined.$schema = 'http://json-schema.org/draft-07/schema#';

--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -286,12 +286,14 @@ async function* iterSSEChunks(iterator: AsyncIterableIterator<Bytes>): AsyncGene
       continue;
     }
 
-    const binaryChunk =
-      chunk instanceof ArrayBuffer
-        ? new Uint8Array(chunk)
-        : typeof chunk === 'string'
-          ? encodeUTF8(chunk)
-          : chunk;
+    let binaryChunk: Uint8Array;
+    if (chunk instanceof ArrayBuffer) {
+      binaryChunk = new Uint8Array(chunk);
+    } else if (typeof chunk === 'string') {
+      binaryChunk = encodeUTF8(chunk);
+    } else {
+      binaryChunk = chunk;
+    }
 
     const newData = new Uint8Array(data.length + binaryChunk.length);
     newData.set(data);

--- a/src/internal/bedrock.ts
+++ b/src/internal/bedrock.ts
@@ -68,9 +68,7 @@ export function resolveBedrockEndpoint(options: BedrockEndpointOptions): {
   const configuredBaseURL =
     options.baseURL === undefined
       ? normalizeOptionalString(readEnv('AWS_BEDROCK_BASE_URL'))
-      : options.baseURL === null
-        ? undefined
-        : normalizeOptionalString(options.baseURL);
+      : normalizeOptionalString(options.baseURL);
 
   if (configuredBaseURL) return { region, baseURL: normalizeBaseURL(configuredBaseURL) };
   if (!region) {

--- a/src/internal/decoders/line.ts
+++ b/src/internal/decoders/line.ts
@@ -26,12 +26,14 @@ export class LineDecoder {
       return [];
     }
 
-    const binaryChunk =
-      chunk instanceof ArrayBuffer
-        ? new Uint8Array(chunk)
-        : typeof chunk === 'string'
-          ? encodeUTF8(chunk)
-          : chunk;
+    let binaryChunk: Uint8Array;
+    if (chunk instanceof ArrayBuffer) {
+      binaryChunk = new Uint8Array(chunk);
+    } else if (typeof chunk === 'string') {
+      binaryChunk = encodeUTF8(chunk);
+    } else {
+      binaryChunk = chunk;
+    }
 
     this.#buffer = concatBytes([this.#buffer, binaryChunk]);
 

--- a/src/internal/qs/stringify.ts
+++ b/src/internal/qs/stringify.ts
@@ -182,11 +182,15 @@ function inner_stringify(
 
     // @ts-ignore
     const encoded_key = allowDots && encodeDotInKeys ? (key as any).replace(/\./g, '%2E') : key;
-    const key_prefix = isArray(obj)
-      ? typeof generateArrayPrefix === 'function'
-        ? generateArrayPrefix(adjusted_prefix, encoded_key)
-        : adjusted_prefix
-      : adjusted_prefix + (allowDots ? '.' + encoded_key : '[' + encoded_key + ']');
+    let key_prefix: string;
+    if (isArray(obj)) {
+      key_prefix =
+        typeof generateArrayPrefix === 'function'
+          ? generateArrayPrefix(adjusted_prefix, encoded_key)
+          : adjusted_prefix;
+    } else {
+      key_prefix = adjusted_prefix + (allowDots ? '.' + encoded_key : '[' + encoded_key + ']');
+    }
 
     sideChannel.set(object, step);
     const valueSideChannel = new WeakMap([[sentinel, sideChannel]]);
@@ -266,12 +270,12 @@ function normalize_stringify_options(
     throw new TypeError('`commaRoundTrip` must be a boolean, or absent');
   }
 
-  const allowDots =
-    typeof opts.allowDots === 'undefined'
-      ? !!opts.encodeDotInKeys === true
-        ? true
-        : defaults.allowDots
-      : !!opts.allowDots;
+  let allowDots: boolean;
+  if (opts.allowDots === undefined) {
+    allowDots = !!opts.encodeDotInKeys === true ? true : defaults.allowDots;
+  } else {
+    allowDots = !!opts.allowDots;
+  }
 
   return {
     addQueryPrefix: typeof opts.addQueryPrefix === 'boolean' ? opts.addQueryPrefix : defaults.addQueryPrefix,

--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -501,11 +501,13 @@ export class AbstractChatCompletionRunner<
   }
 
   static #stringifyFunctionCallResult(rawContent: unknown): string {
-    return typeof rawContent === 'string'
-      ? rawContent
-      : rawContent === undefined
-        ? 'undefined'
-        : JSON.stringify(rawContent);
+    if (typeof rawContent === 'string') {
+      return rawContent;
+    }
+    if (rawContent === undefined) {
+      return 'undefined';
+    }
+    return JSON.stringify(rawContent);
   }
 }
 

--- a/src/lib/ChatCompletionStream.ts
+++ b/src/lib/ChatCompletionStream.ts
@@ -377,15 +377,18 @@ export class ChatCompletionStream<ParsedT = null>
         (tool) => isChatCompletionFunctionTool(tool) && tool.function.name === toolCallSnapshot.function.name,
       ) as ChatCompletionFunctionTool | undefined; // TS doesn't narrow based on isChatCompletionTool
 
+      let parsedArguments: unknown = null;
+      if (isAutoParsableTool(inputTool)) {
+        parsedArguments = inputTool.$parseRaw(toolCallSnapshot.function.arguments);
+      } else if (inputTool?.function.strict) {
+        parsedArguments = JSON.parse(toolCallSnapshot.function.arguments);
+      }
+
       this._emit('tool_calls.function.arguments.done', {
         name: toolCallSnapshot.function.name,
         index: toolCallIndex,
         arguments: toolCallSnapshot.function.arguments,
-        parsed_arguments: isAutoParsableTool(inputTool)
-          ? inputTool.$parseRaw(toolCallSnapshot.function.arguments)
-          : inputTool?.function.strict
-            ? JSON.parse(toolCallSnapshot.function.arguments)
-            : null,
+        parsed_arguments: parsedArguments,
       });
     } else {
       assertNever(toolCallSnapshot.type);

--- a/src/lib/ResponsesParser.ts
+++ b/src/lib/ResponsesParser.ts
@@ -217,14 +217,17 @@ function parseToolCall<Params extends ResponseCreateParamsBase>(
 ): ParsedResponseFunctionToolCall {
   const inputTool = getInputToolByName(params.tools ?? [], toolCall.name);
 
+  let parsedArguments: unknown = null;
+  if (isAutoParsableTool(inputTool)) {
+    parsedArguments = inputTool.$parseRaw(toolCall.arguments);
+  } else if (inputTool?.strict) {
+    parsedArguments = JSON.parse(toolCall.arguments);
+  }
+
   return {
     ...toolCall,
     ...toolCall,
-    parsed_arguments: isAutoParsableTool(inputTool)
-      ? inputTool.$parseRaw(toolCall.arguments)
-      : inputTool?.strict
-        ? JSON.parse(toolCall.arguments)
-        : null,
+    parsed_arguments: parsedArguments,
   };
 }
 

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -244,15 +244,18 @@ function parseToolCall<Params extends ChatCompletionCreateParams>(
     (inputTool) =>
       isChatCompletionFunctionTool(inputTool) && inputTool.function?.name === toolCall.function.name,
   ) as ChatCompletionFunctionTool | undefined; // TS doesn't narrow based on isChatCompletionTool
+  let parsedArguments: unknown = null;
+  if (isAutoParsableTool(inputTool)) {
+    parsedArguments = inputTool.$parseRaw(toolCall.function.arguments);
+  } else if (inputTool?.function.strict) {
+    parsedArguments = JSON.parse(toolCall.function.arguments);
+  }
+
   return {
     ...toolCall,
     function: {
       ...toolCall.function,
-      parsed_arguments: isAutoParsableTool(inputTool)
-        ? inputTool.$parseRaw(toolCall.function.arguments)
-        : inputTool?.function.strict
-          ? JSON.parse(toolCall.function.arguments)
-          : null,
+      parsed_arguments: parsedArguments,
     },
   };
 }

--- a/src/providers/bedrock/aws.ts
+++ b/src/providers/bedrock/aws.ts
@@ -83,12 +83,13 @@ function requestTarget(parsedURL: URL): { path: string; query: Record<string, st
   const query: Record<string, string | string[]> = {};
   for (const [name, value] of parsedURL.searchParams) {
     const existing = query[name];
-    query[name] =
-      existing === undefined
-        ? value
-        : typeof existing === 'string'
-          ? [existing, value]
-          : [...existing, value];
+    if (existing === undefined) {
+      query[name] = value;
+    } else if (typeof existing === 'string') {
+      query[name] = [existing, value];
+    } else {
+      query[name] = [...existing, value];
+    }
   }
   return { path: parsedURL.pathname, query };
 }

--- a/tests/lib/bedrock.test.ts
+++ b/tests/lib/bedrock.test.ts
@@ -330,14 +330,14 @@ describe('instantiate bedrock client', () => {
       const requestURL = new URL(url.toString());
       requests.push(`${init?.method} ${requestURL.pathname}`);
 
-      const body =
-        requestURL.pathname === '/openai/v1/responses/compact'
-          ? COMPACTED_RESPONSE_BODY
-          : requestURL.pathname === '/openai/v1/responses/input_tokens'
-            ? INPUT_TOKENS_BODY
-            : requestURL.pathname === '/openai/v1/responses/resp_123/input_items'
-              ? INPUT_ITEMS_BODY
-              : RESPONSE_BODY;
+      let body: unknown = RESPONSE_BODY;
+      if (requestURL.pathname === '/openai/v1/responses/compact') {
+        body = COMPACTED_RESPONSE_BODY;
+      } else if (requestURL.pathname === '/openai/v1/responses/input_tokens') {
+        body = INPUT_TOKENS_BODY;
+      } else if (requestURL.pathname === '/openai/v1/responses/resp_123/input_items') {
+        body = INPUT_ITEMS_BODY;
+      }
 
       return new globalThis.Response(JSON.stringify(body), {
         status: 200,


### PR DESCRIPTION
## Summary

- Removes `unicorn/no-nested-ternary` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 127 of 185.
- Base: `dev/hayden/ultracite-126-unicorn-no-await-expression-member`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`