### PR TITLE
chore(lint): enable unicorn/no-console-spaces

### DIFF
--- a/ecosystem-tests/browser-direct-import/public/index.js
+++ b/ecosystem-tests/browser-direct-import/public/index.js
@@ -30,10 +30,10 @@ async function runTests() {
           setTimeout(() => reject(new Error(`Test timed out after ${timeout} ms`)), timeout),
         ),
       ]);
-      console.log('passed ', ...path);
+      console.log('passed', ...path);
       results.push({ path, passed: true });
     } catch (error) {
-      console.log('error  ', ...path);
+      console.log('error', ...path);
       console.error(error);
       results.push({ path, passed: false, error: error instanceof Error ? error.stack : String(error) });
     }

--- a/ecosystem-tests/cloudflare-worker/src/worker.ts
+++ b/ecosystem-tests/cloudflare-worker/src/worker.ts
@@ -83,9 +83,9 @@ export default {
 				console.error('running', description);
 				try {
 					await handler();
-					console.error('passed ', description);
+					console.error('passed', description);
 				} catch (error) {
-					console.error('failed ', description, error);
+					console.error('failed', description, error);
 					return new Response('Internal Server Error', { status: 500 });
 				}
 			}

--- a/ecosystem-tests/ts-browser-webpack/src/index.ts
+++ b/ecosystem-tests/ts-browser-webpack/src/index.ts
@@ -33,10 +33,10 @@ async function runTests() {
           setTimeout(() => reject(new Error(`Test timed out after ${timeout} ms`)), timeout),
         ),
       ]);
-      console.log('passed ', ...path);
+      console.log('passed', ...path);
       results.push({ path, passed: true });
     } catch (error) {
-      console.log('error  ', ...path);
+      console.log('error', ...path);
       console.error(error);
       results.push({ path, passed: false, error: error instanceof Error ? error.stack : String(error) });
     }

--- a/ecosystem-tests/vercel-edge/src/pages/api/edge-test.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/edge-test.ts
@@ -58,9 +58,9 @@ export default async function handler(request: NextRequest) {
       console.error('running', description);
       try {
         await handler();
-        console.error('passed ', description);
+        console.error('passed', description);
       } catch (error) {
-        console.error('failed ', description, error);
+        console.error('failed', description, error);
         return new NextResponse('Internal Server Error', { status: 500 });
       }
     }

--- a/ecosystem-tests/vercel-edge/src/pages/api/node-test.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/node-test.ts
@@ -47,9 +47,9 @@ export default async function handler(request: NextApiRequest, response: NextApi
       console.error('running', description);
       try {
         await handler();
-        console.error('passed ', description);
+        console.error('passed', description);
       } catch (error) {
-        console.error('failed ', description, error);
+        console.error('failed', description, error);
         response.status(500).end('Internal Server Error');
         return;
       }

--- a/examples/client/errors.ts
+++ b/examples/client/errors.ts
@@ -15,10 +15,10 @@ async function main() {
     if (err instanceof NotFoundError) {
       console.log(`Caught NotFoundError!`);
       console.log(err);
-      console.log(`message: `, err.message);
-      console.log(`code: `, err.code);
-      console.log(`type: `, err.type);
-      console.log(`param: `, err.param);
+      console.log(`message:`, err.message);
+      console.log(`code:`, err.code);
+      console.log(`type:`, err.type);
+      console.log(`param:`, err.param);
     } else {
       console.log(`Raised unknown error`);
       throw err;

--- a/examples/client/raw-response.ts
+++ b/examples/client/raw-response.ts
@@ -14,8 +14,8 @@ async function main() {
         model: 'gpt-3.5-turbo-instruct',
       })
       .asResponse();
-    console.log(`response headers: `, Object.fromEntries(response.headers.entries()));
-    console.log(`response json: `, await response.json());
+    console.log(`response headers:`, Object.fromEntries(response.headers.entries()));
+    console.log(`response json:`, await response.json());
   }
 
   // getting the usual return value plus raw Response:
@@ -26,8 +26,8 @@ async function main() {
         model: 'gpt-3.5-turbo-instruct',
       })
       .withResponse();
-    console.log(`response headers: `, Object.fromEntries(response.headers.entries()));
-    console.log(`completion: `, completion);
+    console.log(`response headers:`, Object.fromEntries(response.headers.entries()));
+    console.log(`completion:`, completion);
   }
 }
 

--- a/examples/responses/structured-outputs.ts
+++ b/examples/responses/structured-outputs.ts
@@ -26,7 +26,7 @@ async function main() {
   });
 
   console.log(rsp.output_parsed);
-  console.log('answer: ', rsp.output_parsed?.final_answer);
+  console.log('answer:', rsp.output_parsed?.final_answer);
 }
 
 main().catch(console.error);

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -49,7 +49,6 @@ const compatibilityRules = [
   'unicorn/consistent-assert',
   'unicorn/consistent-function-scoping',
   'unicorn/filename-case',
-  'unicorn/no-console-spaces',
   'unicorn/no-useless-undefined',
   'unicorn/numeric-separators-style',
   'unicorn/prefer-module',


### PR DESCRIPTION
## Summary

- Removes `unicorn/no-console-spaces` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 134 of 185.
- Base: `dev/hayden/ultracite-133-func-name-matching`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`