### PR TITLE
chore(lint): enable unicorn/prefer-node-protocol

### DIFF
--- a/ecosystem-tests/bun/openai.test.ts
+++ b/ecosystem-tests/bun/openai.test.ts
@@ -1,5 +1,5 @@
 import OpenAI, { toFile } from 'openai';
-import fs from 'fs';
+import fs from 'node:fs';
 import { distance } from 'fastest-levenshtein';
 import { test, expect } from 'bun:test';
 import { ChatCompletion } from 'openai/resources/chat/completions';

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -1,10 +1,10 @@
-import fs from 'fs/promises';
+import fs from 'node:fs/promises';
 import execa from 'execa';
 import yargs from 'yargs';
-import assert from 'assert';
-import path from 'path';
-import { createServer } from 'http';
-import { connect } from 'net';
+import assert from 'node:assert';
+import path from 'node:path';
+import { createServer } from 'node:http';
+import { connect } from 'node:net';
 
 const TAR_NAME = 'openai.tgz';
 const PACK_FOLDER = '.pack';

--- a/ecosystem-tests/node-ts-cjs-auto/tests/test.ts
+++ b/ecosystem-tests/node-ts-cjs-auto/tests/test.ts
@@ -1,7 +1,7 @@
 import OpenAI, { APIUserAbortError, toFile } from 'openai';
 import { TranscriptionCreateParams } from 'openai/resources/audio/transcriptions';
 import { File as FormDataFile, Blob as FormDataBlob } from 'formdata-node';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { distance } from 'fastest-levenshtein';
 
 const url = 'https://audio-samples.github.io/samples/mp3/blizzard_biased/sample-1.mp3';

--- a/ecosystem-tests/node-ts-cjs/tests/test-node.ts
+++ b/ecosystem-tests/node-ts-cjs/tests/test-node.ts
@@ -2,7 +2,7 @@ import OpenAI, { toFile } from 'openai';
 import { TranscriptionCreateParams } from 'openai/resources/audio/transcriptions';
 import * as undici from 'undici';
 import { File as FormDataFile, Blob as FormDataBlob } from 'formdata-node';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { distance } from 'fastest-levenshtein';
 import { ChatCompletion } from 'openai/resources/chat/completions';
 

--- a/ecosystem-tests/node-ts-esm-auto/tests/test.ts
+++ b/ecosystem-tests/node-ts-esm-auto/tests/test.ts
@@ -1,7 +1,7 @@
 import OpenAI, { toFile } from 'openai';
 import { TranscriptionCreateParams } from 'openai/resources/audio/transcriptions';
 import { File as FormDataFile, Blob as FormDataBlob } from 'formdata-node';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { distance } from 'fastest-levenshtein';
 import { ChatCompletion } from 'openai/resources/chat/completions';
 

--- a/ecosystem-tests/node-ts-esm/tests/test.ts
+++ b/ecosystem-tests/node-ts-esm/tests/test.ts
@@ -1,7 +1,7 @@
 import OpenAI, { toFile } from 'openai';
 import { TranscriptionCreateParams } from 'openai/resources/audio/transcriptions';
 import { File as FormDataFile, Blob as FormDataBlob } from 'formdata-node';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { distance } from 'fastest-levenshtein';
 
 const url = 'https://audio-samples.github.io/samples/mp3/blizzard_biased/sample-1.mp3';

--- a/ecosystem-tests/node-ts4.5-jest28/tests/test.ts
+++ b/ecosystem-tests/node-ts4.5-jest28/tests/test.ts
@@ -1,7 +1,7 @@
 import OpenAI, { toFile } from 'openai';
 import { TranscriptionCreateParams } from 'openai/resources/audio/transcriptions';
 import { File as FormDataFile, Blob as FormDataBlob } from 'formdata-node';
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 import { distance } from 'fastest-levenshtein';
 import { ChatCompletion } from 'openai/resources/chat/completions';
 

--- a/ecosystem-tests/proxy.ts
+++ b/ecosystem-tests/proxy.ts
@@ -1,5 +1,5 @@
-import { createServer } from 'http';
-import { connect } from 'net';
+import { createServer } from 'node:http';
+import { connect } from 'node:net';
 
 async function startProxy() {
   const proxy = createServer((_req, res) => {

--- a/ecosystem-tests/ts-browser-webpack/webpack.config.js
+++ b/ecosystem-tests/ts-browser-webpack/webpack.config.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const publicPath = path.resolve(__dirname, 'public');

--- a/examples/audio/audio.ts
+++ b/examples/audio/audio.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S npm run tsn -- -T
 
 import OpenAI, { toFile } from 'openai';
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 // gets API Key from environment variable OPENAI_API_KEY
 const openai = new OpenAI();

--- a/examples/chat-completions/function-call-stream-raw.ts
+++ b/examples/chat-completions/function-call-stream-raw.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S npm run tsn -- -T
 
-import { formatWithOptions } from 'util';
+import { formatWithOptions } from 'node:util';
 import OpenAI from 'openai';
 import {
   ChatCompletionMessage,

--- a/examples/chat-completions/function-call-stream.ts
+++ b/examples/chat-completions/function-call-stream.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S npm run tsn -- -T
 
-import { formatWithOptions } from 'util';
+import { formatWithOptions } from 'node:util';
 import OpenAI from 'openai';
 import {
   ChatCompletionMessage,

--- a/examples/chat-completions/tool-calls-stream.ts
+++ b/examples/chat-completions/tool-calls-stream.ts
@@ -19,7 +19,7 @@
 //
 //
 
-import { formatWithOptions } from 'util';
+import { formatWithOptions } from 'node:util';
 import OpenAI from 'openai';
 import {
   ChatCompletionMessage,

--- a/examples/fine-tuning/fine-tuning.ts
+++ b/examples/fine-tuning/fine-tuning.ts
@@ -7,7 +7,7 @@
  * - https://platform.openai.com/docs/guides/fine-tuning
  */
 
-import fs from 'fs';
+import fs from 'node:fs';
 import OpenAI from 'openai';
 import { FineTuningJobEvent } from 'openai/resources/fine-tuning';
 

--- a/examples/images/image-stream.ts
+++ b/examples/images/image-stream.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env -S npm run tsn -- -T
 
 import OpenAI from 'openai';
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const client = new OpenAI();
 

--- a/examples/images/picture.ts
+++ b/examples/images/picture.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S npm run tsn -- -T
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import OpenAI, { toFile } from 'openai';
 
 const openai = new OpenAI();

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -31,7 +31,6 @@ const compatibilityRules = [
   'typescript/no-explicit-any',
   'typescript/no-non-null-assertion',
   'unicorn/consistent-function-scoping',
-  'unicorn/prefer-node-protocol',
   'unicorn/prefer-response-static-json',
   'unicorn/switch-case-braces',
 ];

--- a/scripts/_vendor/tsc-multi/src/build.ts
+++ b/scripts/_vendor/tsc-multi/src/build.ts
@@ -1,8 +1,8 @@
-import { fork } from 'child_process';
-import path = require('path');
+import { fork } from 'node:child_process';
+import path = require('node:path');
 import { Config, Target } from './config';
 import { WorkerOptions } from './worker/types';
-import { Stream } from 'stream';
+import { Stream } from 'node:stream';
 import { trimPrefix } from './utils';
 import { getReportStyles } from './report';
 import onExit from 'signal-exit';

--- a/scripts/_vendor/tsc-multi/src/config.ts
+++ b/scripts/_vendor/tsc-multi/src/config.ts
@@ -1,4 +1,4 @@
-import nodePath = require('path');
+import nodePath = require('node:path');
 import { object, string, array, Infer, validate, optional, type, integer, min, boolean } from 'superstruct';
 import Debug from './debug';
 import { readJSON, tryReadJSON } from './utils';

--- a/scripts/_vendor/tsc-multi/src/debug.ts
+++ b/scripts/_vendor/tsc-multi/src/debug.ts
@@ -1,4 +1,4 @@
-import { debuglog } from 'util';
+import { debuglog } from 'node:util';
 
 type DebugLogger = ((formatter: string, ...args: unknown[]) => void) & {
   extend(name: string): DebugLogger;

--- a/scripts/_vendor/tsc-multi/src/report.ts
+++ b/scripts/_vendor/tsc-multi/src/report.ts
@@ -1,4 +1,4 @@
-import { Writable } from 'stream';
+import { Writable } from 'node:stream';
 import type ts from 'typescript';
 
 type Formatter = (input: string) => string;

--- a/scripts/_vendor/tsc-multi/src/transformer.ts
+++ b/scripts/_vendor/tsc-multi/src/transformer.ts
@@ -1,7 +1,7 @@
-import nodePath = require('path');
+import nodePath = require('node:path');
 import type ts from 'typescript';
 import { trimSuffix } from './utils';
-import assert from 'assert';
+import assert from 'node:assert';
 
 const JS_EXT = '.js';
 const MJS_EXT = '.mjs';

--- a/scripts/_vendor/tsc-multi/src/utils.ts
+++ b/scripts/_vendor/tsc-multi/src/utils.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'fs/promises';
+import { readFile } from 'node:fs/promises';
 import ts from 'typescript';
 
 export function trimPrefix(input: string, prefix: string): string {

--- a/scripts/_vendor/tsc-multi/src/worker/entry.ts
+++ b/scripts/_vendor/tsc-multi/src/worker/entry.ts
@@ -1,4 +1,4 @@
-import { text } from 'stream/consumers';
+import { text } from 'node:stream/consumers';
 import debug from './debug';
 import { Worker } from './worker';
 import { WorkerOptions } from './types';

--- a/scripts/_vendor/tsc-multi/src/worker/worker.ts
+++ b/scripts/_vendor/tsc-multi/src/worker/worker.ts
@@ -4,8 +4,8 @@ import { createReporter, Reporter } from '../report';
 import { mergeCustomTransformers, trimSuffix, isIncrementalCompilation } from '../utils';
 import { createTransformer } from '../transformer';
 import { WorkerOptions } from './types';
-import nodePath = require('path');
-import assert from 'assert';
+import nodePath = require('node:path');
+import assert from 'node:assert';
 import { helpers } from '../helpers';
 
 const JS_EXT = '.js';

--- a/scripts/utils/attw-report.cjs
+++ b/scripts/utils/attw-report.cjs
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('node:fs');
 
 const problems = Object.values(JSON.parse(fs.readFileSync('.attw.json', 'utf-8')).problems)
   .flat()

--- a/scripts/utils/check-version.cjs
+++ b/scripts/utils/check-version.cjs
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const pkg = require('../../package.json');
 
 const main = () => {

--- a/scripts/utils/fix-index-exports.cjs
+++ b/scripts/utils/fix-index-exports.cjs
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const indexJs = process.env['DIST_PATH']
   ? path.resolve(process.env['DIST_PATH'], 'index.js')

--- a/scripts/utils/postprocess-files.cjs
+++ b/scripts/utils/postprocess-files.cjs
@@ -1,6 +1,6 @@
 // @ts-check
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const distDir = process.env['DIST_PATH']
   ? path.resolve(process.env['DIST_PATH'])

--- a/src/auth/subject-token-providers.ts
+++ b/src/auth/subject-token-providers.ts
@@ -12,7 +12,7 @@ type ReadFile = (path: string) => Promise<string>;
 let fsPromisesModule: Promise<typeof import('node:fs/promises')> | undefined;
 
 async function defaultReadFile(path: string): Promise<string> {
-  fsPromisesModule ??= import('fs/promises').catch((error) => {
+  fsPromisesModule ??= import('node:fs/promises').catch((error) => {
     fsPromisesModule = undefined;
     throw error;
   });

--- a/tests/auth/subject-token-providers.test.ts
+++ b/tests/auth/subject-token-providers.test.ts
@@ -17,7 +17,7 @@ describe('Kubernetes Service Account Token Provider', () => {
   });
 
   test('reads token from file', async () => {
-    const fsPromises = await import('fs/promises');
+    const fsPromises = await import('node:fs/promises');
     (fsPromises.readFile as Mock).mockResolvedValue('  my-k8s-token  \n');
 
     const provider = k8sServiceAccountTokenProvider('/custom/path/token');
@@ -34,7 +34,7 @@ describe('Kubernetes Service Account Token Provider', () => {
   });
 
   test('throws SubjectTokenProviderError on file read failure', async () => {
-    const fsPromises = await import('fs/promises');
+    const fsPromises = await import('node:fs/promises');
     (fsPromises.readFile as Mock).mockRejectedValue(new Error('ENOENT: no such file or directory'));
 
     const provider = k8sServiceAccountTokenProvider('/nonexistent/path');

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -1,7 +1,7 @@
 import OpenAI from 'openai';
 import { Stream } from 'openai/core/streaming';
 import { OpenAIError, APIConnectionError } from 'openai/error';
-import { PassThrough } from 'stream';
+import { PassThrough } from 'node:stream';
 import {
   ParsingToolFunction,
   ChatCompletionRunner,

--- a/tests/qs/stringify.test.ts
+++ b/tests/qs/stringify.test.ts
@@ -3,7 +3,7 @@ import { stringify } from 'openai/internal/qs';
 import { encode } from 'openai/internal/qs/utils';
 import { StringifyOptions } from 'openai/internal/qs/types';
 import { empty_test_cases } from './empty-keys-cases';
-import assert from 'assert';
+import assert from 'node:assert';
 
 describe('stringify()', function () {
   test('stringifies a querystring object', function () {

--- a/tests/streaming.test.ts
+++ b/tests/streaming.test.ts
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import assert from 'node:assert';
 import { _iterSSEMessages } from 'openai/core/streaming';
 import { ReadableStreamFrom } from 'openai/internal/shims';
 

--- a/tests/uploads.test.ts
+++ b/tests/uploads.test.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 
-import fs from 'fs';
+import fs from 'node:fs';
 import type { ResponseLike } from 'openai/internal/to-file';
 import { toFile } from 'openai/core/uploads';
 

--- a/tests/utils/mock-snapshots.ts
+++ b/tests/utils/mock-snapshots.ts
@@ -1,7 +1,7 @@
 import OpenAI from 'openai/index';
 import { RequestInfo } from 'openai/internal/builtin-types';
 import { mockFetch } from './mock-fetch';
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 
 const defaultFetch = fetch;
 


### PR DESCRIPTION
## Summary

- Removes `unicorn/prefer-node-protocol` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 160 of 185.
- Base: `dev/hayden/ultracite-159-unicorn-numeric-separators-style`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`