### PR TITLE
chore(lint): enable unicorn/switch-case-braces

### DIFF
--- a/ecosystem-tests/vercel-edge/src/pages/api/vercel-ai-streaming.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/vercel-ai-streaming.ts
@@ -22,14 +22,18 @@ export default async function handler(request: NextRequest) {
       .join('');
 
     switch (message.role) {
-      case 'system':
+      case 'system': {
         return { role: 'system', content };
-      case 'assistant':
+      }
+      case 'assistant': {
         return { role: 'assistant', content };
-      case 'user':
+      }
+      case 'user': {
         return { role: 'user', content };
-      default:
+      }
+      default: {
         throw new Error('Unsupported message role');
+      }
     }
   });
 

--- a/examples/chat-completions/function-call-diy.ts
+++ b/examples/chat-completions/function-call-diy.ts
@@ -43,17 +43,21 @@ const functions: OpenAI.Chat.ChatCompletionCreateParams.Function[] = [
 async function callFunction(function_call: ChatCompletionMessage.FunctionCall): Promise<any> {
   const args = JSON.parse(function_call.arguments!);
   switch (function_call.name) {
-    case 'list':
+    case 'list': {
       return await list(args['genre']);
+    }
 
-    case 'search':
+    case 'search': {
       return await search(args['name']);
+    }
 
-    case 'get':
+    case 'get': {
       return await get(args['id']);
+    }
 
-    default:
+    default: {
       throw new Error('No function found');
+    }
   }
 }
 

--- a/examples/chat-completions/function-call-stream-raw.ts
+++ b/examples/chat-completions/function-call-stream-raw.ts
@@ -48,17 +48,21 @@ const functions: OpenAI.Chat.ChatCompletionCreateParams.Function[] = [
 async function callFunction(function_call: ChatCompletionMessage.FunctionCall): Promise<any> {
   const args = JSON.parse(function_call.arguments!);
   switch (function_call.name) {
-    case 'list':
+    case 'list': {
       return await list(args['genre']);
+    }
 
-    case 'search':
+    case 'search': {
       return await search(args['name']);
+    }
 
-    case 'get':
+    case 'get': {
       return await get(args['id']);
+    }
 
-    default:
+    default: {
       throw new Error('No function found');
+    }
   }
 }
 

--- a/examples/chat-completions/function-call-stream.ts
+++ b/examples/chat-completions/function-call-stream.ts
@@ -48,17 +48,21 @@ const functions: OpenAI.Chat.ChatCompletionCreateParams.Function[] = [
 async function callFunction(function_call: ChatCompletionMessage.FunctionCall): Promise<any> {
   const args = JSON.parse(function_call.arguments!);
   switch (function_call.name) {
-    case 'list':
+    case 'list': {
       return await list(args['genre']);
+    }
 
-    case 'search':
+    case 'search': {
       return await search(args['name']);
+    }
 
-    case 'get':
+    case 'get': {
       return await get(args['id']);
+    }
 
-    default:
+    default: {
       throw new Error('No function found');
+    }
   }
 }
 

--- a/examples/chat-completions/function-call.ts
+++ b/examples/chat-completions/function-call.ts
@@ -43,17 +43,21 @@ const functions: OpenAI.Chat.ChatCompletionCreateParams.Function[] = [
 async function callFunction(function_call: ChatCompletionMessage.FunctionCall): Promise<any> {
   const args = JSON.parse(function_call.arguments!);
   switch (function_call.name) {
-    case 'list':
+    case 'list': {
       return await list(args['genre']);
+    }
 
-    case 'search':
+    case 'search': {
       return await search(args['name']);
+    }
 
-    case 'get':
+    case 'get': {
       return await get(args['id']);
+    }
 
-    default:
+    default: {
       throw new Error('No function found');
+    }
   }
 }
 

--- a/examples/chat-completions/tool-calls-stream.ts
+++ b/examples/chat-completions/tool-calls-stream.ts
@@ -81,17 +81,21 @@ async function callTool(
 ): Promise<any> {
   const args = JSON.parse(tool_call.function.arguments);
   switch (tool_call.function.name) {
-    case 'list':
+    case 'list': {
       return await list(args['genre']);
+    }
 
-    case 'search':
+    case 'search': {
       return await search(args['name']);
+    }
 
-    case 'get':
+    case 'get': {
       return await get(args['id']);
+    }
 
-    default:
+    default: {
       throw new Error('No function found');
+    }
   }
 }
 

--- a/examples/images/image-stream.ts
+++ b/examples/images/image-stream.ts
@@ -20,7 +20,7 @@ const main = async () => {
     let filename: string;
     let imageBuffer: Buffer;
     switch (event.type) {
-      case 'image_generation.partial_image':
+      case 'image_generation.partial_image': {
         console.log(`  Partial image ${event.partial_image_index + 1}/3 received`);
         console.log(`   Size: ${event.b64_json.length} characters (base64)`);
 
@@ -30,7 +30,8 @@ const main = async () => {
         fs.writeFileSync(filename, imageBuffer);
         console.log(`   💾 Saved to: ${path.resolve(filename)}`);
         break;
-      case 'image_generation.completed':
+      }
+      case 'image_generation.completed': {
         console.log(`\n✅ Final image completed!`);
         console.log(`   Size: ${event.b64_json.length} characters (base64)`);
 
@@ -40,8 +41,10 @@ const main = async () => {
         fs.writeFileSync(filename, imageBuffer);
         console.log(`    Saved to: ${path.resolve(filename)}`);
         break;
-      default:
+      }
+      default: {
         console.log(`❓ Unknown event: ${event}`);
+      }
     }
   }
 };

--- a/examples/images/picture.ts
+++ b/examples/images/picture.ts
@@ -49,15 +49,19 @@ async function createImageEdit(imageFiles: string[]) {
 
 function imageContentType(file: string): string {
   switch (path.extname(file).toLowerCase()) {
-    case '.png':
+    case '.png': {
       return 'image/png';
+    }
     case '.jpg':
-    case '.jpeg':
+    case '.jpeg': {
       return 'image/jpeg';
-    case '.webp':
+    }
+    case '.webp': {
       return 'image/webp';
-    default:
+    }
+    default: {
       throw new Error(`Unsupported image type for ${file}. Use a PNG, JPEG, or WebP file.`);
+    }
   }
 }
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -15,7 +15,6 @@ const compatibilityRules = [
   'sort-keys',
   'typescript/consistent-type-imports',
   'typescript/no-explicit-any',
-  'unicorn/switch-case-braces',
 ];
 
 module.exports = defineConfig({

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -128,8 +128,9 @@ const get$ref = (
   | {}
   | undefined => {
   switch (refs.$refStrategy) {
-    case 'root':
+    case 'root': {
       return { $ref: item.path.join('/') };
+    }
     // this case is needed as OpenAI strict mode doesn't support top-level `$ref`s, i.e.
     // the top-level schema *must* be `{"type": "object", "properties": {...}}` but if we ever
     // need to define a `$ref`, relative `$ref`s aren't supported, so we need to extract
@@ -155,8 +156,9 @@ const get$ref = (
 
       return { $ref: [...refs.basePath, refs.definitionPath, name].join('/') };
     }
-    case 'relative':
+    case 'relative': {
       return { $ref: getRelativePath(refs.currentPath, item.path) };
+    }
     case 'none':
     case 'seen': {
       if (
@@ -203,76 +205,109 @@ const selectParser = (
   forceResolution: boolean,
 ): JsonSchema7Type | undefined => {
   switch (typeName) {
-    case ZodFirstPartyTypeKind.ZodString:
+    case ZodFirstPartyTypeKind.ZodString: {
       return parseStringDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodNumber:
+    }
+    case ZodFirstPartyTypeKind.ZodNumber: {
       return parseNumberDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodObject:
+    }
+    case ZodFirstPartyTypeKind.ZodObject: {
       return parseObjectDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodBigInt:
+    }
+    case ZodFirstPartyTypeKind.ZodBigInt: {
       return parseBigintDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodBoolean:
+    }
+    case ZodFirstPartyTypeKind.ZodBoolean: {
       return parseBooleanDef();
-    case ZodFirstPartyTypeKind.ZodDate:
+    }
+    case ZodFirstPartyTypeKind.ZodDate: {
       return parseDateDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodUndefined:
+    }
+    case ZodFirstPartyTypeKind.ZodUndefined: {
       return parseUndefinedDef();
-    case ZodFirstPartyTypeKind.ZodNull:
+    }
+    case ZodFirstPartyTypeKind.ZodNull: {
       return parseNullDef(refs);
-    case ZodFirstPartyTypeKind.ZodArray:
+    }
+    case ZodFirstPartyTypeKind.ZodArray: {
       return parseArrayDef(def, refs);
+    }
     case ZodFirstPartyTypeKind.ZodUnion:
-    case ZodFirstPartyTypeKind.ZodDiscriminatedUnion:
+    case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
       return parseUnionDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodIntersection:
+    }
+    case ZodFirstPartyTypeKind.ZodIntersection: {
       return parseIntersectionDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodTuple:
+    }
+    case ZodFirstPartyTypeKind.ZodTuple: {
       return parseTupleDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodRecord:
+    }
+    case ZodFirstPartyTypeKind.ZodRecord: {
       return parseRecordDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodLiteral:
+    }
+    case ZodFirstPartyTypeKind.ZodLiteral: {
       return parseLiteralDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodEnum:
+    }
+    case ZodFirstPartyTypeKind.ZodEnum: {
       return parseEnumDef(def);
-    case ZodFirstPartyTypeKind.ZodNativeEnum:
+    }
+    case ZodFirstPartyTypeKind.ZodNativeEnum: {
       return parseNativeEnumDef(def);
-    case ZodFirstPartyTypeKind.ZodNullable:
+    }
+    case ZodFirstPartyTypeKind.ZodNullable: {
       return parseNullableDef(def, refs, forceResolution);
-    case ZodFirstPartyTypeKind.ZodOptional:
+    }
+    case ZodFirstPartyTypeKind.ZodOptional: {
       return parseOptionalDef(def, refs, forceResolution);
-    case ZodFirstPartyTypeKind.ZodMap:
+    }
+    case ZodFirstPartyTypeKind.ZodMap: {
       return parseMapDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodSet:
+    }
+    case ZodFirstPartyTypeKind.ZodSet: {
       return parseSetDef(def, refs);
-    case ZodFirstPartyTypeKind.ZodLazy:
+    }
+    case ZodFirstPartyTypeKind.ZodLazy: {
       return parseDef(def.getter()._def, refs, forceResolution);
-    case ZodFirstPartyTypeKind.ZodPromise:
+    }
+    case ZodFirstPartyTypeKind.ZodPromise: {
       return parsePromiseDef(def, refs, forceResolution);
+    }
     case ZodFirstPartyTypeKind.ZodNaN:
-    case ZodFirstPartyTypeKind.ZodNever:
+    case ZodFirstPartyTypeKind.ZodNever: {
       return parseNeverDef();
-    case ZodFirstPartyTypeKind.ZodEffects:
+    }
+    case ZodFirstPartyTypeKind.ZodEffects: {
       return parseEffectsDef(def, refs, forceResolution);
-    case ZodFirstPartyTypeKind.ZodAny:
+    }
+    case ZodFirstPartyTypeKind.ZodAny: {
       return parseAnyDef();
-    case ZodFirstPartyTypeKind.ZodUnknown:
+    }
+    case ZodFirstPartyTypeKind.ZodUnknown: {
       return parseUnknownDef();
-    case ZodFirstPartyTypeKind.ZodDefault:
+    }
+    case ZodFirstPartyTypeKind.ZodDefault: {
       return parseDefaultDef(def, refs, forceResolution);
-    case ZodFirstPartyTypeKind.ZodBranded:
+    }
+    case ZodFirstPartyTypeKind.ZodBranded: {
       return parseBrandedDef(def, refs, forceResolution);
-    case ZodFirstPartyTypeKind.ZodReadonly:
+    }
+    case ZodFirstPartyTypeKind.ZodReadonly: {
       return parseReadonlyDef(def, refs, forceResolution);
-    case ZodFirstPartyTypeKind.ZodCatch:
+    }
+    case ZodFirstPartyTypeKind.ZodCatch: {
       return parseCatchDef(def, refs, forceResolution);
-    case ZodFirstPartyTypeKind.ZodPipeline:
+    }
+    case ZodFirstPartyTypeKind.ZodPipeline: {
       return parsePipelineDef(def, refs, forceResolution);
+    }
     case ZodFirstPartyTypeKind.ZodFunction:
     case ZodFirstPartyTypeKind.ZodVoid:
-    case ZodFirstPartyTypeKind.ZodSymbol:
+    case ZodFirstPartyTypeKind.ZodSymbol: {
       return undefined;
-    default:
+    }
+    default: {
       return ((_: never) => undefined)(typeName);
+    }
   }
 };
 

--- a/src/_vendor/zod-to-json-schema/parsers/bigint.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/bigint.ts
@@ -23,7 +23,7 @@ export function parseBigintDef(def: ZodBigIntDef, refs: Refs): JsonSchema7Bigint
 
   for (const check of def.checks) {
     switch (check.kind) {
-      case 'min':
+      case 'min': {
         if (refs.target === 'jsonSchema7') {
           if (check.inclusive) {
             setResponseValueAndErrors(res, 'minimum', check.value, check.message, refs);
@@ -37,7 +37,8 @@ export function parseBigintDef(def: ZodBigIntDef, refs: Refs): JsonSchema7Bigint
           setResponseValueAndErrors(res, 'minimum', check.value, check.message, refs);
         }
         break;
-      case 'max':
+      }
+      case 'max': {
         if (refs.target === 'jsonSchema7') {
           if (check.inclusive) {
             setResponseValueAndErrors(res, 'maximum', check.value, check.message, refs);
@@ -51,9 +52,11 @@ export function parseBigintDef(def: ZodBigIntDef, refs: Refs): JsonSchema7Bigint
           setResponseValueAndErrors(res, 'maximum', check.value, check.message, refs);
         }
         break;
-      case 'multipleOf':
+      }
+      case 'multipleOf': {
         setResponseValueAndErrors(res, 'multipleOf', check.value, check.message, refs);
         break;
+      }
     }
   }
   return res;

--- a/src/_vendor/zod-to-json-schema/parsers/date.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/date.ts
@@ -31,18 +31,21 @@ export function parseDateDef(
 
   switch (strategy) {
     case 'string':
-    case 'format:date-time':
+    case 'format:date-time': {
       return {
         type: 'string',
         format: 'date-time',
       };
-    case 'format:date':
+    }
+    case 'format:date': {
       return {
         type: 'string',
         format: 'date',
       };
-    case 'integer':
+    }
+    case 'integer': {
       return integerDateParser(def, refs);
+    }
   }
 }
 
@@ -58,7 +61,7 @@ const integerDateParser = (def: ZodDateDef, refs: Refs) => {
 
   for (const check of def.checks) {
     switch (check.kind) {
-      case 'min':
+      case 'min': {
         setResponseValueAndErrors(
           res,
           'minimum',
@@ -67,7 +70,8 @@ const integerDateParser = (def: ZodDateDef, refs: Refs) => {
           refs,
         );
         break;
-      case 'max':
+      }
+      case 'max': {
         setResponseValueAndErrors(
           res,
           'maximum',
@@ -76,6 +80,7 @@ const integerDateParser = (def: ZodDateDef, refs: Refs) => {
           refs,
         );
         break;
+      }
     }
   }
 

--- a/src/_vendor/zod-to-json-schema/parsers/number.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/number.ts
@@ -21,11 +21,12 @@ export function parseNumberDef(def: ZodNumberDef, refs: Refs): JsonSchema7Number
 
   for (const check of def.checks) {
     switch (check.kind) {
-      case 'int':
+      case 'int': {
         res.type = 'integer';
         addErrorMessage(res, 'type', check.message, refs);
         break;
-      case 'min':
+      }
+      case 'min': {
         if (refs.target === 'jsonSchema7') {
           if (check.inclusive) {
             setResponseValueAndErrors(res, 'minimum', check.value, check.message, refs);
@@ -39,7 +40,8 @@ export function parseNumberDef(def: ZodNumberDef, refs: Refs): JsonSchema7Number
           setResponseValueAndErrors(res, 'minimum', check.value, check.message, refs);
         }
         break;
-      case 'max':
+      }
+      case 'max': {
         if (refs.target === 'jsonSchema7') {
           if (check.inclusive) {
             setResponseValueAndErrors(res, 'maximum', check.value, check.message, refs);
@@ -53,9 +55,11 @@ export function parseNumberDef(def: ZodNumberDef, refs: Refs): JsonSchema7Number
           setResponseValueAndErrors(res, 'maximum', check.value, check.message, refs);
         }
         break;
-      case 'multipleOf':
+      }
+      case 'multipleOf': {
         setResponseValueAndErrors(res, 'multipleOf', check.value, check.message, refs);
         break;
+      }
     }
   }
   return res;

--- a/src/_vendor/zod-to-json-schema/parsers/string.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/string.ts
@@ -96,7 +96,7 @@ export function parseStringDef(def: ZodStringDef, refs: Refs): JsonSchema7String
   if (def.checks) {
     for (const check of def.checks) {
       switch (check.kind) {
-        case 'min':
+        case 'min': {
           setResponseValueAndErrors(
             res,
             'minLength',
@@ -105,7 +105,8 @@ export function parseStringDef(def: ZodStringDef, refs: Refs): JsonSchema7String
             refs,
           );
           break;
-        case 'max':
+        }
+        case 'max': {
           setResponseValueAndErrors(
             res,
             'maxLength',
@@ -115,55 +116,71 @@ export function parseStringDef(def: ZodStringDef, refs: Refs): JsonSchema7String
           );
 
           break;
-        case 'email':
+        }
+        case 'email': {
           switch (refs.emailStrategy) {
-            case 'format:email':
+            case 'format:email': {
               addFormat(res, 'email', check.message, refs);
               break;
-            case 'format:idn-email':
+            }
+            case 'format:idn-email': {
               addFormat(res, 'idn-email', check.message, refs);
               break;
-            case 'pattern:zod':
+            }
+            case 'pattern:zod': {
               addPattern(res, zodPatterns.email, check.message, refs);
               break;
+            }
           }
 
           break;
-        case 'url':
+        }
+        case 'url': {
           addFormat(res, 'uri', check.message, refs);
           break;
-        case 'uuid':
+        }
+        case 'uuid': {
           addFormat(res, 'uuid', check.message, refs);
           break;
-        case 'regex':
+        }
+        case 'regex': {
           addPattern(res, check.regex, check.message, refs);
           break;
-        case 'cuid':
+        }
+        case 'cuid': {
           addPattern(res, zodPatterns.cuid, check.message, refs);
           break;
-        case 'cuid2':
+        }
+        case 'cuid2': {
           addPattern(res, zodPatterns.cuid2, check.message, refs);
           break;
-        case 'startsWith':
+        }
+        case 'startsWith': {
           addPattern(res, new RegExp(`^${processPattern(check.value)}`), check.message, refs);
           break;
-        case 'endsWith':
+        }
+        case 'endsWith': {
           addPattern(res, new RegExp(`${processPattern(check.value)}$`), check.message, refs);
           break;
+        }
 
-        case 'datetime':
+        case 'datetime': {
           addFormat(res, 'date-time', check.message, refs);
           break;
-        case 'date':
+        }
+        case 'date': {
           addFormat(res, 'date', check.message, refs);
           break;
-        case 'time':
+        }
+        case 'time': {
           addFormat(res, 'time', check.message, refs);
           break;
-        case 'duration':
+        }
+        case 'duration': {
           addFormat(res, 'duration', check.message, refs);
           break;
-        case 'length':
+        }
+        case 'length': {
           setResponseValueAndErrors(
             res,
             'minLength',
@@ -179,6 +196,7 @@ export function parseStringDef(def: ZodStringDef, refs: Refs): JsonSchema7String
             refs,
           );
           break;
+        }
         case 'includes': {
           addPattern(res, new RegExp(processPattern(check.value)), check.message, refs);
           break;
@@ -192,9 +210,10 @@ export function parseStringDef(def: ZodStringDef, refs: Refs): JsonSchema7String
           }
           break;
         }
-        case 'emoji':
+        case 'emoji': {
           addPattern(res, zodPatterns.emoji, check.message, refs);
           break;
+        }
         case 'ulid': {
           addPattern(res, zodPatterns.ulid, check.message, refs);
           break;
@@ -224,10 +243,12 @@ export function parseStringDef(def: ZodStringDef, refs: Refs): JsonSchema7String
         }
         case 'toLowerCase':
         case 'toUpperCase':
-        case 'trim':
+        case 'trim': {
           break;
-        default:
+        }
+        default: {
           ((_: never) => undefined)(check);
+        }
       }
     }
   }

--- a/src/_vendor/zod-to-json-schema/parsers/union.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/union.ts
@@ -61,15 +61,18 @@ export function parseUnionDef(
       switch (type) {
         case 'string':
         case 'number':
-        case 'boolean':
+        case 'boolean': {
           types.push(type);
           break;
-        case 'bigint':
+        }
+        case 'bigint': {
           types.push('integer');
           break;
-        case 'object':
+        }
+        case 'object': {
           if (x._def.value === null) types.push('null');
           break;
+        }
       }
     }
 

--- a/src/internal/ws-adapter-browser.ts
+++ b/src/internal/ws-adapter-browser.ts
@@ -92,18 +92,20 @@ export class BrowserWebSocket implements WebSocketLike {
    */
   private static _wrapListener(event: string, listener: Listener): DOMEventHandler {
     switch (event) {
-      case 'message':
+      case 'message': {
         return (ev: MessageEvent) => {
           const isBinary = typeof ev.data !== 'string';
           listener(ev.data, isBinary);
         };
+      }
 
-      case 'close':
+      case 'close': {
         return (ev: CloseEvent) => {
           listener(ev.code, ev.reason);
         };
+      }
 
-      case 'error':
+      case 'error': {
         return (ev: any) => {
           // Some environments provide an ErrorEvent with a `.message`;
           // fall back to a generic message when the event carries nothing.
@@ -114,9 +116,11 @@ export class BrowserWebSocket implements WebSocketLike {
           }
           listener(err);
         };
+      }
 
-      default:
+      default: {
         return listener as DOMEventHandler;
+      }
     }
   }
 }

--- a/src/internal/ws-adapter-node.ts
+++ b/src/internal/ws-adapter-node.ts
@@ -87,19 +87,22 @@ export class NodeWebSocket implements WebSocketLike {
 
   private static _wrapListener(event: string, listener: Listener): Listener {
     switch (event) {
-      case 'message':
+      case 'message': {
         return (data: Buffer | ArrayBuffer | Buffer[], isBinary: boolean) => {
           listener(NodeWebSocket._normalizeMessageData(data, isBinary), isBinary);
         };
+      }
 
-      case 'close':
+      case 'close': {
         return (code: number, reason: Buffer) => {
           listener(code, reason.toString());
         };
+      }
 
       // 'open' and 'error' pass through unchanged
-      default:
+      default: {
         return listener;
+      }
     }
   }
 }

--- a/src/internal/ws.ts
+++ b/src/internal/ws.ts
@@ -160,35 +160,50 @@ export class SendQueue<T = unknown> {
 // RFC 6455 §7.4.1
 export function isRecoverableClose(code: number): boolean {
   switch (code) {
-    case 1000:
-      return false; // Normal closure
-    case 1001:
-      return true; // Going away (server shutting down)
-    case 1002:
-      return false; // Protocol error
-    case 1003:
-      return false; // Unsupported data
-    case 1005:
-      return true; // No status code (abnormal)
-    case 1006:
-      return true; // Abnormal closure (network drop)
-    case 1007:
-      return false; // Invalid payload
-    case 1008:
-      return false; // Policy violation
-    case 1009:
-      return false; // Message too big
-    case 1010:
-      return false; // Missing extension
-    case 1011:
-      return true; // Internal server error
-    case 1012:
-      return true; // Service restart
-    case 1013:
-      return true; // Try again later
-    case 1015:
-      return true; // TLS handshake failure
-    default:
+    case 1000: {
       return false;
+    } // Normal closure
+    case 1001: {
+      return true;
+    } // Going away (server shutting down)
+    case 1002: {
+      return false;
+    } // Protocol error
+    case 1003: {
+      return false;
+    } // Unsupported data
+    case 1005: {
+      return true;
+    } // No status code (abnormal)
+    case 1006: {
+      return true;
+    } // Abnormal closure (network drop)
+    case 1007: {
+      return false;
+    } // Invalid payload
+    case 1008: {
+      return false;
+    } // Policy violation
+    case 1009: {
+      return false;
+    } // Message too big
+    case 1010: {
+      return false;
+    } // Missing extension
+    case 1011: {
+      return true;
+    } // Internal server error
+    case 1012: {
+      return true;
+    } // Service restart
+    case 1013: {
+      return true;
+    } // Try again later
+    case 1015: {
+      return true;
+    } // TLS handshake failure
+    default: {
+      return false;
+    }
   }
 }

--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -344,9 +344,10 @@ export class AssistantStream
     this.#handleEvent(event);
 
     switch (event.event) {
-      case 'thread.created':
+      case 'thread.created': {
         //No action on this event.
         break;
+      }
 
       case 'thread.run.created':
       case 'thread.run.queued':
@@ -357,9 +358,10 @@ export class AssistantStream
       case 'thread.run.failed':
       case 'thread.run.cancelling':
       case 'thread.run.cancelled':
-      case 'thread.run.expired':
+      case 'thread.run.expired': {
         this.#handleRun(event);
         break;
+      }
 
       case 'thread.run.step.created':
       case 'thread.run.step.in_progress':
@@ -367,25 +369,29 @@ export class AssistantStream
       case 'thread.run.step.completed':
       case 'thread.run.step.failed':
       case 'thread.run.step.cancelled':
-      case 'thread.run.step.expired':
+      case 'thread.run.step.expired': {
         this.#handleRunStep(event);
         break;
+      }
 
       case 'thread.message.created':
       case 'thread.message.in_progress':
       case 'thread.message.delta':
       case 'thread.message.completed':
-      case 'thread.message.incomplete':
+      case 'thread.message.incomplete': {
         this.#handleMessage(event);
         break;
+      }
 
-      case 'error':
+      case 'error': {
         //This is included for completeness, but errors are processed in the SSE event processing so this should not occur
         throw new Error(
           'Encountered an error event in event processing - errors should be processed earlier',
         );
-      default:
+      }
+      default: {
         assertNever(event);
+      }
     }
   }
 
@@ -412,14 +418,16 @@ export class AssistantStream
     }
 
     switch (event.event) {
-      case 'thread.message.created':
+      case 'thread.message.created': {
         this._emit('messageCreated', event.data);
         break;
+      }
 
-      case 'thread.message.in_progress':
+      case 'thread.message.in_progress': {
         break;
+      }
 
-      case 'thread.message.delta':
+      case 'thread.message.delta': {
         this._emit('messageDelta', event.data.delta, accumulatedMessage);
 
         if (event.data.delta.content) {
@@ -439,12 +447,14 @@ export class AssistantStream
               //See if we have in progress content
               if (this.#currentContent) {
                 switch (this.#currentContent.type) {
-                  case 'text':
+                  case 'text': {
                     this._emit('textDone', this.#currentContent.text, this.#messageSnapshot);
                     break;
-                  case 'image_file':
+                  }
+                  case 'image_file': {
                     this._emit('imageFileDone', this.#currentContent.image_file, this.#messageSnapshot);
                     break;
+                  }
                 }
               }
 
@@ -456,20 +466,23 @@ export class AssistantStream
         }
 
         break;
+      }
 
       case 'thread.message.completed':
-      case 'thread.message.incomplete':
+      case 'thread.message.incomplete': {
         //We emit the latest content we were working on on completion (including incomplete)
         if (this.#currentContentIndex !== undefined) {
           const currentContent = event.data.content[this.#currentContentIndex];
           if (currentContent) {
             switch (currentContent.type) {
-              case 'image_file':
+              case 'image_file': {
                 this._emit('imageFileDone', currentContent.image_file, this.#messageSnapshot);
                 break;
-              case 'text':
+              }
+              case 'text': {
                 this._emit('textDone', currentContent.text, this.#messageSnapshot);
                 break;
+              }
             }
           }
         }
@@ -479,6 +492,7 @@ export class AssistantStream
         }
 
         this.#messageSnapshot = undefined;
+      }
     }
   }
 
@@ -487,9 +501,10 @@ export class AssistantStream
     this.#currentRunStepSnapshot = accumulatedRunStep;
 
     switch (event.event) {
-      case 'thread.run.step.created':
+      case 'thread.run.step.created': {
         this._emit('runStepCreated', event.data);
         break;
+      }
       case 'thread.run.step.delta': {
         const delta = event.data.delta;
         if (
@@ -533,8 +548,9 @@ export class AssistantStream
         this._emit('runStepDone', event.data, accumulatedRunStep);
         break;
       }
-      case 'thread.run.step.in_progress':
+      case 'thread.run.step.in_progress': {
         break;
+      }
     }
   }
 
@@ -545,9 +561,10 @@ export class AssistantStream
 
   #accumulateRunStep(event: RunStepStreamEvent): Runs.RunStep {
     switch (event.event) {
-      case 'thread.run.step.created':
+      case 'thread.run.step.created': {
         this.#runStepSnapshots[event.data.id] = event.data;
         return event.data;
+      }
 
       case 'thread.run.step.delta': {
         const snapshot = this.#runStepSnapshots[event.data.id] as Runs.RunStep;
@@ -569,9 +586,10 @@ export class AssistantStream
       case 'thread.run.step.failed':
       case 'thread.run.step.cancelled':
       case 'thread.run.step.expired':
-      case 'thread.run.step.in_progress':
+      case 'thread.run.step.in_progress': {
         this.#runStepSnapshots[event.data.id] = event.data;
         break;
+      }
     }
 
     if (this.#runStepSnapshots[event.data.id]) return this.#runStepSnapshots[event.data.id] as Runs.RunStep;
@@ -585,9 +603,10 @@ export class AssistantStream
     const newContent: MessageContentDelta[] = [];
 
     switch (event.event) {
-      case 'thread.message.created':
+      case 'thread.message.created': {
         //On creation the snapshot is just the initial message
         return [event.data, newContent];
+      }
 
       case 'thread.message.delta': {
         if (!snapshot) {
@@ -620,12 +639,13 @@ export class AssistantStream
 
       case 'thread.message.in_progress':
       case 'thread.message.completed':
-      case 'thread.message.incomplete':
+      case 'thread.message.incomplete': {
         //No changes on other thread events
         if (snapshot) {
           return [snapshot, newContent];
         }
         throw new Error('Received thread message event with no existing snapshot');
+      }
     }
     throw new Error('Tried to accumulate a non-message event');
   }
@@ -708,26 +728,31 @@ export class AssistantStream
     this.#currentRunSnapshot = event.data;
 
     switch (event.event) {
-      case 'thread.run.created':
+      case 'thread.run.created': {
         break;
-      case 'thread.run.queued':
+      }
+      case 'thread.run.queued': {
         break;
-      case 'thread.run.in_progress':
+      }
+      case 'thread.run.in_progress': {
         break;
+      }
       case 'thread.run.requires_action':
       case 'thread.run.cancelled':
       case 'thread.run.failed':
       case 'thread.run.completed':
       case 'thread.run.expired':
-      case 'thread.run.incomplete':
+      case 'thread.run.incomplete': {
         this.#finalRun = event.data;
         if (this.#currentToolCall) {
           this._emit('toolCallDone', this.#currentToolCall);
           this.#currentToolCall = undefined;
         }
         break;
-      case 'thread.run.cancelling':
+      }
+      case 'thread.run.cancelling': {
         break;
+      }
     }
   }
 

--- a/src/lib/responses/ResponseStream.ts
+++ b/src/lib/responses/ResponseStream.ts
@@ -153,9 +153,10 @@ export class ResponseStream<ParsedT = null>
         }
         break;
       }
-      default:
+      default: {
         maybeEmit(event.type, event);
         break;
+      }
     }
   }
 

--- a/tests/lib/AssistantStream.test.ts
+++ b/tests/lib/AssistantStream.test.ts
@@ -532,19 +532,21 @@ describe('AssistantStream factories and async iteration', () => {
       let runner: AssistantStream;
 
       switch (kind) {
-        case 'run':
+        case 'run': {
           runner = AssistantStream.createAssistantStream(
             'thread_123',
             { create: vi.fn().mockResolvedValue(stream) } as any,
             { assistant_id: 'assistant_123' },
           );
           break;
-        case 'thread':
+        }
+        case 'thread': {
           runner = AssistantStream.createThreadAssistantStream({ assistant_id: 'assistant_123' }, {
             createAndRun: vi.fn().mockResolvedValue(stream),
           } as any);
           break;
-        case 'tool':
+        }
+        case 'tool': {
           runner = AssistantStream.createToolAssistantStream(
             'run_123',
             { submitToolOutputs: vi.fn().mockResolvedValue(stream) } as any,
@@ -552,6 +554,7 @@ describe('AssistantStream factories and async iteration', () => {
             undefined,
           );
           break;
+        }
       }
 
       await expect(runner.done()).rejects.toThrow(APIUserAbortError);

--- a/tests/live/bedrock.live.test.ts
+++ b/tests/live/bedrock.live.test.ts
@@ -46,15 +46,19 @@ async function providerForAuth(
   endpoint: { region: string; baseURL?: string | undefined },
 ): Promise<Provider> {
   switch (mode) {
-    case 'bearer':
+    case 'bearer': {
       return bearerBedrock({ ...endpoint, apiKey: requiredEnv('AWS_BEARER_TOKEN_BEDROCK') });
-    case 'environment-bearer':
+    }
+    case 'environment-bearer': {
       requiredEnv('AWS_BEARER_TOKEN_BEDROCK');
       return bearerBedrock(endpoint);
-    case 'default-chain':
+    }
+    case 'default-chain': {
       return awsBedrock({ ...endpoint, apiKey: null });
-    case 'profile':
+    }
+    case 'profile': {
       return awsBedrock({ ...endpoint, apiKey: null, profile: requiredEnv('AWS_PROFILE') });
+    }
     case 'static': {
       const sessionToken = process.env['AWS_SESSION_TOKEN']?.trim();
       return awsBedrock({


### PR DESCRIPTION
## Summary

- Removes `unicorn/switch-case-braces` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 178 of 185.
- Base: `dev/hayden/ultracite-177-require-unicode-regexp`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`