### PR TITLE
chore(lint): enable import/no-cycle

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -9,7 +9,6 @@ const compatibilityRules = [
   'curly',
   'func-names',
   'func-style',
-  'import/no-cycle',
   'no-use-before-define',
   'prefer-arrow-callback',
   'require-await',
@@ -931,6 +930,28 @@ module.exports = defineConfig({
       ],
       rules: {
         'typescript/no-non-null-assertion': 'off',
+      },
+    },
+    {
+      // These are the two existing SDK/vendor cycle clusters; untangling module
+      // topology would be a behavior and public-surface refactor, not lint cleanup.
+      files: [
+        'src/_vendor/zod-to-json-schema/**',
+        'src/azure.ts',
+        'src/bedrock.ts',
+        'src/core/streaming.ts',
+        'src/lib/AbstractChatCompletionRunner.ts',
+        'src/lib/AssistantStream.ts',
+        'src/lib/ChatCompletionRunner.ts',
+        'src/lib/ChatCompletionStream.ts',
+        'src/lib/ChatCompletionStreamingRunner.ts',
+        'src/lib/ResponsesParser.ts',
+        'src/lib/parser.ts',
+        'src/lib/responses/ResponseAccumulator.ts',
+        'src/lib/responses/ResponseStream.ts',
+      ],
+      rules: {
+        'import/no-cycle': 'off',
       },
     },
     {


### PR DESCRIPTION
## Summary

- Removes `import/no-cycle` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 176 of 185.
- Base: `dev/hayden/ultracite-175-typescript-no-non-null-assertion`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`