### PR TITLE
chore(lint): enable unicorn/consistent-assert

### DIFF
--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -124,7 +124,7 @@ const projectRunners = {
     // dependency. For the default path, add that declaration only after npm
     // installs the local tarball so it cannot substitute a registry package.
     const installedPackage = JSON.parse(await fs.readFile('node_modules/openai/package.json', 'utf8'));
-    assert(typeof installedPackage.version === 'string');
+    assert.ok(typeof installedPackage.version === 'string');
     await fs.writeFile(
       'package.json',
       JSON.stringify(
@@ -164,7 +164,7 @@ async function startProxy() {
   await new Promise<void>((resolve) => proxy.listen(0, '127.0.0.1', resolve));
 
   const address = proxy.address();
-  assert(address && typeof address !== 'string');
+  assert.ok(address && typeof address !== 'string');
   process.env['ECOSYSTEM_TESTS_PROXY'] = 'http://127.0.0.1:' + address.port;
 
   return () => {
@@ -579,8 +579,8 @@ async function buildPackage() {
   });
 
   const pack = JSON.parse(proc.stdout);
-  assert(Array.isArray(pack), `Expected pack output to be an array but got ${typeof pack}`);
-  assert(pack.length === 1, `Expected pack output to be an array of length 1 but got ${pack.length}`);
+  assert.ok(Array.isArray(pack), `Expected pack output to be an array but got ${typeof pack}`);
+  assert.ok(pack.length === 1, `Expected pack output to be an array of length 1 but got ${pack.length}`);
 
   const filename = path.join('dist', (pack[0] as any).filename);
   console.error({ filename });

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -45,7 +45,6 @@ const compatibilityRules = [
   'typescript/no-non-null-assertion',
   'typescript/prefer-ts-expect-error',
   'unicorn/catch-error-name',
-  'unicorn/consistent-assert',
   'unicorn/consistent-function-scoping',
   'unicorn/filename-case',
   'unicorn/no-useless-undefined',

--- a/scripts/_vendor/tsc-multi/src/transformer.ts
+++ b/scripts/_vendor/tsc-multi/src/transformer.ts
@@ -329,7 +329,7 @@ export function createTransformer<T extends ts.SourceFile | ts.Bundle>(
           }),
         ) as any;
       }
-      assert(false);
+      assert.ok(false);
     };
   };
 }

--- a/scripts/_vendor/tsc-multi/src/worker/worker.ts
+++ b/scripts/_vendor/tsc-multi/src/worker/worker.ts
@@ -312,7 +312,7 @@ export class Worker {
 
         if (this.data.shareHelpers) {
           const out = program.getCompilerOptions().outDir;
-          assert(out, 'outDir must be set when specifying shareHelpers');
+          assert.ok(out, 'outDir must be set when specifying shareHelpers');
           const write = writeFile || this.system.writeFile;
           this.writeHelpers(helpersNeeded, write, out, program.getCompilerOptions());
         }
@@ -330,7 +330,7 @@ export class Worker {
     out: string,
     compilerOptions: ts.CompilerOptions,
   ) {
-    assert(this.data.shareHelpers);
+    assert.ok(this.data.shareHelpers);
     const helperDeps = [...helpersNeeded].filter((e) => helpers[e]);
     let helperLength = 0;
     while (helperLength !== helperDeps.length) {
@@ -433,7 +433,7 @@ export class Worker {
 
     if (this.data.shareHelpers) {
       const out = config.options.outDir;
-      assert(out, 'outDir must be set when specifying shareHelpers');
+      assert.ok(out, 'outDir must be set when specifying shareHelpers');
       this.writeHelpers(helpersNeeded, this.system.writeFile, out, config.options);
     }
   }

--- a/tests/streaming.test.ts
+++ b/tests/streaming.test.ts
@@ -15,7 +15,7 @@ describe('streaming decoding', () => {
     ]();
 
     let event = await stream.next();
-    assert(event.value);
+    assert.ok(event.value);
     expect(JSON.parse(event.value.data)).toEqual({ foo: true });
 
     event = await stream.next();
@@ -33,7 +33,7 @@ describe('streaming decoding', () => {
     ]();
 
     let event = await stream.next();
-    assert(event.value);
+    assert.ok(event.value);
     expect(event.value.event).toBeNull();
     expect(JSON.parse(event.value.data)).toEqual({ foo: true });
 
@@ -52,7 +52,7 @@ describe('streaming decoding', () => {
     ]();
 
     let event = await stream.next();
-    assert(event.value);
+    assert.ok(event.value);
     expect(event.value.event).toEqual('foo');
     expect(event.value.data).toEqual('');
 
@@ -73,12 +73,12 @@ describe('streaming decoding', () => {
     ]();
 
     let event = await stream.next();
-    assert(event.value);
+    assert.ok(event.value);
     expect(event.value.event).toEqual('foo');
     expect(event.value.data).toEqual('');
 
     event = await stream.next();
-    assert(event.value);
+    assert.ok(event.value);
     expect(event.value.event).toEqual('ping');
     expect(event.value.data).toEqual('');
 
@@ -101,12 +101,12 @@ describe('streaming decoding', () => {
     ]();
 
     let event = await stream.next();
-    assert(event.value);
+    assert.ok(event.value);
     expect(event.value.event).toEqual('foo');
     expect(JSON.parse(event.value.data)).toEqual({ foo: true });
 
     event = await stream.next();
-    assert(event.value);
+    assert.ok(event.value);
     expect(event.value.event).toEqual('ping');
     expect(JSON.parse(event.value.data)).toEqual({ bar: false });
 
@@ -130,7 +130,7 @@ describe('streaming decoding', () => {
     ]();
 
     let event = await stream.next();
-    assert(event.value);
+    assert.ok(event.value);
     expect(event.value.event).toEqual('ping');
     expect(JSON.parse(event.value.data)).toEqual({ foo: true });
     expect(event.value.data).toEqual('{\n"foo":\n\n\ntrue}');
@@ -151,7 +151,7 @@ describe('streaming decoding', () => {
     ]();
 
     let event = await stream.next();
-    assert(event.value);
+    assert.ok(event.value);
     expect(event.value.event).toEqual('ping');
     expect(JSON.parse(event.value.data)).toEqual({ foo: 'my long\n\ncontent' });
 
@@ -176,15 +176,15 @@ describe('streaming decoding', () => {
     ]();
 
     let event = await stream.next();
-    assert(event.value);
+    assert.ok(event.value);
     expect(JSON.parse(event.value.data)).toEqual({ content: 'culpa ' });
 
     event = await stream.next();
-    assert(event.value);
+    assert.ok(event.value);
     expect(JSON.parse(event.value.data)).toEqual({ content: Buffer.from([0xe2, 0x80, 0xa8]).toString() });
 
     event = await stream.next();
-    assert(event.value);
+    assert.ok(event.value);
     expect(JSON.parse(event.value.data)).toEqual({ content: 'foo' });
 
     event = await stream.next();
@@ -209,7 +209,7 @@ describe('streaming decoding', () => {
     ]();
 
     let event = await stream.next();
-    assert(event.value);
+    assert.ok(event.value);
     expect(event.value.event).toEqual('completion');
     expect(JSON.parse(event.value.data)).toEqual({ content: 'известни' });
 


### PR DESCRIPTION
## Summary

- Removes `unicorn/consistent-assert` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 137 of 185.
- Base: `dev/hayden/ultracite-136-vars-on-top`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`