### PR TITLE
chore(lint): enable typescript/no-import-type-side-effects

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -42,7 +42,6 @@ const compatibilityRules = [
   'typescript/consistent-type-imports',
   'typescript/method-signature-style',
   'typescript/no-explicit-any',
-  'typescript/no-import-type-side-effects',
   'typescript/no-non-null-assertion',
   'typescript/prefer-ts-expect-error',
   'unicorn/catch-error-name',

--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -1,5 +1,5 @@
 import { OpenAIError, APIError } from './error';
-import { type ReadableStream } from '../internal/shim-types';
+import type { ReadableStream } from '../internal/shim-types';
 import { makeReadableStream, ReadableStreamToAsyncIterable } from '../internal/shims';
 import { findDoubleNewlineIndex, LineDecoder } from '../internal/decoders/line';
 import { isAbortError } from '../internal/errors';

--- a/src/helpers/standard-schema.ts
+++ b/src/helpers/standard-schema.ts
@@ -8,7 +8,7 @@ import {
   makeParseableTool,
 } from '../lib/parser';
 import { AutoParseableResponseTool, makeParseableResponseTool } from '../lib/ResponsesParser';
-import { type JSONSchema } from '../lib/jsonschema';
+import type { JSONSchema } from '../lib/jsonschema';
 import {
   assertNoNestedSchemaIds,
   forEachJSONSchemaChild,
@@ -19,7 +19,7 @@ import {
   toStrictJsonSchema,
 } from '../lib/transform';
 import { ResponseFormatJSONSchema } from '../resources/index';
-import { type ResponseFormatTextJSONSchemaConfig } from '../resources/responses/responses';
+import type { ResponseFormatTextJSONSchemaConfig } from '../resources/responses/responses';
 
 type StandardSchemaIssue = {
   readonly message: string;

--- a/src/helpers/zod.ts
+++ b/src/helpers/zod.ts
@@ -12,8 +12,8 @@ import {
 } from '../lib/parser';
 import { zodToJsonSchema as _zodToJsonSchema } from '../_vendor/zod-to-json-schema';
 import { AutoParseableResponseTool, makeParseableResponseTool } from '../lib/ResponsesParser';
-import { type ResponseFormatTextJSONSchemaConfig } from '../resources/responses/responses';
-import { type RealtimeFunctionTool } from '../resources/realtime/realtime';
+import type { ResponseFormatTextJSONSchemaConfig } from '../resources/responses/responses';
+import type { RealtimeFunctionTool } from '../resources/realtime/realtime';
 import { toStrictJsonSchema } from '../lib/transform';
 import { JSONSchema } from '../lib/jsonschema';
 import { hasOwn } from '../internal/utils/values';

--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -1,4 +1,4 @@
-import { type RequestOptions } from './request-options';
+import type { RequestOptions } from './request-options';
 import type { FilePropertyBag, Fetch } from './builtin-types';
 import type { OpenAI } from '../client';
 import { buildHeaders } from './headers';

--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -18,7 +18,7 @@ import {
   RunSubmitToolOutputsParamsBase,
   RunSubmitToolOutputsParamsStreaming,
 } from '../resources/beta/threads/runs/runs';
-import { type ReadableStream } from '../internal/shim-types';
+import type { ReadableStream } from '../internal/shim-types';
 import { Stream } from '../streaming';
 import { APIUserAbortError, OpenAIError } from '../error';
 import {

--- a/src/lib/ChatCompletionRunner.ts
+++ b/src/lib/ChatCompletionRunner.ts
@@ -1,6 +1,6 @@
-import {
-  type ChatCompletionMessageParam,
-  type ChatCompletionCreateParamsNonStreaming,
+import type {
+  ChatCompletionMessageParam,
+  ChatCompletionCreateParamsNonStreaming,
 } from '../resources/chat/completions';
 import { type BaseFunctionsArgs, RunnableTools } from './RunnableFunction';
 import {

--- a/src/lib/ChatCompletionStream.ts
+++ b/src/lib/ChatCompletionStream.ts
@@ -7,7 +7,7 @@ import {
 } from '../error';
 import OpenAI from '../index';
 import { RequestOptions } from '../internal/request-options';
-import { type ReadableStream } from '../internal/shim-types';
+import type { ReadableStream } from '../internal/shim-types';
 import { uuid4 } from '../internal/utils/uuid';
 import {
   AutoParseableResponseFormat,

--- a/src/lib/ChatCompletionStreamingRunner.ts
+++ b/src/lib/ChatCompletionStreamingRunner.ts
@@ -1,10 +1,10 @@
-import {
-  type ChatCompletionChunk,
-  type ChatCompletionCreateParamsStreaming,
-  type ChatCompletionMessageParam,
+import type {
+  ChatCompletionChunk,
+  ChatCompletionCreateParamsStreaming,
+  ChatCompletionMessageParam,
 } from '../resources/chat/completions';
 import { RunnerOptions, type AbstractChatCompletionRunnerEvents } from './AbstractChatCompletionRunner';
-import { type ReadableStream } from '../internal/shim-types';
+import type { ReadableStream } from '../internal/shim-types';
 import { RunnableTools, type BaseFunctionsArgs } from './RunnableFunction';
 import {
   type ChatCompletionReadableStreamItem,

--- a/src/lib/RunnableFunction.ts
+++ b/src/lib/RunnableFunction.ts
@@ -1,5 +1,5 @@
-import { type ChatCompletionRunner } from './ChatCompletionRunner';
-import { type ChatCompletionStreamingRunner } from './ChatCompletionStreamingRunner';
+import type { ChatCompletionRunner } from './ChatCompletionRunner';
+import type { ChatCompletionStreamingRunner } from './ChatCompletionStreamingRunner';
 import { JSONSchema } from './jsonschema';
 
 type PromiseOrValue<T> = T | Promise<T>;

--- a/src/lib/chatCompletionUtils.ts
+++ b/src/lib/chatCompletionUtils.ts
@@ -1,7 +1,7 @@
-import {
-  type ChatCompletionAssistantMessageParam,
-  type ChatCompletionMessageParam,
-  type ChatCompletionToolMessageParam,
+import type {
+  ChatCompletionAssistantMessageParam,
+  ChatCompletionMessageParam,
+  ChatCompletionToolMessageParam,
 } from '../resources';
 
 export const isAssistantMessage = (

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -15,7 +15,7 @@ import {
   ParsedChoice,
   ParsedFunctionToolCall,
 } from '../resources/chat/completions';
-import { type ResponseFormatTextJSONSchemaConfig } from '../resources/responses/responses';
+import type { ResponseFormatTextJSONSchemaConfig } from '../resources/responses/responses';
 import { ResponseFormatJSONSchema } from '../resources/shared';
 
 type AnyChatCompletionCreateParams =

--- a/src/lib/responses/ResponseAccumulator.ts
+++ b/src/lib/responses/ResponseAccumulator.ts
@@ -1,8 +1,4 @@
-import {
-  type Response,
-  type ResponseOutputText,
-  type ResponseStreamEvent,
-} from '../../resources/responses/responses';
+import type { Response, ResponseOutputText, ResponseStreamEvent } from '../../resources/responses/responses';
 import { OpenAIError } from '../../error';
 import { addOutputText } from '../ResponsesParser';
 

--- a/src/lib/responses/ResponseStream.ts
+++ b/src/lib/responses/ResponseStream.ts
@@ -7,11 +7,11 @@ import {
   type ResponseStreamEvent,
 } from '../../resources/responses/responses';
 import { RequestOptions } from '../../internal/request-options';
-import { type ReadableStream } from '../../internal/shim-types';
+import type { ReadableStream } from '../../internal/shim-types';
 import { APIUserAbortError, OpenAIError } from '../../error';
 import OpenAI from '../../index';
 import { type BaseEvents, EventStream } from '../EventStream';
-import { type ResponseFunctionCallArgumentsDeltaEvent, type ResponseTextDeltaEvent } from './EventTypes';
+import type { ResponseFunctionCallArgumentsDeltaEvent, ResponseTextDeltaEvent } from './EventTypes';
 import { accumulateResponse } from './ResponseAccumulator';
 import { maybeParseResponse, ParseableToolsParams } from '../ResponsesParser';
 import { Stream } from '../../streaming';

--- a/tests/lib/bedrock.test.ts
+++ b/tests/lib/bedrock.test.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 import { BedrockOpenAI, NotFoundError, type BedrockClientOptions } from 'openai';
-import { type RequestInfo, type RequestInit } from 'openai/internal/builtin-types';
+import type { RequestInfo, RequestInit } from 'openai/internal/builtin-types';
 
 const RESPONSE_BODY = {
   id: 'resp_123',

--- a/tests/utils/mock-fetch.ts
+++ b/tests/utils/mock-fetch.ts
@@ -1,4 +1,4 @@
-import { type Fetch, type RequestInfo, type RequestInit, type Response } from 'openai/internal/builtin-types';
+import type { Fetch, RequestInfo, RequestInit, Response } from 'openai/internal/builtin-types';
 
 /**
  * Creates a mock `fetch` function and a `handleRequest` function for intercepting `fetch` calls.


### PR DESCRIPTION
## Summary

- Removes `typescript/no-import-type-side-effects` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 135 of 185.
- Base: `dev/hayden/ultracite-134-unicorn-no-console-spaces`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`