### PR TITLE
chore(lint): enable unicorn/text-encoding-identifier-case

### DIFF
--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -123,7 +123,7 @@ const projectRunners = {
     // Deno's BYONM resolver requires package.json to declare the npm
     // dependency. For the default path, add that declaration only after npm
     // installs the local tarball so it cannot substitute a registry package.
-    const installedPackage = JSON.parse(await fs.readFile('node_modules/openai/package.json', 'utf8'));
+    const installedPackage = JSON.parse(await fs.readFile('node_modules/openai/package.json', 'utf-8'));
     assert.ok(typeof installedPackage.version === 'string');
     await fs.writeFile(
       'package.json',
@@ -422,7 +422,7 @@ async function main() {
                     ],
                     {
                       stdio: 'pipe',
-                      encoding: 'utf8',
+                      encoding: 'utf-8',
                       maxBuffer: 100 * 1024 * 1024,
                       env: {
                         DISABLE_V8_COMPILE_CACHE: process.env['DISABLE_V8_COMPILE_CACHE'] ?? '1',

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -41,7 +41,6 @@ const compatibilityRules = [
   'unicorn/prefer-node-protocol',
   'unicorn/prefer-response-static-json',
   'unicorn/switch-case-braces',
-  'unicorn/text-encoding-identifier-case',
 ];
 
 module.exports = defineConfig({

--- a/scripts/_vendor/tsc-multi/src/utils.ts
+++ b/scripts/_vendor/tsc-multi/src/utils.ts
@@ -18,7 +18,7 @@ export function trimSuffix(input: string, suffix: string): string {
 }
 
 export async function readJSON(path: string): Promise<any> {
-  const content = await readFile(path, 'utf8');
+  const content = await readFile(path, 'utf-8');
   return JSON.parse(content);
 }
 

--- a/scripts/check-node-version-policy.ts
+++ b/scripts/check-node-version-policy.ts
@@ -49,7 +49,7 @@ const nodeVersionPolicyPath = require('node:path');
     policyStatuses.some((status) => status === value);
 
   const root = path.resolve(__dirname, '..');
-  const read = (file: string): string => fs.readFileSync(path.join(root, file), 'utf8');
+  const read = (file: string): string => fs.readFileSync(path.join(root, file), 'utf-8');
   const readJSON = <Value>(file: string): Value => JSON.parse(read(file)) as Value;
   const unique = <Value>(values: Value[]): Value[] => [...new Set(values)];
 

--- a/scripts/lint-generated.cjs
+++ b/scripts/lint-generated.cjs
@@ -14,7 +14,7 @@ function requestedFiles(arguments_) {
   if (arguments_[0] !== '--file-list') return arguments_;
   if (arguments_.length !== 2) throw new Error('--file-list requires exactly one path');
 
-  return fs.readFileSync(arguments_[1], 'utf8').split(/\r?\n/u).filter(Boolean);
+  return fs.readFileSync(arguments_[1], 'utf-8').split(/\r?\n/u).filter(Boolean);
 }
 
 function selectedGeneratedFiles(arguments_) {
@@ -68,7 +68,7 @@ function checkGeneratedFiles(files) {
   const result = spawnSync(
     process.execPath,
     [oxlint, '--config', generatedConfig, '--format', 'json', ...files],
-    { cwd: repositoryRoot, encoding: 'utf8', maxBuffer: 10 * 1024 * 1024 },
+    { cwd: repositoryRoot, encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
   );
 
   if (result.error) throw result.error;

--- a/scripts/stainless-generated-files.cjs
+++ b/scripts/stainless-generated-files.cjs
@@ -14,7 +14,7 @@ function findGeneratedFiles(directory) {
 
     if (entry.isDirectory()) return ignoredDirectories.has(entry.name) ? [] : findGeneratedFiles(file);
     if (!entry.isFile() || !/\.[cm]?[jt]sx?$/.test(entry.name)) return [];
-    const content = fs.readFileSync(file, 'utf8');
+    const content = fs.readFileSync(file, 'utf-8');
     if (!generatedHeaders.some((header) => content.startsWith(header))) return [];
 
     return [path.relative(repositoryRoot, file).split(path.sep).join('/')];

--- a/scripts/test-packed-package.ts
+++ b/scripts/test-packed-package.ts
@@ -33,12 +33,12 @@ const packedPackagePath = require('node:path');
   const run = (command: string, args: string[], options: RunOptions = {}): string =>
     childProcess.execFileSync(command, args, {
       cwd: temporaryDirectory,
-      encoding: 'utf8',
+      encoding: 'utf-8',
       stdio: 'pipe',
       ...options,
     });
   const readPackage = (file: string): PackageMetadata =>
-    JSON.parse(fs.readFileSync(file, 'utf8')) as PackageMetadata;
+    JSON.parse(fs.readFileSync(file, 'utf-8')) as PackageMetadata;
   const findSourceMaps = (directory: string): string[] => {
     const maps: string[] = [];
     const entries = fs.readdirSync(directory, { withFileTypes: true }) as import('node:fs').Dirent[];
@@ -190,7 +190,7 @@ const packedPackagePath = require('node:path');
     const sourceMaps = findSourceMaps(installedPackageRoot);
     sourceMaps.sort();
     for (const mapPath of sourceMaps) {
-      const sourceMap = JSON.parse(fs.readFileSync(mapPath, 'utf8')) as SourceMap;
+      const sourceMap = JSON.parse(fs.readFileSync(mapPath, 'utf-8')) as SourceMap;
       for (const source of sourceMap.sources) {
         const resolvedSource: string = path.resolve(
           path.dirname(mapPath),

--- a/scripts/utils/check-version.cjs
+++ b/scripts/utils/check-version.cjs
@@ -12,7 +12,7 @@ const main = () => {
   }
 
   const versionFile = path.resolve(__dirname, '..', '..', 'src', 'version.ts');
-  const contents = fs.readFileSync(versionFile, 'utf8');
+  const contents = fs.readFileSync(versionFile, 'utf-8');
   const output = contents.replaceAll(/(export const VERSION = ')(.*)(')/g, `$1${version}$3`);
   fs.writeFileSync(versionFile, output);
 };

--- a/scripts/utils/fix-index-exports.cjs
+++ b/scripts/utils/fix-index-exports.cjs
@@ -5,7 +5,7 @@ const indexJs = process.env['DIST_PATH']
   ? path.resolve(process.env['DIST_PATH'], 'index.js')
   : path.resolve(__dirname, '..', '..', 'dist', 'index.js');
 
-const before = fs.readFileSync(indexJs, 'utf8');
+const before = fs.readFileSync(indexJs, 'utf-8');
 const after = before.replace(
   /^(\s*Object\.defineProperty\s*\(exports,\s*["']__esModule["'].+)$/m,
   `exports = module.exports = function (...args) {
@@ -13,4 +13,4 @@ const after = before.replace(
   }
   $1`.replaceAll(/^ {2}/gm, ''),
 );
-fs.writeFileSync(indexJs, after, 'utf8');
+fs.writeFileSync(indexJs, after, 'utf-8');

--- a/scripts/utils/postprocess-files.cjs
+++ b/scripts/utils/postprocess-files.cjs
@@ -18,7 +18,7 @@ async function postprocess() {
   for await (const file of walk(distDir)) {
     if (!/(\.d)?[cm]?ts$/.test(file)) continue;
 
-    const code = await fs.promises.readFile(file, 'utf8');
+    const code = await fs.promises.readFile(file, 'utf-8');
 
     // strip out lib="dom", types="node", and types="react" references; these
     // are needed at build time, but would pollute the user's TS environment
@@ -37,7 +37,7 @@ async function postprocess() {
 
     if (transformed !== code) {
       console.error(`wrote ${path.relative(process.cwd(), file)}`);
-      await fs.promises.writeFile(file, transformed, 'utf8');
+      await fs.promises.writeFile(file, transformed, 'utf-8');
     }
   }
 

--- a/src/auth/subject-token-providers.ts
+++ b/src/auth/subject-token-providers.ts
@@ -18,7 +18,7 @@ async function defaultReadFile(path: string): Promise<string> {
   });
 
   const { readFile } = await fsPromisesModule;
-  return readFile(path, 'utf8');
+  return readFile(path, 'utf-8');
 }
 
 export function k8sServiceAccountTokenProvider(

--- a/tests/auth/subject-token-providers.test.ts
+++ b/tests/auth/subject-token-providers.test.ts
@@ -25,7 +25,7 @@ describe('Kubernetes Service Account Token Provider', () => {
     const token = await provider.getToken();
 
     expect(token).toBe('my-k8s-token');
-    expect(fsPromises.readFile).toHaveBeenCalledWith('/custom/path/token', 'utf8');
+    expect(fsPromises.readFile).toHaveBeenCalledWith('/custom/path/token', 'utf-8');
   });
 
   test('uses default path when none provided', async () => {

--- a/tests/oxlint-config.test.ts
+++ b/tests/oxlint-config.test.ts
@@ -10,7 +10,7 @@ const oxfmt = path.join(repoRoot, 'node_modules/oxfmt/bin/oxfmt');
 test('inherits Ultracite native plugins and enforces their rules', () => {
   const printed = spawnSync(process.execPath, [oxlint, '--print-config', 'src/internal/uploads.ts'], {
     cwd: repoRoot,
-    encoding: 'utf8',
+    encoding: 'utf-8',
   });
 
   expect(printed.status).toBe(0);
@@ -36,7 +36,7 @@ test('inherits Ultracite native plugins and enforces their rules', () => {
     const linted = spawnSync(
       process.execPath,
       [oxlint, '--config', path.join(repoRoot, 'oxlint.config.ts'), '--format', 'json', fixturePath],
-      { cwd: repoRoot, encoding: 'utf8' },
+      { cwd: repoRoot, encoding: 'utf-8' },
     );
 
     expect(linted.status).toBe(1);
@@ -47,7 +47,7 @@ test('inherits Ultracite native plugins and enforces their rules', () => {
     const formatted = spawnSync(
       process.execPath,
       [oxfmt, '--config', path.join(repoRoot, 'oxfmt.config.ts'), '--check', fixturePath],
-      { cwd: repoRoot, encoding: 'utf8' },
+      { cwd: repoRoot, encoding: 'utf-8' },
     );
 
     expect(formatted.status).toBe(0);
@@ -92,7 +92,7 @@ test('formats generated SDK files without linting them', () => {
 
   const formatted = spawnSync(process.execPath, [oxfmt, `--stdin-filepath=${generatedPath}`], {
     cwd: repoRoot,
-    encoding: 'utf8',
+    encoding: 'utf-8',
     input: unformatted,
   });
 
@@ -102,7 +102,7 @@ test('formats generated SDK files without linting them', () => {
   const linted = spawnSync(
     process.execPath,
     [oxlint, '--format', 'json', '--no-error-on-unmatched-pattern', generatedPath],
-    { cwd: repoRoot, encoding: 'utf8' },
+    { cwd: repoRoot, encoding: 'utf-8' },
   );
 
   expect(linted.status).toBe(0);
@@ -143,18 +143,18 @@ test('removes adjacent unused imports from generated files until fixes stabilize
       const fixed = spawnSync(
         process.execPath,
         [path.join(repoRoot, 'scripts/lint-generated.cjs'), '--fix', generatedPath, handwrittenPath],
-        { cwd: repoRoot, encoding: 'utf8' },
+        { cwd: repoRoot, encoding: 'utf-8' },
       );
 
       expect(fixed.status).toBe(0);
 
-      const result = readFileSync(generatedPath, 'utf8');
+      const result = readFileSync(generatedPath, 'utf-8');
       expect(result).not.toMatch(/\bUnused(?:\d+|Named)\b/u);
       expect(result).toContain("import { Retained } from './dependency';");
       expect(result).toContain("import './side-effect';");
       expect(result).toContain('const intentionallyUnused = 1;');
       expect(result).toContain('export interface Result<T>');
-      expect(readFileSync(handwrittenPath, 'utf8')).toBe(handwritten);
+      expect(readFileSync(handwrittenPath, 'utf-8')).toBe(handwritten);
     }
   } finally {
     rmSync(fixtureRoot, { recursive: true, force: true });
@@ -178,12 +178,12 @@ test('limits generated import cleanup to paths supplied through a fast-format fi
     const fixed = spawnSync(
       process.execPath,
       [path.join(repoRoot, 'scripts/lint-generated.cjs'), '--fix', '--file-list', fileList],
-      { cwd: repoRoot, encoding: 'utf8' },
+      { cwd: repoRoot, encoding: 'utf-8' },
     );
 
     expect(fixed.status).toBe(0);
-    expect(readFileSync(selectedPath, 'utf8')).not.toContain('Unused');
-    expect(readFileSync(untouchedPath, 'utf8')).toBe(source);
+    expect(readFileSync(selectedPath, 'utf-8')).not.toContain('Unused');
+    expect(readFileSync(untouchedPath, 'utf-8')).toBe(source);
   } finally {
     rmSync(fixtureRoot, { recursive: true, force: true });
   }
@@ -206,28 +206,28 @@ test('checks unused generated imports without rejecting intentionally unused var
     const checked = spawnSync(
       process.execPath,
       [path.join(repoRoot, 'scripts/lint-generated.cjs'), '--check', generatedPath],
-      { cwd: repoRoot, encoding: 'utf8' },
+      { cwd: repoRoot, encoding: 'utf-8' },
     );
 
     expect(checked.status).toBe(1);
     expect(checked.stderr).toContain("Identifier 'Unused' is imported but never used.");
     expect(checked.stderr).not.toContain('intentionallyUnused');
     expect(checked.stderr).not.toContain("Variable 'T'");
-    expect(readFileSync(generatedPath, 'utf8')).toBe(source);
+    expect(readFileSync(generatedPath, 'utf-8')).toBe(source);
 
     const fixed = spawnSync(
       process.execPath,
       [path.join(repoRoot, 'scripts/lint-generated.cjs'), '--fix', generatedPath],
-      { cwd: repoRoot, encoding: 'utf8' },
+      { cwd: repoRoot, encoding: 'utf-8' },
     );
 
     expect(fixed.status).toBe(0);
-    expect(readFileSync(generatedPath, 'utf8')).toContain('const intentionallyUnused = 1;');
+    expect(readFileSync(generatedPath, 'utf-8')).toContain('const intentionallyUnused = 1;');
 
     const rechecked = spawnSync(
       process.execPath,
       [path.join(repoRoot, 'scripts/lint-generated.cjs'), '--check', generatedPath],
-      { cwd: repoRoot, encoding: 'utf8' },
+      { cwd: repoRoot, encoding: 'utf-8' },
     );
 
     expect(rechecked.status).toBe(0);
@@ -252,31 +252,31 @@ test('rejects SDK package imports in generated source but allows them in generat
     const checkedSource = spawnSync(
       process.execPath,
       [path.join(repoRoot, 'scripts/lint-generated.cjs'), '--check', sourcePath],
-      { cwd: repoRoot, encoding: 'utf8' },
+      { cwd: repoRoot, encoding: 'utf-8' },
     );
 
     expect(checkedSource.status).toBe(1);
     expect(checkedSource.stderr).toContain('Use a relative import, not a package import.');
-    expect(readFileSync(sourcePath, 'utf8')).toBe(source);
+    expect(readFileSync(sourcePath, 'utf-8')).toBe(source);
 
     const fixedSource = spawnSync(
       process.execPath,
       [path.join(repoRoot, 'scripts/lint-generated.cjs'), '--fix', sourcePath],
-      { cwd: repoRoot, encoding: 'utf8' },
+      { cwd: repoRoot, encoding: 'utf-8' },
     );
 
     expect(fixedSource.status).toBe(1);
-    expect(readFileSync(sourcePath, 'utf8')).toBe(source);
+    expect(readFileSync(sourcePath, 'utf-8')).toBe(source);
 
     for (const mode of ['--check', '--fix']) {
       const generatedTest = spawnSync(
         process.execPath,
         [path.join(repoRoot, 'scripts/lint-generated.cjs'), mode, testPath],
-        { cwd: repoRoot, encoding: 'utf8' },
+        { cwd: repoRoot, encoding: 'utf-8' },
       );
 
       expect(generatedTest.status).toBe(0);
-      expect(readFileSync(testPath, 'utf8')).toBe(source);
+      expect(readFileSync(testPath, 'utf-8')).toBe(source);
     }
   } finally {
     rmSync(sourceRoot, { recursive: true, force: true });
@@ -299,19 +299,19 @@ test('checks and fixes generated imports through the public package commands', (
       ].join('\n'),
     );
 
-    const rejected = spawnSync('pnpm', ['lint'], { cwd: repoRoot, encoding: 'utf8' });
+    const rejected = spawnSync('pnpm', ['lint'], { cwd: repoRoot, encoding: 'utf-8' });
 
     expect(rejected.status).toBe(1);
     expect(`${rejected.stdout}${rejected.stderr}`).toContain(
       "Identifier 'Unused' is imported but never used.",
     );
 
-    const fixed = spawnSync('pnpm', ['format'], { cwd: repoRoot, encoding: 'utf8' });
+    const fixed = spawnSync('pnpm', ['format'], { cwd: repoRoot, encoding: 'utf-8' });
 
     expect(fixed.status).toBe(0);
-    expect(readFileSync(generatedPath, 'utf8')).not.toContain('Unused');
+    expect(readFileSync(generatedPath, 'utf-8')).not.toContain('Unused');
 
-    const accepted = spawnSync('pnpm', ['lint'], { cwd: repoRoot, encoding: 'utf8' });
+    const accepted = spawnSync('pnpm', ['lint'], { cwd: repoRoot, encoding: 'utf-8' });
 
     expect(accepted.status).toBe(0);
   } finally {

--- a/tests/test-script.test.ts
+++ b/tests/test-script.test.ts
@@ -21,7 +21,7 @@ const generatedTestPatternsPath = path.join(process.cwd(), 'scripts/generated-te
 const generatedTopLevelTests = readdirSync(path.join(process.cwd(), 'tests')).filter(
   (file) =>
     file.endsWith('.test.ts') &&
-    readFileSync(path.join(process.cwd(), 'tests', file), 'utf8').startsWith(
+    readFileSync(path.join(process.cwd(), 'tests', file), 'utf-8').startsWith(
       '// File generated from our OpenAPI spec by Stainless.',
     ),
 );
@@ -73,7 +73,7 @@ printf '%s\\0' "$@" > "$VITEST_ARGS_FILE"
     const jestArgsFile = path.join(fixtureDir, 'jest-args');
     const vitestArgsFile = path.join(fixtureDir, 'vitest-args');
     const result = spawnSync(path.join(fixtureDir, 'scripts/test'), args, {
-      encoding: 'utf8',
+      encoding: 'utf-8',
       env: {
         ...process.env,
         JEST_ARGS_FILE: jestArgsFile,
@@ -90,7 +90,7 @@ printf '%s\\0' "$@" > "$VITEST_ARGS_FILE"
     }
 
     const readArgs = (path: string) =>
-      existsSync(path) ? readFileSync(path, 'utf8').split('\0').slice(0, -1) : [];
+      existsSync(path) ? readFileSync(path, 'utf-8').split('\0').slice(0, -1) : [];
 
     return { jestArgs: readArgs(jestArgsFile), vitestArgs: readArgs(vitestArgsFile) };
   }


### PR DESCRIPTION
## Summary

- Removes `unicorn/text-encoding-identifier-case` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 152 of 185.
- Base: `dev/hayden/ultracite-151-unicorn-filename-case`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`