### PR TITLE
chore(lint): enable eqeqeq

### DIFF
--- a/examples/assistants/assistants.ts
+++ b/examples/assistants/assistants.ts
@@ -43,7 +43,7 @@ async function main() {
 
   console.log('Run finished with status: ' + run.status);
 
-  if (run.status == 'completed') {
+  if (run.status === 'completed') {
     const messages = await openai.beta.threads.messages.list(thread.id);
     for (const message of messages.getPaginatedItems()) {
       console.log(message);

--- a/examples/fine-tuning/fine-tuning.ts
+++ b/examples/fine-tuning/fine-tuning.ts
@@ -49,7 +49,7 @@ async function main() {
 
   const events: Record<string, FineTuningJobEvent> = {};
 
-  while (fineTune.status == 'running' || fineTune.status == 'queued') {
+  while (fineTune.status === 'running' || fineTune.status === 'queued') {
     fineTune = await client.fineTuning.jobs.retrieve(fineTune.id);
     console.log(`${fineTune.status}`);
 

--- a/examples/responses/stream_background.ts
+++ b/examples/responses/stream_background.ts
@@ -14,12 +14,12 @@ async function main() {
   let id: string | null = null;
 
   for await (const event of runner) {
-    if (event.type == 'response.created') {
+    if (event.type === 'response.created') {
       id = event.response.id;
     }
 
     console.log('event', event);
-    if (event.sequence_number == 10) {
+    if (event.sequence_number === 10) {
       break;
     }
   }

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -7,7 +7,6 @@ const stainlessGeneratedFiles = requireConfig('./scripts/stainless-generated-fil
 // Existing handwritten SDK patterns predate these preset rules.
 const compatibilityRules = [
   'curly',
-  'eqeqeq',
   'func-names',
   'func-style',
   'import/consistent-type-specifier-style',
@@ -36,6 +35,9 @@ module.exports = defineConfig({
   },
   rules: {
     ...Object.fromEntries(compatibilityRules.map((rule) => [rule, 'off'])),
+    // Preserve intentional paired null-or-undefined checks while enforcing strict
+    // equality for every other comparison.
+    eqeqeq: ['error', 'always', { null: 'ignore' }],
     'jsdoc/check-tag-names': ['error', { definedTags: ['jest-environment'] }],
     'no-restricted-imports': [
       'error',

--- a/src/_vendor/partial-json-parser/parser.ts
+++ b/src/_vendor/partial-json-parser/parser.ts
@@ -130,7 +130,7 @@ const _parseJSON = (jsonString: string, allow: number) => {
       escape = jsonString[index] === '\\' ? !escape : false;
       index++;
     }
-    if (jsonString.charAt(index) == '"') {
+    if (jsonString.charAt(index) === '"') {
       try {
         return JSON.parse(jsonString.substring(start, ++index - Number(escape)));
       } catch (e) {
@@ -221,7 +221,7 @@ const _parseJSON = (jsonString: string, allow: number) => {
     if (jsonString[index] === '-') index++;
     while (jsonString[index] && !',]}'.includes(jsonString[index]!)) index++;
 
-    if (index == length && !(Allow.NUM & allow)) markPartialJSON('Unterminated number literal');
+    if (index === length && !(Allow.NUM & allow)) markPartialJSON('Unterminated number literal');
 
     try {
       return JSON.parse(jsonString.substring(start, index));

--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -76,7 +76,7 @@ export class Stream<Item> implements AsyncIterable<Item> {
               throw e;
             }
             // SSE error events surface as APIError instances.
-            if (sse.event == 'error') {
+            if (sse.event === 'error') {
               throw new APIError(undefined, data.error, data.message, undefined);
             }
             yield { event: sse.event, data } as any;

--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -406,7 +406,7 @@ export class AssistantStream
 
     for (const content of newContent) {
       const snapshotContent = accumulatedMessage.content[content.index];
-      if (snapshotContent?.type == 'text') {
+      if (snapshotContent?.type === 'text') {
         this._emit('textCreated', snapshotContent.text);
       }
     }
@@ -425,17 +425,17 @@ export class AssistantStream
         if (event.data.delta.content) {
           for (const content of event.data.delta.content) {
             //If it is text delta, emit a text delta event
-            if (content.type == 'text' && content.text) {
+            if (content.type === 'text' && content.text) {
               const textDelta = content.text;
               const snapshot = accumulatedMessage.content[content.index];
-              if (snapshot && snapshot.type == 'text') {
+              if (snapshot && snapshot.type === 'text') {
                 this._emit('textDelta', textDelta, snapshot.text);
               } else {
                 throw new Error('The snapshot associated with this text delta is not text or missing');
               }
             }
 
-            if (content.index != this.#currentContentIndex) {
+            if (content.index !== this.#currentContentIndex) {
               //See if we have in progress content
               if (this.#currentContent) {
                 switch (this.#currentContent.type) {
@@ -494,12 +494,12 @@ export class AssistantStream
         const delta = event.data.delta;
         if (
           delta.step_details &&
-          delta.step_details.type == 'tool_calls' &&
+          delta.step_details.type === 'tool_calls' &&
           delta.step_details.tool_calls &&
-          accumulatedRunStep.step_details.type == 'tool_calls'
+          accumulatedRunStep.step_details.type === 'tool_calls'
         ) {
           for (const toolCall of delta.step_details.tool_calls) {
-            if (toolCall.index == this.#currentToolCallIndex) {
+            if (toolCall.index === this.#currentToolCallIndex) {
               this._emit(
                 'toolCallDelta',
                 toolCall,
@@ -526,7 +526,7 @@ export class AssistantStream
       case 'thread.run.step.expired': {
         this.#currentRunStepSnapshot = undefined;
         const details = event.data.step_details;
-        if (details.type == 'tool_calls' && this.#currentToolCall) {
+        if (details.type === 'tool_calls' && this.#currentToolCall) {
           this._emit('toolCallDone', this.#currentToolCall as ToolCall);
           this.#currentToolCall = undefined;
         }


### PR DESCRIPTION
## Summary

- Removes `eqeqeq` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 167 of 185.
- Base: `dev/hayden/ultracite-166-no-var`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`