### PR TITLE
chore(lint): enable curly

### DIFF
--- a/ecosystem-tests/browser-direct-import/public/index.js
+++ b/ecosystem-tests/browser-direct-import/public/index.js
@@ -40,7 +40,7 @@ async function runTests() {
     displayResults();
   }
   const runningEl = document.querySelector('#running');
-  if (runningEl) runningEl.remove();
+  if (runningEl) {runningEl.remove();}
 }
 
 /** @type {string[]} */
@@ -86,7 +86,7 @@ function expect(received) {
     },
     toBeSimilarTo(comparedTo, expectedDistance) {
       const actualDistance = distance(received, comparedTo);
-      if (actualDistance < expectedDistance) return;
+      if (actualDistance < expectedDistance) {return;}
 
       throw new Error(
         [
@@ -130,7 +130,7 @@ it(`raw response`, async () => {
 
   // test that we can use web Response API
   const { body } = response;
-  if (!body) throw new Error('expected response.body to be defined');
+  if (!body) {throw new Error('expected response.body to be defined');}
 
   const reader = body.getReader();
   /** @type {Uint8Array[]} */
@@ -138,7 +138,7 @@ it(`raw response`, async () => {
   let result;
   do {
     result = await reader.read();
-    if (!result.done) chunks.push(result.value);
+    if (!result.done) {chunks.push(result.value);}
   } while (!result.done);
 
   reader.releaseLock();

--- a/ecosystem-tests/browser-direct-import/src/test.ts
+++ b/ecosystem-tests/browser-direct-import/src/test.ts
@@ -28,7 +28,7 @@ import puppeteer from 'puppeteer';
 
     const apiKey = process.env.OPENAI_API_KEY;
 
-    if (!apiKey) throw new Error('missing process.env.OPENAI_API_KEY');
+    if (!apiKey) {throw new Error('missing process.env.OPENAI_API_KEY');}
 
     // Navigate the page to a URL
     await page.goto(`http://localhost:8081/index.html?apiKey=${apiKey}`);

--- a/ecosystem-tests/bun/openai.test.ts
+++ b/ecosystem-tests/bun/openai.test.ts
@@ -67,14 +67,14 @@ test(`raw response`, async () => {
 
   // test that we can use web Response API
   const { body } = response;
-  if (!body) throw new Error('expected response.body to be defined');
+  if (!body) {throw new Error('expected response.body to be defined');}
 
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];
   let result;
   do {
     result = await reader.read();
-    if (!result.done) chunks.push(result.value);
+    if (!result.done) {chunks.push(result.value);}
   } while (!result.done);
 
   reader.releaseLock();

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -139,7 +139,9 @@ const projectRunners = {
 
     await run('deno', ['task', 'check']);
 
-    if (state.live) await run('deno', ['task', 'test']);
+    if (state.live) {
+      await run('deno', ['task', 'test']);
+    }
   },
 };
 
@@ -451,7 +453,9 @@ async function main() {
             for (const { data } of chunks) {
               process.stdout.write(data);
             }
-            if (IS_CI) console.log('::endgroup::');
+            if (IS_CI) {
+              console.log('::endgroup::');
+            }
           }
         }),
       );
@@ -514,7 +518,9 @@ async function withRetry(
     try {
       return await fn();
     } catch (err) {
-      if (retriesLeft <= 0 || !shouldRetry(err)) throw err;
+      if (retriesLeft <= 0 || !shouldRetry(err)) {
+        throw err;
+      }
       retriesLeft -= 1;
       console.error(
         `${identifier} failed due to ${errorMessage(
@@ -555,7 +561,9 @@ function centerPad(text: string, width = text.length, char = ' '): string {
 
 function banner(name: string, width = 80): string {
   function line(text = ''): string {
-    if (text) text = centerPad(text, width - 40);
+    if (text) {
+      text = centerPad(text, width - 40);
+    }
     return centerPad(text, width, '/');
   }
   return [line(), line(), line(' '), line(name), line(' '), line(), line()].join('\n');
@@ -630,8 +638,12 @@ async function run(command: string, args: string[], config?: RunOpts): Promise<e
   } catch (error) {
     if (error instanceof Object && !state.verbose) {
       const { stderr, stdout } = error as any;
-      if (stderr) process.stderr.write(stderr);
-      if (stdout) process.stderr.write(stdout);
+      if (stderr) {
+        process.stderr.write(stderr);
+      }
+      if (stdout) {
+        process.stderr.write(stdout);
+      }
     }
     throw error;
   }

--- a/ecosystem-tests/cloudflare-worker/src/uploadWebApiTestCases.ts
+++ b/ecosystem-tests/cloudflare-worker/src/uploadWebApiTestCases.ts
@@ -57,14 +57,14 @@ export function uploadWebApiTestCases({
 
 		// test that we can use web Response API
 		const { body } = response;
-		if (!body) throw new Error('expected response.body to be defined');
+		if (!body) {throw new Error('expected response.body to be defined');}
 
 		const reader = body.getReader();
 		const chunks: Uint8Array[] = [];
 		let result;
 		do {
 			result = await reader.read();
-			if (!result.done) chunks.push(result.value);
+			if (!result.done) {chunks.push(result.value);}
 		} while (!result.done);
 
 		reader.releaseLock();

--- a/ecosystem-tests/cloudflare-worker/src/worker.ts
+++ b/ecosystem-tests/cloudflare-worker/src/worker.ts
@@ -35,9 +35,9 @@ export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
 		const url = new URL(request.url);
 		// start-server-and-test polls / to see if the server is up and running
-		if (url.pathname === '/') return new Response();
+		if (url.pathname === '/') {return new Response();}
 		// then the test code requests /test
-		if (url.pathname !== '/test') return new Response(null, { status: 404 });
+		if (url.pathname !== '/test') {return new Response(null, { status: 404 });}
 		try {
 			console.error('importing openai');
 			const { default: OpenAI } = await import('openai');

--- a/ecosystem-tests/deno/main_test.ts
+++ b/ecosystem-tests/deno/main_test.ts
@@ -46,14 +46,14 @@ Deno.test('rawResponse', async () => {
 
   // test that we can use web Response API
   const { body } = response;
-  if (!body) throw new Error('expected response.body to be defined');
+  if (!body) {throw new Error('expected response.body to be defined');}
 
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];
   let result;
   do {
     result = await reader.read();
-    if (!result.done) chunks.push(result.value);
+    if (!result.done) {chunks.push(result.value);}
   } while (!result.done);
 
   reader.releaseLock();

--- a/ecosystem-tests/node-ts-cjs-web/tests/test-jsdom.ts
+++ b/ecosystem-tests/node-ts-cjs-web/tests/test-jsdom.ts
@@ -74,14 +74,14 @@ it.skip(`raw response`, async () => {
 
   // test that we can use web Response API
   const { body } = response;
-  if (!body) throw new Error('expected response.body to be defined');
+  if (!body) {throw new Error('expected response.body to be defined');}
 
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];
   let result;
   do {
     result = await reader.read();
-    if (!result.done) chunks.push(result.value);
+    if (!result.done) {chunks.push(result.value);}
   } while (!result.done);
 
   reader.releaseLock();

--- a/ecosystem-tests/node-ts-cjs-web/tests/test-node.ts
+++ b/ecosystem-tests/node-ts-cjs-web/tests/test-node.ts
@@ -62,14 +62,14 @@ it(`raw response`, async () => {
 
   // test that we can use web Response API
   const { body } = response;
-  if (!body) throw new Error('expected response.body to be defined');
+  if (!body) {throw new Error('expected response.body to be defined');}
 
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];
   let result;
   do {
     result = await reader.read();
-    if (!result.done) chunks.push(result.value);
+    if (!result.done) {chunks.push(result.value);}
   } while (!result.done);
 
   reader.releaseLock();

--- a/ecosystem-tests/node-ts-esm-web/tests/test.ts
+++ b/ecosystem-tests/node-ts-esm-web/tests/test.ts
@@ -62,14 +62,14 @@ it(`raw response`, async () => {
 
   // test that we can use web Response API
   const { body } = response;
-  if (!body) throw new Error('expected response.body to be defined');
+  if (!body) {throw new Error('expected response.body to be defined');}
 
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];
   let result;
   do {
     result = await reader.read();
-    if (!result.done) chunks.push(result.value);
+    if (!result.done) {chunks.push(result.value);}
   } while (!result.done);
 
   reader.releaseLock();

--- a/ecosystem-tests/node-ts-esm/tests/test-esnext.ts
+++ b/ecosystem-tests/node-ts-esm/tests/test-esnext.ts
@@ -52,7 +52,7 @@ it(`raw response`, async () => {
     .asResponse();
 
   const chunks: string[] = [];
-  if (!response.body) throw new Error(`expected response.body to be defined`);
+  if (!response.body) {throw new Error(`expected response.body to be defined`);}
 
   const decoder = new TextDecoder();
 

--- a/ecosystem-tests/ts-browser-webpack/src/index.ts
+++ b/ecosystem-tests/ts-browser-webpack/src/index.ts
@@ -43,7 +43,7 @@ async function runTests() {
     displayResults();
   }
   const runningEl = document.querySelector('#running');
-  if (runningEl) runningEl.remove();
+  if (runningEl) {runningEl.remove();}
 }
 
 const testPath: string[] = [];
@@ -72,7 +72,7 @@ function expect(received: any) {
     },
     toBeSimilarTo(comparedTo: string, expectedDistance: number) {
       const actualDistance = distance(received, comparedTo);
-      if (actualDistance < expectedDistance) return;
+      if (actualDistance < expectedDistance) {return;}
 
       throw new Error(
         [
@@ -132,14 +132,14 @@ it(`raw response`, async () => {
 
   // test that we can use web Response API
   const { body } = response;
-  if (!body) throw new Error('expected response.body to be defined');
+  if (!body) {throw new Error('expected response.body to be defined');}
 
   const reader = body.getReader();
   const chunks: Uint8Array[] = [];
   let result;
   do {
     result = await reader.read();
-    if (!result.done) chunks.push(result.value);
+    if (!result.done) {chunks.push(result.value);}
   } while (!result.done);
 
   reader.releaseLock();

--- a/ecosystem-tests/ts-browser-webpack/src/test.ts
+++ b/ecosystem-tests/ts-browser-webpack/src/test.ts
@@ -28,7 +28,7 @@ import puppeteer from 'puppeteer';
 
     const apiKey = process.env.OPENAI_API_KEY;
 
-    if (!apiKey) throw new Error('missing process.env.OPENAI_API_KEY');
+    if (!apiKey) {throw new Error('missing process.env.OPENAI_API_KEY');}
 
     // Navigate the page to a URL
     await page.goto(`http://localhost:8080/index.html?apiKey=${apiKey}`);

--- a/ecosystem-tests/vercel-edge/src/pages/ai-streaming.tsx
+++ b/ecosystem-tests/vercel-edge/src/pages/ai-streaming.tsx
@@ -11,7 +11,7 @@ export default function Chat() {
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!input.trim()) return;
+    if (!input.trim()) {return;}
 
     void sendMessage({ text: input });
     setInput('');

--- a/ecosystem-tests/vercel-edge/src/pages/api/vercel-ai-streaming.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/vercel-ai-streaming.ts
@@ -50,7 +50,7 @@ export default async function handler(request: NextRequest) {
 
       for await (const chunk of completion) {
         const delta = chunk.choices[0]?.delta.content;
-        if (delta) writer.write({ type: 'text-delta', id: textPartID, delta });
+        if (delta) {writer.write({ type: 'text-delta', id: textPartID, delta });}
       }
 
       writer.write({ type: 'text-end', id: textPartID });

--- a/ecosystem-tests/vercel-edge/src/uploadWebApiTestCases.ts
+++ b/ecosystem-tests/vercel-edge/src/uploadWebApiTestCases.ts
@@ -84,14 +84,14 @@ export function uploadWebApiTestCases({
 
       // test that we can use web Response API
       const { body } = response;
-      if (!body) throw new Error('expected response.body to be defined');
+      if (!body) {throw new Error('expected response.body to be defined');}
 
       const reader = body.getReader();
       const chunks: Uint8Array[] = [];
       let result;
       do {
         result = await reader.read();
-        if (!result.done) chunks.push(result.value);
+        if (!result.done) {chunks.push(result.value);}
       } while (!result.done);
 
       reader.releaseLock();

--- a/examples/azure/assistants.ts
+++ b/examples/azure/assistants.ts
@@ -16,7 +16,9 @@ import 'dotenv/config';
 
 function requireEnv(name: string): string {
   const value = process.env[name];
-  if (!value) throw new Error(`Missing ${name}`);
+  if (!value) {
+    throw new Error(`Missing ${name}`);
+  }
   return value;
 }
 

--- a/examples/azure/chat.ts
+++ b/examples/azure/chat.ts
@@ -6,7 +6,9 @@ import 'dotenv/config';
 
 function requireEnv(name: string): string {
   const value = process.env[name];
-  if (!value) throw new Error(`Missing ${name}`);
+  if (!value) {
+    throw new Error(`Missing ${name}`);
+  }
   return value;
 }
 

--- a/examples/azure/responses.ts
+++ b/examples/azure/responses.ts
@@ -6,7 +6,9 @@ import 'dotenv/config';
 
 function requireEnv(name: string): string {
   const value = process.env[name];
-  if (!value) throw new Error(`Missing ${name}`);
+  if (!value) {
+    throw new Error(`Missing ${name}`);
+  }
   return value;
 }
 

--- a/examples/fine-tuning/fine-tuning.ts
+++ b/examples/fine-tuning/fine-tuning.ts
@@ -56,9 +56,13 @@ async function main() {
     const { data } = await client.fineTuning.jobs.listEvents(fineTune.id, { limit: 100 });
     for (let index = data.length - 1; index >= 0; index -= 1) {
       const event = data[index];
-      if (event === undefined) continue;
+      if (event === undefined) {
+        continue;
+      }
 
-      if (event.id in events) continue;
+      if (event.id in events) {
+        continue;
+      }
       events[event.id] = event;
       const timestamp = new Date(event.created_at * 1000);
       console.log(`- ${timestamp.toLocaleTimeString()}: ${event.message}`);

--- a/examples/mtls/bun.mjs
+++ b/examples/mtls/bun.mjs
@@ -26,6 +26,8 @@ console.log('mTLS request succeeded; received ' + models.data.length + ' models.
 
 function requiredEnv(name) {
   const value = process.env[name];
-  if (!value) throw new Error('Missing required environment variable: ' + name);
+  if (!value) {
+    throw new Error('Missing required environment variable: ' + name);
+  }
   return value;
 }

--- a/examples/mtls/deno.mjs
+++ b/examples/mtls/deno.mjs
@@ -27,7 +27,9 @@ try {
 
 function requiredEnv(name) {
   const value = Deno.env.get(name);
-  if (!value) throw new Error('Missing required environment variable: ' + name);
+  if (!value) {
+    throw new Error('Missing required environment variable: ' + name);
+  }
   return value;
 }
 

--- a/examples/mtls/node.mjs
+++ b/examples/mtls/node.mjs
@@ -38,6 +38,8 @@ try {
 
 function requiredEnv(name) {
   const value = process.env[name];
-  if (!value) throw new Error('Missing required environment variable: ' + name);
+  if (!value) {
+    throw new Error('Missing required environment variable: ' + name);
+  }
   return value;
 }

--- a/examples/responses/multi-agent-websocket.ts
+++ b/examples/responses/multi-agent-websocket.ts
@@ -24,8 +24,12 @@ async function main() {
   const agents = new Map<string, string>();
   let currentItemID: string | undefined;
   for await (const message of ws) {
-    if (message.type === 'error') throw message.error;
-    if (message.type !== 'message') continue;
+    if (message.type === 'error') {
+      throw message.error;
+    }
+    if (message.type !== 'message') {
+      continue;
+    }
 
     const event = message.message;
     if (event.type === 'response.output_item.added' && event.item.type === 'message') {

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -5,13 +5,7 @@ const core = requireConfig('ultracite/oxlint/core').default;
 const stainlessGeneratedFiles = requireConfig('./scripts/stainless-generated-files.cjs');
 
 // Existing handwritten SDK patterns predate these preset rules.
-const compatibilityRules = [
-  'curly',
-  'func-style',
-  'no-use-before-define',
-  'sort-keys',
-  'typescript/no-explicit-any',
-];
+const compatibilityRules = ['func-style', 'no-use-before-define', 'sort-keys', 'typescript/no-explicit-any'];
 
 module.exports = defineConfig({
   extends: [core],

--- a/scripts/_vendor/tsc-multi/src/config.ts
+++ b/scripts/_vendor/tsc-multi/src/config.ts
@@ -47,7 +47,9 @@ export async function loadConfig({ cwd = process.cwd(), path }: LoadConfigOption
   debug('Read config from %s', configPath);
 
   const json = await (() => {
-    if (mustLoadConfig) return readJSON(configPath);
+    if (mustLoadConfig) {
+      return readJSON(configPath);
+    }
     return tryReadJSON(configPath);
   })();
 

--- a/scripts/_vendor/tsc-multi/src/transformer.ts
+++ b/scripts/_vendor/tsc-multi/src/transformer.ts
@@ -70,7 +70,9 @@ export function createTransformer<T extends ts.SourceFile | ts.Bundle>(
     sourceFile: ts.SourceFile,
     node: T,
   ): ts.LiteralExpression | T {
-    if (!isStringLiteral(node) || !isRelativePath(node.text)) return node;
+    if (!isStringLiteral(node) || !isRelativePath(node.text)) {
+      return node;
+    }
 
     const ext = nodePath.extname(node.text);
 
@@ -165,7 +167,9 @@ export function createTransformer<T extends ts.SourceFile | ts.Bundle>(
 
       // ESM export
       if (isExportDeclaration(node)) {
-        if (!node.moduleSpecifier) return node;
+        if (!node.moduleSpecifier) {
+          return node;
+        }
 
         return factory.updateExportDeclaration(
           node,
@@ -180,7 +184,9 @@ export function createTransformer<T extends ts.SourceFile | ts.Bundle>(
       // ESM dynamic import
       if (isCallExpression(node) && node.expression.kind === SyntaxKind.ImportKeyword) {
         const [firstArg, ...restArg] = node.arguments;
-        if (!firstArg) return node;
+        if (!firstArg) {
+          return node;
+        }
 
         return factory.updateCallExpression(node, node.expression, node.typeArguments, [
           updateModuleSpecifier(ctx, sourceFile, firstArg),
@@ -195,7 +201,9 @@ export function createTransformer<T extends ts.SourceFile | ts.Bundle>(
         node.expression.escapedText === 'require'
       ) {
         const [firstArg, ...restArgs] = node.arguments;
-        if (!firstArg) return node;
+        if (!firstArg) {
+          return node;
+        }
 
         return factory.updateCallExpression(node, node.expression, node.typeArguments, [
           resolvedShareHelpers && tslibRequires.has(node)
@@ -220,7 +228,9 @@ export function createTransformer<T extends ts.SourceFile | ts.Bundle>(
     };
 
     const pureClassAssignment = (sourceFile: ts.SourceFile) => {
-      if (!options.pureClassAssignment) return sourceFile;
+      if (!options.pureClassAssignment) {
+        return sourceFile;
+      }
       const newStatements = [];
       const classes: Record<
         string,

--- a/scripts/_vendor/tsc-multi/src/utils.ts
+++ b/scripts/_vendor/tsc-multi/src/utils.ts
@@ -26,7 +26,9 @@ export async function tryReadJSON(path: string): Promise<any> {
   try {
     return await readJSON(path);
   } catch (err: any) {
-    if (err.code === 'ENOENT') return {};
+    if (err.code === 'ENOENT') {
+      return {};
+    }
     throw err;
   }
 }

--- a/scripts/_vendor/tsc-multi/src/worker/worker.ts
+++ b/scripts/_vendor/tsc-multi/src/worker/worker.ts
@@ -64,25 +64,33 @@ export class Worker {
   }
 
   private getJSPath(path: string): string {
-    if (!this.data.extname) return path;
+    if (!this.data.extname) {
+      return path;
+    }
 
     return trimSuffix(path, JS_EXT) + this.data.extname;
   }
 
   private getJSMapPath(path: string): string {
-    if (!this.data.extname) return path;
+    if (!this.data.extname) {
+      return path;
+    }
 
     return trimSuffix(path, JS_MAP_EXT) + this.data.extname + MAP_EXT;
   }
 
   private getDTSPath(path: string): string {
-    if (!this.data.extname) return path;
+    if (!this.data.extname) {
+      return path;
+    }
 
     return trimSuffix(path, DTS_EXT) + extnameDeclMap[this.data.extname];
   }
 
   private getDTSMapPath(path: string): string {
-    if (!this.data.extname) return path;
+    if (!this.data.extname) {
+      return path;
+    }
 
     return trimSuffix(path, DTS_MAP_EXT) + extnameDeclMap[this.data.extname] + MAP_EXT;
   }
@@ -152,14 +160,18 @@ export class Worker {
       ...sys,
       fileExists: (inputPath) => {
         for (const path of getReadPaths(inputPath)) {
-          if (sys.fileExists(path)) return true;
+          if (sys.fileExists(path)) {
+            return true;
+          }
         }
         return false;
       },
       readFile: (inputPath, encoding) => {
         for (const path of getReadPaths(inputPath)) {
           const result = sys.readFile(path, encoding);
-          if (result !== undefined && result !== null) return result;
+          if (result !== undefined && result !== null) {
+            return result;
+          }
         }
         return undefined;
       },
@@ -274,7 +286,9 @@ export class Worker {
       );
 
       const config = this.ts.getParsedCommandLineOfConfigFile(path, options, parseConfigFileHost);
-      if (!config) return;
+      if (!config) {
+        return;
+      }
 
       if (this.data.shareHelpers) {
         const root = (this.ts as any).getCommonSourceDirectoryOfConfig(config);
@@ -379,7 +393,9 @@ export class Worker {
     };
 
     const config = this.ts.getParsedCommandLineOfConfigFile(tsConfigPath, options, parseConfigFileHost);
-    if (!config) return;
+    if (!config) {
+      return;
+    }
 
     let resolvedShareHelpers: string | undefined;
     if (this.data.shareHelpers) {

--- a/scripts/lint-generated.cjs
+++ b/scripts/lint-generated.cjs
@@ -11,14 +11,20 @@ const generatedConfig = path.join(repositoryRoot, 'oxlint.generated.config.json'
 const maximumFixPasses = 10;
 
 function requestedFiles(arguments_) {
-  if (arguments_[0] !== '--file-list') return arguments_;
-  if (arguments_.length !== 2) throw new Error('--file-list requires exactly one path');
+  if (arguments_[0] !== '--file-list') {
+    return arguments_;
+  }
+  if (arguments_.length !== 2) {
+    throw new Error('--file-list requires exactly one path');
+  }
 
   return fs.readFileSync(arguments_[1], 'utf-8').split(/\r?\n/u).filter(Boolean);
 }
 
 function selectedGeneratedFiles(arguments_) {
-  if (arguments_.length === 0) return generatedFiles;
+  if (arguments_.length === 0) {
+    return generatedFiles;
+  }
 
   const generated = new Set(generatedFiles);
   return requestedFiles(arguments_)
@@ -52,13 +58,17 @@ function fixGeneratedFiles(files) {
       { cwd: repositoryRoot, stdio: 'inherit' },
     );
 
-    if (result.error) throw result.error;
+    if (result.error) {
+      throw result.error;
+    }
     if (result.status !== 0) {
       process.exitCode = result.status ?? 1;
       return;
     }
 
-    if (fingerprint(files) === before) return;
+    if (fingerprint(files) === before) {
+      return;
+    }
   }
 
   throw new Error(`generated import cleanup did not stabilize after ${maximumFixPasses} passes`);
@@ -71,8 +81,12 @@ function checkGeneratedFiles(files) {
     { cwd: repositoryRoot, encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
   );
 
-  if (result.error) throw result.error;
-  if (result.stderr) process.stderr.write(result.stderr);
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
 
   const { diagnostics } = JSON.parse(result.stdout);
   const violations = diagnostics.filter(
@@ -85,20 +99,29 @@ function checkGeneratedFiles(files) {
     const span = diagnostic.labels?.[0]?.span;
     const location = span ? `${diagnostic.filename}:${span.line}:${span.column}` : diagnostic.filename;
     console.error(`${location}: ${diagnostic.message} (${diagnostic.code})`);
-    if (diagnostic.help) console.error(`  ${diagnostic.help}`);
+    if (diagnostic.help) {
+      console.error(`  ${diagnostic.help}`);
+    }
   }
 
-  if (violations.length > 0 || result.status !== 0) process.exitCode = result.status || 1;
+  if (violations.length > 0 || result.status !== 0) {
+    process.exitCode = result.status || 1;
+  }
 }
 
 try {
   const [mode, ...arguments_] = process.argv.slice(2);
-  if (mode !== '--fix' && mode !== '--check') throw new Error('expected --fix or --check');
+  if (mode !== '--fix' && mode !== '--check') {
+    throw new Error('expected --fix or --check');
+  }
 
   const files = selectedGeneratedFiles(arguments_);
   if (files.length > 0) {
-    if (mode === '--fix') fixGeneratedFiles(files);
-    else checkGeneratedFiles(files);
+    if (mode === '--fix') {
+      fixGeneratedFiles(files);
+    } else {
+      checkGeneratedFiles(files);
+    }
   }
 } catch (error) {
   console.error(error);

--- a/scripts/stainless-generated-files.cjs
+++ b/scripts/stainless-generated-files.cjs
@@ -12,10 +12,16 @@ function findGeneratedFiles(directory) {
   return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const file = path.join(directory, entry.name);
 
-    if (entry.isDirectory()) return ignoredDirectories.has(entry.name) ? [] : findGeneratedFiles(file);
-    if (!entry.isFile() || !/\.[cm]?[jt]sx?$/.test(entry.name)) return [];
+    if (entry.isDirectory()) {
+      return ignoredDirectories.has(entry.name) ? [] : findGeneratedFiles(file);
+    }
+    if (!entry.isFile() || !/\.[cm]?[jt]sx?$/.test(entry.name)) {
+      return [];
+    }
     const content = fs.readFileSync(file, 'utf-8');
-    if (!generatedHeaders.some((header) => content.startsWith(header))) return [];
+    if (!generatedHeaders.some((header) => content.startsWith(header))) {
+      return [];
+    }
 
     return [path.relative(repositoryRoot, file).split(path.sep).join('/')];
   });

--- a/scripts/utils/check-version.cjs
+++ b/scripts/utils/check-version.cjs
@@ -4,7 +4,9 @@ const pkg = require('../../package.json');
 
 const main = () => {
   const version = pkg['version'];
-  if (!version) throw new Error('The version property is not set in the package.json file');
+  if (!version) {
+    throw new Error('The version property is not set in the package.json file');
+  }
   if (typeof version !== 'string') {
     throw new TypeError(
       `Unexpected type for the package.json version field; got ${typeof version}, expected string`,

--- a/scripts/utils/make-dist-package-json.cjs
+++ b/scripts/utils/make-dist-package-json.cjs
@@ -2,17 +2,24 @@ const pkgJson = require(process.env['PKG_JSON_PATH'] || '../../package.json');
 
 function processExportMap(m) {
   for (const key in m) {
-    if (!Object.hasOwn(m, key)) continue;
+    if (!Object.hasOwn(m, key)) {
+      continue;
+    }
 
     const value = m[key];
-    if (typeof value === 'string') m[key] = value.replace(/^\.\/dist\//, './');
-    else processExportMap(value);
+    if (typeof value === 'string') {
+      m[key] = value.replace(/^\.\/dist\//, './');
+    } else {
+      processExportMap(value);
+    }
   }
 }
 processExportMap(pkgJson.exports);
 
 for (const key of ['types', 'main', 'module']) {
-  if (typeof pkgJson[key] === 'string') pkgJson[key] = pkgJson[key].replace(/^(\.\/)?dist\//, './');
+  if (typeof pkgJson[key] === 'string') {
+    pkgJson[key] = pkgJson[key].replace(/^(\.\/)?dist\//, './');
+  }
 }
 
 delete pkgJson.devDependencies;

--- a/scripts/utils/postprocess-files.cjs
+++ b/scripts/utils/postprocess-files.cjs
@@ -9,14 +9,19 @@ const distDir = process.env['DIST_PATH']
 async function* walk(dir) {
   for await (const d of await fs.promises.opendir(dir)) {
     const entry = path.join(dir, d.name);
-    if (d.isDirectory()) yield* walk(entry);
-    else if (d.isFile()) yield entry;
+    if (d.isDirectory()) {
+      yield* walk(entry);
+    } else if (d.isFile()) {
+      yield entry;
+    }
   }
 }
 
 async function postprocess() {
   for await (const file of walk(distDir)) {
-    if (!/(\.d)?[cm]?ts$/.test(file)) continue;
+    if (!/(\.d)?[cm]?ts$/.test(file)) {
+      continue;
+    }
 
     const code = await fs.promises.readFile(file, 'utf-8');
 

--- a/src/_vendor/partial-json-parser/parser.ts
+++ b/src/_vendor/partial-json-parser/parser.ts
@@ -70,10 +70,18 @@ const _parseJSON = (jsonString: string, allow: number) => {
 
   const parseAny: () => any = () => {
     skipBlank();
-    if (index >= length) markPartialJSON('Unexpected end of input');
-    if (jsonString[index] === '"') return parseStr();
-    if (jsonString[index] === '{') return parseObj();
-    if (jsonString[index] === '[') return parseArr();
+    if (index >= length) {
+      markPartialJSON('Unexpected end of input');
+    }
+    if (jsonString[index] === '"') {
+      return parseStr();
+    }
+    if (jsonString[index] === '{') {
+      return parseObj();
+    }
+    if (jsonString[index] === '[') {
+      return parseArr();
+    }
     if (
       jsonString.substring(index, index + 4) === 'null' ||
       (Allow.NULL & allow && length - index < 4 && 'null'.startsWith(jsonString.substring(index)))
@@ -154,7 +162,9 @@ const _parseJSON = (jsonString: string, allow: number) => {
     try {
       while (jsonString[index] !== '}') {
         skipBlank();
-        if (index >= length && Allow.OBJ & allow) return obj;
+        if (index >= length && Allow.OBJ & allow) {
+          return obj;
+        }
         const key = parseStr();
         skipBlank();
         index++; // skip colon
@@ -162,14 +172,20 @@ const _parseJSON = (jsonString: string, allow: number) => {
           const value = parseAny();
           Object.defineProperty(obj, key, { value, writable: true, enumerable: true, configurable: true });
         } catch (e) {
-          if (Allow.OBJ & allow) return obj;
+          if (Allow.OBJ & allow) {
+            return obj;
+          }
           throw e;
         }
         skipBlank();
-        if (jsonString[index] === ',') index++; // skip comma
+        if (jsonString[index] === ',') {
+          index++;
+        } // skip comma
       }
     } catch {
-      if (Allow.OBJ & allow) return obj;
+      if (Allow.OBJ & allow) {
+        return obj;
+      }
       markPartialJSON("Expected '}' at end of object");
     }
     index++; // skip final brace
@@ -199,14 +215,17 @@ const _parseJSON = (jsonString: string, allow: number) => {
 
   const parseNum = () => {
     if (index === 0) {
-      if (jsonString === '-' && Allow.NUM & allow) markPartialJSON("Not sure what '-' is");
+      if (jsonString === '-' && Allow.NUM & allow) {
+        markPartialJSON("Not sure what '-' is");
+      }
       try {
         return JSON.parse(jsonString);
       } catch (e) {
         if (Allow.NUM & allow) {
           try {
-            if (jsonString[jsonString.length - 1] === '.')
+            if (jsonString[jsonString.length - 1] === '.') {
               return JSON.parse(jsonString.substring(0, jsonString.lastIndexOf('.')));
+            }
             return JSON.parse(jsonString.substring(0, jsonString.lastIndexOf('e')));
           } catch {
             // Fall through to report malformed input below.
@@ -218,16 +237,23 @@ const _parseJSON = (jsonString: string, allow: number) => {
 
     const start = index;
 
-    if (jsonString[index] === '-') index++;
-    while (jsonString[index] && !',]}'.includes(jsonString[index]!)) index++;
+    if (jsonString[index] === '-') {
+      index++;
+    }
+    while (jsonString[index] && !',]}'.includes(jsonString[index]!)) {
+      index++;
+    }
 
-    if (index === length && !(Allow.NUM & allow)) markPartialJSON('Unterminated number literal');
+    if (index === length && !(Allow.NUM & allow)) {
+      markPartialJSON('Unterminated number literal');
+    }
 
     try {
       return JSON.parse(jsonString.substring(start, index));
     } catch {
-      if (jsonString.substring(start, index) === '-' && Allow.NUM & allow)
+      if (jsonString.substring(start, index) === '-' && Allow.NUM & allow) {
         markPartialJSON("Not sure what '-' is");
+      }
       try {
         return JSON.parse(jsonString.substring(start, jsonString.lastIndexOf('e')));
       } catch (e) {

--- a/src/_vendor/zod-to-json-schema/errorMessages.ts
+++ b/src/_vendor/zod-to-json-schema/errorMessages.ts
@@ -11,7 +11,9 @@ export function addErrorMessage<T extends { errorMessage?: ErrorMessages<any> }>
   errorMessage: string | undefined,
   refs: Refs,
 ) {
-  if (!refs?.errorMessages) return;
+  if (!refs?.errorMessages) {
+    return;
+  }
   if (errorMessage) {
     res.errorMessage = {
       ...res.errorMessage,

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -216,7 +216,9 @@ const encodeDefinitionPathPart = (part: string) => {
 const getRelativePath = (pathA: string[], pathB: string[]) => {
   let i = 0;
   for (; i < pathA.length && i < pathB.length; i++) {
-    if (pathA[i] !== pathB[i]) break;
+    if (pathA[i] !== pathB[i]) {
+      break;
+    }
   }
   return [(pathA.length - i).toString(), ...pathB.slice(i)].join('/');
 };

--- a/src/_vendor/zod-to-json-schema/parsers/bigint.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/bigint.ts
@@ -20,7 +20,9 @@ export function parseBigintDef(def: ZodBigIntDef, refs: Refs): JsonSchema7Bigint
     format: 'int64',
   };
 
-  if (!def.checks) return res;
+  if (!def.checks) {
+    return res;
+  }
 
   for (const check of def.checks) {
     switch (check.kind) {

--- a/src/_vendor/zod-to-json-schema/parsers/intersection.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/intersection.ts
@@ -12,7 +12,9 @@ export type JsonSchema7AllOfType = {
 const isJsonSchema7AllOfType = (
   type: JsonSchema7Type | JsonSchema7StringType,
 ): type is JsonSchema7AllOfType => {
-  if ('type' in type && type.type === 'string') return false;
+  if ('type' in type && type.type === 'string') {
+    return false;
+  }
   return 'allOf' in type;
 };
 

--- a/src/_vendor/zod-to-json-schema/parsers/nullable.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/nullable.ts
@@ -44,7 +44,9 @@ export function parseNullableDef(
       forceResolution,
     );
 
-    if (base && '$ref' in base) return { allOf: [base], nullable: true } as any;
+    if (base && '$ref' in base) {
+      return { allOf: [base], nullable: true } as any;
+    }
 
     return base && ({ ...base, nullable: true } as any);
   }

--- a/src/_vendor/zod-to-json-schema/parsers/number.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/number.ts
@@ -18,7 +18,9 @@ export function parseNumberDef(def: ZodNumberDef, refs: Refs): JsonSchema7Number
     type: 'number',
   };
 
-  if (!def.checks) return res;
+  if (!def.checks) {
+    return res;
+  }
 
   for (const check of def.checks) {
     switch (check.kind) {

--- a/src/_vendor/zod-to-json-schema/parsers/object.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/object.ts
@@ -31,14 +31,18 @@ export function parseObjectDef(def: ZodObjectDef, refs: Refs) {
   const properties: Record<string, JsonSchema7Type> = {};
   const required: string[] = [];
   for (const [propName, propDef] of Object.entries(def.shape())) {
-    if (propDef === undefined || propDef._def === undefined) continue;
+    if (propDef === undefined || propDef._def === undefined) {
+      continue;
+    }
     const propertyPath = [...refs.currentPath, 'properties', propName];
     const parsedDef = parseDef(propDef._def, {
       ...refs,
       currentPath: propertyPath,
       propertyPath,
     });
-    if (parsedDef === undefined) continue;
+    if (parsedDef === undefined) {
+      continue;
+    }
     if (
       refs.openaiStrictMode &&
       propDef.isOptional() &&
@@ -52,7 +56,9 @@ export function parseObjectDef(def: ZodObjectDef, refs: Refs) {
       );
     }
     properties[propName] = parsedDef;
-    if (!propDef.isOptional() || refs.openaiStrictMode) required.push(propName);
+    if (!propDef.isOptional() || refs.openaiStrictMode) {
+      required.push(propName);
+    }
   }
 
   const result: JsonSchema7ObjectType = {
@@ -61,6 +67,8 @@ export function parseObjectDef(def: ZodObjectDef, refs: Refs) {
     required,
     additionalProperties: decideAdditionalProperties(def, refs),
   };
-  if (!result.required!.length) delete result.required;
+  if (!result.required!.length) {
+    delete result.required;
+  }
   return result;
 }

--- a/src/_vendor/zod-to-json-schema/parsers/string.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/string.ts
@@ -337,7 +337,9 @@ const addPattern = (
 // Mutate z.string.regex() in a best attempt to accommodate for regex flags when applyRegexFlags is true
 const processRegExp = (regexOrFunction: RegExp | (() => RegExp), refs: Refs): string => {
   const regex = typeof regexOrFunction === 'function' ? regexOrFunction() : regexOrFunction;
-  if (!refs.applyRegexFlags || !regex.flags) return regex.source;
+  if (!refs.applyRegexFlags || !regex.flags) {
+    return regex.source;
+  }
 
   // Currently handled flags
   const flags = {

--- a/src/_vendor/zod-to-json-schema/parsers/union.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/union.ts
@@ -32,7 +32,9 @@ export function parseUnionDef(
   def: ZodUnionDef | ZodDiscriminatedUnionDef<any, any>,
   refs: Refs,
 ): JsonSchema7PrimitiveUnionType | JsonSchema7AnyOfType | undefined {
-  if (refs.target === 'openApi3') return asAnyOf(def, refs);
+  if (refs.target === 'openApi3') {
+    return asAnyOf(def, refs);
+  }
 
   const options: readonly ZodTypeAny[] = def.options instanceof Map ? [...def.options.values()] : def.options;
 
@@ -71,7 +73,9 @@ export function parseUnionDef(
           break;
         }
         case 'object': {
-          if (x._def.value === null) types.push('null');
+          if (x._def.value === null) {
+            types.push('null');
+          }
           break;
         }
       }

--- a/src/_vendor/zod-to-json-schema/util.ts
+++ b/src/_vendor/zod-to-json-schema/util.ts
@@ -4,8 +4,12 @@ export const zodDef = (zodSchema: ZodSchema | ZodTypeDef): ZodTypeDef =>
   '_def' in zodSchema ? zodSchema._def : zodSchema;
 
 export function isEmptyObj(obj: object | null | undefined): boolean {
-  if (!obj) return true;
+  if (!obj) {
+    return true;
+  }
   // oxlint-disable-next-line guard-for-in -- inherited enumerable properties make the object non-empty
-  for (const _k in obj) return false;
+  for (const _k in obj) {
+    return false;
+  }
   return true;
 }

--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -66,7 +66,9 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
       const newDefinitions = Object.entries(refs.definitions).filter(
         ([key]) => !processedDefinitions.has(key),
       );
-      if (newDefinitions.length === 0) break;
+      if (newDefinitions.length === 0) {
+        break;
+      }
 
       for (const [key, schema] of newDefinitions) {
         definitions[key] =

--- a/src/core/EventEmitter.ts
+++ b/src/core/EventEmitter.ts
@@ -37,9 +37,13 @@ export class EventEmitter<EventTypes extends Record<string, (...args: any) => an
    */
   off<Event extends keyof EventTypes>(event: Event, listener: EventListener<EventTypes, Event>): this {
     const listeners = this.#listeners[event];
-    if (!listeners) return this;
+    if (!listeners) {
+      return this;
+    }
     const index = listeners.findIndex((l) => l.listener === listener);
-    if (index !== -1) listeners.splice(index, 1);
+    if (index !== -1) {
+      listeners.splice(index, 1);
+    }
     return this;
   }
 

--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -43,7 +43,9 @@ export class Stream<Item> implements AsyncIterable<Item> {
       let done = false;
       try {
         for await (const sse of _iterSSEMessages(response, controller)) {
-          if (done) continue;
+          if (done) {
+            continue;
+          }
 
           if (sse.data.startsWith('[DONE]')) {
             done = true;
@@ -85,11 +87,15 @@ export class Stream<Item> implements AsyncIterable<Item> {
         done = true;
       } catch (e) {
         // If the user calls `stream.controller.abort()`, we should exit without throwing.
-        if (isAbortError(e)) return;
+        if (isAbortError(e)) {
+          return;
+        }
         throw e;
       } finally {
         // If the user `break`s, abort the ongoing request.
-        if (!done) controller.abort();
+        if (!done) {
+          controller.abort();
+        }
       }
     }
 
@@ -130,22 +136,32 @@ export class Stream<Item> implements AsyncIterable<Item> {
             closed = true;
             break;
           }
-          if (controller.signal.aborted) return;
+          if (controller.signal.aborted) {
+            return;
+          }
 
           for (const line of lineDecoder.decode(chunk)) {
-            if (controller.signal.aborted) return;
+            if (controller.signal.aborted) {
+              return;
+            }
             yield line;
           }
         }
 
-        if (controller.signal.aborted) return;
+        if (controller.signal.aborted) {
+          return;
+        }
         for (const line of lineDecoder.flush()) {
-          if (controller.signal.aborted) return;
+          if (controller.signal.aborted) {
+            return;
+          }
           yield line;
         }
       } finally {
         controller.signal.removeEventListener('abort', cancel);
-        if (!closed) cancel();
+        if (!closed) {
+          cancel();
+        }
         reader.releaseLock();
       }
     }
@@ -158,17 +174,25 @@ export class Stream<Item> implements AsyncIterable<Item> {
       let done = false;
       try {
         for await (const line of iterLines()) {
-          if (done) continue;
-          if (line) yield JSON.parse(line) as Item;
+          if (done) {
+            continue;
+          }
+          if (line) {
+            yield JSON.parse(line) as Item;
+          }
         }
         done = true;
       } catch (e) {
         // If the user calls `stream.controller.abort()`, we should exit without throwing.
-        if (controller.signal.aborted || isAbortError(e)) return;
+        if (controller.signal.aborted || isAbortError(e)) {
+          return;
+        }
         throw e;
       } finally {
         // If the user `break`s, abort the ongoing request.
-        if (!done) controller.abort();
+        if (!done) {
+          controller.abort();
+        }
       }
     }
 
@@ -220,7 +244,9 @@ export class Stream<Item> implements AsyncIterable<Item> {
       async pull(ctrl: any) {
         try {
           const { value, done } = await iter.next();
-          if (done) return ctrl.close();
+          if (done) {
+            return ctrl.close();
+          }
 
           const bytes = encodeUTF8(JSON.stringify(value) + '\n');
 
@@ -260,13 +286,17 @@ export async function* _iterSSEMessages(
   for await (const sseChunk of iterSSEChunks(iter)) {
     for (const line of lineDecoder.decode(sseChunk)) {
       const sse = sseDecoder.decode(line);
-      if (sse) yield sse;
+      if (sse) {
+        yield sse;
+      }
     }
   }
 
   for (const line of lineDecoder.flush()) {
     const sse = sseDecoder.decode(line);
-    if (sse) yield sse;
+    if (sse) {
+      yield sse;
+    }
   }
 }
 
@@ -327,7 +357,9 @@ class SSEDecoder {
 
     if (!line) {
       // empty line and we didn't previously encounter any messages
-      if (!this.event && !this.data.length) return null;
+      if (!this.event && !this.data.length) {
+        return null;
+      }
 
       const sse: ServerSentEvent = {
         event: this.event,

--- a/src/helpers/standard-schema.ts
+++ b/src/helpers/standard-schema.ts
@@ -130,7 +130,9 @@ const JSON_SCHEMA_TYPES = new Set(['string', 'number', 'integer', 'boolean', 'ob
 type JSONPrimitive = string | number | boolean | null;
 
 function getSchemaTypes(schema: unknown): Set<string> | undefined {
-  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) return undefined;
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+    return undefined;
+  }
 
   const type = (schema as Record<string, unknown>)['type'];
   if (type === undefined) {
@@ -157,7 +159,9 @@ function isJSONPrimitive(value: unknown): value is JSONPrimitive {
 }
 
 function getLiteralValues(schema: unknown): JSONPrimitive[] | undefined {
-  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) return undefined;
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+    return undefined;
+  }
 
   const record = schema as Record<string, unknown>;
   if ('const' in record && isJSONPrimitive(record['const'])) {
@@ -174,11 +178,15 @@ function getLiteralValues(schema: unknown): JSONPrimitive[] | undefined {
 
 function getLiteralSchemaTypes(schema: unknown): Set<string> | undefined {
   const literalValues = getLiteralValues(schema);
-  if (!literalValues) return undefined;
+  if (!literalValues) {
+    return undefined;
+  }
 
   return new Set(
     literalValues.map((value) => {
-      if (value === null) return 'null';
+      if (value === null) {
+        return 'null';
+      }
       return typeof value;
     }),
   );
@@ -187,7 +195,9 @@ function getLiteralSchemaTypes(schema: unknown): Set<string> | undefined {
 function haveDisjointLiteralValues(left: unknown, right: unknown): boolean {
   const leftValues = getLiteralValues(left);
   const rightValues = getLiteralValues(right);
-  if (!leftValues || !rightValues) return false;
+  if (!leftValues || !rightValues) {
+    return false;
+  }
 
   return leftValues.every((leftValue) => !rightValues.some((rightValue) => leftValue === rightValue));
 }
@@ -204,7 +214,9 @@ function isObjectOnlySchema(schema: unknown): boolean {
 }
 
 function haveDisjointObjectDiscriminator(left: unknown, right: unknown, root: JSONSchema): boolean {
-  if (!isObjectOnlySchema(left) || !isObjectOnlySchema(right)) return false;
+  if (!isObjectOnlySchema(left) || !isObjectOnlySchema(right)) {
+    return false;
+  }
 
   const leftRecord = left as Record<string, unknown>;
   const rightRecord = right as Record<string, unknown>;
@@ -244,7 +256,9 @@ function haveDisjointObjectDiscriminator(left: unknown, right: unknown, root: JS
 function getClosedObjectPropertySet(
   schema: unknown,
 ): { properties: Set<string>; required: string[] } | undefined {
-  if (!isObjectOnlySchema(schema)) return undefined;
+  if (!isObjectOnlySchema(schema)) {
+    return undefined;
+  }
 
   const record = schema as Record<string, unknown>;
   const properties = record['properties'];
@@ -275,7 +289,9 @@ function getClosedObjectPropertySet(
 function haveDisjointClosedObjectPropertySets(left: unknown, right: unknown): boolean {
   const leftShape = getClosedObjectPropertySet(left);
   const rightShape = getClosedObjectPropertySet(right);
-  if (!leftShape || !rightShape) return false;
+  if (!leftShape || !rightShape) {
+    return false;
+  }
 
   // If either closed branch requires a property the other branch does not
   // declare, every instance satisfying the first is rejected by the second as
@@ -312,7 +328,9 @@ function resolveLocalRefForExclusivity(
   root: JSONSchema,
   seenRefs = new Set<string>(),
 ): unknown | undefined {
-  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) return schema;
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+    return schema;
+  }
 
   const record = schema as Record<string, unknown>;
   const ref = record['$ref'];
@@ -323,18 +341,26 @@ function resolveLocalRefForExclusivity(
     if (typeof ref !== 'string' || !hasOnlyRefAndAnnotations(record as JSONSchema)) {
       return undefined;
     }
-    if (seenRefs.has(ref)) return undefined;
+    if (seenRefs.has(ref)) {
+      return undefined;
+    }
 
     const resolved = resolveLocalRef(root, ref);
-    if (resolved === undefined) return undefined;
+    if (resolved === undefined) {
+      return undefined;
+    }
 
     return resolveLocalRefForExclusivity(resolved, root, new Set([...seenRefs, ref]));
   }
 
   if (record['allOf'] !== undefined) {
-    if (!Array.isArray(record['allOf'])) return undefined;
+    if (!Array.isArray(record['allOf'])) {
+      return undefined;
+    }
     const normalized = normalizeObjectAllOfForExclusivity(record as JSONSchema, root);
-    if (normalized === undefined) return undefined;
+    if (normalized === undefined) {
+      return undefined;
+    }
 
     // Flattening a singleton allOf can expose a bare local ref. Feed that
     // result through this same resolver so URI-fragment decoding and the
@@ -366,9 +392,13 @@ function normalizeStructuredOutputSchema(schema: JSONSchema): JSONSchema {
   const visitedSchemas = new Set<Record<string, unknown>>();
 
   const visitSchema = (value: unknown): void => {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) return;
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return;
+    }
     const record = value as Record<string, unknown>;
-    if (visitedSchemas.has(record)) return;
+    if (visitedSchemas.has(record)) {
+      return;
+    }
     visitedSchemas.add(record);
 
     if (record['oneOf'] !== undefined) {

--- a/src/helpers/zod.ts
+++ b/src/helpers/zod.ts
@@ -67,10 +67,14 @@ function escapeSchemaDefinitionRefs<T extends object>(
   );
 
   const visit = (value: unknown): void => {
-    if (!value || typeof value !== 'object') return;
+    if (!value || typeof value !== 'object') {
+      return;
+    }
 
     if (Array.isArray(value)) {
-      for (const child of value) visit(child);
+      for (const child of value) {
+        visit(child);
+      }
       return;
     }
 
@@ -80,7 +84,9 @@ function escapeSchemaDefinitionRefs<T extends object>(
       record['$ref'] = refReplacements.get(ref) ?? ref;
     }
 
-    for (const child of Object.values(record)) visit(child);
+    for (const child of Object.values(record)) {
+      visit(child);
+    }
   };
 
   visit(schema);
@@ -88,7 +94,9 @@ function escapeSchemaDefinitionRefs<T extends object>(
 }
 
 function getZodV3RootName(name: string, schemaDefinitions: ZodSchemaDefinitions | undefined): string {
-  if (!schemaDefinitions) return name;
+  if (!schemaDefinitions) {
+    return name;
+  }
 
   let rootName = name;
   while (hasOwn(schemaDefinitions, rootName)) {

--- a/src/internal/bedrock.ts
+++ b/src/internal/bedrock.ts
@@ -70,7 +70,9 @@ export function resolveBedrockEndpoint(options: BedrockEndpointOptions): {
       ? normalizeOptionalString(readEnv('AWS_BEDROCK_BASE_URL'))
       : normalizeOptionalString(options.baseURL);
 
-  if (configuredBaseURL) return { region, baseURL: normalizeBaseURL(configuredBaseURL) };
+  if (configuredBaseURL) {
+    return { region, baseURL: normalizeBaseURL(configuredBaseURL) };
+  }
   if (!region) {
     throw new Errors.OpenAIError(
       'Bedrock requires an AWS region. Pass `region` to `bedrock(...)`, or set `AWS_REGION` or `AWS_DEFAULT_REGION`.',

--- a/src/internal/qs/utils.ts
+++ b/src/internal/qs/utils.ts
@@ -23,7 +23,9 @@ const hex_table = /* @__PURE__ */ (() => {
 function compact_queue<T extends Record<string, any>>(queue: { obj: T; prop: string }[]) {
   while (queue.length > 1) {
     const item = queue.pop();
-    if (!item) continue;
+    if (!item) {
+      continue;
+    }
 
     const obj = item.obj[item.prop];
 

--- a/src/internal/stream-utils.ts
+++ b/src/internal/stream-utils.ts
@@ -5,14 +5,18 @@
  * This polyfill was pulled from https://github.com/MattiasBuelens/web-streams-polyfill/pull/122#issuecomment-1627354490
  */
 export function ReadableStreamToAsyncIterable<T>(stream: any): AsyncIterableIterator<T> {
-  if (stream[Symbol.asyncIterator]) return stream;
+  if (stream[Symbol.asyncIterator]) {
+    return stream;
+  }
 
   const reader = stream.getReader();
   return {
     async next() {
       try {
         const result = await reader.read();
-        if (result?.done) reader.releaseLock(); // release lock when stream becomes closed
+        if (result?.done) {
+          reader.releaseLock();
+        } // release lock when stream becomes closed
         return result;
       } catch (e) {
         reader.releaseLock(); // release lock when stream becomes errored

--- a/src/internal/to-file.ts
+++ b/src/internal/to-file.ts
@@ -148,7 +148,9 @@ async function getBytes(value: BlobLikePart | AsyncIterable<BlobLikePart>): Prom
 }
 
 function propsForError(value: unknown): string {
-  if (typeof value !== 'object' || value === null) return '';
+  if (typeof value !== 'object' || value === null) {
+    return '';
+  }
   const props = Object.getOwnPropertyNames(value);
   return `; props: [${props.map((p) => `"${p}"`).join(', ')}]`;
 }

--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -130,7 +130,9 @@ export const maybeMultipartFormRequestOptions = async (
   opts: RequestOptions,
   fetch: OpenAI | Fetch,
 ): Promise<RequestOptions> => {
-  if (!hasUploadableValue(opts.body)) return opts;
+  if (!hasUploadableValue(opts.body)) {
+    return opts;
+  }
 
   if (hasStreamingUploadableValue(opts.body)) {
     return createStreamingFormRequestOptions(opts);
@@ -163,7 +165,9 @@ const supportsFormDataMap = /* @__PURE__ */ new WeakMap<Fetch, Promise<boolean>>
 function supportsFormData(fetchObject: OpenAI | Fetch): Promise<boolean> {
   const fetch: Fetch = typeof fetchObject === 'function' ? fetchObject : (fetchObject as any).fetch;
   const cached = supportsFormDataMap.get(fetch);
-  if (cached) return cached;
+  if (cached) {
+    return cached;
+  }
   const promise = (async () => {
     try {
       let FetchResponse: typeof Response;
@@ -225,22 +229,34 @@ const isUploadable = (value: unknown): value is Uploadable =>
     isNamedBlob(value));
 
 const hasStreamingUploadableValue = (value: unknown): boolean => {
-  if (isStreamingFile(value) || isAsyncIterable(value) || isReadableStream(value)) return true;
-  if (Array.isArray(value)) return value.some(hasStreamingUploadableValue);
+  if (isStreamingFile(value) || isAsyncIterable(value) || isReadableStream(value)) {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.some(hasStreamingUploadableValue);
+  }
   if (value && typeof value === 'object' && !isNamedBlob(value) && !(value instanceof Response)) {
     for (const k in value) {
-      if (hasStreamingUploadableValue((value as Record<string, unknown>)[k])) return true;
+      if (hasStreamingUploadableValue((value as Record<string, unknown>)[k])) {
+        return true;
+      }
     }
   }
   return false;
 };
 
 const hasUploadableValue = (value: unknown): boolean => {
-  if (isUploadable(value)) return true;
-  if (Array.isArray(value)) return value.some(hasUploadableValue);
+  if (isUploadable(value)) {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.some(hasUploadableValue);
+  }
   if (value && typeof value === 'object') {
     for (const k in value) {
-      if (hasUploadableValue((value as any)[k])) return true;
+      if (hasUploadableValue((value as any)[k])) {
+        return true;
+      }
     }
   }
   return false;
@@ -282,7 +298,9 @@ async function* iterateMultipartBody(body: unknown, boundary: string): AsyncGene
 }
 
 async function* iterateFormEntries(body: unknown): AsyncGenerator<FormEntry> {
-  if (!body || typeof body !== 'object') return;
+  if (!body || typeof body !== 'object') {
+    return;
+  }
 
   for (const [key, value] of Object.entries(body)) {
     yield* iterateFormValue(key, value);
@@ -290,7 +308,9 @@ async function* iterateFormEntries(body: unknown): AsyncGenerator<FormEntry> {
 }
 
 async function* iterateFormValue(key: string, value: unknown): AsyncGenerator<FormEntry> {
-  if (value === undefined) return;
+  if (value === undefined) {
+    return;
+  }
   if (value == null) {
     throw new TypeError(
       `Received null for "${key}"; to pass null in FormData, you must use the string 'null'`,
@@ -324,14 +344,22 @@ function getStreamingFileName(value: Uploadable): string {
 }
 
 function getStreamingFileType(value: Uploadable): string {
-  if (isStreamingFile(value)) return value.type || 'application/octet-stream';
-  if (isNamedBlob(value) && value.type) return value.type;
-  if (value instanceof Response) return value.headers.get('content-type') || 'application/octet-stream';
+  if (isStreamingFile(value)) {
+    return value.type || 'application/octet-stream';
+  }
+  if (isNamedBlob(value) && value.type) {
+    return value.type;
+  }
+  if (value instanceof Response) {
+    return value.headers.get('content-type') || 'application/octet-stream';
+  }
   return 'application/octet-stream';
 }
 
 function getStreamingFileData(value: Uploadable): unknown {
-  if (isStreamingFile(value)) return value.data;
+  if (isStreamingFile(value)) {
+    return value.data;
+  }
   return value;
 }
 
@@ -368,7 +396,9 @@ function escapeHeaderValue(value: string): string {
 }
 
 const addFormValue = async (form: FormData, key: string, value: unknown): Promise<void> => {
-  if (value === undefined) return;
+  if (value === undefined) {
+    return;
+  }
   if (value == null) {
     throw new TypeError(
       `Received null for "${key}"; to pass null in FormData, you must use the string 'null'`,

--- a/src/internal/utils/path.ts
+++ b/src/internal/utils/path.ts
@@ -17,7 +17,9 @@ const EMPTY = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.create(null))
 export const createPathTagFunction = (pathEncoder = encodeURIPath) =>
   function path(statics: readonly string[], ...params: readonly unknown[]): string {
     // If there are no params, no processing is needed.
-    if (statics.length === 1) return statics[0]!;
+    if (statics.length === 1) {
+      return statics[0]!;
+    }
 
     let postPath = false;
     const invalidSegments = [];

--- a/src/internal/ws-adapter-browser.ts
+++ b/src/internal/ws-adapter-browser.ts
@@ -59,7 +59,9 @@ export class BrowserWebSocket implements WebSocketLike {
 
   off(event: string, listener: Listener): void {
     const byListener = this._listenerMap.get(event);
-    if (!byListener) return;
+    if (!byListener) {
+      return;
+    }
     const wrapped = byListener.get(listener);
     if (wrapped) {
       byListener.delete(listener);

--- a/src/internal/ws-adapter-node.ts
+++ b/src/internal/ws-adapter-node.ts
@@ -39,7 +39,9 @@ export class NodeWebSocket implements WebSocketLike {
 
   off(event: string, listener: Listener): void {
     const byListener = this._listenerMap.get(event);
-    if (!byListener) return;
+    if (!byListener) {
+      return;
+    }
     const wrapped = byListener.get(listener);
     if (wrapped) {
       byListener.delete(listener);
@@ -75,13 +77,21 @@ export class NodeWebSocket implements WebSocketLike {
     isBinary: boolean,
   ): string | Buffer {
     if (!isBinary) {
-      if (Array.isArray(data)) return Buffer.concat(data).toString();
-      if (data instanceof ArrayBuffer) return Buffer.from(data).toString();
+      if (Array.isArray(data)) {
+        return Buffer.concat(data).toString();
+      }
+      if (data instanceof ArrayBuffer) {
+        return Buffer.from(data).toString();
+      }
       return data.toString();
     }
 
-    if (Array.isArray(data)) return Buffer.concat(data);
-    if (data instanceof ArrayBuffer) return Buffer.from(data);
+    if (Array.isArray(data)) {
+      return Buffer.concat(data);
+    }
+    if (data instanceof ArrayBuffer) {
+      return Buffer.from(data);
+    }
     return data;
   }
 

--- a/src/internal/ws.ts
+++ b/src/internal/ws.ts
@@ -45,7 +45,9 @@ type QueueEntry =
   | { kind: 'raw'; data: RawWebSocketData; byteLength: number };
 
 function toUint8Array(view: ArrayBufferView): Uint8Array {
-  if (view instanceof Uint8Array) return view;
+  if (view instanceof Uint8Array) {
+    return view;
+  }
   return new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
 }
 
@@ -54,13 +56,19 @@ function toUint8Array(view: ArrayBufferView): Uint8Array {
  * `ws.send()` transmits the correct bytes.
  */
 export function flattenRawData(data: RawWebSocketData): Exclude<RawWebSocketData, ArrayBufferView[]> {
-  if (Array.isArray(data)) return concatBytes(data.map(toUint8Array));
+  if (Array.isArray(data)) {
+    return concatBytes(data.map(toUint8Array));
+  }
   return data;
 }
 
 function snapshotRawData(data: RawWebSocketData): Exclude<RawWebSocketData, ArrayBufferView[]> {
-  if (typeof data === 'string') return data;
-  if (Array.isArray(data)) return concatBytes(data.map(toUint8Array));
+  if (typeof data === 'string') {
+    return data;
+  }
+  if (Array.isArray(data)) {
+    return concatBytes(data.map(toUint8Array));
+  }
   if (ArrayBuffer.isView(data)) {
     const copy = new Uint8Array(data.byteLength);
     copy.set(toUint8Array(data));
@@ -71,9 +79,15 @@ function snapshotRawData(data: RawWebSocketData): Exclude<RawWebSocketData, Arra
 }
 
 function rawByteLength(data: RawWebSocketData): number {
-  if (typeof data === 'string') return encodeUTF8(data).byteLength;
-  if (Array.isArray(data)) return data.reduce((sum, buf) => sum + buf.byteLength, 0);
-  if ('byteLength' in data) return data.byteLength;
+  if (typeof data === 'string') {
+    return encodeUTF8(data).byteLength;
+  }
+  if (Array.isArray(data)) {
+    return data.reduce((sum, buf) => sum + buf.byteLength, 0);
+  }
+  if ('byteLength' in data) {
+    return data.byteLength;
+  }
   return 0;
 }
 
@@ -148,7 +162,9 @@ export class SendQueue<T = unknown> {
    */
   drain(): UnsentMessage<T>[] {
     const unsent = this._queue.map((entry): UnsentMessage<T> => {
-      if (entry.kind === 'raw') return { type: 'raw', data: entry.data };
+      if (entry.kind === 'raw') {
+        return { type: 'raw', data: entry.data };
+      }
       return { type: 'message', message: JSON.parse(entry.data) as T };
     });
     this._queue = [];

--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -52,15 +52,27 @@ function normalizeToolCallIds(chatCompletion: ChatCompletion): void {
  * on runner.messages for callers, but only replay valid request fields.
  */
 function toRequestMessage(message: ChatCompletionMessageParam): ChatCompletionMessageParam {
-  if (!isAssistantMessage(message)) return message;
+  if (!isAssistantMessage(message)) {
+    return message;
+  }
 
   const requestMessage: ChatCompletionAssistantMessageParam = { role: 'assistant' };
 
-  if (message.audio != null) requestMessage.audio = { id: message.audio.id };
-  if (message.content !== undefined) requestMessage.content = message.content;
-  if (message.function_call != null) requestMessage.function_call = message.function_call;
-  if (message.name !== undefined) requestMessage.name = message.name;
-  if (message.refusal != null) requestMessage.refusal = message.refusal;
+  if (message.audio != null) {
+    requestMessage.audio = { id: message.audio.id };
+  }
+  if (message.content !== undefined) {
+    requestMessage.content = message.content;
+  }
+  if (message.function_call != null) {
+    requestMessage.function_call = message.function_call;
+  }
+  if (message.name !== undefined) {
+    requestMessage.name = message.name;
+  }
+  if (message.refusal != null) {
+    requestMessage.refusal = message.refusal;
+  }
   if (message.tool_calls !== undefined) {
     requestMessage.tool_calls = message.tool_calls.map((toolCall) => {
       if (toolCall.type === 'custom') {
@@ -120,7 +132,9 @@ export class AbstractChatCompletionRunner<
     this._chatCompletions.push(chatCompletion);
     this._emit('chatCompletion', chatCompletion);
     const message = chatCompletion.choices[0]?.message;
-    if (message) this._addMessage(message as ChatCompletionMessageParam);
+    if (message) {
+      this._addMessage(message as ChatCompletionMessageParam);
+    }
     return chatCompletion;
   }
 
@@ -129,7 +143,9 @@ export class AbstractChatCompletionRunner<
     message: ChatCompletionMessageParam,
     emit = true,
   ) {
-    if (!('content' in message)) message.content = null;
+    if (!('content' in message)) {
+      message.content = null;
+    }
 
     this.messages.push(message);
 
@@ -155,7 +171,9 @@ export class AbstractChatCompletionRunner<
   async finalChatCompletion(): Promise<ParsedChatCompletion<ParsedT>> {
     await this.done();
     const completion = this._chatCompletions[this._chatCompletions.length - 1];
-    if (!completion) throw new OpenAIError('stream ended without producing a ChatCompletion');
+    if (!completion) {
+      throw new OpenAIError('stream ended without producing a ChatCompletion');
+    }
     return completion;
   }
 
@@ -277,17 +295,27 @@ export class AbstractChatCompletionRunner<
     this: AbstractChatCompletionRunner<AbstractChatCompletionRunnerEvents, ParsedT>,
   ) {
     const completion = this._chatCompletions[this._chatCompletions.length - 1];
-    if (completion) this._emit('finalChatCompletion', completion);
+    if (completion) {
+      this._emit('finalChatCompletion', completion);
+    }
     const finalMessage = this.#getFinalMessage();
-    if (finalMessage) this._emit('finalMessage', finalMessage);
+    if (finalMessage) {
+      this._emit('finalMessage', finalMessage);
+    }
     const finalContent = this.#getFinalContent();
-    if (finalContent) this._emit('finalContent', finalContent);
+    if (finalContent) {
+      this._emit('finalContent', finalContent);
+    }
 
     const finalFunctionCall = this.#getFinalFunctionToolCall();
-    if (finalFunctionCall) this._emit('finalFunctionToolCall', finalFunctionCall);
+    if (finalFunctionCall) {
+      this._emit('finalFunctionToolCall', finalFunctionCall);
+    }
 
     const finalFunctionCallResult = this.#getFinalFunctionToolCallResult();
-    if (finalFunctionCallResult != null) this._emit('finalFunctionToolCallResult', finalFunctionCallResult);
+    if (finalFunctionCallResult != null) {
+      this._emit('finalFunctionToolCallResult', finalFunctionCallResult);
+    }
 
     if (this._chatCompletions.some((c) => c.usage)) {
       this._emit('totalUsage', this.#calculateTotalUsage());
@@ -403,7 +431,9 @@ export class AbstractChatCompletionRunner<
     };
 
     const runToolCall = async (toolCall: ChatCompletionMessageToolCall): Promise<ToolCallResult> => {
-      if (toolCall.type !== 'function') return { message: undefined, functionCalled: false };
+      if (toolCall.type !== 'function') {
+        return { message: undefined, functionCalled: false };
+      }
 
       const tool_call_id = toolCall.id;
       const { name, arguments: args } = toolCall.function;
@@ -468,7 +498,9 @@ export class AbstractChatCompletionRunner<
       if (singleFunctionToCall || params.parallel_tool_calls === false) {
         for (const toolCall of message.tool_calls) {
           const result = await runToolCall(toolCall);
-          if (result.message) this._addMessage(result.message);
+          if (result.message) {
+            this._addMessage(result.message);
+          }
 
           if (singleFunctionToCall && result.functionCalled) {
             await afterCompletion?.(chatCompletion, runner);
@@ -481,7 +513,9 @@ export class AbstractChatCompletionRunner<
         // Wait for every concurrently running tool to settle before surfacing an
         // error so tool side effects cannot continue after the runner has ended.
         for (const result of results) {
-          if (result.status === 'rejected') throw result.reason;
+          if (result.status === 'rejected') {
+            throw result.reason;
+          }
         }
 
         // Promise.allSettled preserves input order, so the next request receives

--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -287,7 +287,9 @@ export class AssistantStream
 
   async finalRun(): Promise<Run> {
     await this.done();
-    if (!this.#finalRun) throw new Error('Final run was not received.');
+    if (!this.#finalRun) {
+      throw new Error('Final run was not received.');
+    }
 
     return this.#finalRun;
   }
@@ -338,7 +340,9 @@ export class AssistantStream
   }
 
   #addEvent(event: AssistantStreamEvent) {
-    if (this.ended) return;
+    if (this.ended) {
+      return;
+    }
 
     this.#currentEvent = event;
 
@@ -401,7 +405,9 @@ export class AssistantStream
       throw new OpenAIError(`stream has ended, this shouldn't happen`);
     }
 
-    if (!this.#finalRun) throw new Error('Final run has not been received');
+    if (!this.#finalRun) {
+      throw new Error('Final run has not been received');
+    }
 
     return this.#finalRun;
   }
@@ -528,7 +534,9 @@ export class AssistantStream
 
               this.#currentToolCallIndex = toolCall.index;
               this.#currentToolCall = accumulatedRunStep.step_details.tool_calls[toolCall.index];
-              if (this.#currentToolCall) this._emit('toolCallCreated', this.#currentToolCall);
+              if (this.#currentToolCall) {
+                this._emit('toolCallCreated', this.#currentToolCall);
+              }
             }
           }
         }
@@ -593,7 +601,9 @@ export class AssistantStream
       }
     }
 
-    if (this.#runStepSnapshots[event.data.id]) return this.#runStepSnapshots[event.data.id] as Runs.RunStep;
+    if (this.#runStepSnapshots[event.data.id]) {
+      return this.#runStepSnapshots[event.data.id] as Runs.RunStep;
+    }
     throw new Error('No snapshot available');
   }
 

--- a/src/lib/ChatCompletionStream.ts
+++ b/src/lib/ChatCompletionStream.ts
@@ -240,7 +240,9 @@ export class ChatCompletionStream<ParsedT = null>
   }
 
   #beginRequest() {
-    if (this.ended) return;
+    if (this.ended) {
+      return;
+    }
     this.#audioDoneChoiceIndexes = new Set();
     this.#currentChatCompletionSnapshot = undefined;
   }
@@ -264,7 +266,9 @@ export class ChatCompletionStream<ParsedT = null>
   }
 
   #addChunk(this: ChatCompletionStream<ParsedT>, chunk: ChatCompletionChunk) {
-    if (this.ended) return;
+    if (this.ended) {
+      return;
+    }
 
     const completion = this.#accumulateChatCompletion(chunk);
     this._emit('chunk', chunk, completion);
@@ -502,7 +506,9 @@ export class ChatCompletionStream<ParsedT = null>
       }
 
       this.#addChunk(chunk);
-      if (chunk.id) chatId = chunk.id;
+      if (chunk.id) {
+        chatId = chunk.id;
+      }
     }
     if (stream.controller.signal?.aborted) {
       throw new APIUserAbortError();
@@ -584,7 +590,9 @@ export class ChatCompletionStream<ParsedT = null>
 
       Object.assign(choice, other);
 
-      if (!delta) continue; // Shouldn't happen; just in case.
+      if (!delta) {
+        continue;
+      } // Shouldn't happen; just in case.
 
       this.#audioDoneChoiceIndexes.delete(index);
       const { audio, content, refusal, function_call, role, tool_calls, ...rest } = delta as typeof delta & {
@@ -611,19 +619,29 @@ export class ChatCompletionStream<ParsedT = null>
         choice.message.refusal = (choice.message.refusal || '') + refusal;
       }
 
-      if (role) choice.message.role = role;
+      if (role) {
+        choice.message.role = role;
+      }
       if (audio) {
         const audioSnapshot = (choice.message.audio ??= {});
-        if (audio.id != null) audioSnapshot.id = audio.id;
-        if (audio.data != null) audioSnapshot.data = (audioSnapshot.data ?? '') + audio.data;
+        if (audio.id != null) {
+          audioSnapshot.id = audio.id;
+        }
+        if (audio.data != null) {
+          audioSnapshot.data = (audioSnapshot.data ?? '') + audio.data;
+        }
         if (audio.transcript != null) {
           audioSnapshot.transcript = (audioSnapshot.transcript ?? '') + audio.transcript;
         }
-        if (audio.expires_at != null) audioSnapshot.expires_at = audio.expires_at;
+        if (audio.expires_at != null) {
+          audioSnapshot.expires_at = audio.expires_at;
+        }
       }
       if (function_call) {
         if (choice.message.function_call) {
-          if (function_call.name) choice.message.function_call.name = function_call.name;
+          if (function_call.name) {
+            choice.message.function_call.name = function_call.name;
+          }
           if (function_call.arguments) {
             choice.message.function_call.arguments ??= '';
             choice.message.function_call.arguments += function_call.arguments;
@@ -642,16 +660,26 @@ export class ChatCompletionStream<ParsedT = null>
       }
 
       if (tool_calls) {
-        if (!choice.message.tool_calls) choice.message.tool_calls = [];
+        if (!choice.message.tool_calls) {
+          choice.message.tool_calls = [];
+        }
 
         for (const { index, id, type, function: fn, ...rest } of tool_calls) {
           const tool_call = (choice.message.tool_calls[index] ??=
             {} as ChatCompletionSnapshot.Choice.Message.ToolCall);
           Object.assign(tool_call, rest);
-          if (id) tool_call.id = id;
-          if (type) tool_call.type = type;
-          if (fn) tool_call.function ??= { name: fn.name ?? '', arguments: '' };
-          if (fn?.name) tool_call.function!.name = fn.name;
+          if (id) {
+            tool_call.id = id;
+          }
+          if (type) {
+            tool_call.type = type;
+          }
+          if (fn) {
+            tool_call.function ??= { name: fn.name ?? '', arguments: '' };
+          }
+          if (fn?.name) {
+            tool_call.function!.name = fn.name;
+          }
           if (fn?.arguments) {
             tool_call.function!.arguments += fn.arguments;
 

--- a/src/lib/EventEmitter.ts
+++ b/src/lib/EventEmitter.ts
@@ -37,9 +37,13 @@ export class EventEmitter<EventTypes extends Record<string, (...args: any) => an
    */
   off<Event extends keyof EventTypes>(event: Event, listener: EventListener<EventTypes, Event>): this {
     const listeners = this.#listeners[event];
-    if (!listeners) return this;
+    if (!listeners) {
+      return this;
+    }
     const index = listeners.findIndex((l) => l.listener === listener);
-    if (index !== -1) listeners.splice(index, 1);
+    if (index !== -1) {
+      listeners.splice(index, 1);
+    }
     return this;
   }
 
@@ -80,11 +84,15 @@ export class EventEmitter<EventTypes extends Record<string, (...args: any) => an
         reject(error);
       };
       const onEvent = (value: unknown) => {
-        if (event !== 'error') this.off('error', onError as any);
+        if (event !== 'error') {
+          this.off('error', onError as any);
+        }
         resolve(value as any);
       };
 
-      if (event !== 'error') this.once('error', onError as any);
+      if (event !== 'error') {
+        this.once('error', onError as any);
+      }
       this.once(event, onEvent as any);
     });
   }

--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -55,7 +55,9 @@ export class EventStream<EventTypes extends BaseEvents> {
           this.#handleError(error);
         })
         .then(() => {
-          if (failed) return;
+          if (failed) {
+            return;
+          }
 
           try {
             this._emitFinal();
@@ -69,7 +71,9 @@ export class EventStream<EventTypes extends BaseEvents> {
   }
 
   protected _connected(this: EventStream<EventTypes>) {
-    if (this.ended) return;
+    if (this.ended) {
+      return;
+    }
     this.#resolveConnectedPromise();
     this._emit('connect');
   }
@@ -91,7 +95,9 @@ export class EventStream<EventTypes extends BaseEvents> {
   }
 
   protected _listenForAbort(signal: AbortSignal | null | undefined) {
-    if (!signal || this.ended) return;
+    if (!signal || this.ended) {
+      return;
+    }
     if (signal.aborted) {
       this.controller.abort();
       return;
@@ -130,9 +136,13 @@ export class EventStream<EventTypes extends BaseEvents> {
    */
   off<Event extends keyof EventTypes>(event: Event, listener: EventListener<EventTypes, Event>): this {
     const listeners = this.#listeners[event];
-    if (!listeners) return this;
+    if (!listeners) {
+      return this;
+    }
     const index = listeners.findIndex((l) => l.listener === listener);
-    if (index !== -1) listeners.splice(index, 1);
+    if (index !== -1) {
+      listeners.splice(index, 1);
+    }
     return this;
   }
 
@@ -169,7 +179,9 @@ export class EventStream<EventTypes extends BaseEvents> {
   > {
     return new Promise((resolve, reject) => {
       this.#catchingPromiseCreated = true;
-      if (event !== 'error') this.once('error', reject);
+      if (event !== 'error') {
+        this.once('error', reject);
+      }
       this.once(event, resolve as any);
     });
   }
@@ -209,18 +221,26 @@ export class EventStream<EventTypes extends BaseEvents> {
       }
     };
     const rejectReader = () => {
-      if (!failure || failureDelivered || !readQueue.length) return;
+      if (!failure || failureDelivered || !readQueue.length) {
+        return;
+      }
       failureDelivered = true;
       readQueue.shift()!.reject(failure);
     };
     const cleanup = () => {
       this.off(event, onEvent as EventListener<EventTypes, Event>);
       this.off('end', onEnd);
-      if (event !== 'error') this.off('error', onFailure);
-      if (event !== 'abort') this.off('abort', onFailure);
+      if (event !== 'error') {
+        this.off('error', onFailure);
+      }
+      if (event !== 'abort') {
+        this.off('abort', onFailure);
+      }
     };
     const onEvent = (...args: Parameters) => {
-      if (ended) return;
+      if (ended) {
+        return;
+      }
       const reader = readQueue.shift();
       if (reader) {
         reader.resolve({ value: args, done: false });
@@ -230,7 +250,9 @@ export class EventStream<EventTypes extends BaseEvents> {
     };
     const onFailure = (error: OpenAIError) => {
       failure = error;
-      if (!pushQueue.length) rejectReader();
+      if (!pushQueue.length) {
+        rejectReader();
+      }
     };
     const onEnd = () => {
       ended = true;
@@ -244,21 +266,29 @@ export class EventStream<EventTypes extends BaseEvents> {
     if (!ended) {
       this.on(event, onEvent as EventListener<EventTypes, Event>);
       this.on('end', onEnd);
-      if (event !== 'error') this.on('error', onFailure);
-      if (event !== 'abort') this.on('abort', onFailure);
+      if (event !== 'error') {
+        this.on('error', onFailure);
+      }
+      if (event !== 'abort') {
+        this.on('abort', onFailure);
+      }
     }
 
     return {
       next: () => {
         const value = pushQueue.shift();
-        if (value) return Promise.resolve({ value, done: false });
+        if (value) {
+          return Promise.resolve({ value, done: false });
+        }
 
         if (failure && !failureDelivered) {
           failureDelivered = true;
           return Promise.reject(failure);
         }
 
-        if (ended) return Promise.resolve(doneResult());
+        if (ended) {
+          return Promise.resolve(doneResult());
+        }
 
         return new Promise<Result>((resolve, reject) => {
           readQueue.push({ resolve, reject });

--- a/src/lib/responses/ResponseStream.ts
+++ b/src/lib/responses/ResponseStream.ts
@@ -102,12 +102,16 @@ export class ResponseStream<ParsedT = null>
   }
 
   #beginRequest() {
-    if (this.ended) return;
+    if (this.ended) {
+      return;
+    }
     this.#currentResponseSnapshot = undefined;
   }
 
   #addEvent(this: ResponseStream<ParsedT>, event: ResponseStreamEvent, starting_after: number | null) {
-    if (this.ended) return;
+    if (this.ended) {
+      return;
+    }
 
     const maybeEmit = (name: string, event: ResponseStreamEvent & { snapshot?: string }) => {
       if (starting_after == null || event.sequence_number > starting_after) {
@@ -297,7 +301,9 @@ export class ResponseStream<ParsedT = null>
   async finalResponse(): Promise<ParsedResponse<ParsedT>> {
     await this.done();
     const response = this.#finalResponse;
-    if (!response) throw new OpenAIError('stream ended without producing a ChatCompletion');
+    if (!response) {
+      throw new OpenAIError('stream ended without producing a ChatCompletion');
+    }
     return response;
   }
 }

--- a/src/lib/transform.ts
+++ b/src/lib/transform.ts
@@ -120,12 +120,16 @@ export function forEachJSONSchemaChild(
 
   for (const keyword of JSON_SCHEMA_MAP_SCHEMA_KEYWORDS) {
     const children = record[keyword];
-    if (!isObject(children)) continue;
+    if (!isObject(children)) {
+      continue;
+    }
 
     for (const [key, child] of Object.entries(children)) {
       // Draft 7 dependencies also permits property dependency arrays. They
       // are not schemas and must not be traversed as literal JSON payloads.
-      if (keyword === 'dependencies' && !isSchemaDefinition(child)) continue;
+      if (keyword === 'dependencies' && !isSchemaDefinition(child)) {
+        continue;
+      }
       visit(child, [...path, keyword, key], keyword);
     }
   }
@@ -1807,7 +1811,9 @@ function mergeObjectAllOf(
 
   const mergeAnnotations = (schema: JSONSchema) => {
     for (const keyword of JSON_SCHEMA_ANNOTATION_KEYWORDS) {
-      if (!(keyword in schema)) continue;
+      if (!(keyword in schema)) {
+        continue;
+      }
       // Annotation keywords do not affect Draft 7 validation. Preserve the
       // first value (the outer schema, then earlier branches) instead of
       // rejecting an otherwise exactly mergeable intersection.
@@ -1819,7 +1825,9 @@ function mergeObjectAllOf(
 
   mergeAnnotations(jsonSchema);
   for (const resolvedEntry of resolvedEntries) {
-    if (resolvedEntry === undefined) continue;
+    if (resolvedEntry === undefined) {
+      continue;
+    }
     for (const entry of resolvedEntry.refChain) {
       mergeAnnotations(entry);
     }
@@ -1827,7 +1835,9 @@ function mergeObjectAllOf(
 
   for (const { schema: branch, sourcePath } of branches) {
     for (const keyword of Object.keys(branch)) {
-      if (keyword === 'allOf' && branch === jsonSchema) continue;
+      if (keyword === 'allOf' && branch === jsonSchema) {
+        continue;
+      }
       if (
         (keyword === '$defs' || keyword === 'definitions') &&
         isObject((branch as Record<string, unknown>)[keyword])
@@ -1872,7 +1882,9 @@ function mergeObjectAllOf(
         fail();
       }
       sawRequired = true;
-      for (const key of branch.required) mergedRequired.add(key);
+      for (const key of branch.required) {
+        mergedRequired.add(key);
+      }
     }
 
     if ('additionalProperties' in branch) {
@@ -1942,9 +1954,15 @@ function mergeObjectAllOf(
   if (hasExplicitObjectType || hasExplicitNullableObjectType) {
     merged.type = hasExplicitObjectType ? 'object' : ['object', 'null'];
   }
-  if (sawProperties) merged.properties = Object.fromEntries(Object.entries(mergedProperties));
-  if (sawRequired) merged.required = [...mergedRequired];
-  if (closedPropertySets.length > 0) merged.additionalProperties = false;
+  if (sawProperties) {
+    merged.properties = Object.fromEntries(Object.entries(mergedProperties));
+  }
+  if (sawRequired) {
+    merged.required = [...mergedRequired];
+  }
+  if (closedPropertySets.length > 0) {
+    merged.additionalProperties = false;
+  }
 
   for (const keyword of Object.keys(jsonSchema)) {
     delete (jsonSchema as any)[keyword];

--- a/src/providers/bedrock/aws.ts
+++ b/src/providers/bedrock/aws.ts
@@ -56,7 +56,9 @@ function validateStaticCredentials(options: BedrockProviderOptions): AwsCredenti
       'The `accessKeyId` and `secretAccessKey` options must be provided together. A `sessionToken` may only be used with both.',
     );
   }
-  if (!hasAccessKey) return undefined;
+  if (!hasAccessKey) {
+    return undefined;
+  }
 
   if (
     typeof options.accessKeyId !== 'string' ||
@@ -98,8 +100,12 @@ function requestTarget(parsedURL: URL): { path: string; query: Record<string, st
 }
 
 function signableBody(body: BodyInit | null | undefined): string | ArrayBuffer | ArrayBufferView | undefined {
-  if (body === undefined || body === null) return undefined;
-  if (typeof body === 'string' || body instanceof ArrayBuffer || ArrayBuffer.isView(body)) return body;
+  if (body === undefined || body === null) {
+    return undefined;
+  }
+  if (typeof body === 'string' || body instanceof ArrayBuffer || ArrayBuffer.isView(body)) {
+    return body;
+  }
   throw new Errors.OpenAIError(
     "The SDK's Bedrock SigV4 mode requires a replayable request body. Buffer the body before sending or use bearer authentication.",
   );
@@ -139,7 +145,9 @@ class BedrockSigV4Auth implements BedrockRequestAuth {
   }
 
   private credentialsProvider(): () => Promise<AwsCredentialIdentity> {
-    if (this.resolvedCredentialsProvider) return this.resolvedCredentialsProvider;
+    if (this.resolvedCredentialsProvider) {
+      return this.resolvedCredentialsProvider;
+    }
 
     if (this.options.staticCredentials) {
       const credentials = this.options.staticCredentials;

--- a/tests/helpers/zod.test.ts
+++ b/tests/helpers/zod.test.ts
@@ -14,10 +14,14 @@ import { z as zv4 } from 'zod/v4';
 import { z as zv4Mini } from 'zod/v4-mini';
 
 function collectRefs(value: unknown, refs: string[] = []): string[] {
-  if (!value || typeof value !== 'object') return refs;
+  if (!value || typeof value !== 'object') {
+    return refs;
+  }
 
   const maybeRef = (value as { $ref?: unknown }).$ref;
-  if (typeof maybeRef === 'string') refs.push(maybeRef);
+  if (typeof maybeRef === 'string') {
+    refs.push(maybeRef);
+  }
 
   for (const child of Object.values(value)) {
     collectRefs(child, refs);
@@ -27,7 +31,9 @@ function collectRefs(value: unknown, refs: string[] = []): string[] {
 }
 
 function countEnumValues(value: unknown): number {
-  if (!value || typeof value !== 'object') return 0;
+  if (!value || typeof value !== 'object') {
+    return 0;
+  }
   if (Array.isArray(value)) {
     let total = 0;
     for (const child of value) {
@@ -64,7 +70,9 @@ function resolveJsonPointer(root: Record<string, unknown>, pointer: string): unk
 
 function expectDefinitionRefsToResolve(schema: Record<string, unknown>) {
   const visit = (value: unknown, resolving: Set<string>) => {
-    if (!value || typeof value !== 'object') return;
+    if (!value || typeof value !== 'object') {
+      return;
+    }
 
     const ref = (value as Record<string, unknown>)['$ref'];
     if (typeof ref === 'string') {

--- a/tests/internal/detect-platform.test.ts
+++ b/tests/internal/detect-platform.test.ts
@@ -29,8 +29,11 @@ async function withGlobals<T>(overrides: PlatformGlobals, run: (detection: Platf
     return run(detection);
   } finally {
     for (const [name, descriptor] of descriptors) {
-      if (descriptor) Object.defineProperty(globalThis, name, descriptor);
-      else delete (globalThis as Record<string, unknown>)[name];
+      if (descriptor) {
+        Object.defineProperty(globalThis, name, descriptor);
+      } else {
+        delete (globalThis as Record<string, unknown>)[name];
+      }
     }
   }
 }

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -27,7 +27,10 @@ function mockChatCompletionFetch() {
   ): Promise<void> {
     return handleRawRequest(async (req, init) => {
       const rawBody = init?.body;
-      if (typeof rawBody !== 'string') throw new Error(`expected init.body to be a string`);
+      if (typeof rawBody !== 'string') {
+        // oxlint-disable-next-line unicorn/prefer-type-error -- Preserve the mock's historical Error identity.
+        throw new Error(`expected init.body to be a string`);
+      }
       const body: ChatCompletionToolRunnerParams<any[]> = JSON.parse(rawBody);
       return Response.json(await handler(body), {
         headers: { 'Content-Type': 'application/json' },
@@ -49,7 +52,10 @@ function mockStreamingChatCompletionFetch() {
   ): Promise<void> {
     return handleRawRequest(async (req, init) => {
       const rawBody = init?.body;
-      if (typeof rawBody !== 'string') throw new Error(`expected init.body to be a string`);
+      if (typeof rawBody !== 'string') {
+        // oxlint-disable-next-line unicorn/prefer-type-error -- Preserve the mock's historical Error identity.
+        throw new Error(`expected init.body to be a string`);
+      }
       const body: ChatCompletionStreamingToolRunnerParams<any[]> = JSON.parse(rawBody);
       const stream = new PassThrough();
       (async () => {
@@ -72,7 +78,9 @@ function mockStreamingChatCompletionFetch() {
 function findLastAssistantMessage(messages: ChatCompletionMessageParam[]) {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
-    if (message && isAssistantMessage(message)) return message;
+    if (message && isAssistantMessage(message)) {
+      return message;
+    }
   }
   return undefined;
 }
@@ -192,7 +200,9 @@ class RunnerListener {
   } = {}) {
     expect(this.onceMessageCallCount).toBeLessThanOrEqual(1);
     expect(this.gotAbort).toEqual(this.runner.aborted);
-    if (this.runner.aborted) expect(this.runner.errored).toBe(true);
+    if (this.runner.aborted) {
+      expect(this.runner.errored).toBe(true);
+    }
     if (error) {
       expect(this.error?.message).toEqual(error);
       expect(this.runner.errored).toBe(true);
@@ -224,7 +234,9 @@ class RunnerListener {
       return;
     }
 
-    if (error) return;
+    if (error) {
+      return;
+    }
 
     const expectedContents = this.messages
       .filter(isAssistantMessage)
@@ -341,9 +353,13 @@ class StreamingRunnerListener {
       return;
     }
 
-    if (error) return;
+    if (error) {
+      return;
+    }
 
-    if (this.eventContents.length) expect(this.eventChunks.length).toBeGreaterThan(0);
+    if (this.eventContents.length) {
+      expect(this.eventChunks.length).toBeGreaterThan(0);
+    }
     expect(this.finalMessage).toEqual(findLastAssistantMessage(this.eventMessages));
     expect(await this.runner.finalMessage()).toEqual(this.finalMessage);
     expect(this.finalContent).toEqual(this.eventContents[this.eventContents.length - 1]?.[1] ?? null);
@@ -621,7 +637,9 @@ describe('resource completions', () => {
         {
           afterCompletion: (completion, runner) => {
             completionIDs.push(completion.id);
-            if (completion.id === '1') runner.messages.push(injectedMessage);
+            if (completion.id === '1') {
+              runner.messages.push(injectedMessage);
+            }
           },
         },
       );
@@ -1956,7 +1974,9 @@ describe('resource completions', () => {
         {
           afterCompletion: (completion, runner) => {
             completionIDs.push(completion.id);
-            if (completion.id === '1') runner.messages.push(injectedMessage);
+            if (completion.id === '1') {
+              runner.messages.push(injectedMessage);
+            }
           },
         },
       );

--- a/tests/lib/ChatCompletionStream.test.ts
+++ b/tests/lib/ChatCompletionStream.test.ts
@@ -149,7 +149,9 @@ describe('.stream()', () => {
       } as unknown as OpenAI.Chat.ChatCompletionChunk,
     ];
     const readable = new Stream(async function* readable() {
-      for (const chunk of chunks) yield chunk;
+      for (const chunk of chunks) {
+        yield chunk;
+      }
     }, new AbortController()).toReadableStream();
 
     const stream = ChatCompletionStreamingRunner.fromReadableStream(readable);
@@ -222,7 +224,9 @@ describe('.stream()', () => {
       },
     ] as unknown as OpenAI.Chat.ChatCompletionChunk[];
     const readable = new Stream(async function* readable() {
-      for (const chunk of chunks) yield chunk;
+      for (const chunk of chunks) {
+        yield chunk;
+      }
     }, new AbortController()).toReadableStream();
 
     const stream = ChatCompletionStreamingRunner.fromReadableStream(readable);
@@ -297,7 +301,9 @@ describe('.stream()', () => {
       },
     ] as unknown as OpenAI.Chat.ChatCompletionChunk[];
     const readable = new Stream(async function* readable() {
-      for (const chunk of chunks) yield chunk;
+      for (const chunk of chunks) {
+        yield chunk;
+      }
     }, new AbortController()).toReadableStream();
 
     const stream = ChatCompletionStreamingRunner.fromReadableStream(readable);

--- a/tests/lib/bedrock-provider-dependencies.test.ts
+++ b/tests/lib/bedrock-provider-dependencies.test.ts
@@ -12,7 +12,9 @@ const optionalDependencies = [
 
 beforeEach(() => {
   vi.resetModules();
-  for (const dependency of optionalDependencies) vi.doUnmock(dependency);
+  for (const dependency of optionalDependencies) {
+    vi.doUnmock(dependency);
+  }
 
   process.env = { ...originalEnv };
   delete process.env['AWS_BEARER_TOKEN_BEDROCK'];

--- a/tests/lib/bedrock-provider.test.ts
+++ b/tests/lib/bedrock-provider.test.ts
@@ -23,7 +23,9 @@ const BEDROCK_ENVIRONMENT_VARIABLES = [
 
 beforeEach(() => {
   process.env = { ...originalEnv };
-  for (const name of BEDROCK_ENVIRONMENT_VARIABLES) delete process.env[name];
+  for (const name of BEDROCK_ENVIRONMENT_VARIABLES) {
+    delete process.env[name];
+  }
 });
 
 afterEach(() => {
@@ -321,7 +323,9 @@ describe('bedrock provider', () => {
     } catch (error) {
       thrown = error;
     } finally {
-      if (processDescriptor) Object.defineProperty(globalThis, 'process', processDescriptor);
+      if (processDescriptor) {
+        Object.defineProperty(globalThis, 'process', processDescriptor);
+      }
     }
 
     expect(thrown).toMatchObject({

--- a/tests/lib/responsesWebSocket.test.ts
+++ b/tests/lib/responsesWebSocket.test.ts
@@ -56,7 +56,9 @@ describe.each(variants)('%s Responses WebSocket', (_version, Base, WebSocketErro
 
   async function waitForConnection(websocket: TestResponsesWebSocket, count: number) {
     for (let attempt = 0; attempt < 20; attempt++) {
-      if (websocket.connections.length >= count) return websocket.connections[count - 1]!;
+      if (websocket.connections.length >= count) {
+        return websocket.connections[count - 1]!;
+      }
       await new Promise((resolve) => setTimeout(resolve, 0));
     }
     throw new Error(`Expected ${count} WebSocket connections`);

--- a/tests/lib/transform.test.ts
+++ b/tests/lib/transform.test.ts
@@ -2554,7 +2554,9 @@ describe('toStrictJsonSchema', () => {
 
       const strict = toStrictJsonSchema(schema);
       const valueSchema = strict.properties?.['value'] as JSONSchema | undefined;
-      if (!valueSchema) throw new Error('Expected value schema');
+      if (!valueSchema) {
+        throw new Error('Expected value schema');
+      }
       const properties = valueSchema.properties;
 
       expect(properties).toEqual(

--- a/tests/live/bedrock.live.test.ts
+++ b/tests/live/bedrock.live.test.ts
@@ -31,13 +31,17 @@ type AuthMode = (typeof authModes)[number];
 
 function requiredEnv(name: string): string {
   const value = process.env[name]?.trim();
-  if (!value) throw new Error(`Set ${name} before running the Bedrock live test.`);
+  if (!value) {
+    throw new Error(`Set ${name} before running the Bedrock live test.`);
+  }
   return value;
 }
 
 function readAuthMode(): AuthMode {
   const value = requiredEnv(AUTH_MODE_ENV);
-  if ((authModes as readonly string[]).includes(value)) return value as AuthMode;
+  if ((authModes as readonly string[]).includes(value)) {
+    return value as AuthMode;
+  }
   throw new Error(`${AUTH_MODE_ENV} must be one of: ${authModes.join(', ')}.`);
 }
 
@@ -88,7 +92,9 @@ if (process.env[LIVE_TEST_FLAG] !== '1') {
 }
 
 const region = process.env['AWS_REGION']?.trim() || process.env['AWS_DEFAULT_REGION']?.trim();
-if (!region) throw new Error('Set AWS_REGION or AWS_DEFAULT_REGION before running the Bedrock live test.');
+if (!region) {
+  throw new Error('Set AWS_REGION or AWS_DEFAULT_REGION before running the Bedrock live test.');
+}
 
 const model = requiredEnv(MODEL_ENV);
 const authMode = readAuthMode();

--- a/tests/path.test.ts
+++ b/tests/path.test.ts
@@ -27,8 +27,12 @@ describe('path template tag function', () => {
     ];
 
     function paramPermutations(len: number): string[][] {
-      if (len === 0) return [];
-      if (len === 1) return testParams.map((e) => [e]);
+      if (len === 0) {
+        return [];
+      }
+      if (len === 1) {
+        return testParams.map((e) => [e]);
+      }
       const rest = paramPermutations(len - 1);
       return testParams.flatMap((e) => rest.map((r) => [e, ...r]));
     }

--- a/tests/realtime-websocket.test.ts
+++ b/tests/realtime-websocket.test.ts
@@ -154,11 +154,17 @@ describe.each([
       );
       expect(new Realtime({ model: 'gpt-realtime' }, ephemeral).socket).toBe(lastBrowserSocket());
     } finally {
-      if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
-      else Reflect.deleteProperty(globalThis, 'window');
+      if (originalWindow) {
+        Object.defineProperty(globalThis, 'window', originalWindow);
+      } else {
+        Reflect.deleteProperty(globalThis, 'window');
+      }
 
-      if (originalNavigator) Object.defineProperty(globalThis, 'navigator', originalNavigator);
-      else Reflect.deleteProperty(globalThis, 'navigator');
+      if (originalNavigator) {
+        Object.defineProperty(globalThis, 'navigator', originalNavigator);
+      } else {
+        Reflect.deleteProperty(globalThis, 'navigator');
+      }
     }
   });
 

--- a/tests/resource-exports.test.ts
+++ b/tests/resource-exports.test.ts
@@ -8,7 +8,9 @@ function findResourceIndexes(directory: string): string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const path = nodePath.join(directory, entry.name);
 
-    if (entry.isDirectory()) return findResourceIndexes(path);
+    if (entry.isDirectory()) {
+      return findResourceIndexes(path);
+    }
     return entry.name === 'index.ts' ? [path] : [];
   });
 }

--- a/tests/utils/mock-fetch.ts
+++ b/tests/utils/mock-fetch.ts
@@ -27,9 +27,13 @@ export function mockFetch(): { fetch: Fetch; handleRequest: (handle: Fetch) => P
 
   async function fetch(req: string | RequestInfo, init?: RequestInit): Promise<Response> {
     const handler = await handlerQueue.shift();
-    if (!handler) throw new Error('expected handler to be defined');
+    if (!handler) {
+      throw new Error('expected handler to be defined');
+    }
     const signal = init?.signal;
-    if (!signal) return await handler(req, init);
+    if (!signal) {
+      return await handler(req, init);
+    }
     return await Promise.race([
       handler(req, init),
       new Promise<Response>((resolve, reject) => {

--- a/tests/ws.test.ts
+++ b/tests/ws.test.ts
@@ -63,7 +63,9 @@ describe('SendQueue', () => {
     expect(() =>
       queue.flush((data: RawWebSocketData) => {
         callCount++;
-        if (callCount === 2) throw new Error('send failed');
+        if (callCount === 2) {
+          throw new Error('send failed');
+        }
       }),
     ).toThrow('send failed');
 


### PR DESCRIPTION
## Summary

- Removes `curly` from `compatibilityRules`.
- Resolves existing diagnostics with behavior-preserving fixes or narrowly documented exceptions.

## Stack

- Part 183 of 185.
- Base: `dev/hayden/ultracite-182-func-names`.
- This PR is stacked on the prior rule cleanup.

## Validation

Validated cumulatively at the stack head:

- `pnpm lint`
- `pnpm exec tsc --pretty false`
- `NODE_NO_WARNINGS=1 pnpm exec vitest run --config vitest.config.mts --update=none`
- `pnpm run build`
- `node --experimental-strip-types scripts/test-packed-package.ts`