### PR TITLE
chore(lint): enable func-name-matching

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -10,7 +10,6 @@ const compatibilityRules = [
   'complexity',
   'curly',
   'eqeqeq',
-  'func-name-matching',
   'func-names',
   'func-style',
   'import/consistent-type-specifier-style',
@@ -256,6 +255,14 @@ module.exports = defineConfig({
       ],
       rules: {
         'promise/prefer-await-to-callbacks': 'off',
+      },
+    },
+    {
+      // Function-tool fixtures intentionally give callbacks semantic names such as
+      // getWeather while assigning them to the protocol function field.
+      files: ['tests/lib/ChatCompletionRunFunctions.test.ts'],
+      rules: {
+        'func-name-matching': 'off',
       },
     },
     {


### PR DESCRIPTION
## Summary

- Removes `func-name-matching` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 133 of 185.
- Base: `dev/hayden/ultracite-132-promise-prefer-await-to-callbacks`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`