### PR TITLE
chore(lint): enable promise/prefer-await-to-callbacks

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -33,7 +33,6 @@ const compatibilityRules = [
   'prefer-named-capture-group',
   'prefer-template',
   'promise/avoid-new',
-  'promise/prefer-await-to-callbacks',
   'promise/prefer-await-to-then',
   'require-await',
   'require-unicode-regexp',
@@ -233,6 +232,30 @@ module.exports = defineConfig({
       ],
       rules: {
         'default-case': 'off',
+      },
+    },
+    {
+      // These promise callbacks are intentional entrypoint, memoization, deferred
+      // execution, or Node stream callback boundaries whose timing must stay stable.
+      files: [
+        'ecosystem-tests/cli.ts',
+        'examples/azure/assistants.ts',
+        'examples/azure/chat.ts',
+        'examples/azure/responses.ts',
+        'examples/fine-tuning/fine-tuning.ts',
+        'examples/images/image-stream.ts',
+        'examples/images/picture.ts',
+        'examples/responses/manual-conversation-state.ts',
+        'examples/responses/websocket.ts',
+        'scripts/_vendor/tsc-multi/src/worker/entry.ts',
+        'src/auth/subject-token-providers.ts',
+        'src/helpers/audio.ts',
+        'src/lib/EventStream.ts',
+        'tests/helpers/audio-recording.test.ts',
+        'tests/helpers/audio.test.ts',
+      ],
+      rules: {
+        'promise/prefer-await-to-callbacks': 'off',
       },
     },
     {


### PR DESCRIPTION
## Summary

- Removes `promise/prefer-await-to-callbacks` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 132 of 185.
- Base: `dev/hayden/ultracite-131-no-nested-ternary`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`