### PR TITLE
chore(lint): enable object-shorthand

### DIFF
--- a/examples/chat-completions/chat-params-types.ts
+++ b/examples/chat-completions/chat-params-types.ts
@@ -105,7 +105,7 @@ export async function createCompletionParams(
   const params = {
     model: 'gpt-3.5-turbo',
     messages: [{ role: 'user' as const, content: 'Hello!' }],
-    stream: stream,
+    stream,
   };
 
   // <your logic here>

--- a/examples/chat-completions/function-call-diy.ts
+++ b/examples/chat-completions/function-call-diy.ts
@@ -78,7 +78,7 @@ async function main() {
     const completion = await openai.chat.completions.create({
       model: 'gpt-3.5-turbo',
       messages,
-      functions: functions,
+      functions,
     });
 
     const message = completion.choices[0]!.message;

--- a/examples/chat-completions/function-call-stream-raw.ts
+++ b/examples/chat-completions/function-call-stream-raw.ts
@@ -83,7 +83,7 @@ async function main() {
     const stream = await openai.chat.completions.create({
       model: 'gpt-3.5-turbo',
       messages,
-      functions: functions,
+      functions,
       stream: true,
     });
 

--- a/examples/chat-completions/function-call-stream.ts
+++ b/examples/chat-completions/function-call-stream.ts
@@ -83,7 +83,7 @@ async function main() {
     const stream = await openai.chat.completions.create({
       model: 'gpt-3.5-turbo',
       messages,
-      functions: functions,
+      functions,
       stream: true,
     });
 

--- a/examples/chat-completions/function-call.ts
+++ b/examples/chat-completions/function-call.ts
@@ -78,7 +78,7 @@ async function main() {
     const completion = await openai.chat.completions.create({
       model: 'gpt-3.5-turbo',
       messages,
-      functions: functions,
+      functions,
     });
 
     const message = completion.choices[0]!.message;

--- a/examples/chat-completions/tool-calls-stream.ts
+++ b/examples/chat-completions/tool-calls-stream.ts
@@ -117,7 +117,7 @@ async function main() {
     const stream = await openai.chat.completions.create({
       model: 'gpt-3.5-turbo',
       messages,
-      tools: tools,
+      tools,
       stream: true,
     });
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -22,7 +22,6 @@ const compatibilityRules = [
   'no-unused-vars',
   'no-use-before-define',
   'no-var',
-  'object-shorthand',
   'prefer-arrow-callback',
   'prefer-destructuring',
   'prefer-named-capture-group',

--- a/src/_vendor/zod-to-json-schema/Refs.ts
+++ b/src/_vendor/zod-to-json-schema/Refs.ts
@@ -29,7 +29,7 @@ export const getRefs = (options?: string | Partial<Options<Targets>>): Refs => {
       : [..._options.basePath, _options.definitionPath, _options.name];
   return {
     ..._options,
-    currentPath: currentPath,
+    currentPath,
     propertyPath: undefined,
     seenRefs: new Set(),
     seen: new Map(

--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -79,7 +79,7 @@ export class Stream<Item> implements AsyncIterable<Item> {
             if (sse.event == 'error') {
               throw new APIError(undefined, data.error, data.message, undefined);
             }
-            yield { event: sse.event, data: data } as any;
+            yield { event: sse.event, data } as any;
           }
         }
         done = true;

--- a/src/internal/qs/stringify.ts
+++ b/src/internal/qs/stringify.ts
@@ -280,11 +280,11 @@ function normalize_stringify_options(
   return {
     addQueryPrefix: typeof opts.addQueryPrefix === 'boolean' ? opts.addQueryPrefix : defaults.addQueryPrefix,
     // @ts-ignore
-    allowDots: allowDots,
+    allowDots,
     allowEmptyArrays:
       typeof opts.allowEmptyArrays === 'boolean' ? !!opts.allowEmptyArrays : defaults.allowEmptyArrays,
-    arrayFormat: arrayFormat,
-    charset: charset,
+    arrayFormat,
+    charset,
     charsetSentinel:
       typeof opts.charsetSentinel === 'boolean' ? opts.charsetSentinel : defaults.charsetSentinel,
     commaRoundTrip: !!opts.commaRoundTrip,
@@ -295,9 +295,9 @@ function normalize_stringify_options(
     encoder: typeof opts.encoder === 'function' ? opts.encoder : defaults.encoder,
     encodeValuesOnly:
       typeof opts.encodeValuesOnly === 'boolean' ? opts.encodeValuesOnly : defaults.encodeValuesOnly,
-    filter: filter,
-    format: format,
-    formatter: formatter,
+    filter,
+    format,
+    formatter,
     serializeDate: typeof opts.serializeDate === 'function' ? opts.serializeDate : defaults.serializeDate,
     skipNulls: typeof opts.skipNulls === 'boolean' ? opts.skipNulls : defaults.skipNulls,
     // @ts-ignore

--- a/src/internal/qs/utils.ts
+++ b/src/internal/qs/utils.ts
@@ -231,7 +231,7 @@ export function compact(value: any) {
     for (const key of keys) {
       const val = obj[key];
       if (typeof val === 'object' && val !== null && !refs.includes(val)) {
-        queue.push({ obj: obj, prop: key });
+        queue.push({ obj, prop: key });
         refs.push(val);
       }
     }

--- a/tests/qs/stringify.test.ts
+++ b/tests/qs/stringify.test.ts
@@ -1454,8 +1454,8 @@ describe('stringify()', function () {
     // 	stringify({ a: 'c', z: { j: 'a', i: 'b' }, b: 'f' }, { sort: sort }),
     // 	'a=c&b=f&z%5Bi%5D=b&z%5Bj%5D=a',
     // );
-    expect(stringify({ a: 'c', z: 'y', b: 'f' }, { sort: sort })).toBe('a=c&b=f&z=y');
-    expect(stringify({ a: 'c', z: { j: 'a', i: 'b' }, b: 'f' }, { sort: sort })).toBe(
+    expect(stringify({ a: 'c', z: 'y', b: 'f' }, { sort })).toBe('a=c&b=f&z=y');
+    expect(stringify({ a: 'c', z: { j: 'a', i: 'b' }, b: 'f' }, { sort })).toBe(
       'a=c&b=f&z%5Bi%5D=b&z%5Bj%5D=a',
     );
   });
@@ -1482,7 +1482,7 @@ describe('stringify()', function () {
     expect(
       stringify(
         { a: 'a', z: { zj: { zjb: 'zjb', zja: 'zja' }, zi: { zib: 'zib', zia: 'zia' } }, b: 'b' },
-        { sort: sort, encode: false },
+        { sort, encode: false },
       ),
     ).toBe('a=a&b=b&z[zi][zia]=zia&z[zi][zib]=zib&z[zj][zja]=zja&z[zj][zjb]=zjb');
     expect(
@@ -1517,7 +1517,7 @@ describe('stringify()', function () {
       stringify(
         { 県: '大阪府', '': '' },
         {
-          encoder: function (str) {
+          encoder(str) {
             if (str.length === 0) {
               return '';
             }
@@ -1547,7 +1547,7 @@ describe('stringify()', function () {
     stringify(
       { a: 1, b: new Date(), c: true, d: [1] },
       {
-        encoder: function (str) {
+        encoder(str) {
           // st.match(typeof str, /^(?:string|number|boolean)$/);
           assert.match(typeof str, /^(?:string|number|boolean)$/);
           return '';
@@ -1570,7 +1570,7 @@ describe('stringify()', function () {
       { a: 1 },
       {
         // @ts-ignore
-        encoder: function (_str, defaultEncoder) {
+        encoder(_str, defaultEncoder) {
           expect(defaultEncoder).toBe(encode);
         },
       },
@@ -1609,7 +1609,7 @@ describe('stringify()', function () {
         stringify(
           { a: Buffer.from([1]) },
           {
-            encoder: function (buffer) {
+            encoder(buffer) {
               if (typeof buffer === 'string') {
                 return buffer;
               }
@@ -1634,7 +1634,7 @@ describe('stringify()', function () {
         stringify(
           { a: Buffer.from('a b') },
           {
-            encoder: function (buffer) {
+            encoder(buffer) {
               return buffer;
             },
           },
@@ -1689,7 +1689,7 @@ describe('stringify()', function () {
         { a: specificDate },
         {
           // @ts-ignore
-          serializeDate: function (d) {
+          serializeDate(d) {
             return d.getTime() * 7;
           },
         },
@@ -1728,7 +1728,7 @@ describe('stringify()', function () {
         { a: [date] },
         {
           // @ts-expect-error
-          serializeDate: function (d) {
+          serializeDate(d) {
             return d.getTime();
           },
           arrayFormat: 'comma',
@@ -1740,7 +1740,7 @@ describe('stringify()', function () {
         { a: [date] },
         {
           // @ts-expect-error
-          serializeDate: function (d) {
+          serializeDate(d) {
             return d.getTime();
           },
           arrayFormat: 'comma',
@@ -1791,7 +1791,7 @@ describe('stringify()', function () {
       // }, new TypeError('Unknown format option provided.'));
       expect(() => {
         // @ts-expect-error
-        stringify({ a: 'b c' }, { format: format });
+        stringify({ a: 'b c' }, { format });
       }).toThrow(TypeError);
     }
   });
@@ -1932,7 +1932,7 @@ describe('stringify()', function () {
       return value;
     };
 
-    var options = { strictNullHandling: true, filter: filter };
+    var options = { strictNullHandling: true, filter };
     // st.equal(stringify({ key: null }, options), 'key');
     expect(stringify({ key: null }, options)).toBe('key');
   });
@@ -1941,7 +1941,7 @@ describe('stringify()', function () {
     var serializeDate = function () {
       return null;
     };
-    var options = { strictNullHandling: true, serializeDate: serializeDate };
+    var options = { strictNullHandling: true, serializeDate };
     var date = new Date();
     // st.equal(stringify({ key: date }, options), 'key');
     // @ts-expect-error
@@ -1961,7 +1961,7 @@ describe('stringify()', function () {
     };
 
     // st.deepEqual(stringify({ KeY: 'vAlUe' }, { encoder: encoder }), 'key=VALUE');
-    expect(stringify({ KeY: 'vAlUe' }, { encoder: encoder })).toBe('key=VALUE');
+    expect(stringify({ KeY: 'vAlUe' }, { encoder })).toBe('key=VALUE');
   });
 
   test('objects inside arrays', function () {

--- a/tests/qs/utils.test.ts
+++ b/tests/qs/utils.test.ts
@@ -53,11 +53,11 @@ describe('merge()', function () {
       var getCount = 0;
       var observed: any[] = [];
       Object.defineProperty(observed, 0, {
-        get: function () {
+        get() {
           getCount += 1;
           return { bar: 'baz' };
         },
-        set: function () {
+        set() {
           setCount += 1;
         },
       });


### PR DESCRIPTION
## Summary

- Removes `object-shorthand` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 145 of 185.
- Base: `dev/hayden/ultracite-144-unicorn-prefer-string-slice`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`