### PR TITLE
chore(lint): enable func-names

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -7,7 +7,6 @@ const stainlessGeneratedFiles = requireConfig('./scripts/stainless-generated-fil
 // Existing handwritten SDK patterns predate these preset rules.
 const compatibilityRules = [
   'curly',
-  'func-names',
   'func-style',
   'no-use-before-define',
   'sort-keys',
@@ -517,9 +516,11 @@ module.exports = defineConfig({
         'tests/form.test.ts',
         'tests/helpers/standard-schema.test.ts',
         'tests/internal/uploads-branches.test.ts',
+        'tests/internal/stream-utils.test.ts',
         'tests/lib/azure.test.ts',
         'tests/lib/ChatCompletionRunFunctions.test.ts',
         'tests/lib/responsesWebSocket.test.ts',
+        'tests/lib/streaming-core.test.ts',
         'tests/lib/transform.test.ts',
         'tests/lib/workload-identity.test.ts',
         'tests/qs/stringify.test.ts',

--- a/src/internal/qs/stringify.ts
+++ b/src/internal/qs/stringify.ts
@@ -16,7 +16,7 @@ const array_prefix_generators = {
   },
 };
 
-const push_to_array = function (arr: any[], value_or_array: any) {
+const push_to_array = function push_to_array(arr: any[], value_or_array: any) {
   Array.prototype.push.apply(arr, isArray(value_or_array) ? value_or_array : [value_or_array]);
 };
 

--- a/tests/internal/stream-utils.test.ts
+++ b/tests/internal/stream-utils.test.ts
@@ -12,7 +12,7 @@ describe.each([
   ['runtime shim stream adapter', adaptShimReadableStream],
 ])('%s', (_name, adapt) => {
   test('returns streams that are already asynchronously iterable unchanged', () => {
-    const stream = (async function* () {
+    const stream = (async function* stream() {
       yield 'value';
     })();
 
@@ -73,7 +73,7 @@ describe('ReadableStreamFrom', () => {
 
     const asynchronous: string[] = [];
     for await (const value of ReadableStreamFrom(
-      (async function* () {
+      (async function* chunks() {
         yield 'first';
         yield 'second';
       })(),

--- a/tests/internal/uploads-branches.test.ts
+++ b/tests/internal/uploads-branches.test.ts
@@ -263,7 +263,7 @@ describe('lazy multipart stream encoding', () => {
       {
         body: {
           upload: toStreamingFile(
-            (async function* () {
+            (async function* upload() {
               yield legacyBlob;
             })(),
             'legacy.bin',

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -1963,71 +1963,75 @@ describe('resource completions', () => {
       const listener = new StreamingRunnerListener(runner);
 
       await Promise.all([
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
-          yield {
-            id: '1',
-            choices: [
-              {
-                index: 0,
-                finish_reason: 'function_call',
-                logprobs: null,
-                delta: {
-                  role: 'assistant',
-                  content: null,
-                  tool_calls: [
-                    {
-                      type: 'function',
-                      index: 0,
-                      id: '123',
-                      function: {
-                        arguments: '',
-                        name: 'getWeather',
-                      },
-                    },
-                  ],
-                },
-              },
-            ],
-            created: Math.floor(Date.now() / 1000),
-            model: 'gpt-3.5-turbo',
-            object: 'chat.completion.chunk',
-          };
-        }),
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          expect(request.messages).toEqual([
-            { role: 'user', content: 'tell me what the weather is like' },
-            {
-              role: 'assistant',
-              content: null,
-              tool_calls: [
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
+            yield {
+              id: '1',
+              choices: [
                 {
-                  type: 'function',
-                  id: '123',
-                  function: {
-                    arguments: '',
-                    name: 'getWeather',
+                  index: 0,
+                  finish_reason: 'function_call',
+                  logprobs: null,
+                  delta: {
+                    role: 'assistant',
+                    content: null,
+                    tool_calls: [
+                      {
+                        type: 'function',
+                        index: 0,
+                        id: '123',
+                        function: {
+                          arguments: '',
+                          name: 'getWeather',
+                        },
+                      },
+                    ],
                   },
                 },
               ],
-            },
-            {
-              role: 'tool',
-              content: `it's raining`,
-              tool_call_id: '123',
-            },
-            injectedMessage,
-          ]);
-          for (const choice of contentChoiceDeltas(`it's raining`)) {
-            yield {
-              id: '2',
-              choices: [choice],
               created: Math.floor(Date.now() / 1000),
               model: 'gpt-3.5-turbo',
               object: 'chat.completion.chunk',
             };
-          }
-        }),
+          },
+        ),
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            expect(request.messages).toEqual([
+              { role: 'user', content: 'tell me what the weather is like' },
+              {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    type: 'function',
+                    id: '123',
+                    function: {
+                      arguments: '',
+                      name: 'getWeather',
+                    },
+                  },
+                ],
+              },
+              {
+                role: 'tool',
+                content: `it's raining`,
+                tool_call_id: '123',
+              },
+              injectedMessage,
+            ]);
+            for (const choice of contentChoiceDeltas(`it's raining`)) {
+              yield {
+                id: '2',
+                choices: [choice],
+                created: Math.floor(Date.now() / 1000),
+                model: 'gpt-3.5-turbo',
+                object: 'chat.completion.chunk',
+              };
+            }
+          },
+        ),
         runner.done(),
       ]);
 
@@ -2088,70 +2092,74 @@ describe('resource completions', () => {
       const listener = new StreamingRunnerListener(proxied);
 
       await Promise.all([
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
-          yield {
-            id: '1',
-            choices: [
-              {
-                index: 0,
-                finish_reason: 'function_call',
-                logprobs: null,
-                delta: {
-                  role: 'assistant',
-                  content: null,
-                  tool_calls: [
-                    {
-                      type: 'function',
-                      index: 0,
-                      id: '123',
-                      function: {
-                        arguments: '',
-                        name: 'getWeather',
-                      },
-                    },
-                  ],
-                },
-              },
-            ],
-            created: Math.floor(Date.now() / 1000),
-            model: 'gpt-3.5-turbo',
-            object: 'chat.completion.chunk',
-          };
-        }),
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          expect(request.messages).toEqual([
-            { role: 'user', content: 'tell me what the weather is like' },
-            {
-              role: 'assistant',
-              content: null,
-              tool_calls: [
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
+            yield {
+              id: '1',
+              choices: [
                 {
-                  type: 'function',
-                  id: '123',
-                  function: {
-                    arguments: '',
-                    name: 'getWeather',
+                  index: 0,
+                  finish_reason: 'function_call',
+                  logprobs: null,
+                  delta: {
+                    role: 'assistant',
+                    content: null,
+                    tool_calls: [
+                      {
+                        type: 'function',
+                        index: 0,
+                        id: '123',
+                        function: {
+                          arguments: '',
+                          name: 'getWeather',
+                        },
+                      },
+                    ],
                   },
                 },
               ],
-            },
-            {
-              role: 'tool',
-              content: `it's raining`,
-              tool_call_id: '123',
-            },
-          ]);
-          for (const choice of contentChoiceDeltas(`it's raining`)) {
-            yield {
-              id: '2',
-              choices: [choice],
               created: Math.floor(Date.now() / 1000),
               model: 'gpt-3.5-turbo',
               object: 'chat.completion.chunk',
             };
-          }
-        }),
+          },
+        ),
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            expect(request.messages).toEqual([
+              { role: 'user', content: 'tell me what the weather is like' },
+              {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    type: 'function',
+                    id: '123',
+                    function: {
+                      arguments: '',
+                      name: 'getWeather',
+                    },
+                  },
+                ],
+              },
+              {
+                role: 'tool',
+                content: `it's raining`,
+                tool_call_id: '123',
+              },
+            ]);
+            for (const choice of contentChoiceDeltas(`it's raining`)) {
+              yield {
+                id: '2',
+                choices: [choice],
+                created: Math.floor(Date.now() / 1000),
+                model: 'gpt-3.5-turbo',
+                object: 'chat.completion.chunk',
+              };
+            }
+          },
+        ),
         proxied.done(),
       ]);
 
@@ -2214,37 +2222,39 @@ describe('resource completions', () => {
       const listener = new StreamingRunnerListener(proxied);
 
       await Promise.all([
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
-          yield {
-            id: '1',
-            choices: [
-              {
-                index: 0,
-                finish_reason: 'function_call',
-                logprobs: null,
-                delta: {
-                  role: 'assistant',
-                  content: null,
-                  tool_calls: [
-                    {
-                      type: 'function',
-                      index: 0,
-                      id: '123',
-                      function: {
-                        arguments: '',
-                        name: 'getWeather',
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
+            yield {
+              id: '1',
+              choices: [
+                {
+                  index: 0,
+                  finish_reason: 'function_call',
+                  logprobs: null,
+                  delta: {
+                    role: 'assistant',
+                    content: null,
+                    tool_calls: [
+                      {
+                        type: 'function',
+                        index: 0,
+                        id: '123',
+                        function: {
+                          arguments: '',
+                          name: 'getWeather',
+                        },
                       },
-                    },
-                  ],
+                    ],
+                  },
                 },
-              },
-            ],
-            created: Math.floor(Date.now() / 1000),
-            model: 'gpt-3.5-turbo',
-            object: 'chat.completion.chunk',
-          };
-        }),
+              ],
+              created: Math.floor(Date.now() / 1000),
+              model: 'gpt-3.5-turbo',
+              object: 'chat.completion.chunk',
+            };
+          },
+        ),
         runner.done(),
         proxied.done(),
       ]);
@@ -2307,37 +2317,39 @@ describe('resource completions', () => {
       const listener = new StreamingRunnerListener(proxied);
 
       await Promise.all([
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
-          yield {
-            id: '1',
-            choices: [
-              {
-                index: 0,
-                finish_reason: 'function_call',
-                logprobs: null,
-                delta: {
-                  role: 'assistant',
-                  content: null,
-                  tool_calls: [
-                    {
-                      type: 'function',
-                      index: 0,
-                      id: '123',
-                      function: {
-                        arguments: '',
-                        name: 'getWeather',
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
+            yield {
+              id: '1',
+              choices: [
+                {
+                  index: 0,
+                  finish_reason: 'function_call',
+                  logprobs: null,
+                  delta: {
+                    role: 'assistant',
+                    content: null,
+                    tool_calls: [
+                      {
+                        type: 'function',
+                        index: 0,
+                        id: '123',
+                        function: {
+                          arguments: '',
+                          name: 'getWeather',
+                        },
                       },
-                    },
-                  ],
+                    ],
+                  },
                 },
-              },
-            ],
-            created: Math.floor(Date.now() / 1000),
-            model: 'gpt-3.5-turbo',
-            object: 'chat.completion.chunk',
-          };
-        }),
+              ],
+              created: Math.floor(Date.now() / 1000),
+              model: 'gpt-3.5-turbo',
+              object: 'chat.completion.chunk',
+            };
+          },
+        ),
         runner.done(),
         proxied.done(),
       ]);
@@ -2391,7 +2403,7 @@ describe('resource completions', () => {
       const proxied = ChatCompletionStreamingRunner.fromReadableStream(runner.toReadableStream());
 
       await Promise.all([
-        handleRequest(async function* (): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+        handleRequest(async function* requestHandler(): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
           for (const choice of functionCallDeltas('', { id: '', name: 'getWeather' })) {
             yield {
               id: '1',
@@ -2402,30 +2414,32 @@ describe('resource completions', () => {
             };
           }
         }),
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          const assistantMessage = request.messages[1];
-          const toolMessage = request.messages[2];
-          if (assistantMessage?.role !== 'assistant' || !assistantMessage.tool_calls?.[0]) {
-            throw new Error('expected an assistant message with a tool call');
-          }
-          if (toolMessage?.role !== 'tool') {
-            throw new Error('expected a tool result message');
-          }
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            const assistantMessage = request.messages[1];
+            const toolMessage = request.messages[2];
+            if (assistantMessage?.role !== 'assistant' || !assistantMessage.tool_calls?.[0]) {
+              throw new Error('expected an assistant message with a tool call');
+            }
+            if (toolMessage?.role !== 'tool') {
+              throw new Error('expected a tool result message');
+            }
 
-          const generatedID = assistantMessage.tool_calls[0].id;
-          expect(generatedID).toMatch(/^call_/);
-          expect(toolMessage.tool_call_id).toBe(generatedID);
+            const generatedID = assistantMessage.tool_calls[0].id;
+            expect(generatedID).toMatch(/^call_/);
+            expect(toolMessage.tool_call_id).toBe(generatedID);
 
-          for (const choice of contentChoiceDeltas(`it's raining`)) {
-            yield {
-              id: '2',
-              choices: [choice],
-              created: Math.floor(Date.now() / 1000),
-              model: 'gpt-3.5-turbo',
-              object: 'chat.completion.chunk',
-            };
-          }
-        }),
+            for (const choice of contentChoiceDeltas(`it's raining`)) {
+              yield {
+                id: '2',
+                choices: [choice],
+                created: Math.floor(Date.now() / 1000),
+                model: 'gpt-3.5-turbo',
+                object: 'chat.completion.chunk',
+              };
+            }
+          },
+        ),
         runner.done(),
         proxied.done(),
       ]);
@@ -2486,7 +2500,7 @@ describe('resource completions', () => {
       })();
 
       const [, chunks] = await Promise.all([
-        handleRequest(async function* (): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+        handleRequest(async function* requestHandler(): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
           yield {
             id: '1',
             choices: [
@@ -2554,36 +2568,38 @@ describe('resource completions', () => {
       runner.on('functionToolCallResult', () => controller.abort());
       const listener = new StreamingRunnerListener(runner);
 
-      await handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-        expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
-        yield {
-          id: '1',
-          choices: [
-            {
-              index: 0,
-              finish_reason: 'function_call',
-              delta: {
-                role: 'assistant',
-                content: null,
-                tool_calls: [
-                  {
-                    type: 'function',
-                    index: 0,
-                    id: '123',
-                    function: {
-                      arguments: '',
-                      name: 'getWeather',
+      await handleRequest(
+        async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+          expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
+          yield {
+            id: '1',
+            choices: [
+              {
+                index: 0,
+                finish_reason: 'function_call',
+                delta: {
+                  role: 'assistant',
+                  content: null,
+                  tool_calls: [
+                    {
+                      type: 'function',
+                      index: 0,
+                      id: '123',
+                      function: {
+                        arguments: '',
+                        name: 'getWeather',
+                      },
                     },
-                  },
-                ],
+                  ],
+                },
               },
-            },
-          ],
-          created: Math.floor(Date.now() / 1000),
-          model: 'gpt-3.5-turbo',
-          object: 'chat.completion.chunk',
-        };
-      });
+            ],
+            created: Math.floor(Date.now() / 1000),
+            model: 'gpt-3.5-turbo',
+            object: 'chat.completion.chunk',
+          };
+        },
+      );
 
       await runner.done().catch(() => {});
 
@@ -2643,77 +2659,81 @@ describe('resource completions', () => {
       const listener = new StreamingRunnerListener(runner);
 
       await Promise.all([
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          expect(request.messages).toEqual([
-            {
-              role: 'user',
-              content: 'can you tell me how many properties are in {"a": 1, "b": 2, "c": 3}',
-            },
-          ]);
-          yield {
-            id: '1',
-            choices: [
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            expect(request.messages).toEqual([
               {
-                index: 0,
-                finish_reason: 'function_call',
-                delta: {
-                  role: 'assistant',
-                  content: null,
-                  tool_calls: [
-                    {
-                      type: 'function',
-                      id: '123',
-                      index: 0,
-                      function: {
-                        arguments: '{"a": 1, "b": 2, "c": 3}',
-                        name: 'numProperties',
-                      },
-                    },
-                  ],
-                },
+                role: 'user',
+                content: 'can you tell me how many properties are in {"a": 1, "b": 2, "c": 3}',
               },
-            ],
-            created: Math.floor(Date.now() / 1000),
-            model: 'gpt-3.5-turbo',
-            object: 'chat.completion.chunk',
-          };
-        }),
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          expect(request.messages).toEqual([
-            {
-              role: 'user',
-              content: 'can you tell me how many properties are in {"a": 1, "b": 2, "c": 3}',
-            },
-            {
-              role: 'assistant',
-              content: null,
-              tool_calls: [
+            ]);
+            yield {
+              id: '1',
+              choices: [
                 {
-                  type: 'function',
-                  id: '123',
-                  function: {
-                    arguments: '{"a": 1, "b": 2, "c": 3}',
-                    name: 'numProperties',
+                  index: 0,
+                  finish_reason: 'function_call',
+                  delta: {
+                    role: 'assistant',
+                    content: null,
+                    tool_calls: [
+                      {
+                        type: 'function',
+                        id: '123',
+                        index: 0,
+                        function: {
+                          arguments: '{"a": 1, "b": 2, "c": 3}',
+                          name: 'numProperties',
+                        },
+                      },
+                    ],
                   },
                 },
               ],
-            },
-            {
-              role: 'tool',
-              content: '3',
-              tool_call_id: '123',
-            },
-          ]);
-          for (const choice of contentChoiceDeltas(`there are 3 properties in {"a": 1, "b": 2, "c": 3}`)) {
-            yield {
-              id: '2',
-              choices: [choice],
               created: Math.floor(Date.now() / 1000),
               model: 'gpt-3.5-turbo',
               object: 'chat.completion.chunk',
             };
-          }
-        }),
+          },
+        ),
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            expect(request.messages).toEqual([
+              {
+                role: 'user',
+                content: 'can you tell me how many properties are in {"a": 1, "b": 2, "c": 3}',
+              },
+              {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    type: 'function',
+                    id: '123',
+                    function: {
+                      arguments: '{"a": 1, "b": 2, "c": 3}',
+                      name: 'numProperties',
+                    },
+                  },
+                ],
+              },
+              {
+                role: 'tool',
+                content: '3',
+                tool_call_id: '123',
+              },
+            ]);
+            for (const choice of contentChoiceDeltas(`there are 3 properties in {"a": 1, "b": 2, "c": 3}`)) {
+              yield {
+                id: '2',
+                choices: [choice],
+                created: Math.floor(Date.now() / 1000),
+                model: 'gpt-3.5-turbo',
+                object: 'chat.completion.chunk',
+              };
+            }
+          },
+        ),
         runner.done(),
       ]);
 
@@ -2779,120 +2799,126 @@ describe('resource completions', () => {
       const listener = new StreamingRunnerListener(runner);
 
       await Promise.all([
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          expect(request.messages).toEqual([
-            {
-              role: 'user',
-              content: 'can you tell me how many properties are in {"a": 1, "b": 2, "c": 3}',
-            },
-          ]);
-          for (const choice of functionCallDeltas('[{"a": 1, "b": 2, "c": 3}]', {
-            name: 'numProperties',
-            id: '123',
-          })) {
-            yield {
-              id: '1',
-              choices: [choice],
-              created: Math.floor(Date.now() / 1000),
-              model: 'gpt-3.5-turbo',
-              object: 'chat.completion.chunk',
-            };
-          }
-        }),
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          expect(request.messages).toEqual([
-            {
-              role: 'user',
-              content: 'can you tell me how many properties are in {"a": 1, "b": 2, "c": 3}',
-            },
-            {
-              role: 'assistant',
-              content: null,
-              tool_calls: [
-                {
-                  type: 'function',
-                  id: '123',
-                  function: {
-                    arguments: '[{"a": 1, "b": 2, "c": 3}]',
-                    name: 'numProperties',
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            expect(request.messages).toEqual([
+              {
+                role: 'user',
+                content: 'can you tell me how many properties are in {"a": 1, "b": 2, "c": 3}',
+              },
+            ]);
+            for (const choice of functionCallDeltas('[{"a": 1, "b": 2, "c": 3}]', {
+              name: 'numProperties',
+              id: '123',
+            })) {
+              yield {
+                id: '1',
+                choices: [choice],
+                created: Math.floor(Date.now() / 1000),
+                model: 'gpt-3.5-turbo',
+                object: 'chat.completion.chunk',
+              };
+            }
+          },
+        ),
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            expect(request.messages).toEqual([
+              {
+                role: 'user',
+                content: 'can you tell me how many properties are in {"a": 1, "b": 2, "c": 3}',
+              },
+              {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    type: 'function',
+                    id: '123',
+                    function: {
+                      arguments: '[{"a": 1, "b": 2, "c": 3}]',
+                      name: 'numProperties',
+                    },
                   },
-                },
-              ],
-            },
-            {
-              role: 'tool',
-              content: `must be an object`,
-              tool_call_id: '123',
-            },
-          ]);
-          for (const choice of functionCallDeltas('{"a": 1, "b": 2, "c": 3}', {
-            name: 'numProperties',
-            id: '1234',
-          })) {
-            yield {
-              id: '2',
-              choices: [choice],
-              created: Math.floor(Date.now() / 1000),
-              model: 'gpt-3.5-turbo',
-              object: 'chat.completion.chunk',
-            };
-          }
-        }),
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          expect(request.messages).toEqual([
-            {
-              role: 'user',
-              content: 'can you tell me how many properties are in {"a": 1, "b": 2, "c": 3}',
-            },
-            {
-              role: 'assistant',
-              content: null,
-              tool_calls: [
-                {
-                  type: 'function',
-                  id: '123',
-                  function: {
-                    arguments: '[{"a": 1, "b": 2, "c": 3}]',
-                    name: 'numProperties',
+                ],
+              },
+              {
+                role: 'tool',
+                content: `must be an object`,
+                tool_call_id: '123',
+              },
+            ]);
+            for (const choice of functionCallDeltas('{"a": 1, "b": 2, "c": 3}', {
+              name: 'numProperties',
+              id: '1234',
+            })) {
+              yield {
+                id: '2',
+                choices: [choice],
+                created: Math.floor(Date.now() / 1000),
+                model: 'gpt-3.5-turbo',
+                object: 'chat.completion.chunk',
+              };
+            }
+          },
+        ),
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            expect(request.messages).toEqual([
+              {
+                role: 'user',
+                content: 'can you tell me how many properties are in {"a": 1, "b": 2, "c": 3}',
+              },
+              {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    type: 'function',
+                    id: '123',
+                    function: {
+                      arguments: '[{"a": 1, "b": 2, "c": 3}]',
+                      name: 'numProperties',
+                    },
                   },
-                },
-              ],
-            },
-            {
-              role: 'tool',
-              content: `must be an object`,
-              tool_call_id: '123',
-            },
-            {
-              role: 'assistant',
-              content: null,
-              tool_calls: [
-                {
-                  type: 'function',
-                  id: '1234',
-                  function: {
-                    arguments: '{"a": 1, "b": 2, "c": 3}',
-                    name: 'numProperties',
+                ],
+              },
+              {
+                role: 'tool',
+                content: `must be an object`,
+                tool_call_id: '123',
+              },
+              {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    type: 'function',
+                    id: '1234',
+                    function: {
+                      arguments: '{"a": 1, "b": 2, "c": 3}',
+                      name: 'numProperties',
+                    },
                   },
-                },
-              ],
-            },
-            {
-              role: 'tool',
-              content: '3',
-              tool_call_id: '1234',
-            },
-          ]);
-          for (const choice of contentChoiceDeltas(`there are 3 properties in {"a": 1, "b": 2, "c": 3}`)) {
-            yield {
-              id: '3',
-              choices: [choice],
-              created: Math.floor(Date.now() / 1000),
-              model: 'gpt-3.5-turbo',
-              object: 'chat.completion.chunk',
-            };
-          }
-        }),
+                ],
+              },
+              {
+                role: 'tool',
+                content: '3',
+                tool_call_id: '1234',
+              },
+            ]);
+            for (const choice of contentChoiceDeltas(`there are 3 properties in {"a": 1, "b": 2, "c": 3}`)) {
+              yield {
+                id: '3',
+                choices: [choice],
+                created: Math.floor(Date.now() / 1000),
+                model: 'gpt-3.5-turbo',
+                object: 'chat.completion.chunk',
+              };
+            }
+          },
+        ),
         runner.done(),
       ]);
 
@@ -2973,36 +2999,38 @@ describe('resource completions', () => {
       const listener = new StreamingRunnerListener(runner);
 
       await Promise.all([
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
-          yield {
-            id: '1',
-            choices: [
-              {
-                index: 0,
-                finish_reason: 'function_call',
-                delta: {
-                  role: 'assistant',
-                  content: null,
-                  tool_calls: [
-                    {
-                      type: 'function',
-                      index: 0,
-                      id: '123',
-                      function: {
-                        arguments: '',
-                        name: 'getWeather',
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
+            yield {
+              id: '1',
+              choices: [
+                {
+                  index: 0,
+                  finish_reason: 'function_call',
+                  delta: {
+                    role: 'assistant',
+                    content: null,
+                    tool_calls: [
+                      {
+                        type: 'function',
+                        index: 0,
+                        id: '123',
+                        function: {
+                          arguments: '',
+                          name: 'getWeather',
+                        },
                       },
-                    },
-                  ],
+                    ],
+                  },
                 },
-              },
-            ],
-            created: Math.floor(Date.now() / 1000),
-            model: 'gpt-3.5-turbo',
-            object: 'chat.completion.chunk',
-          };
-        }),
+              ],
+              created: Math.floor(Date.now() / 1000),
+              model: 'gpt-3.5-turbo',
+              object: 'chat.completion.chunk',
+            };
+          },
+        ),
         runner.done(),
       ]);
 
@@ -3053,140 +3081,146 @@ describe('resource completions', () => {
       const listener = new StreamingRunnerListener(runner);
 
       await Promise.all([
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
-          yield {
-            id: '1',
-            choices: [
-              {
-                index: 0,
-                finish_reason: 'function_call',
-                delta: {
-                  role: 'assistant',
-                  content: null,
-                  tool_calls: [
-                    {
-                      type: 'function',
-                      index: 0,
-                      id: '123',
-                      function: {
-                        arguments: '',
-                        name: 'get_weather',
-                      },
-                    },
-                  ],
-                },
-              },
-            ],
-            created: Math.floor(Date.now() / 1000),
-            model: 'gpt-3.5-turbo',
-            object: 'chat.completion.chunk',
-          };
-        }),
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          expect(request.messages).toEqual([
-            { role: 'user', content: 'tell me what the weather is like' },
-            {
-              role: 'assistant',
-              content: null,
-              tool_calls: [
-                {
-                  type: 'function',
-                  id: '123',
-                  function: {
-                    arguments: '',
-                    name: 'get_weather',
-                  },
-                },
-              ],
-            },
-            {
-              role: 'tool',
-              content: `Invalid tool_call: "get_weather". Available options are: "getWeather". Please try again`,
-              tool_call_id: '123',
-            },
-          ]);
-          yield {
-            id: '2',
-            choices: [
-              {
-                index: 0,
-                finish_reason: 'function_call',
-                logprobs: null,
-                delta: {
-                  role: 'assistant',
-                  content: null,
-                  tool_calls: [
-                    {
-                      type: 'function',
-                      index: 0,
-                      id: '1234',
-                      function: {
-                        arguments: '',
-                        name: 'getWeather',
-                      },
-                    },
-                  ],
-                },
-              },
-            ],
-            created: Math.floor(Date.now() / 1000),
-            model: 'gpt-3.5-turbo',
-            object: 'chat.completion.chunk',
-          };
-        }),
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          expect(request.messages).toEqual([
-            { role: 'user', content: 'tell me what the weather is like' },
-            {
-              role: 'assistant',
-              content: null,
-              tool_calls: [
-                {
-                  type: 'function',
-                  id: '123',
-                  function: {
-                    arguments: '',
-                    name: 'get_weather',
-                  },
-                },
-              ],
-            },
-            {
-              role: 'tool',
-              content: `Invalid tool_call: "get_weather". Available options are: "getWeather". Please try again`,
-              tool_call_id: '123',
-            },
-            {
-              role: 'assistant',
-              content: null,
-              tool_calls: [
-                {
-                  type: 'function',
-                  id: '1234',
-                  function: {
-                    arguments: '',
-                    name: 'getWeather',
-                  },
-                },
-              ],
-            },
-            {
-              role: 'tool',
-              content: `it's raining`,
-              tool_call_id: '1234',
-            },
-          ]);
-          for (const choice of contentChoiceDeltas(`it's raining`)) {
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
             yield {
-              id: '3',
-              choices: [choice],
+              id: '1',
+              choices: [
+                {
+                  index: 0,
+                  finish_reason: 'function_call',
+                  delta: {
+                    role: 'assistant',
+                    content: null,
+                    tool_calls: [
+                      {
+                        type: 'function',
+                        index: 0,
+                        id: '123',
+                        function: {
+                          arguments: '',
+                          name: 'get_weather',
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
               created: Math.floor(Date.now() / 1000),
               model: 'gpt-3.5-turbo',
               object: 'chat.completion.chunk',
             };
-          }
-        }),
+          },
+        ),
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            expect(request.messages).toEqual([
+              { role: 'user', content: 'tell me what the weather is like' },
+              {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    type: 'function',
+                    id: '123',
+                    function: {
+                      arguments: '',
+                      name: 'get_weather',
+                    },
+                  },
+                ],
+              },
+              {
+                role: 'tool',
+                content: `Invalid tool_call: "get_weather". Available options are: "getWeather". Please try again`,
+                tool_call_id: '123',
+              },
+            ]);
+            yield {
+              id: '2',
+              choices: [
+                {
+                  index: 0,
+                  finish_reason: 'function_call',
+                  logprobs: null,
+                  delta: {
+                    role: 'assistant',
+                    content: null,
+                    tool_calls: [
+                      {
+                        type: 'function',
+                        index: 0,
+                        id: '1234',
+                        function: {
+                          arguments: '',
+                          name: 'getWeather',
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+              created: Math.floor(Date.now() / 1000),
+              model: 'gpt-3.5-turbo',
+              object: 'chat.completion.chunk',
+            };
+          },
+        ),
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            expect(request.messages).toEqual([
+              { role: 'user', content: 'tell me what the weather is like' },
+              {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    type: 'function',
+                    id: '123',
+                    function: {
+                      arguments: '',
+                      name: 'get_weather',
+                    },
+                  },
+                ],
+              },
+              {
+                role: 'tool',
+                content: `Invalid tool_call: "get_weather". Available options are: "getWeather". Please try again`,
+                tool_call_id: '123',
+              },
+              {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    type: 'function',
+                    id: '1234',
+                    function: {
+                      arguments: '',
+                      name: 'getWeather',
+                    },
+                  },
+                ],
+              },
+              {
+                role: 'tool',
+                content: `it's raining`,
+                tool_call_id: '1234',
+              },
+            ]);
+            for (const choice of contentChoiceDeltas(`it's raining`)) {
+              yield {
+                id: '3',
+                choices: [choice],
+                created: Math.floor(Date.now() / 1000),
+                model: 'gpt-3.5-turbo',
+                object: 'chat.completion.chunk',
+              };
+            }
+          },
+        ),
         runner.done(),
       ]);
 
@@ -3260,18 +3294,20 @@ describe('resource completions', () => {
       const listener = new StreamingRunnerListener(runner);
 
       await Promise.all([
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
-          for (const choice of contentChoiceDeltas(`The weather is great today!`)) {
-            yield {
-              id: '1',
-              choices: [choice],
-              created: Math.floor(Date.now() / 1000),
-              model: 'gpt-3.5-turbo',
-              object: 'chat.completion.chunk',
-            };
-          }
-        }),
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
+            for (const choice of contentChoiceDeltas(`The weather is great today!`)) {
+              yield {
+                id: '1',
+                choices: [choice],
+                created: Math.floor(Date.now() / 1000),
+                model: 'gpt-3.5-turbo',
+                object: 'chat.completion.chunk',
+              };
+            }
+          },
+        ),
         runner.done(),
       ]);
 
@@ -3299,18 +3335,20 @@ describe('resource completions', () => {
       const listener = new StreamingRunnerListener(proxied);
 
       await Promise.all([
-        handleRequest(async function* (request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
-          expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
-          for (const choice of contentChoiceDeltas(`The weather is great today!`)) {
-            yield {
-              id: '1',
-              choices: [choice],
-              created: Math.floor(Date.now() / 1000),
-              model: 'gpt-3.5-turbo',
-              object: 'chat.completion.chunk',
-            };
-          }
-        }),
+        handleRequest(
+          async function* requestHandler(request): AsyncIterable<OpenAI.Chat.ChatCompletionChunk> {
+            expect(request.messages).toEqual([{ role: 'user', content: 'tell me what the weather is like' }]);
+            for (const choice of contentChoiceDeltas(`The weather is great today!`)) {
+              yield {
+                id: '1',
+                choices: [choice],
+                created: Math.floor(Date.now() / 1000),
+                model: 'gpt-3.5-turbo',
+                object: 'chat.completion.chunk',
+              };
+            }
+          },
+        ),
         proxied.done(),
       ]);
 

--- a/tests/lib/ChatCompletionStream.test.ts
+++ b/tests/lib/ChatCompletionStream.test.ts
@@ -148,7 +148,7 @@ describe('.stream()', () => {
         ],
       } as unknown as OpenAI.Chat.ChatCompletionChunk,
     ];
-    const readable = new Stream(async function* () {
+    const readable = new Stream(async function* readable() {
       for (const chunk of chunks) yield chunk;
     }, new AbortController()).toReadableStream();
 
@@ -221,7 +221,7 @@ describe('.stream()', () => {
         ],
       },
     ] as unknown as OpenAI.Chat.ChatCompletionChunk[];
-    const readable = new Stream(async function* () {
+    const readable = new Stream(async function* readable() {
       for (const chunk of chunks) yield chunk;
     }, new AbortController()).toReadableStream();
 
@@ -296,7 +296,7 @@ describe('.stream()', () => {
         ],
       },
     ] as unknown as OpenAI.Chat.ChatCompletionChunk[];
-    const readable = new Stream(async function* () {
+    const readable = new Stream(async function* readable() {
       for (const chunk of chunks) yield chunk;
     }, new AbortController()).toReadableStream();
 
@@ -320,7 +320,7 @@ describe('.stream()', () => {
         },
       ],
     };
-    const readable = new Stream(async function* () {
+    const readable = new Stream(async function* readable() {
       yield chunk;
     }, new AbortController()).toReadableStream();
 

--- a/tests/lib/streaming-core.test.ts
+++ b/tests/lib/streaming-core.test.ts
@@ -173,7 +173,7 @@ describe('Stream.tee', () => {
     const controller = new AbortController();
     const source = new Stream(
       () =>
-        (async function* () {
+        (async function* sourceItems() {
           yield 1;
           yield 2;
           yield 3;
@@ -201,7 +201,7 @@ describe('Stream.toReadableStream', () => {
   test('round-trips structured values as newline-delimited JSON', async () => {
     const original = new Stream(
       () =>
-        (async function* () {
+        (async function* originalItems() {
           yield { id: 1 };
           yield { id: 2 };
         })(),

--- a/tests/qs/stringify.test.ts
+++ b/tests/qs/stringify.test.ts
@@ -37,7 +37,7 @@ describe('stringify()', () => {
   test('stringifies bigints', () => {
     const three = 3n;
     // @ts-expect-error
-    const encodeWithN = function (value, defaultEncoder, charset) {
+    const encodeWithN = function encodeWithN(value, defaultEncoder, charset) {
       const result = defaultEncoder(value, defaultEncoder, charset);
       return typeof value === 'bigint' ? result + 'n' : result;
     };
@@ -1409,7 +1409,7 @@ describe('stringify()', () => {
   test('supports custom representations when filter=function', () => {
     let calls = 0;
     const obj = { a: 'b', c: 'd', e: { f: new Date(1_257_894_000_000) } };
-    const filterFunc: StringifyOptions['filter'] = function (prefix, value) {
+    const filterFunc: StringifyOptions['filter'] = function filterFunc(prefix, value) {
       calls += 1;
       if (calls === 1) {
         // st.equal(prefix, '', 'prefix is empty');
@@ -1446,7 +1446,7 @@ describe('stringify()', () => {
 
   test('can sort the keys', () => {
     // @ts-expect-error
-    const sort: NonNullable<StringifyOptions['sort']> = function (a: string, b: string) {
+    const sort: NonNullable<StringifyOptions['sort']> = function sort(a: string, b: string) {
       return a.localeCompare(b);
     };
     // st.equal(stringify({ a: 'c', z: 'y', b: 'f' }, { sort: sort }), 'a=c&b=f&z=y');
@@ -1462,7 +1462,7 @@ describe('stringify()', () => {
 
   test('can sort the keys at depth 3 or more too', () => {
     // @ts-expect-error
-    const sort: NonNullable<StringifyOptions['sort']> = function (a: string, b: string) {
+    const sort: NonNullable<StringifyOptions['sort']> = function sort(a: string, b: string) {
       return a.localeCompare(b);
     };
     // st.equal(
@@ -1650,7 +1650,7 @@ describe('stringify()', () => {
     expect(stringify({ a: date })).toBe('a=' + date.toISOString().replace(/:/g, '%3A'));
 
     const mutatedDate = new Date();
-    mutatedDate.toISOString = function () {
+    mutatedDate.toISOString = function toISOString() {
       throw new SyntaxError('Invalid date serialization');
     };
     // st['throws'](function () {
@@ -1925,7 +1925,7 @@ describe('stringify()', () => {
 
   test('strictNullHandling works with custom filter', () => {
     // @ts-expect-error
-    const filter = function (_prefix, value) {
+    const filter = function filter(_prefix, value) {
       return value;
     };
 
@@ -1935,7 +1935,7 @@ describe('stringify()', () => {
   });
 
   test('strictNullHandling works with null serializeDate', () => {
-    const serializeDate = function () {
+    const serializeDate = function serializeDate() {
       return null;
     };
     const options = { strictNullHandling: true, serializeDate };
@@ -1947,7 +1947,7 @@ describe('stringify()', () => {
 
   test('allows for encoding keys and values differently', () => {
     // @ts-expect-error
-    const encoder = function (str, defaultEncoder, charset, type) {
+    const encoder = function encoder(str, defaultEncoder, charset, type) {
       if (type === 'key') {
         return defaultEncoder(str, defaultEncoder, charset, type).toLowerCase();
       }

--- a/tests/qs/utils.test.ts
+++ b/tests/qs/utils.test.ts
@@ -150,21 +150,7 @@ describe('combine()', () => {
 });
 
 test('is_buffer()', () => {
-  for (const x of [
-    null,
-    undefined,
-    true,
-    false,
-    '',
-    'abc',
-    42,
-    0,
-    Number.NaN,
-    {},
-    [],
-    function () {},
-    /a/g,
-  ]) {
+  for (const x of [null, undefined, true, false, '', 'abc', 42, 0, Number.NaN, {}, [], () => {}, /a/g]) {
     // t.equal(is_buffer(x), false, inspect(x) + ' is not a buffer');
     expect(is_buffer(x)).toEqual(false);
   }

--- a/tests/realtime-websocket.test.ts
+++ b/tests/realtime-websocket.test.ts
@@ -20,7 +20,7 @@ type FakeNodeSocket = {
 };
 
 vi.mock('ws', () => ({
-  WebSocket: vi.fn().mockImplementation(function (url: URL, options: FakeNodeSocket['options']) {
+  WebSocket: vi.fn().mockImplementation(function WebSocket(url: URL, options: FakeNodeSocket['options']) {
     const listeners = new Map<string, Listener>();
 
     return {


### PR DESCRIPTION
## Summary

- Removes `func-names` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 182 of 185.
- Base: `dev/hayden/ultracite-181-prefer-arrow-callback`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`