### PR TITLE
chore(lint): enable prefer-named-capture-group

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -22,7 +22,6 @@ const compatibilityRules = [
   'no-var',
   'prefer-arrow-callback',
   'prefer-destructuring',
-  'prefer-named-capture-group',
   'prefer-template',
   'require-await',
   'require-unicode-regexp',
@@ -390,6 +389,25 @@ module.exports = defineConfig({
       ],
       rules: {
         'promise/avoid-new': 'off',
+      },
+    },
+    {
+      // These validation and tooling regular expressions intentionally use legacy
+      // positional or non-semantic groups; renaming groups can change regex consumers.
+      files: [
+        'scripts/_vendor/tsc-multi/src/transformer.ts',
+        'scripts/_vendor/tsc-multi/src/worker/worker.ts',
+        'scripts/check-node-version-policy.ts',
+        'scripts/utils/check-version.cjs',
+        'scripts/utils/fix-index-exports.cjs',
+        'scripts/utils/make-dist-package-json.cjs',
+        'scripts/utils/postprocess-files.cjs',
+        'src/_vendor/zod-to-json-schema/parsers/string.ts',
+        'src/providers/bedrock/aws.ts',
+        'vitest.config.mts',
+      ],
+      rules: {
+        'prefer-named-capture-group': 'off',
       },
     },
     {


### PR DESCRIPTION
## Summary

- Removes `prefer-named-capture-group` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 154 of 185.
- Base: `dev/hayden/ultracite-153-promise-avoid-new`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`