### PR TITLE
chore(lint): enable typescript/array-type

### DIFF
--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -143,7 +143,7 @@ const projectRunners = {
   },
 };
 
-let projectNames = Object.keys(projectRunners) as Array<keyof typeof projectRunners>;
+let projectNames = Object.keys(projectRunners) as (keyof typeof projectRunners)[];
 const projectNamesSet = new Set(projectNames);
 
 async function startProxy() {
@@ -678,7 +678,7 @@ export const packageDir = async (): Promise<string> => {
 // so that they can be restored when the script either finishes or is
 // terminated
 const fileCache = (() => {
-  const filesToCache: Array<string> = ['package.json', 'package-lock.json', 'deno.lock', 'bun.lockb'];
+  const filesToCache: string[] = ['package.json', 'package-lock.json', 'deno.lock', 'bun.lockb'];
   const generatedFilesToRemove = new Set(['deno/package.json']);
 
   return {

--- a/examples/chat-completions/ui-generation.ts
+++ b/examples/chat-completions/ui-generation.ts
@@ -9,7 +9,7 @@ const openai = new OpenAI();
 interface UI {
   type: 'div' | 'button' | 'header' | 'section' | 'field' | 'form';
   label: string;
-  children: Array<UI>;
+  children: UI[];
   attributes: {
     value: string;
     name: string;

--- a/examples/responses/websocket.ts
+++ b/examples/responses/websocket.ts
@@ -40,7 +40,7 @@ type SupplierShipment = {
 
 type SupplierETAOutput = {
   sku: string;
-  supplier_shipments: Array<SupplierShipment>;
+  supplier_shipments: SupplierShipment[];
 };
 
 type QualityAlert = {
@@ -52,7 +52,7 @@ type QualityAlert = {
 
 type QualityAlertsOutput = {
   sku: string;
-  alerts: Array<QualityAlert>;
+  alerts: QualityAlert[];
 };
 
 type ToolOutput = SKUInventoryOutput | SupplierETAOutput | QualityAlertsOutput;
@@ -66,7 +66,7 @@ type FunctionCallRequest = {
 type RunResponseResult = {
   text: string;
   responseID: string;
-  functionCalls: Array<FunctionCallRequest>;
+  functionCalls: FunctionCallRequest[];
 };
 
 type RunTurnResult = {
@@ -91,7 +91,7 @@ type CLIArgs = {
 
 const BETA_HEADER_VALUE = 'responses_websockets=2026-02-06';
 
-const TOOLS: Array<FunctionTool> = [
+const TOOLS: FunctionTool[] = [
   {
     type: 'function',
     name: 'get_sku_inventory',
@@ -145,7 +145,7 @@ const TOOLS: Array<FunctionTool> = [
   },
 ];
 
-const DEMO_TURNS: Array<DemoTurn> = [
+const DEMO_TURNS: DemoTurn[] = [
   {
     tool_name: 'get_sku_inventory',
     prompt:
@@ -162,7 +162,7 @@ const DEMO_TURNS: Array<DemoTurn> = [
   },
 ];
 
-const parseArgs = (argv: Array<string>): CLIArgs => {
+const parseArgs = (argv: string[]): CLIArgs => {
   let model = 'gpt-5.2';
   let useBetaHeader = false;
   let showEvents = false;
@@ -342,8 +342,8 @@ const runResponse = async ({
   showEvents: boolean;
 }): Promise<RunResponseResult> =>
   await new Promise<RunResponseResult>((resolve, reject) => {
-    const textParts: Array<string> = [];
-    const functionCalls: Array<FunctionCallRequest> = [];
+    const textParts: string[] = [];
+    const functionCalls: FunctionCallRequest[] = [];
 
     const finish = (responseID: string): void => {
       cleanup();
@@ -436,7 +436,7 @@ const runTurn = async ({
   showEvents: boolean;
   showToolIO: boolean;
 }): Promise<RunTurnResult> => {
-  const accumulatedTextParts: Array<string> = [];
+  const accumulatedTextParts: string[] = [];
 
   let currentInput: string | ResponseInput = turnPrompt;
   let currentToolChoice: ToolChoice = { type: 'function', name: forcedToolName };

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -25,7 +25,6 @@ const compatibilityRules = [
   'require-await',
   'require-unicode-regexp',
   'sort-keys',
-  'typescript/array-type',
   'typescript/ban-ts-comment',
   'typescript/consistent-type-definitions',
   'typescript/consistent-type-imports',

--- a/src/core/EventEmitter.ts
+++ b/src/core/EventEmitter.ts
@@ -1,9 +1,9 @@
 type EventListener<Events, EventType extends keyof Events> = Events[EventType];
 
-type EventListeners<Events, EventType extends keyof Events> = Array<{
+type EventListeners<Events, EventType extends keyof Events> = {
   listener: EventListener<Events, EventType>;
   once?: boolean;
-}>;
+}[];
 
 export type EventParameters<Events, EventType extends keyof Events> = Record<
   EventType,

--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -184,11 +184,11 @@ export class Stream<Item> implements AsyncIterable<Item> {
    * independently read from at different speeds.
    */
   tee(): [Stream<Item>, Stream<Item>] {
-    const left: Array<Promise<IteratorResult<Item>>> = [];
-    const right: Array<Promise<IteratorResult<Item>>> = [];
+    const left: Promise<IteratorResult<Item>>[] = [];
+    const right: Promise<IteratorResult<Item>>[] = [];
     const iterator = this.iterator();
 
-    const teeIterator = (queue: Array<Promise<IteratorResult<Item>>>): AsyncIterator<Item> => ({
+    const teeIterator = (queue: Promise<IteratorResult<Item>>[]): AsyncIterator<Item> => ({
       next: () => {
         if (queue.length === 0) {
           const result = iterator.next();

--- a/src/helpers/standard-schema.ts
+++ b/src/helpers/standard-schema.ts
@@ -23,7 +23,7 @@ import type { ResponseFormatTextJSONSchemaConfig } from '../resources/responses/
 
 type StandardSchemaIssue = {
   readonly message: string;
-  readonly path?: ReadonlyArray<PropertyKey | { readonly key: PropertyKey }> | undefined;
+  readonly path?: readonly (PropertyKey | { readonly key: PropertyKey })[] | undefined;
 };
 
 type StandardSchemaResult<Output> =
@@ -32,7 +32,7 @@ type StandardSchemaResult<Output> =
       readonly issues?: undefined;
     }
   | {
-      readonly issues: ReadonlyArray<StandardSchemaIssue>;
+      readonly issues: readonly StandardSchemaIssue[];
     };
 
 type StandardJSONSchemaOptions = {
@@ -116,7 +116,7 @@ function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
   return typeof value === 'object' && value !== null && 'then' in value && typeof value.then === 'function';
 }
 
-function formatStandardSchemaIssues(issues: ReadonlyArray<StandardSchemaIssue>): string {
+function formatStandardSchemaIssues(issues: readonly StandardSchemaIssue[]): string {
   return issues
     .map((issue) => {
       const path = issue.path

--- a/src/internal/qs/types.ts
+++ b/src/internal/qs/types.ts
@@ -19,7 +19,7 @@ export type StringifyBaseOptions = {
     type: 'key' | 'value',
     format?: Format,
   ) => string;
-  filter?: Array<PropertyKey> | ((prefix: PropertyKey, value: any) => any);
+  filter?: PropertyKey[] | ((prefix: PropertyKey, value: any) => any);
   arrayFormat?: 'indices' | 'brackets' | 'repeat' | 'comma';
   indices?: boolean;
   sort?: ((a: PropertyKey, b: PropertyKey) => number) | null;

--- a/src/internal/qs/utils.ts
+++ b/src/internal/qs/utils.ts
@@ -20,7 +20,7 @@ const hex_table = /* @__PURE__ */ (() => {
   return array;
 })();
 
-function compact_queue<T extends Record<string, any>>(queue: Array<{ obj: T; prop: string }>) {
+function compact_queue<T extends Record<string, any>>(queue: { obj: T; prop: string }[]) {
   while (queue.length > 1) {
     const item = queue.pop();
     if (!item) continue;

--- a/src/internal/to-file.ts
+++ b/src/internal/to-file.ts
@@ -118,8 +118,8 @@ export async function toFile(
   return makeFile(parts, name, options);
 }
 
-async function getBytes(value: BlobLikePart | AsyncIterable<BlobLikePart>): Promise<Array<BlobPart>> {
-  const parts: Array<BlobPart> = [];
+async function getBytes(value: BlobLikePart | AsyncIterable<BlobLikePart>): Promise<BlobPart[]> {
+  const parts: BlobPart[] = [];
   if (
     typeof value === 'string' ||
     ArrayBuffer.isView(value) || // includes Uint8Array, Buffer, etc.

--- a/src/lib/ChatCompletionStream.ts
+++ b/src/lib/ChatCompletionStream.ts
@@ -79,21 +79,21 @@ export interface FunctionToolCallArgumentsDoneEvent {
 }
 
 export interface LogProbsContentDeltaEvent {
-  content: Array<ChatCompletionTokenLogprob>;
-  snapshot: Array<ChatCompletionTokenLogprob>;
+  content: ChatCompletionTokenLogprob[];
+  snapshot: ChatCompletionTokenLogprob[];
 }
 
 export interface LogProbsContentDoneEvent {
-  content: Array<ChatCompletionTokenLogprob>;
+  content: ChatCompletionTokenLogprob[];
 }
 
 export interface LogProbsRefusalDeltaEvent {
-  refusal: Array<ChatCompletionTokenLogprob>;
-  snapshot: Array<ChatCompletionTokenLogprob>;
+  refusal: ChatCompletionTokenLogprob[];
+  snapshot: ChatCompletionTokenLogprob[];
 }
 
 export interface LogProbsRefusalDoneEvent {
-  refusal: Array<ChatCompletionTokenLogprob>;
+  refusal: ChatCompletionTokenLogprob[];
 }
 
 export interface ChatCompletionStreamEvents<ParsedT = null> extends AbstractChatCompletionRunnerEvents {
@@ -866,7 +866,7 @@ export interface ChatCompletionSnapshot {
    * A list of chat completion choices. Can be more than one if `n` is greater
    * than 1.
    */
-  choices: Array<ChatCompletionSnapshot.Choice>;
+  choices: ChatCompletionSnapshot.Choice[];
 
   /**
    * The Unix timestamp (in seconds) of when the chat completion was created.
@@ -940,7 +940,7 @@ export namespace ChatCompletionSnapshot {
        */
       function_call?: Message.FunctionCall;
 
-      tool_calls?: Array<Message.ToolCall>;
+      tool_calls?: Message.ToolCall[];
 
       /**
        * The role of the author of this message.

--- a/src/lib/EventEmitter.ts
+++ b/src/lib/EventEmitter.ts
@@ -1,9 +1,9 @@
 type EventListener<Events, EventType extends keyof Events> = Events[EventType];
 
-type EventListeners<Events, EventType extends keyof Events> = Array<{
+type EventListeners<Events, EventType extends keyof Events> = {
   listener: EventListener<Events, EventType>;
   once?: boolean;
-}>;
+}[];
 
 export type EventParameters<Events, EventType extends keyof Events> = Record<
   EventType,

--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -16,7 +16,7 @@ export class EventStream<EventTypes extends BaseEvents> {
   #listeners: {
     [Event in keyof EventTypes]?: EventListeners<EventTypes, Event>;
   } = {};
-  #abortListeners: Array<{ signal: AbortSignal; listener: () => void }> = [];
+  #abortListeners: { signal: AbortSignal; listener: () => void }[] = [];
 
   #ended = false;
   #errored = false;
@@ -367,10 +367,10 @@ export class EventStream<EventTypes extends BaseEvents> {
 
 type EventListener<Events, EventType extends keyof Events> = Events[EventType];
 
-type EventListeners<Events, EventType extends keyof Events> = Array<{
+type EventListeners<Events, EventType extends keyof Events> = {
   listener: EventListener<Events, EventType>;
   once?: boolean;
-}>;
+}[];
 
 export type EventParameters<Events, EventType extends keyof Events> = Record<
   EventType,

--- a/src/lib/ResponsesParser.ts
+++ b/src/lib/ResponsesParser.ts
@@ -15,7 +15,7 @@ import {
 } from '../resources/responses/responses';
 import { type AutoParseableTextFormat, isAutoParsableResponseFormat } from '../lib/parser';
 
-export type ParseableToolsParams = Array<Tool> | ChatCompletionTool | null;
+export type ParseableToolsParams = Tool[] | ChatCompletionTool | null;
 
 export type ResponseCreateParamsWithTools = ResponseCreateParamsBase & {
   tools?: ParseableToolsParams;
@@ -70,13 +70,13 @@ export function parseResponse<
   ParsedT = ExtractParsedContentFromParams<Params>,
 >(response: Response, params: Params): ParsedResponse<ParsedT> {
   const shouldParse = !response.status || response.status === 'completed';
-  const output: Array<ParsedResponseOutputItem<ParsedT>> = response.output.map(
+  const output: ParsedResponseOutputItem<ParsedT>[] = response.output.map(
     (item): ParsedResponseOutputItem<ParsedT> => {
       if (item.type === 'function_call') {
         return shouldParse ? parseToolCall(params, item) : { ...item, parsed_arguments: null };
       }
       if (item.type === 'message') {
-        const content: Array<ParsedContent<ParsedT>> = item.content.map((content) => {
+        const content: ParsedContent<ParsedT>[] = item.content.map((content) => {
           if (content.type === 'output_text') {
             return {
               ...content,
@@ -205,7 +205,7 @@ export function isAutoParsableTool(tool: any): tool is AutoParseableResponseTool
   return tool?.['$brand'] === 'auto-parseable-tool';
 }
 
-function getInputToolByName(input_tools: Array<Tool>, name: string): FunctionTool | undefined {
+function getInputToolByName(input_tools: Tool[], name: string): FunctionTool | undefined {
   return input_tools.find((tool) => tool.type === 'function' && tool.name === name) as
     | FunctionTool
     | undefined;

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -183,7 +183,7 @@ export function parseChatCompletion<
   Params extends ChatCompletionCreateParams,
   ParsedT = ExtractParsedContentFromParams<Params>,
 >(completion: ChatCompletion, params: Params): ParsedChatCompletion<ParsedT> {
-  const choices: Array<ParsedChoice<ParsedT>> = completion.choices.map((choice): ParsedChoice<ParsedT> => {
+  const choices: ParsedChoice<ParsedT>[] = completion.choices.map((choice): ParsedChoice<ParsedT> => {
     if (choice.finish_reason === 'length') {
       throw new LengthFinishReasonError();
     }

--- a/src/lib/responses/ResponseAccumulator.ts
+++ b/src/lib/responses/ResponseAccumulator.ts
@@ -404,7 +404,7 @@ function getOutput(snapshot: Response, outputIndex: number): Response['output'][
   return output;
 }
 
-function getContent<T>(content: Array<T>, contentIndex: number): T {
+function getContent<T>(content: T[], contentIndex: number): T {
   const part = content[contentIndex];
   if (!part) {
     throw new OpenAIError(`missing content at index ${contentIndex}`);

--- a/src/lib/transform.ts
+++ b/src/lib/transform.ts
@@ -918,7 +918,7 @@ export function resolveLocalRef(root: JSONSchema, ref: string): JSONSchemaDefini
   return isSchemaDefinition(resolved) ? resolved : undefined;
 }
 
-function isObject<T>(obj: T | Array<any>): obj is Extract<T, Record<string, any>> {
+function isObject<T>(obj: T | any[]): obj is Extract<T, Record<string, any>> {
   return typeof obj === 'object' && obj !== null && !Array.isArray(obj);
 }
 
@@ -1751,7 +1751,7 @@ function mergeObjectAllOf(
     }
   }
 
-  const branches: Array<{ schema: JSONSchema; sourcePath: string[] | undefined }> = [];
+  const branches: { schema: JSONSchema; sourcePath: string[] | undefined }[] = [];
   if (parentHasObjectShape) {
     branches.push({ schema: jsonSchema, sourcePath: path });
   }
@@ -1795,11 +1795,11 @@ function mergeObjectAllOf(
   const mergedProperties = Object.create(null) as Record<string, JSONSchemaDefinition>;
   const mergedRequired = new Set<string>();
   const closedPropertySets: Set<string>[] = [];
-  const propertyEntries: Array<{
+  const propertyEntries: {
     key: string;
     propertySchema: JSONSchemaDefinition;
     sourcePath: string[] | undefined;
-  }> = [];
+  }[] = [];
   let sawProperties = false;
   let sawRequired = false;
   let hasExplicitObjectType = false;

--- a/tests/benchmarks/streaming.bench.ts
+++ b/tests/benchmarks/streaming.bench.ts
@@ -21,7 +21,7 @@ type BenchmarkPayload = {
 type BenchmarkFixture = {
   label: string;
   chunks: Uint8Array[];
-  expected: Array<{ data: string; payload: BenchmarkPayload }>;
+  expected: { data: string; payload: BenchmarkPayload }[];
 };
 
 const BENCHMARK_OPTIONS = {

--- a/tests/lib/ResponseInputItems.test.ts
+++ b/tests/lib/ResponseInputItems.test.ts
@@ -3,7 +3,7 @@ import type { ResponseInputItem, ResponseOutputItem } from 'openai/resources/res
 
 describe('toResponseInputItems', () => {
   test('normalizes mixed response history items', () => {
-    const history: Array<ResponseInputItem | ResponseOutputItem> = [
+    const history: (ResponseInputItem | ResponseOutputItem)[] = [
       {
         type: 'function_call_output',
         call_id: 'function_call_123',

--- a/tests/lib/transform-branches.test.ts
+++ b/tests/lib/transform-branches.test.ts
@@ -11,7 +11,7 @@ import {
 
 describe('JSON Schema child traversal', () => {
   test('visits schema-valued keywords without descending into literal payloads', () => {
-    const visited: Array<{ path: string; keyword: string; value: unknown }> = [];
+    const visited: { path: string; keyword: string; value: unknown }[] = [];
     const schema = {
       type: 'object',
       additionalProperties: false,

--- a/tests/responses.test.ts
+++ b/tests/responses.test.ts
@@ -15,7 +15,7 @@ describe('request id', () => {
     compareType<Awaited<APIPromise<{ foo: string }>>, { foo: string } & { _request_id?: string | null }>(
       true,
     );
-    compareType<Awaited<APIPromise<Array<{ foo: string }>>>, Array<{ foo: string }>>(true);
+    compareType<Awaited<APIPromise<{ foo: string }[]>>, { foo: string }[]>(true);
   });
 
   test('withResponse', async () => {
@@ -89,7 +89,7 @@ describe('request id', () => {
   });
 
   test('array response', async () => {
-    const promise = new APIPromise<Array<{ foo: string }>>(
+    const promise = new APIPromise<{ foo: string }[]>(
       client,
       Promise.resolve({
         response: new Response(JSON.stringify([{ foo: 'bar' }]), {

--- a/tests/responsesItems.test.ts
+++ b/tests/responsesItems.test.ts
@@ -25,7 +25,7 @@ const unused = async () => {
     input: 'You are a helpful assistant.',
   });
 
-  const history: Array<ResponseInputItem | ResponseOutputItem> = [
+  const history: (ResponseInputItem | ResponseOutputItem)[] = [
     {
       type: 'function_call_output',
       call_id: 'call_123',

--- a/tests/responsesTools.test.ts
+++ b/tests/responsesTools.test.ts
@@ -109,7 +109,7 @@ type _AutoParseableToolRemainsFunctionTool = Assert<
 type _ParseableToolsStillAcceptNull = Assert<IsAssignable<null, ParseableToolsParams>>;
 type _ParseableToolsStillAcceptChatTools = Assert<IsAssignable<ChatCompletionTool, ParseableToolsParams>>;
 type _ResponseCreateParamsWithToolsStillAcceptSharedTools = Assert<
-  IsAssignable<{ tools?: Array<Tool> }, Pick<ResponseCreateParamsWithTools, 'tools'>>
+  IsAssignable<{ tools?: Tool[] }, Pick<ResponseCreateParamsWithTools, 'tools'>>
 >;
 
 test('response tools and parser helpers stay backwards compatible', () => {


### PR DESCRIPTION
## Summary

- Removes `typescript/array-type` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 158 of 185.
- Base: `dev/hayden/ultracite-157-no-bitwise`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`