### PR TITLE
chore(lint): enable no-bitwise

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -13,7 +13,6 @@ const compatibilityRules = [
   'import/consistent-type-specifier-style',
   'import/no-cycle',
   'no-await-in-loop',
-  'no-bitwise',
   'no-eq-null',
   'no-inline-comments',
   'no-plusplus',
@@ -475,6 +474,18 @@ module.exports = defineConfig({
       ],
       rules: {
         'typescript/method-signature-style': 'off',
+      },
+    },
+    {
+      // These parser, encoding, and benchmark paths intentionally use bit masks
+      // and shifts; arithmetic rewrites would change low-level behavior.
+      files: [
+        'src/_vendor/partial-json-parser/parser.ts',
+        'src/internal/qs/utils.ts',
+        'tests/benchmarks/streaming.bench.ts',
+      ],
+      rules: {
+        'no-bitwise': 'off',
       },
     },
     {


### PR DESCRIPTION
## Summary

- Removes `no-bitwise` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 157 of 185.
- Base: `dev/hayden/ultracite-156-typescript-method-signature-style`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`