### PR TITLE
chore(lint): enable unicorn/prefer-response-static-json

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -30,7 +30,6 @@ const compatibilityRules = [
   'typescript/no-explicit-any',
   'typescript/no-non-null-assertion',
   'unicorn/consistent-function-scoping',
-  'unicorn/prefer-response-static-json',
   'unicorn/switch-case-braces',
 ];
 

--- a/tests/auth/subject-token-providers.test.ts
+++ b/tests/auth/subject-token-providers.test.ts
@@ -62,11 +62,11 @@ describe('Azure IMDS Token Provider', () => {
       const headers = new Headers(init?.headers);
       expect(headers.get('Metadata')).toBe('true');
 
-      return new Response(
-        JSON.stringify({
+      return Response.json(
+        {
           access_token: 'azure-token',
           expires_in: '3600',
-        }),
+        },
         { status: 200 },
       );
     }) as typeof fetch;
@@ -83,7 +83,7 @@ describe('Azure IMDS Token Provider', () => {
       const urlObj = new URL(url);
       expect(urlObj.searchParams.get('resource')).toBe('https://cognitiveservices.azure.com/');
 
-      return new Response(JSON.stringify({ access_token: 'azure-token' }), { status: 200 });
+      return Response.json({ access_token: 'azure-token' }, { status: 200 });
     }) as typeof fetch;
 
     const provider = azureManagedIdentityTokenProvider('https://cognitiveservices.azure.com/');
@@ -96,10 +96,10 @@ describe('Azure IMDS Token Provider', () => {
     global.fetch = vi.fn(async (url: string) => {
       expect(url).toContain('api-version=2019-08-01');
 
-      return new Response(
-        JSON.stringify({
+      return Response.json(
+        {
           access_token: 'azure-token',
-        }),
+        },
         { status: 200 },
       );
     }) as typeof fetch;
@@ -113,14 +113,13 @@ describe('Azure IMDS Token Provider', () => {
   });
 
   test('uses the configured fetch implementation', async () => {
-    const customFetch = vi.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
-            access_token: 'azure-token',
-          }),
-          { status: 200 },
-        ),
+    const customFetch = vi.fn(async () =>
+      Response.json(
+        {
+          access_token: 'azure-token',
+        },
+        { status: 200 },
+      ),
     ) as typeof fetch;
 
     const provider = azureManagedIdentityTokenProvider(undefined, {
@@ -140,9 +139,7 @@ describe('Azure IMDS Token Provider', () => {
   });
 
   test('throws SubjectTokenProviderError when access_token missing', async () => {
-    global.fetch = vi.fn(
-      async () => new Response(JSON.stringify({ expires_in: '3600' }), { status: 200 }),
-    ) as typeof fetch;
+    global.fetch = vi.fn(async () => Response.json({ expires_in: '3600' }, { status: 200 })) as typeof fetch;
 
     const provider = azureManagedIdentityTokenProvider();
     await expect(provider.getToken()).rejects.toThrow(SubjectTokenProviderError);

--- a/tests/auth/workload-identity-auth.test.ts
+++ b/tests/auth/workload-identity-auth.test.ts
@@ -33,13 +33,13 @@ describe('WorkloadIdentityAuth', () => {
 
     global.fetch = vi.fn(async () => {
       fetchCallCount++;
-      return new Response(
-        JSON.stringify({
+      return Response.json(
+        {
           access_token: 'access-token',
           issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
           token_type: 'Bearer',
           expires_in: 3600,
-        }),
+        },
         { status: 200 },
       );
     }) as typeof fetch;
@@ -73,13 +73,13 @@ describe('WorkloadIdentityAuth', () => {
 
     global.fetch = vi.fn(async () => {
       fetchCallCount++;
-      return new Response(
-        JSON.stringify({
+      return Response.json(
+        {
           access_token: `access-token-${fetchCallCount}`,
           issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
           token_type: 'Bearer',
           expires_in: 1,
-        }),
+        },
         { status: 200 },
       );
     }) as typeof fetch;
@@ -117,13 +117,13 @@ describe('WorkloadIdentityAuth', () => {
     global.fetch = vi.fn(async () => {
       fetchCallCount++;
       await new Promise((resolve) => setTimeout(resolve, 100));
-      return new Response(
-        JSON.stringify({
+      return Response.json(
+        {
           access_token: 'access-token',
           issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
           token_type: 'Bearer',
           expires_in: 3600,
-        }),
+        },
         { status: 200 },
       );
     }) as typeof fetch;
@@ -157,13 +157,13 @@ describe('WorkloadIdentityAuth', () => {
 
       capturedRequest = { url, body, headers };
 
-      return new Response(
-        JSON.stringify({
+      return Response.json(
+        {
           access_token: 'access-token',
           issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
           token_type: 'Bearer',
           expires_in: 3600,
-        }),
+        },
         { status: 200 },
       );
     }) as typeof fetch;
@@ -199,13 +199,13 @@ describe('WorkloadIdentityAuth', () => {
     global.fetch = vi.fn(async (url: string, init?: RequestInit) => {
       capturedBody = init?.body?.toString() || '';
 
-      return new Response(
-        JSON.stringify({
+      return Response.json(
+        {
           access_token: 'access-token',
           issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
           token_type: 'Bearer',
           expires_in: 3600,
-        }),
+        },
         { status: 200 },
       );
     }) as typeof fetch;
@@ -237,13 +237,13 @@ describe('WorkloadIdentityAuth', () => {
     global.fetch = vi.fn(async (url: string, init?: RequestInit) => {
       capturedBody = init?.body?.toString() || '';
 
-      return new Response(
-        JSON.stringify({
+      return Response.json(
+        {
           access_token: 'access-token',
           issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
           token_type: 'Bearer',
           expires_in: 3600,
-        }),
+        },
         { status: 200 },
       );
     }) as typeof fetch;
@@ -265,15 +265,14 @@ describe('WorkloadIdentityAuth', () => {
       },
     };
 
-    global.fetch = vi.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
-            error: 'invalid_grant',
-            error_description: 'The subject token is invalid',
-          }),
-          { status: 400 },
-        ),
+    global.fetch = vi.fn(async () =>
+      Response.json(
+        {
+          error: 'invalid_grant',
+          error_description: 'The subject token is invalid',
+        },
+        { status: 400 },
+      ),
     ) as typeof fetch;
 
     const auth = new WorkloadIdentityAuth(config);
@@ -292,16 +291,15 @@ describe('WorkloadIdentityAuth', () => {
       },
     };
 
-    global.fetch = vi.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
-            access_token: 'access-token',
-            issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
-            token_type: 'Bearer',
-          }),
-          { status: 200 },
-        ),
+    global.fetch = vi.fn(async () =>
+      Response.json(
+        {
+          access_token: 'access-token',
+          issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+          token_type: 'Bearer',
+        },
+        { status: 200 },
+      ),
     ) as typeof fetch;
 
     const auth = new WorkloadIdentityAuth(config);
@@ -348,7 +346,7 @@ describe('WorkloadIdentityAuth', () => {
       },
     };
 
-    global.fetch = vi.fn(async () => new Response(JSON.stringify(body), { status: 200 })) as typeof fetch;
+    global.fetch = vi.fn(async () => Response.json(body, { status: 200 })) as typeof fetch;
 
     const auth = new WorkloadIdentityAuth(config);
     const tokenPromise = auth.getToken();
@@ -371,13 +369,13 @@ describe('WorkloadIdentityAuth', () => {
 
     global.fetch = vi.fn(async () => {
       fetchCallCount++;
-      return new Response(
-        JSON.stringify({
+      return Response.json(
+        {
           access_token: `access-token-${fetchCallCount}`,
           issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
           token_type: 'Bearer',
           expires_in: 3600,
-        }),
+        },
         { status: 200 },
       );
     }) as typeof fetch;
@@ -404,17 +402,16 @@ describe('WorkloadIdentityAuth', () => {
       },
     };
 
-    const customFetch = vi.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
-            access_token: 'access-token',
-            issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
-            token_type: 'Bearer',
-            expires_in: 3600,
-          }),
-          { status: 200 },
-        ),
+    const customFetch = vi.fn(async () =>
+      Response.json(
+        {
+          access_token: 'access-token',
+          issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+          token_type: 'Bearer',
+          expires_in: 3600,
+        },
+        { status: 200 },
+      ),
     ) as typeof fetch;
 
     const auth = new WorkloadIdentityAuth(config, customFetch);

--- a/tests/client-behavior.test.ts
+++ b/tests/client-behavior.test.ts
@@ -18,7 +18,7 @@ class IdempotentOpenAI extends OpenAI {
 }
 
 function jsonResponse(value: unknown = {}, init: ResponseInit = {}): Response {
-  return new Response(JSON.stringify(value), {
+  return Response.json(value, {
     ...init,
     headers: { 'content-type': 'application/json', ...init.headers },
   });

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -26,7 +26,7 @@ function mockChatCompletionFetch() {
       const rawBody = init?.body;
       if (typeof rawBody !== 'string') throw new Error(`expected init.body to be a string`);
       const body: ChatCompletionToolRunnerParams<any[]> = JSON.parse(rawBody);
-      return new Response(JSON.stringify(await handler(body)), {
+      return Response.json(await handler(body), {
         headers: { 'Content-Type': 'application/json' },
       });
     });

--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -120,9 +120,12 @@ describe('instantiate azure client', () => {
       apiVersion,
       fetch: (url) =>
         Promise.resolve(
-          new Response(JSON.stringify({ url, custom: true }), {
-            headers: { 'Content-Type': 'application/json' },
-          }),
+          Response.json(
+            { url, custom: true },
+            {
+              headers: { 'Content-Type': 'application/json' },
+            },
+          ),
         ),
     });
 
@@ -246,7 +249,7 @@ describe('instantiate azure client', () => {
   describe('Azure Active Directory (AD)', () => {
     test('with azureADTokenProvider', async () => {
       const testFetch = async (url: RequestInfo, { headers }: RequestInit = {}): Promise<Response> =>
-        new Response(JSON.stringify({ a: 1 }), { headers: headers ?? [] });
+        Response.json({ a: 1 }, { headers: headers ?? [] });
       const client = new AzureOpenAI({
         baseURL: 'http://localhost:5000/',
         azureADTokenProvider: async () => 'my token',
@@ -283,9 +286,12 @@ describe('instantiate azure client', () => {
             },
           });
         }
-        return new Response(JSON.stringify({}), {
-          headers: headers ?? [],
-        });
+        return Response.json(
+          {},
+          {
+            headers: headers ?? [],
+          },
+        );
       };
       let counter = 0;
       async function azureADTokenProvider() {
@@ -309,7 +315,7 @@ describe('instantiate azure client', () => {
 
   test('uses api-key header when apiKey is provided', async () => {
     const testFetch = async (url: RequestInfo, { headers }: RequestInit = {}): Promise<Response> =>
-      new Response(JSON.stringify({ a: 1 }), { headers: headers ?? [] });
+      Response.json({ a: 1 }, { headers: headers ?? [] });
     const client = new AzureOpenAI({
       baseURL: 'http://localhost:5000/',
       apiKey: 'My API Key',
@@ -353,7 +359,7 @@ describe('azure request building', () => {
 
   describe('model to deployment mapping', function () {
     const testFetch = async (url: RequestInfo): Promise<Response> =>
-      new Response(JSON.stringify({ url }), { headers: { 'content-type': 'application/json' } });
+      Response.json({ url }, { headers: { 'content-type': 'application/json' } });
     describe('with client-level deployment', function () {
       const client = new AzureOpenAI({
         endpoint: 'https://example.com',
@@ -635,7 +641,7 @@ describe('retries', () => {
           signal?.addEventListener('abort', () => reject(new Error('timed out'))),
         );
       }
-      return new Response(JSON.stringify({ a: 1 }), { headers: { 'Content-Type': 'application/json' } });
+      return Response.json({ a: 1 }, { headers: { 'Content-Type': 'application/json' } });
     };
 
     const client = new AzureOpenAI({
@@ -668,7 +674,7 @@ describe('retries', () => {
           },
         });
       }
-      return new Response(JSON.stringify({ a: 1 }), { headers: { 'Content-Type': 'application/json' } });
+      return Response.json({ a: 1 }, { headers: { 'Content-Type': 'application/json' } });
     };
 
     const client = new AzureOpenAI({
@@ -700,7 +706,7 @@ describe('retries', () => {
           },
         });
       }
-      return new Response(JSON.stringify({ a: 1 }), { headers: { 'Content-Type': 'application/json' } });
+      return Response.json({ a: 1 }, { headers: { 'Content-Type': 'application/json' } });
     };
 
     const client = new AzureOpenAI({

--- a/tests/lib/bedrock-provider-dependencies.test.ts
+++ b/tests/lib/bedrock-provider-dependencies.test.ts
@@ -30,7 +30,7 @@ afterEach(() => {
 });
 
 function jsonResponse(body: unknown = {}): Response {
-  return new Response(JSON.stringify(body), {
+  return Response.json(body, {
     headers: { 'Content-Type': 'application/json' },
   });
 }

--- a/tests/lib/bedrock-provider.test.ts
+++ b/tests/lib/bedrock-provider.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
 });
 
 function jsonResponse(body: unknown = {}): Response {
-  return new Response(JSON.stringify(body), {
+  return Response.json(body, {
     headers: { 'Content-Type': 'application/json' },
   });
 }

--- a/tests/lib/pagination.test.ts
+++ b/tests/lib/pagination.test.ts
@@ -46,9 +46,12 @@ describe('Page', () => {
 describe('PagePromise', () => {
   test('parses and asynchronously iterates over the resolved page', async () => {
     const client = { requestAPIList: vi.fn() } as any;
-    const pageResponse = new Response(JSON.stringify({ object: 'list', data: [{ id: 'first' }] }), {
-      headers: { 'content-type': 'application/json', 'x-request-id': 'req_123' },
-    });
+    const pageResponse = Response.json(
+      { object: 'list', data: [{ id: 'first' }] },
+      {
+        headers: { 'content-type': 'application/json', 'x-request-id': 'req_123' },
+      },
+    );
     const promise = new PagePromise<Page<Item>>(
       client,
       Promise.resolve({

--- a/tests/lib/workload-identity.test.ts
+++ b/tests/lib/workload-identity.test.ts
@@ -65,20 +65,20 @@ describe('OpenAI with Workload Identity', () => {
       const urlStr = url.toString();
 
       if (urlStr.includes('/oauth/token')) {
-        return new Response(
-          JSON.stringify({
+        return Response.json(
+          {
             access_token: 'exchanged-access-token',
             issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
             token_type: 'Bearer',
             expires_in: 3600,
-          }),
+          },
           { status: 200 },
         );
       }
 
       if (urlStr.includes('/models')) {
         apiRequestHeaders = new Headers(init?.headers);
-        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        return Response.json({ data: [] }, { status: 200 });
       }
 
       return new Response('Not found', { status: 404 });
@@ -118,19 +118,19 @@ describe('OpenAI with Workload Identity', () => {
 
       if (urlStr.includes('/oauth/token')) {
         tokenExchangeCallCount++;
-        return new Response(
-          JSON.stringify({
+        return Response.json(
+          {
             access_token: 'exchanged-access-token',
             issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
             token_type: 'Bearer',
             expires_in: 3600,
-          }),
+          },
           { status: 200 },
         );
       }
 
       if (urlStr.includes('/models')) {
-        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        return Response.json({ data: [] }, { status: 200 });
       }
 
       return new Response('Not found', { status: 404 });
@@ -154,13 +154,13 @@ describe('OpenAI with Workload Identity', () => {
 
       if (urlStr.includes('/oauth/token')) {
         tokenExchangeCallCount++;
-        return new Response(
-          JSON.stringify({
+        return Response.json(
+          {
             access_token: `access-token-${tokenExchangeCallCount}`,
             issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
             token_type: 'Bearer',
             expires_in: 3600,
-          }),
+          },
           { status: 200 },
         );
       }
@@ -168,9 +168,9 @@ describe('OpenAI with Workload Identity', () => {
       if (urlStr.includes('/models')) {
         apiCallCount++;
         if (apiCallCount === 1) {
-          return new Response(JSON.stringify({ error: { message: 'Unauthorized' } }), { status: 401 });
+          return Response.json({ error: { message: 'Unauthorized' } }, { status: 401 });
         }
-        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        return Response.json({ data: [] }, { status: 200 });
       }
 
       return new Response('Not found', { status: 404 });
@@ -194,20 +194,20 @@ describe('OpenAI with Workload Identity', () => {
 
       if (urlStr.includes('/oauth/token')) {
         tokenExchangeCallCount++;
-        return new Response(
-          JSON.stringify({
+        return Response.json(
+          {
             access_token: 'access-token',
             issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
             token_type: 'Bearer',
             expires_in: 3600,
-          }),
+          },
           { status: 200 },
         );
       }
 
       if (urlStr.includes('/models')) {
         apiCallCount++;
-        return new Response(JSON.stringify({ error: { message: 'Unauthorized' } }), { status: 401 });
+        return Response.json({ error: { message: 'Unauthorized' } }, { status: 401 });
       }
 
       return new Response('Not found', { status: 404 });
@@ -230,20 +230,20 @@ describe('OpenAI with Workload Identity', () => {
 
       if (urlStr.includes('/oauth/token')) {
         tokenExchangeCallCount++;
-        return new Response(
-          JSON.stringify({
+        return Response.json(
+          {
             access_token: 'access-token',
             issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
             token_type: 'Bearer',
             expires_in: 3600,
-          }),
+          },
           { status: 200 },
         );
       }
 
       if (urlStr.includes('/files')) {
         apiCallCount++;
-        return new Response(JSON.stringify({ error: { message: 'Unauthorized' } }), { status: 401 });
+        return Response.json({ error: { message: 'Unauthorized' } }, { status: 401 });
       }
 
       return new Response('Not found', { status: 404 });
@@ -290,11 +290,11 @@ describe('OpenAI with Workload Identity', () => {
       const urlStr = url.toString();
 
       if (urlStr.includes('/oauth/token')) {
-        return new Response(
-          JSON.stringify({
+        return Response.json(
+          {
             error: 'invalid_grant',
             error_description: 'Invalid subject token',
-          }),
+          },
           { status: 400 },
         );
       }
@@ -315,19 +315,19 @@ describe('OpenAI with Workload Identity', () => {
 
       if (urlStr.includes('/oauth/token')) {
         tokenExchangeCallCount++;
-        return new Response(
-          JSON.stringify({
+        return Response.json(
+          {
             access_token: `access-token-${tokenExchangeCallCount}`,
             issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
             token_type: 'Bearer',
             expires_in: 1,
-          }),
+          },
           { status: 200 },
         );
       }
 
       if (urlStr.includes('/models')) {
-        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        return Response.json({ data: [] }, { status: 200 });
       }
 
       return new Response('Not found', { status: 404 });
@@ -349,19 +349,19 @@ describe('OpenAI with Workload Identity', () => {
       const urlStr = url.toString();
 
       if (urlStr.includes('/oauth/token')) {
-        return new Response(
-          JSON.stringify({
+        return Response.json(
+          {
             access_token: 'access-token',
             issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
             token_type: 'Bearer',
             expires_in: 3600,
-          }),
+          },
           { status: 200 },
         );
       }
 
       if (urlStr.includes('/models')) {
-        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        return Response.json({ data: [] }, { status: 200 });
       }
 
       return new Response('Not found', { status: 404 });
@@ -383,19 +383,19 @@ describe('OpenAI with Workload Identity', () => {
       const urlStr = url.toString();
 
       if (urlStr.includes('/oauth/token')) {
-        return new Response(
-          JSON.stringify({
+        return Response.json(
+          {
             access_token: 'access-token',
             issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
             token_type: 'Bearer',
             expires_in: 3600,
-          }),
+          },
           { status: 200 },
         );
       }
 
       if (urlStr.includes('/models')) {
-        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        return Response.json({ data: [] }, { status: 200 });
       }
 
       return new Response('Not found', { status: 404 });
@@ -430,19 +430,19 @@ describe('OpenAI with Workload Identity', () => {
       const urlStr = url.toString();
 
       if (urlStr.includes('/oauth/token')) {
-        return new Response(
-          JSON.stringify({
+        return Response.json(
+          {
             access_token: 'access-token',
             issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
             token_type: 'Bearer',
             expires_in: 3600,
-          }),
+          },
           { status: 200 },
         );
       }
 
       if (urlStr.includes('/models')) {
-        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+        return Response.json({ data: [] }, { status: 200 });
       }
 
       return new Response('Not found', { status: 404 });

--- a/tests/log.test.ts
+++ b/tests/log.test.ts
@@ -8,9 +8,12 @@ const opts: ClientOptions = {
   logLevel: 'debug',
   fetch: (url) =>
     Promise.resolve(
-      new Response(JSON.stringify({ url, custom: true }), {
-        headers: { 'Content-Type': 'application/json' },
-      }),
+      Response.json(
+        { url, custom: true },
+        {
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
     ),
 };
 

--- a/tests/responses.test.ts
+++ b/tests/responses.test.ts
@@ -22,9 +22,12 @@ describe('request id', () => {
     const client = new OpenAI({
       apiKey: 'dummy',
       fetch: async () =>
-        new Response(JSON.stringify({ id: 'bar' }), {
-          headers: { 'x-request-id': 'req_id_xxx', 'content-type': 'application/json' },
-        }),
+        Response.json(
+          { id: 'bar' },
+          {
+            headers: { 'x-request-id': 'req_id_xxx', 'content-type': 'application/json' },
+          },
+        ),
     });
 
     const {
@@ -43,9 +46,12 @@ describe('request id', () => {
     const client = new OpenAI({
       apiKey: 'dummy',
       fetch: async () =>
-        new Response(JSON.stringify({ id: 'bar' }), {
-          headers: { 'x-request-id': 'req_id_xxx', 'content-type': 'application/json' },
-        }),
+        Response.json(
+          { id: 'bar' },
+          {
+            headers: { 'x-request-id': 'req_id_xxx', 'content-type': 'application/json' },
+          },
+        ),
     });
 
     const rsp = await client.chat.completions.create({ messages: [], model: 'gpt-4' });
@@ -58,9 +64,12 @@ describe('request id', () => {
     const promise = new APIPromise<{ data: { foo: string } }>(
       client,
       Promise.resolve({
-        response: new Response(JSON.stringify({ data: { foo: 'bar' } }), {
-          headers: { 'x-request-id': 'req_id_xxx', 'content-type': 'application/json' },
-        }),
+        response: Response.json(
+          { data: { foo: 'bar' } },
+          {
+            headers: { 'x-request-id': 'req_id_xxx', 'content-type': 'application/json' },
+          },
+        ),
         controller: {} as any,
         options: {} as any,
         requestLogID: 'log_...',
@@ -78,9 +87,12 @@ describe('request id', () => {
     const client = new OpenAI({
       apiKey: 'dummy',
       fetch: async () =>
-        new Response(JSON.stringify({ data: [{ foo: 'bar' }] }), {
-          headers: { 'x-request-id': 'req_id_xxx', 'content-type': 'application/json' },
-        }),
+        Response.json(
+          { data: [{ foo: 'bar' }] },
+          {
+            headers: { 'x-request-id': 'req_id_xxx', 'content-type': 'application/json' },
+          },
+        ),
     });
 
     const page = await client.fineTuning.jobs.list();
@@ -92,7 +104,7 @@ describe('request id', () => {
     const promise = new APIPromise<{ foo: string }[]>(
       client,
       Promise.resolve({
-        response: new Response(JSON.stringify([{ foo: 'bar' }]), {
+        response: Response.json([{ foo: 'bar' }], {
           headers: { 'x-request-id': 'req_id_xxx', 'content-type': 'application/json' },
         }),
         controller: {} as any,

--- a/tests/sdk-behavior.test.ts
+++ b/tests/sdk-behavior.test.ts
@@ -6,7 +6,7 @@ import { compact, decode, is_regexp, maybe_map } from 'openai/internal/qs/utils'
 import { toFloat32Array } from 'openai/internal/utils/base64';
 
 function jsonResponse(body: unknown): Response {
-  return new Response(JSON.stringify(body), {
+  return Response.json(body, {
     headers: { 'content-type': 'application/json' },
   });
 }
@@ -35,12 +35,14 @@ describe('handwritten SDK behavior', () => {
     const client = new OpenAI({
       apiKey: 'test-key',
       maxRetries: 0,
-      fetch: vi.fn(
-        async () =>
-          new Response(JSON.stringify({ error: { message: 'request failed' } }), {
+      fetch: vi.fn(async () =>
+        Response.json(
+          { error: { message: 'request failed' } },
+          {
             headers: { 'content-type': 'application/json' },
             status: 400,
-          }),
+          },
+        ),
       ),
     });
 


### PR DESCRIPTION
## Summary

- Removes `unicorn/prefer-response-static-json` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 162 of 185.
- Base: `dev/hayden/ultracite-161-no-eq-null`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`