### PR TITLE
chore(lint): enable unicorn/prefer-string-replace-all

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -49,7 +49,6 @@ const compatibilityRules = [
   'unicorn/prefer-module',
   'unicorn/prefer-node-protocol',
   'unicorn/prefer-response-static-json',
-  'unicorn/prefer-string-replace-all',
   'unicorn/prefer-string-slice',
   'unicorn/switch-case-braces',
   'unicorn/text-encoding-identifier-case',
@@ -288,6 +287,28 @@ module.exports = defineConfig({
       ],
       rules: {
         'promise/prefer-await-to-then': 'off',
+      },
+    },
+    {
+      // These TypeScript files intentionally stay compatible with the ES2020
+      // declaration library, which does not include String.prototype.replaceAll.
+      files: [
+        'scripts/_vendor/tsc-multi/src/worker/worker.ts',
+        'src/helpers/zod.ts',
+        'src/internal/qs/formats.ts',
+        'src/internal/qs/stringify.ts',
+        'src/internal/qs/utils.ts',
+        'src/internal/uploads.ts',
+        'src/internal/utils/path.ts',
+        'src/lib/transform.ts',
+        'src/realtime/internal-base.ts',
+        'tests/helpers/zod.test.ts',
+        'tests/path.test.ts',
+        'tests/qs/stringify.test.ts',
+        'tests/utils/mock-snapshots.ts',
+      ],
+      rules: {
+        'unicorn/prefer-string-replace-all': 'off',
       },
     },
     {

--- a/scripts/utils/check-version.cjs
+++ b/scripts/utils/check-version.cjs
@@ -13,7 +13,7 @@ const main = () => {
 
   const versionFile = path.resolve(__dirname, '..', '..', 'src', 'version.ts');
   const contents = fs.readFileSync(versionFile, 'utf8');
-  const output = contents.replace(/(export const VERSION = ')(.*)(')/g, `$1${version}$3`);
+  const output = contents.replaceAll(/(export const VERSION = ')(.*)(')/g, `$1${version}$3`);
   fs.writeFileSync(versionFile, output);
 };
 

--- a/scripts/utils/fix-index-exports.cjs
+++ b/scripts/utils/fix-index-exports.cjs
@@ -11,6 +11,6 @@ const after = before.replace(
   `exports = module.exports = function (...args) {
     return new exports.default(...args)
   }
-  $1`.replace(/^ {2}/gm, ''),
+  $1`.replaceAll(/^ {2}/gm, ''),
 );
 fs.writeFileSync(indexJs, after, 'utf8');

--- a/scripts/utils/postprocess-files.cjs
+++ b/scripts/utils/postprocess-files.cjs
@@ -22,14 +22,17 @@ async function postprocess() {
 
     // strip out lib="dom", types="node", and types="react" references; these
     // are needed at build time, but would pollute the user's TS environment
-    let transformed = code.replace(
+    let transformed = code.replaceAll(
       /^ *\/\/\/ *<reference +(lib="dom"|types="(node|react)").*?\n/gm,
       // replace with same number of characters to avoid breaking source maps
       (match) => ' '.repeat(match.length - 1) + '\n',
     );
 
     if (/\.d\.[cm]?ts$/.test(file)) {
-      transformed = transformed.replace(/\/\*\* @ts-ignore ([^*]+?) \*\/ type /g, '// @ts-ignore $1\ntype ');
+      transformed = transformed.replaceAll(
+        /\/\*\* @ts-ignore ([^*]+?) \*\/ type /g,
+        '// @ts-ignore $1\ntype ',
+      );
     }
 
     if (transformed !== code) {


### PR DESCRIPTION
## Summary

- Removes `unicorn/prefer-string-replace-all` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 141 of 185.
- Base: `dev/hayden/ultracite-140-promise-prefer-await-to-then`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`