### PR TITLE
chore(lint): enable unicorn/prefer-at

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -56,7 +56,6 @@ const compatibilityRules = [
   'unicorn/no-console-spaces',
   'unicorn/no-useless-undefined',
   'unicorn/numeric-separators-style',
-  'unicorn/prefer-at',
   'unicorn/prefer-module',
   'unicorn/prefer-node-protocol',
   'unicorn/prefer-response-static-json',
@@ -202,6 +201,22 @@ module.exports = defineConfig({
       ],
       rules: {
         'typescript/no-dynamic-delete': 'off',
+      },
+    },
+    {
+      // These last-item reads intentionally stay compatible with the repository's
+      // ES2020 declaration library, which does not include Array.prototype.at.
+      files: [
+        'scripts/check-node-version-policy.ts',
+        'src/_vendor/partial-json-parser/parser.ts',
+        'src/lib/AbstractChatCompletionRunner.ts',
+        'src/lib/ChatCompletionStream.ts',
+        'tests/_vendor/partial-json-parser/partial-json-parsing.test.ts',
+        'tests/lib/ChatCompletionRunFunctions.test.ts',
+        'tests/realtime-websocket.test.ts',
+      ],
+      rules: {
+        'unicorn/prefer-at': 'off',
       },
     },
     {


### PR DESCRIPTION
## Summary

- Removes `unicorn/prefer-at` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 129 of 185.
- Base: `dev/hayden/ultracite-128-unicorn-no-typeof-undefined`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`