### PR TITLE
chore(lint): enable no-nested-ternary

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -19,7 +19,6 @@ const compatibilityRules = [
   'no-bitwise',
   'no-eq-null',
   'no-inline-comments',
-  'no-nested-ternary',
   'no-param-reassign',
   'no-plusplus',
   'no-promise-executor-return',

--- a/src/_vendor/zod-to-json-schema/parsers/nativeEnum.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/nativeEnum.ts
@@ -14,10 +14,13 @@ export function parseNativeEnumDef(def: ZodNativeEnumDef): JsonSchema7NativeEnum
   const actualValues = actualKeys.map((key: string) => object[key]!);
 
   const parsedTypes = [...new Set(actualValues.map((values: string | number) => typeof values))];
+  let type: 'string' | 'number' | ['string', 'number'] = ['string', 'number'];
+  if (parsedTypes.length === 1) {
+    type = parsedTypes[0] === 'string' ? 'string' : 'number';
+  }
 
   return {
-    type:
-      parsedTypes.length === 1 ? (parsedTypes[0] === 'string' ? 'string' : 'number') : ['string', 'number'],
+    type,
     enum: actualValues,
   };
 }


### PR DESCRIPTION
## Summary

- Removes `no-nested-ternary` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 131 of 185.
- Base: `dev/hayden/ultracite-130-default-case`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`