### PR TITLE
fix(api): clarify audio upload metadata requirements

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,6 +1,6 @@
 schema_version: 1
-generation_id: 73e3d1e9-edfd-4ea1-b823-93be2fd9c250
-openapi_spec_hash: 8d5c14d02f8cc28de343933fae3a9c28
-openapi_transformed_spec_hash: cc042503b90491f4f162ce95fae87c36
+generation_id: edcb259e-5f1d-4169-95bd-e16ab91e9999
+openapi_spec_hash: 1faf0319c407c6534ef7c381614afbb6
+openapi_transformed_spec_hash: 53eff50caa9d18046e4ff0615bc7512d
 config_hash: 4617b0962f16d328804312ac81aac630
-codegen_sha: de475f7f8d4ab4851625ebeb62a4c9794da13142
+codegen_sha: 02537d77afe76ec6924c20fee723ad4466a2db1e

--- a/api_reference/openapi.transformed.yml
+++ b/api_reference/openapi.transformed.yml
@@ -34062,6 +34062,7 @@ components:
         file:
           description: |
             The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+            The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.
           type: string
           x-oaiTypeLabel: file
           format: binary
@@ -34369,7 +34370,7 @@ components:
       properties:
         file:
           description: |
-            The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+            The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.
           type: string
           x-oaiTypeLabel: file
           format: binary

--- a/src/resources/audio/transcriptions.ts
+++ b/src/resources/audio/transcriptions.ts
@@ -665,7 +665,9 @@ export interface TranscriptionCreateParamsBase<
 > {
   /**
    * The audio file object (not file name) to transcribe, in one of these formats:
-   * flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+   * flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include
+   * enough format metadata for the file to be identified. We recommend an
+   * extension-bearing filename and an appropriate content type.
    */
   file: Uploadable;
 

--- a/src/resources/audio/translations.ts
+++ b/src/resources/audio/translations.ts
@@ -80,7 +80,9 @@ export interface TranslationCreateParams<
 > {
   /**
    * The audio file object (not file name) translate, in one of these formats: flac,
-   * mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+   * mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough
+   * format metadata for the file to be identified. We recommend an extension-bearing
+   * filename and an appropriate content type.
    */
   file: Uploadable;
 


### PR DESCRIPTION
## Summary

Regenerates the Node SDK from the latest OpenAPI input for the audio upload documentation change.

- Clarifies that transcription and translation uploads must include enough metadata for the file format to be identified.
- Recommends an extension-bearing filename and an appropriate content type.
- Updates generated parameter documentation, the transformed OpenAPI document, and Castiron provenance.

This is documentation-only; runtime behavior and exported type shapes are unchanged.

## Source

- Originating API change: [openai/openai#1270941](https://github.com/openai/openai/pull/1270941)
- OpenAPI input: [openai/openai-openapi@577fa922](https://github.com/openai/openai-openapi/commit/577fa92299e000af1616f3be1fec740e3383a86a)

## Validation

- Rebased directly onto the current public `main`
- Every changed file matches the Castiron-generated candidate
- `git diff --check`
- `pnpm lint`
- Thermo-nuclear code-quality review