### PR TITLE
chore(lint): enable unicorn/prefer-string-slice

### DIFF
--- a/ecosystem-tests/browser-direct-import/src/test.ts
+++ b/ecosystem-tests/browser-direct-import/src/test.ts
@@ -15,7 +15,7 @@ import puppeteer from 'puppeteer';
         console.error(
           `${debugEvent('console')} ${message
             .type()
-            .substr(0, 'warning'.length)
+            .slice(0, 'warning'.length)
             .toUpperCase()
             .padEnd('warning'.length)} ${message.text()}`,
         ),

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -382,8 +382,10 @@ async function main() {
         progressDisplayed = true;
         const spin = spinner[Math.floor(Date.now() / 500) % spinner.length];
         process.stderr.write(
-          `${spin} Running ${[...runningProjects].join(', ')}`.substring(0, process.stdout.columns - 3) +
-            '...',
+          `${spin} Running ${[...runningProjects].join(', ')}`.slice(
+            0,
+            Math.max(0, process.stdout.columns - 3),
+          ) + '...',
         );
       };
 

--- a/ecosystem-tests/ts-browser-webpack/src/test.ts
+++ b/ecosystem-tests/ts-browser-webpack/src/test.ts
@@ -15,7 +15,7 @@ import puppeteer from 'puppeteer';
         console.error(
           `${debugEvent('console')} ${message
             .type()
-            .substr(0, 'warning'.length)
+            .slice(0, 'warning'.length)
             .toUpperCase()
             .padEnd('warning'.length)} ${message.text()}`,
         ),

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -47,7 +47,6 @@ const compatibilityRules = [
   'unicorn/prefer-module',
   'unicorn/prefer-node-protocol',
   'unicorn/prefer-response-static-json',
-  'unicorn/prefer-string-slice',
   'unicorn/switch-case-braces',
   'unicorn/text-encoding-identifier-case',
 ];
@@ -342,6 +341,14 @@ module.exports = defineConfig({
       files: ['tests/qs/stringify.test.ts'],
       rules: {
         'no-sparse-arrays': 'off',
+      },
+    },
+    {
+      // The vendored partial parser relies on substring's clamping and bound-swapping
+      // behavior for malformed input, which is not equivalent to slice.
+      files: ['src/_vendor/partial-json-parser/parser.ts'],
+      rules: {
+        'unicorn/prefer-string-slice': 'off',
       },
     },
     {

--- a/scripts/_vendor/tsc-multi/src/utils.ts
+++ b/scripts/_vendor/tsc-multi/src/utils.ts
@@ -3,7 +3,7 @@ import ts from 'typescript';
 
 export function trimPrefix(input: string, prefix: string): string {
   if (input.startsWith(prefix)) {
-    return input.substring(prefix.length);
+    return input.slice(prefix.length);
   }
 
   return input;
@@ -11,7 +11,7 @@ export function trimPrefix(input: string, prefix: string): string {
 
 export function trimSuffix(input: string, suffix: string): string {
   if (input.endsWith(suffix)) {
-    return input.substring(0, input.length - suffix.length);
+    return input.slice(0, input.length - suffix.length);
   }
 
   return input;

--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -324,7 +324,7 @@ class SSEDecoder {
 
   decode(line: string) {
     if (line.endsWith('\r')) {
-      line = line.substring(0, line.length - 1);
+      line = line.slice(0, -1);
     }
 
     if (!line) {
@@ -354,7 +354,7 @@ class SSEDecoder {
     let value = initialValue;
 
     if (value.startsWith(' ')) {
-      value = value.substring(1);
+      value = value.slice(1);
     }
 
     if (fieldname === 'event') {
@@ -370,7 +370,7 @@ class SSEDecoder {
 function partition(str: string, delimiter: string): [string, string, string] {
   const index = str.indexOf(delimiter);
   if (index !== -1) {
-    return [str.substring(0, index), delimiter, str.substring(index + delimiter.length)];
+    return [str.slice(0, index), delimiter, str.slice(index + delimiter.length)];
   }
 
   return [str, '', ''];

--- a/tests/_vendor/partial-json-parser/partial-json-parsing.test.ts
+++ b/tests/_vendor/partial-json-parser/partial-json-parsing.test.ts
@@ -41,7 +41,7 @@ describe('partial parsing', () => {
         for (let i = 1; i < jsonString.length; i++) {
           // speedup
           i += Math.floor(Math.random() * 3);
-          const substring = jsonString.substring(0, i);
+          const substring = jsonString.slice(0, i);
 
           // since we don't allow partial parsing for numbers
           if (


### PR DESCRIPTION
## Summary

- Removes `unicorn/prefer-string-slice` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 144 of 185.
- Base: `dev/hayden/ultracite-143-no-sparse-arrays`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`