### PR TITLE
chore(lint): enable vars-on-top

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -57,7 +57,6 @@ const compatibilityRules = [
   'unicorn/prefer-string-slice',
   'unicorn/switch-case-braces',
   'unicorn/text-encoding-identifier-case',
-  'vars-on-top',
 ];
 
 module.exports = defineConfig({

--- a/tests/qs/stringify.test.ts
+++ b/tests/qs/stringify.test.ts
@@ -1286,7 +1286,7 @@ describe('stringify()', function () {
       stringify({ 'foo[bar]': 'baz', 'foo[baz]': a });
     }).toThrow('Cyclic object value');
 
-    var circular: any = {
+    const circular: any = {
       a: 'value',
     };
     circular.a = circular;
@@ -1301,7 +1301,7 @@ describe('stringify()', function () {
       stringify(circular);
     }).toThrow('Cyclic object value');
 
-    var arr = ['a'];
+    const arr = ['a'];
     // st.doesNotThrow(function () {
     // 	stringify({ x: arr, y: arr });
     // }, 'non-cyclic values do not throw');
@@ -1521,9 +1521,9 @@ describe('stringify()', function () {
             if (str.length === 0) {
               return '';
             }
-            var buf = iconv.encode(str, 'shiftjis');
-            var result = [];
-            for (var i = 0; i < buf.length; ++i) {
+            const buf = iconv.encode(str, 'shiftjis');
+            const result = [];
+            for (let i = 0; i < buf.length; i += 1) {
               result.push(buf.readUInt8(i).toString(16));
             }
             return '%' + result.join('%');
@@ -1652,7 +1652,7 @@ describe('stringify()', function () {
     // );
     expect(stringify({ a: date })).toBe('a=' + date.toISOString().replace(/:/g, '%3A'));
 
-    var mutatedDate = new Date();
+    const mutatedDate = new Date();
     mutatedDate.toISOString = function () {
       throw new SyntaxError('Invalid date serialization');
     };
@@ -1671,7 +1671,7 @@ describe('stringify()', function () {
       'a=' + Date.prototype.toISOString.call(mutatedDate).replace(/:/g, '%3A'),
     );
 
-    var specificDate = new Date(6);
+    const specificDate = new Date(6);
     // st.equal(
     // 	stringify(
     // 		{ a: specificDate },
@@ -2153,15 +2153,15 @@ describe('stringify()', function () {
   });
 
   test('encodes a very long string', function () {
-    var chars = [];
-    var expected = [];
-    for (var i = 0; i < 5e3; i++) {
+    const chars = [];
+    const expected = [];
+    for (let i = 0; i < 5e3; i += 1) {
       chars.push(' ' + i);
 
       expected.push('%20' + i);
     }
 
-    var obj = {
+    const obj = {
       foo: chars.join(''),
     };
 

--- a/tests/qs/utils.test.ts
+++ b/tests/qs/utils.test.ts
@@ -14,7 +14,7 @@ describe('merge()', function () {
   // );
   expect(merge({ a: 'b' }, { a: 'c' })).toEqual({ a: ['b', 'c'] });
 
-  var oneMerged = merge({ foo: 'bar' }, { foo: { first: '123' } });
+  const oneMerged = merge({ foo: 'bar' }, { foo: { first: '123' } });
   // t.deepEqual(
   // 	oneMerged,
   // 	{ foo: ['bar', { first: '123' }] },
@@ -22,7 +22,7 @@ describe('merge()', function () {
   // );
   expect(oneMerged).toEqual({ foo: ['bar', { first: '123' }] });
 
-  var twoMerged = merge({ foo: ['bar', { first: '123' }] }, { foo: { second: '456' } });
+  const twoMerged = merge({ foo: ['bar', { first: '123' }] }, { foo: { second: '456' } });
   // t.deepEqual(
   // 	twoMerged,
   // 	{ foo: { 0: 'bar', 1: { first: '123' }, second: '456' } },
@@ -30,7 +30,7 @@ describe('merge()', function () {
   // );
   expect(twoMerged).toEqual({ foo: { 0: 'bar', 1: { first: '123' }, second: '456' } });
 
-  var sandwiched = merge({ foo: ['bar', { first: '123', second: '456' }] }, { foo: 'baz' });
+  const sandwiched = merge({ foo: ['bar', { first: '123', second: '456' }] }, { foo: 'baz' });
   // t.deepEqual(
   // 	sandwiched,
   // 	{ foo: ['bar', { first: '123', second: '456' }, 'baz'] },
@@ -38,11 +38,11 @@ describe('merge()', function () {
   // );
   expect(sandwiched).toEqual({ foo: ['bar', { first: '123', second: '456' }, 'baz'] });
 
-  var nestedArrays = merge({ foo: ['baz'] }, { foo: ['bar', 'xyzzy'] });
+  const nestedArrays = merge({ foo: ['baz'] }, { foo: ['bar', 'xyzzy'] });
   // t.deepEqual(nestedArrays, { foo: ['baz', 'bar', 'xyzzy'] });
   expect(nestedArrays).toEqual({ foo: ['baz', 'bar', 'xyzzy'] });
 
-  var noOptionsNonObjectSource = merge({ foo: 'baz' }, 'bar');
+  const noOptionsNonObjectSource = merge({ foo: 'baz' }, 'bar');
   // t.deepEqual(noOptionsNonObjectSource, { foo: 'baz', bar: true });
   expect(noOptionsNonObjectSource).toEqual({ foo: 'baz', bar: true });
 
@@ -123,7 +123,7 @@ describe('combine()', function () {
     expect(combinedAnB).not.toEqual(b);
     expect(combinedAnB).toEqual([1, 2]);
 
-    var combinedABn = combine(a, bN);
+    const combinedABn = combine(a, bN);
     // st.deepEqual(a, [aN], 'a is not mutated');
     // st.notEqual(aN, combinedABn, 'a + bN !== aN');
     // st.notEqual(a, combinedABn, 'a + bN !== a');
@@ -169,15 +169,15 @@ test('is_buffer()', function () {
     expect(is_buffer(x)).toEqual(false);
   }
 
-  var fakeBuffer = { constructor: Buffer };
+  const fakeBuffer = { constructor: Buffer };
   // t.equal(is_buffer(fakeBuffer), false, 'fake buffer is not a buffer');
   expect(is_buffer(fakeBuffer)).toEqual(false);
 
-  var saferBuffer = Buffer.from('abc');
+  const saferBuffer = Buffer.from('abc');
   // t.equal(is_buffer(saferBuffer), true, 'SaferBuffer instance is a buffer');
   expect(is_buffer(saferBuffer)).toEqual(true);
 
-  var buffer = Buffer.from('abc');
+  const buffer = Buffer.from('abc');
   // t.equal(is_buffer(buffer), true, 'real Buffer instance is a buffer');
   expect(is_buffer(buffer)).toEqual(true);
 });

--- a/tests/utils/mock-snapshots.ts
+++ b/tests/utils/mock-snapshots.ts
@@ -10,7 +10,7 @@ export async function makeSnapshotRequest<T>(
   snapshotIndex = 1,
 ): Promise<T> {
   if (process.env['UPDATE_API_SNAPSHOTS'] === '1') {
-    var capturedResponseContent: string | null = null;
+    let capturedResponseContent: string | null = null;
 
     const snapshotFetch = async (url: RequestInfo, init?: RequestInit) => {
       const response = await defaultFetch(url, init);
@@ -69,7 +69,7 @@ export async function makeStreamSnapshotRequest<T extends AsyncIterable<any>>(
   requestFn: (client: OpenAI) => T,
 ): Promise<T> {
   if (process.env['UPDATE_API_SNAPSHOTS'] === '1') {
-    var capturedResponseContent: string | null = null;
+    let capturedResponseContent: string | null = null;
 
     const snapshotFetch = async (url: RequestInfo, init?: RequestInit) => {
       const response = await defaultFetch(url, init);


### PR DESCRIPTION
## Summary

- Removes `vars-on-top` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 136 of 185.
- Base: `dev/hayden/ultracite-135-typescript-no-import-type-side-effects`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`