### PR TITLE
chore(lint): enable no-sparse-arrays

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -19,7 +19,6 @@ const compatibilityRules = [
   'no-inline-comments',
   'no-plusplus',
   'no-shadow',
-  'no-sparse-arrays',
   'no-unused-vars',
   'no-use-before-define',
   'no-var',
@@ -335,6 +334,14 @@ module.exports = defineConfig({
       ],
       rules: {
         'no-promise-executor-return': 'off',
+      },
+    },
+    {
+      // Sparse holes are the behavior under test in the query-string fixture;
+      // replacing them with explicit undefined values would change coverage.
+      files: ['tests/qs/stringify.test.ts'],
+      rules: {
+        'no-sparse-arrays': 'off',
       },
     },
     {


### PR DESCRIPTION
## Summary

- Removes `no-sparse-arrays` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 143 of 185.
- Base: `dev/hayden/ultracite-142-no-promise-executor-return`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`