### PR TITLE
chore(lint): enable unicorn/no-typeof-undefined

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -54,7 +54,6 @@ const compatibilityRules = [
   'unicorn/consistent-function-scoping',
   'unicorn/filename-case',
   'unicorn/no-console-spaces',
-  'unicorn/no-typeof-undefined',
   'unicorn/no-useless-undefined',
   'unicorn/numeric-separators-style',
   'unicorn/prefer-at',

--- a/src/_vendor/zod-to-json-schema/parsers/object.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/object.ts
@@ -42,7 +42,7 @@ export function parseObjectDef(def: ZodObjectDef, refs: Refs) {
       refs.openaiStrictMode &&
       propDef.isOptional() &&
       !propDef.isNullable() &&
-      typeof propDef._def?.defaultValue === 'undefined'
+      propDef._def?.defaultValue === undefined
     ) {
       throw new Error(
         `Zod field at \`${propertyPath.join(

--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -245,7 +245,7 @@ export async function* _iterSSEMessages(
   if (!response.body) {
     controller.abort();
     if (
-      typeof (globalThis as any).navigator !== 'undefined' &&
+      (globalThis as any).navigator !== undefined &&
       (globalThis as any).navigator.product === 'ReactNative'
     ) {
       throw new OpenAIError(

--- a/src/helpers/audio.ts
+++ b/src/helpers/audio.ts
@@ -24,7 +24,7 @@ const recordingProviders: Record<NodeJS.Platform, string> = {
 };
 
 function isResponse(stream: NodeJS.ReadableStream | Response | File): stream is Response {
-  return typeof (stream as any).body !== 'undefined';
+  return (stream as any).body !== undefined;
 }
 
 function isFile(stream: NodeJS.ReadableStream | Response | File): stream is File {

--- a/src/internal/qs/stringify.ts
+++ b/src/internal/qs/stringify.ts
@@ -86,14 +86,14 @@ function inner_stringify(
     // Where object last appeared in the ref tree
     const pos = tmp_sc.get(object);
     step += 1;
-    if (typeof pos !== 'undefined') {
+    if (pos !== undefined) {
       if (pos === step) {
         throw new RangeError('Cyclic object value');
       } else {
         find_flag = true; // Break while
       }
     }
-    if (typeof tmp_sc.get(sentinel) === 'undefined') {
+    if (tmp_sc.get(sentinel) === undefined) {
       step = 0;
     }
   }
@@ -140,7 +140,7 @@ function inner_stringify(
 
   const values: string[] = [];
 
-  if (typeof obj === 'undefined') {
+  if (obj === undefined) {
     return values;
   }
 
@@ -174,7 +174,7 @@ function inner_stringify(
   for (const key of obj_keys) {
     const value =
       // @ts-ignore
-      typeof key === 'object' && typeof key.value !== 'undefined' ? key.value : obj[key as any];
+      typeof key === 'object' && key.value !== undefined ? key.value : obj[key as any];
 
     if (skipNulls && value === null) {
       continue;
@@ -226,25 +226,25 @@ function inner_stringify(
 function normalize_stringify_options(
   opts: StringifyOptions = defaults,
 ): NonNullableProperties<Omit<StringifyOptions, 'indices'>> & { indices?: boolean } {
-  if (typeof opts.allowEmptyArrays !== 'undefined' && typeof opts.allowEmptyArrays !== 'boolean') {
+  if (opts.allowEmptyArrays !== undefined && typeof opts.allowEmptyArrays !== 'boolean') {
     throw new TypeError('`allowEmptyArrays` option can only be `true` or `false`, when provided');
   }
 
-  if (typeof opts.encodeDotInKeys !== 'undefined' && typeof opts.encodeDotInKeys !== 'boolean') {
+  if (opts.encodeDotInKeys !== undefined && typeof opts.encodeDotInKeys !== 'boolean') {
     throw new TypeError('`encodeDotInKeys` option can only be `true` or `false`, when provided');
   }
 
-  if (opts.encoder !== null && typeof opts.encoder !== 'undefined' && typeof opts.encoder !== 'function') {
+  if (opts.encoder !== null && opts.encoder !== undefined && typeof opts.encoder !== 'function') {
     throw new TypeError('Encoder has to be a function.');
   }
 
   const charset = opts.charset || defaults.charset;
-  if (typeof opts.charset !== 'undefined' && opts.charset !== 'utf-8' && opts.charset !== 'iso-8859-1') {
+  if (opts.charset !== undefined && opts.charset !== 'utf-8' && opts.charset !== 'iso-8859-1') {
     throw new TypeError('The charset option must be either utf-8, iso-8859-1, or undefined');
   }
 
   let format = default_format;
-  if (typeof opts.format !== 'undefined') {
+  if (opts.format !== undefined) {
     if (!has(formatters, opts.format)) {
       throw new TypeError('Unknown format option provided.');
     }
@@ -288,7 +288,7 @@ function normalize_stringify_options(
     charsetSentinel:
       typeof opts.charsetSentinel === 'boolean' ? opts.charsetSentinel : defaults.charsetSentinel,
     commaRoundTrip: !!opts.commaRoundTrip,
-    delimiter: typeof opts.delimiter === 'undefined' ? defaults.delimiter : opts.delimiter,
+    delimiter: opts.delimiter === undefined ? defaults.delimiter : opts.delimiter,
     encode: typeof opts.encode === 'boolean' ? opts.encode : defaults.encode,
     encodeDotInKeys:
       typeof opts.encodeDotInKeys === 'boolean' ? opts.encodeDotInKeys : defaults.encodeDotInKeys,

--- a/src/internal/qs/utils.ts
+++ b/src/internal/qs/utils.ts
@@ -31,7 +31,7 @@ function compact_queue<T extends Record<string, any>>(queue: Array<{ obj: T; pro
       const compacted: unknown[] = [];
 
       for (const value of obj) {
-        if (typeof value !== 'undefined') {
+        if (value !== undefined) {
           compacted.push(value);
         }
       }
@@ -45,7 +45,7 @@ function compact_queue<T extends Record<string, any>>(queue: Array<{ obj: T; pro
 function array_to_object(source: any[], options: { plainObjects: boolean }) {
   const obj = options && options.plainObjects ? Object.create(null) : {};
   for (let i = 0; i < source.length; ++i) {
-    if (typeof source[i] !== 'undefined') {
+    if (source[i] !== undefined) {
       obj[i] = source[i];
     }
   }


### PR DESCRIPTION
## Summary

- Removes `unicorn/no-typeof-undefined` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 128 of 185.
- Base: `dev/hayden/ultracite-127-unicorn-no-nested-ternary`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`