### PR TITLE
chore(lint): enable complexity

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -7,7 +7,6 @@ const stainlessGeneratedFiles = requireConfig('./scripts/stainless-generated-fil
 // Existing handwritten SDK patterns predate these preset rules.
 const compatibilityRules = [
   'arrow-body-style',
-  'complexity',
   'curly',
   'eqeqeq',
   'func-names',
@@ -259,6 +258,28 @@ module.exports = defineConfig({
       files: ['tests/lib/ChatCompletionRunFunctions.test.ts'],
       rules: {
         'func-name-matching': 'off',
+      },
+    },
+    {
+      // These established parsers and stream state machines intentionally encode
+      // protocol branching in one place; splitting them would risk behavior changes.
+      files: [
+        'scripts/_vendor/tsc-multi/src/transformer.ts',
+        'src/_vendor/partial-json-parser/parser.ts',
+        'src/_vendor/zod-to-json-schema/parseDef.ts',
+        'src/_vendor/zod-to-json-schema/parsers/string.ts',
+        'src/_vendor/zod-to-json-schema/parsers/union.ts',
+        'src/internal/qs/stringify.ts',
+        'src/internal/qs/utils.ts',
+        'src/lib/AbstractChatCompletionRunner.ts',
+        'src/lib/AssistantStream.ts',
+        'src/lib/ChatCompletionStream.ts',
+        'src/lib/responses/ResponseAccumulator.ts',
+        'src/lib/responses/ResponseInputItems.ts',
+        'src/lib/transform.ts',
+      ],
+      rules: {
+        complexity: 'off',
       },
     },
     {


### PR DESCRIPTION
## Summary

- Removes `complexity` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 138 of 185.
- Base: `dev/hayden/ultracite-137-unicorn-consistent-assert`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`