### PR TITLE
chore(lint): enable arrow-body-style

### DIFF
--- a/ecosystem-tests/browser-direct-import/src/test.ts
+++ b/ecosystem-tests/browser-direct-import/src/test.ts
@@ -7,9 +7,7 @@ import puppeteer from 'puppeteer';
   let page;
   try {
     page = await browser.newPage();
-    const debugEvent = (subj: string) => {
-      return subj.padEnd('requestfailed'.length);
-    };
+    const debugEvent = (subj: string) => subj.padEnd('requestfailed'.length);
     page
       .on('console', (message) =>
         console.error(

--- a/ecosystem-tests/ts-browser-webpack/src/test.ts
+++ b/ecosystem-tests/ts-browser-webpack/src/test.ts
@@ -7,9 +7,7 @@ import puppeteer from 'puppeteer';
   let page;
   try {
     page = await browser.newPage();
-    const debugEvent = (subj: string) => {
-      return subj.padEnd('requestfailed'.length);
-    };
+    const debugEvent = (subj: string) => subj.padEnd('requestfailed'.length);
     page
       .on('console', (message) =>
         console.error(

--- a/examples/chat-completions/parsing-run-tools.ts
+++ b/examples/chat-completions/parsing-run-tools.ts
@@ -36,9 +36,7 @@ async function main() {
       tools: [
         zodFunction({
           name: 'query',
-          function: (args) => {
-            return { table_name: args.table_name, data: fakeOrders };
-          },
+          function: (args) => ({ table_name: args.table_name, data: fakeOrders }),
           parameters: z.object({
             location: z.string(),
             table_name: Table,

--- a/examples/responses/websocket.ts
+++ b/examples/responses/websocket.ts
@@ -210,9 +210,8 @@ const parseArgs = (argv: Array<string>): CLIArgs => {
   return { model, useBetaHeader, showEvents, showToolIO };
 };
 
-const isRecord = (value: unknown): value is Record<string, unknown> => {
-  return typeof value === 'object' && value !== null;
-};
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
 
 const parseToolName = (name: string): ToolName => {
   if (name === 'get_sku_inventory' || name === 'get_supplier_eta' || name === 'get_quality_alerts') {
@@ -341,8 +340,8 @@ const runResponse = async ({
   inputPayload: string | ResponseInput;
   toolChoice: ToolChoice;
   showEvents: boolean;
-}): Promise<RunResponseResult> => {
-  return await new Promise<RunResponseResult>((resolve, reject) => {
+}): Promise<RunResponseResult> =>
+  await new Promise<RunResponseResult>((resolve, reject) => {
     const textParts: Array<string> = [];
     const functionCalls: Array<FunctionCallRequest> = [];
 
@@ -419,7 +418,6 @@ const runResponse = async ({
     };
     ws.send(createEvent);
   });
-};
 
 const runTurn = async ({
   ws,

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -6,7 +6,6 @@ const stainlessGeneratedFiles = requireConfig('./scripts/stainless-generated-fil
 
 // Existing handwritten SDK patterns predate these preset rules.
 const compatibilityRules = [
-  'arrow-body-style',
   'curly',
   'eqeqeq',
   'func-names',

--- a/scripts/_vendor/tsc-multi/src/build.ts
+++ b/scripts/_vendor/tsc-multi/src/build.ts
@@ -114,8 +114,8 @@ export async function build({
       const prefix = `[${trimPrefix(extname || DEFAULT_EXTNAME, '.')}]: `;
       const prefixStyle = reportStyles[i % reportStyles.length];
 
-      return () => {
-        return runWorker({
+      return () =>
+        runWorker({
           ...options,
           projects,
           stdout,
@@ -127,7 +127,6 @@ export async function build({
           reportPrefix: prefixStyle(prefix),
           transpileOnly,
         });
-      };
     }),
     { concurrency: maxWorkers },
   );

--- a/scripts/_vendor/tsc-multi/src/cli.ts
+++ b/scripts/_vendor/tsc-multi/src/cli.ts
@@ -45,8 +45,8 @@ yargs(process.argv.slice(2))
   .command(
     '$0 [projects..]',
     'Build multiple TypeScript projects to multiple targets.',
-    (cmd) => {
-      return cmd
+    (cmd) =>
+      cmd
         .positional('projects', {
           array: true,
           type: 'string',
@@ -58,8 +58,7 @@ yargs(process.argv.slice(2))
           ['$0 --clean', 'Delete built files.'],
           ['$0 --config ./conf.json', 'Custom config path.'],
           ['$0 ./pkg-a ./pkg-b', 'Build multiple projects.'],
-        ]);
-    },
+        ]),
     async (args) => {
       const projects = args.projects || [];
       const config = await loadConfig({

--- a/src/_vendor/zod-to-json-schema/Options.ts
+++ b/src/_vendor/zod-to-json-schema/Options.ts
@@ -61,21 +61,18 @@ const defaultOptions: Omit<Options, 'definitions' | 'basePath'> = {
 
 export const getDefaultOptions = <Target extends Targets>(
   options: Partial<Options<Target>> | string | undefined,
-) => {
+) =>
   // We need to add `definitions` here as we may mutate it
-  return (
-    typeof options === 'string'
-      ? {
-          ...defaultOptions,
-          basePath: ['#'],
-          definitions: {},
-          name: options,
-        }
-      : {
-          ...defaultOptions,
-          basePath: ['#'],
-          definitions: {},
-          ...options,
-        }
-  ) as Options<Target>;
-};
+  (typeof options === 'string'
+    ? {
+        ...defaultOptions,
+        basePath: ['#'],
+        definitions: {},
+        name: options,
+      }
+    : {
+        ...defaultOptions,
+        basePath: ['#'],
+        definitions: {},
+        ...options,
+      }) as Options<Target>;

--- a/src/_vendor/zod-to-json-schema/parsers/catch.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/catch.ts
@@ -2,6 +2,5 @@ import { ZodCatchDef } from 'zod/v3';
 import { parseDef } from '../parseDef';
 import { Refs } from '../Refs';
 
-export const parseCatchDef = (def: ZodCatchDef<any>, refs: Refs, forceResolution: boolean) => {
-  return parseDef(def.innerType._def, refs, forceResolution);
-};
+export const parseCatchDef = (def: ZodCatchDef<any>, refs: Refs, forceResolution: boolean) =>
+  parseDef(def.innerType._def, refs, forceResolution);

--- a/src/_vendor/zod-to-json-schema/parsers/nativeEnum.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/nativeEnum.ts
@@ -7,9 +7,9 @@ export type JsonSchema7NativeEnumType = {
 
 export function parseNativeEnumDef(def: ZodNativeEnumDef): JsonSchema7NativeEnumType {
   const object = def.values;
-  const actualKeys = Object.keys(def.values).filter((key: string) => {
-    return typeof object[object[key]!] !== 'number';
-  });
+  const actualKeys = Object.keys(def.values).filter(
+    (key: string) => typeof object[object[key]!] !== 'number',
+  );
 
   const actualValues = actualKeys.map((key: string) => object[key]!);
 

--- a/src/_vendor/zod-to-json-schema/parsers/readonly.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/readonly.ts
@@ -2,6 +2,5 @@ import { ZodReadonlyDef } from 'zod/v3';
 import { parseDef } from '../parseDef';
 import { Refs } from '../Refs';
 
-export const parseReadonlyDef = (def: ZodReadonlyDef<any>, refs: Refs, forceResolution: boolean) => {
-  return parseDef(def.innerType._def, refs, forceResolution);
-};
+export const parseReadonlyDef = (def: ZodReadonlyDef<any>, refs: Refs, forceResolution: boolean) =>
+  parseDef(def.innerType._def, refs, forceResolution);

--- a/src/_vendor/zod-to-json-schema/util.ts
+++ b/src/_vendor/zod-to-json-schema/util.ts
@@ -1,8 +1,7 @@
 import type { ZodSchema, ZodTypeDef } from 'zod/v3';
 
-export const zodDef = (zodSchema: ZodSchema | ZodTypeDef): ZodTypeDef => {
-  return '_def' in zodSchema ? zodSchema._def : zodSchema;
-};
+export const zodDef = (zodSchema: ZodSchema | ZodTypeDef): ZodTypeDef =>
+  '_def' in zodSchema ? zodSchema._def : zodSchema;
 
 export function isEmptyObj(obj: object | null | undefined): boolean {
   if (!obj) return true;

--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -188,18 +188,16 @@ export class Stream<Item> implements AsyncIterable<Item> {
     const right: Array<Promise<IteratorResult<Item>>> = [];
     const iterator = this.iterator();
 
-    const teeIterator = (queue: Array<Promise<IteratorResult<Item>>>): AsyncIterator<Item> => {
-      return {
-        next: () => {
-          if (queue.length === 0) {
-            const result = iterator.next();
-            left.push(result);
-            right.push(result);
-          }
-          return queue.shift()!;
-        },
-      };
-    };
+    const teeIterator = (queue: Array<Promise<IteratorResult<Item>>>): AsyncIterator<Item> => ({
+      next: () => {
+        if (queue.length === 0) {
+          const result = iterator.next();
+          left.push(result);
+          right.push(result);
+        }
+        return queue.shift()!;
+      },
+    });
 
     return [
       new Stream(() => teeIterator(left), this.controller, this.#client),

--- a/src/lib/chatCompletionUtils.ts
+++ b/src/lib/chatCompletionUtils.ts
@@ -6,15 +6,11 @@ import type {
 
 export const isAssistantMessage = (
   message: ChatCompletionMessageParam | null | undefined,
-): message is ChatCompletionAssistantMessageParam => {
-  return message?.role === 'assistant';
-};
+): message is ChatCompletionAssistantMessageParam => message?.role === 'assistant';
 
 export const isToolMessage = (
   message: ChatCompletionMessageParam | null | undefined,
-): message is ChatCompletionToolMessageParam => {
-  return message?.role === 'tool';
-};
+): message is ChatCompletionToolMessageParam => message?.role === 'tool';
 
 export function isPresent<T>(obj: T | null | undefined): obj is T {
   return obj != null;

--- a/tests/auth/subject-token-providers.test.ts
+++ b/tests/auth/subject-token-providers.test.ts
@@ -113,14 +113,15 @@ describe('Azure IMDS Token Provider', () => {
   });
 
   test('uses the configured fetch implementation', async () => {
-    const customFetch = vi.fn(async () => {
-      return new Response(
-        JSON.stringify({
-          access_token: 'azure-token',
-        }),
-        { status: 200 },
-      );
-    }) as typeof fetch;
+    const customFetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: 'azure-token',
+          }),
+          { status: 200 },
+        ),
+    ) as typeof fetch;
 
     const provider = azureManagedIdentityTokenProvider(undefined, {
       fetch: customFetch,
@@ -131,9 +132,7 @@ describe('Azure IMDS Token Provider', () => {
   });
 
   test('throws SubjectTokenProviderError on failed request', async () => {
-    global.fetch = vi.fn(async () => {
-      return new Response('Not found', { status: 404 });
-    }) as typeof fetch;
+    global.fetch = vi.fn(async () => new Response('Not found', { status: 404 })) as typeof fetch;
 
     const provider = azureManagedIdentityTokenProvider();
     await expect(provider.getToken()).rejects.toThrow(SubjectTokenProviderError);
@@ -141,9 +140,9 @@ describe('Azure IMDS Token Provider', () => {
   });
 
   test('throws SubjectTokenProviderError when access_token missing', async () => {
-    global.fetch = vi.fn(async () => {
-      return new Response(JSON.stringify({ expires_in: '3600' }), { status: 200 });
-    }) as typeof fetch;
+    global.fetch = vi.fn(
+      async () => new Response(JSON.stringify({ expires_in: '3600' }), { status: 200 }),
+    ) as typeof fetch;
 
     const provider = azureManagedIdentityTokenProvider();
     await expect(provider.getToken()).rejects.toThrow(SubjectTokenProviderError);
@@ -181,9 +180,7 @@ describe('GCP Metadata Server Token Provider', () => {
   });
 
   test('uses the configured fetch implementation', async () => {
-    const customFetch = vi.fn(async () => {
-      return new Response('gcp-id-token', { status: 200 });
-    }) as typeof fetch;
+    const customFetch = vi.fn(async () => new Response('gcp-id-token', { status: 200 })) as typeof fetch;
 
     const provider = gcpIDTokenProvider('https://api.openai.com', {
       fetch: customFetch,
@@ -194,9 +191,7 @@ describe('GCP Metadata Server Token Provider', () => {
   });
 
   test('throws SubjectTokenProviderError on failed request', async () => {
-    global.fetch = vi.fn(async () => {
-      return new Response('Unauthorized', { status: 401 });
-    }) as typeof fetch;
+    global.fetch = vi.fn(async () => new Response('Unauthorized', { status: 401 })) as typeof fetch;
 
     const provider = gcpIDTokenProvider();
     await expect(provider.getToken()).rejects.toThrow(SubjectTokenProviderError);

--- a/tests/auth/workload-identity-auth.test.ts
+++ b/tests/auth/workload-identity-auth.test.ts
@@ -265,15 +265,16 @@ describe('WorkloadIdentityAuth', () => {
       },
     };
 
-    global.fetch = vi.fn(async () => {
-      return new Response(
-        JSON.stringify({
-          error: 'invalid_grant',
-          error_description: 'The subject token is invalid',
-        }),
-        { status: 400 },
-      );
-    }) as typeof fetch;
+    global.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: 'invalid_grant',
+            error_description: 'The subject token is invalid',
+          }),
+          { status: 400 },
+        ),
+    ) as typeof fetch;
 
     const auth = new WorkloadIdentityAuth(config);
 
@@ -291,16 +292,17 @@ describe('WorkloadIdentityAuth', () => {
       },
     };
 
-    global.fetch = vi.fn(async () => {
-      return new Response(
-        JSON.stringify({
-          access_token: 'access-token',
-          issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
-          token_type: 'Bearer',
-        }),
-        { status: 200 },
-      );
-    }) as typeof fetch;
+    global.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: 'access-token',
+            issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+            token_type: 'Bearer',
+          }),
+          { status: 200 },
+        ),
+    ) as typeof fetch;
 
     const auth = new WorkloadIdentityAuth(config);
 
@@ -346,9 +348,7 @@ describe('WorkloadIdentityAuth', () => {
       },
     };
 
-    global.fetch = vi.fn(async () => {
-      return new Response(JSON.stringify(body), { status: 200 });
-    }) as typeof fetch;
+    global.fetch = vi.fn(async () => new Response(JSON.stringify(body), { status: 200 })) as typeof fetch;
 
     const auth = new WorkloadIdentityAuth(config);
     const tokenPromise = auth.getToken();
@@ -404,17 +404,18 @@ describe('WorkloadIdentityAuth', () => {
       },
     };
 
-    const customFetch = vi.fn(async () => {
-      return new Response(
-        JSON.stringify({
-          access_token: 'access-token',
-          issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
-          token_type: 'Bearer',
-          expires_in: 3600,
-        }),
-        { status: 200 },
-      );
-    }) as typeof fetch;
+    const customFetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: 'access-token',
+            issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+            token_type: 'Bearer',
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+    ) as typeof fetch;
 
     const auth = new WorkloadIdentityAuth(config, customFetch);
     await auth.getToken();

--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -118,13 +118,12 @@ describe('instantiate azure client', () => {
       baseURL: 'http://localhost:5000/',
       apiKey: 'My API Key',
       apiVersion,
-      fetch: (url) => {
-        return Promise.resolve(
+      fetch: (url) =>
+        Promise.resolve(
           new Response(JSON.stringify({ url, custom: true }), {
             headers: { 'Content-Type': 'application/json' },
           }),
-        );
-      },
+        ),
     });
 
     const response = await client.get('/foo');
@@ -136,8 +135,8 @@ describe('instantiate azure client', () => {
       baseURL: process.env['TEST_API_BASE_URL'] ?? 'http://127.0.0.1:4010',
       apiKey: 'My API Key',
       apiVersion,
-      fetch: (...args) => {
-        return new Promise((resolve, reject) =>
+      fetch: (...args) =>
+        new Promise((resolve, reject) =>
           setTimeout(
             () =>
               defaultFetch(...args)
@@ -145,8 +144,7 @@ describe('instantiate azure client', () => {
                 .catch(reject),
             300,
           ),
-        );
-      },
+        ),
     });
 
     const controller = new AbortController();
@@ -247,9 +245,8 @@ describe('instantiate azure client', () => {
 
   describe('Azure Active Directory (AD)', () => {
     test('with azureADTokenProvider', async () => {
-      const testFetch = async (url: RequestInfo, { headers }: RequestInit = {}): Promise<Response> => {
-        return new Response(JSON.stringify({ a: 1 }), { headers: headers ?? [] });
-      };
+      const testFetch = async (url: RequestInfo, { headers }: RequestInit = {}): Promise<Response> =>
+        new Response(JSON.stringify({ a: 1 }), { headers: headers ?? [] });
       const client = new AzureOpenAI({
         baseURL: 'http://localhost:5000/',
         azureADTokenProvider: async () => 'my token',
@@ -311,9 +308,8 @@ describe('instantiate azure client', () => {
   });
 
   test('uses api-key header when apiKey is provided', async () => {
-    const testFetch = async (url: RequestInfo, { headers }: RequestInit = {}): Promise<Response> => {
-      return new Response(JSON.stringify({ a: 1 }), { headers: headers ?? [] });
-    };
+    const testFetch = async (url: RequestInfo, { headers }: RequestInit = {}): Promise<Response> =>
+      new Response(JSON.stringify({ a: 1 }), { headers: headers ?? [] });
     const client = new AzureOpenAI({
       baseURL: 'http://localhost:5000/',
       apiKey: 'My API Key',
@@ -356,9 +352,8 @@ describe('azure request building', () => {
   const client = new AzureOpenAI({ baseURL: 'https://example.com', apiKey: 'My API Key', apiVersion });
 
   describe('model to deployment mapping', function () {
-    const testFetch = async (url: RequestInfo): Promise<Response> => {
-      return new Response(JSON.stringify({ url }), { headers: { 'content-type': 'application/json' } });
-    };
+    const testFetch = async (url: RequestInfo): Promise<Response> =>
+      new Response(JSON.stringify({ url }), { headers: { 'content-type': 'application/json' } });
     describe('with client-level deployment', function () {
       const client = new AzureOpenAI({
         endpoint: 'https://example.com',

--- a/tests/lib/workload-identity.test.ts
+++ b/tests/lib/workload-identity.test.ts
@@ -93,9 +93,7 @@ describe('OpenAI with Workload Identity', () => {
   });
 
   test('does not satisfy admin-only auth with workload identity', async () => {
-    global.fetch = vi.fn(async () => {
-      return new Response('Unexpected request', { status: 500 });
-    }) as typeof fetch;
+    global.fetch = vi.fn(async () => new Response('Unexpected request', { status: 500 })) as typeof fetch;
 
     const client = new OpenAI(createTestClientOptions());
 

--- a/tests/log.test.ts
+++ b/tests/log.test.ts
@@ -6,13 +6,12 @@ const opts: ClientOptions = {
   apiKey: 'example-api-key',
   baseURL: 'http://localhost:5000/',
   logLevel: 'debug',
-  fetch: (url) => {
-    return Promise.resolve(
+  fetch: (url) =>
+    Promise.resolve(
       new Response(JSON.stringify({ url, custom: true }), {
         headers: { 'Content-Type': 'application/json' },
       }),
-    );
-  },
+    ),
 };
 
 describe('debug()', () => {

--- a/tests/responses.test.ts
+++ b/tests/responses.test.ts
@@ -57,18 +57,16 @@ describe('request id', () => {
   test('envelope response', async () => {
     const promise = new APIPromise<{ data: { foo: string } }>(
       client,
-      (async () => {
-        return {
-          response: new Response(JSON.stringify({ data: { foo: 'bar' } }), {
-            headers: { 'x-request-id': 'req_id_xxx', 'content-type': 'application/json' },
-          }),
-          controller: {} as any,
-          options: {} as any,
-          requestLogID: 'log_...',
-          retryOfRequestLogID: undefined,
-          startTime: Date.now(),
-        };
-      })(),
+      Promise.resolve({
+        response: new Response(JSON.stringify({ data: { foo: 'bar' } }), {
+          headers: { 'x-request-id': 'req_id_xxx', 'content-type': 'application/json' },
+        }),
+        controller: {} as any,
+        options: {} as any,
+        requestLogID: 'log_...',
+        retryOfRequestLogID: undefined,
+        startTime: Date.now(),
+      }),
     )._thenUnwrap((d) => d.data);
 
     const rsp = await promise;
@@ -93,18 +91,16 @@ describe('request id', () => {
   test('array response', async () => {
     const promise = new APIPromise<Array<{ foo: string }>>(
       client,
-      (async () => {
-        return {
-          response: new Response(JSON.stringify([{ foo: 'bar' }]), {
-            headers: { 'x-request-id': 'req_id_xxx', 'content-type': 'application/json' },
-          }),
-          controller: {} as any,
-          options: {} as any,
-          requestLogID: 'log_...',
-          retryOfRequestLogID: undefined,
-          startTime: Date.now(),
-        };
-      })(),
+      Promise.resolve({
+        response: new Response(JSON.stringify([{ foo: 'bar' }]), {
+          headers: { 'x-request-id': 'req_id_xxx', 'content-type': 'application/json' },
+        }),
+        controller: {} as any,
+        options: {} as any,
+        requestLogID: 'log_...',
+        retryOfRequestLogID: undefined,
+        startTime: Date.now(),
+      }),
     );
 
     const rsp = await promise;
@@ -116,18 +112,16 @@ describe('request id', () => {
   test('string response', async () => {
     const promise = new APIPromise<string>(
       client,
-      (async () => {
-        return {
-          response: new Response('hello world', {
-            headers: { 'x-request-id': 'req_id_xxx', 'content-type': 'application/text' },
-          }),
-          controller: {} as any,
-          options: {} as any,
-          requestLogID: 'log_...',
-          retryOfRequestLogID: undefined,
-          startTime: Date.now(),
-        };
-      })(),
+      Promise.resolve({
+        response: new Response('hello world', {
+          headers: { 'x-request-id': 'req_id_xxx', 'content-type': 'application/text' },
+        }),
+        controller: {} as any,
+        options: {} as any,
+        requestLogID: 'log_...',
+        retryOfRequestLogID: undefined,
+        startTime: Date.now(),
+      }),
     );
 
     const result = await promise;


### PR DESCRIPTION
## Summary

- Removes `arrow-body-style` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 146 of 185.
- Base: `dev/hayden/ultracite-145-object-shorthand`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`