### PR TITLE
fix: prevent prototype pollution in assistant stream deltas

### DIFF
--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -30,8 +30,11 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          # Ensure the comparison base is available to the script below.
+          # Keep the checkout shallow; fetch the exact comparison base below.
           fetch-depth: ${{ env.FETCH_DEPTH }}
+
+      - name: Fetch comparison base
+        run: git fetch --no-tags --depth=1 origin "$BASE_SHA"
 
       - name: Set up pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4

--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -673,6 +673,10 @@ export class AssistantStream
 
   static accumulateDelta(acc: Record<string, any>, delta: Record<string, any>): Record<string, any> {
     for (const [key, deltaValue] of Object.entries(delta)) {
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        throw new OpenAIError(`Assistant stream delta contains an unsafe property: ${key}`);
+      }
+
       if (!hasOwn(acc, key)) {
         acc[key] = deltaValue;
         continue;

--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -630,6 +630,16 @@ export class AssistantStream
 
         //If this delta does not have content, nothing to process
         if (data.delta.content) {
+          assertSafeAssistantStreamDelta(data.delta);
+
+          for (const contentElement of data.delta.content) {
+            if (!Number.isInteger(contentElement.index) || contentElement.index < 0) {
+              throw new OpenAIError(
+                `Assistant stream delta contains an invalid content index: ${contentElement.index}`,
+              );
+            }
+          }
+
           for (const contentElement of data.delta.content) {
             if (contentElement.index in snapshot.content) {
               const currentContent = snapshot.content[contentElement.index];
@@ -672,6 +682,8 @@ export class AssistantStream
   }
 
   static accumulateDelta(acc: Record<string, any>, delta: Record<string, any>): Record<string, any> {
+    assertSafeAssistantStreamDelta(delta);
+
     for (const [key, deltaValue] of Object.entries(delta)) {
       if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
         throw new OpenAIError(`Assistant stream delta contains an unsafe property: ${key}`);
@@ -800,6 +812,20 @@ export class AssistantStream
     options?: RequestOptions,
   ): Promise<Run> {
     return await this._createToolAssistantStream(runs, runId, params, options);
+  }
+}
+
+function assertSafeAssistantStreamDelta(value: unknown): void {
+  if (!isObj(value) && !Array.isArray(value)) {
+    return;
+  }
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      throw new OpenAIError(`Assistant stream delta contains an unsafe property: ${key}`);
+    }
+
+    assertSafeAssistantStreamDelta(nestedValue);
   }
 }
 

--- a/tests/lib/AssistantStream.test.ts
+++ b/tests/lib/AssistantStream.test.ts
@@ -101,6 +101,68 @@ describe('AssistantStream delta accumulation', () => {
     expect(result['status']).toBe('ready');
   });
 
+  test('preserves newly inserted nested objects and arrays', () => {
+    const metadata = { profile: { name: 'Ada' } };
+    const entries = [{ index: 0, details: { text: 'hello' } }];
+    const accumulator = {};
+
+    const result = AssistantStream.accumulateDelta(accumulator, { metadata, entries });
+
+    expect(result).toBe(accumulator);
+    expect(result['metadata']).toBe(metadata);
+    expect(result['entries']).toBe(entries);
+    expect(result).toEqual({
+      metadata: { profile: { name: 'Ada' } },
+      entries: [{ index: 0, details: { text: 'hello' } }],
+    });
+  });
+
+  test('validates newly inserted nested arrays before mutating the accumulator', () => {
+    const failure = new Error('Nested value is unavailable');
+    const unreadable = {
+      get value(): never {
+        throw failure;
+      },
+    };
+    const accumulator = { text: 'hello' };
+
+    expect(() =>
+      AssistantStream.accumulateDelta(accumulator, {
+        text: ' world',
+        entries: [{ index: 0, details: { nested: unreadable } }],
+      }),
+    ).toThrow(failure);
+
+    expect(accumulator).toEqual({ text: 'hello' });
+    expect(Object.getOwnPropertyDescriptor(accumulator, 'entries')).toBeUndefined();
+  });
+
+  test.each(['__proto__', 'constructor', 'prototype'])(
+    'rejects the reserved %s property before mutating any accumulator path',
+    (key) => {
+      const deltas = [
+        { text: ' updated', [key]: 'blocked' },
+        { text: ' updated', metadata: { details: { [key]: 'blocked' } } },
+        {
+          text: ' updated',
+          entries: [
+            { index: 0, text: ' updated' },
+            { index: 1, details: { [key]: 'blocked' } },
+          ],
+        },
+      ];
+
+      for (const delta of deltas) {
+        const accumulator = { text: 'original', entries: [{ index: 0, text: 'first' }] };
+
+        expect(() => AssistantStream.accumulateDelta(accumulator, delta)).toThrow(
+          `Assistant stream delta contains an unsafe property: ${key}`,
+        );
+        expect(accumulator).toEqual({ text: 'original', entries: [{ index: 0, text: 'first' }] });
+      }
+    },
+  );
+
   test('replaces null values and special index or type properties', () => {
     expect(
       AssistantStream.accumulateDelta(
@@ -156,6 +218,57 @@ describe('AssistantStream delta accumulation', () => {
 });
 
 describe('AssistantStream snapshots and message lifecycle', () => {
+  test.each(['__proto__', 'constructor', 'prototype'])(
+    'rejects the reserved %s property in newly inserted message content',
+    async (key) => {
+      const message = { id: 'msg_123', role: 'assistant', content: [] };
+      const runner = assistantStream([
+        { event: 'thread.message.created', data: message },
+        {
+          event: 'thread.message.delta',
+          data: {
+            id: 'msg_123',
+            delta: {
+              content: [{ index: 0, type: 'text', text: { value: 'hello', [key]: 'blocked' } }],
+            },
+          },
+        },
+      ]);
+
+      await expect(runner.done()).rejects.toThrow(`unsafe property: ${key}`);
+      expect(runner.currentMessageSnapshot()).toEqual(message);
+    },
+  );
+
+  test.each(['invalid', -1, 1.5, null])(
+    'rejects the invalid content index %j without mutating the message snapshot',
+    async (index) => {
+      const message = {
+        id: 'msg_123',
+        role: 'assistant',
+        content: [{ type: 'text', text: { value: 'original', annotations: [] } }],
+      };
+      const runner = assistantStream([
+        { event: 'thread.message.created', data: message },
+        {
+          event: 'thread.message.delta',
+          data: {
+            id: 'msg_123',
+            delta: {
+              content: [
+                { index: 0, type: 'text', text: { value: ' updated' } },
+                { index, type: 'text', text: { value: 'ignored', annotations: [] } },
+              ],
+            },
+          },
+        },
+      ]);
+
+      await expect(runner.done()).rejects.toThrow('invalid content index');
+      expect(runner.currentMessageSnapshot()).toEqual(message);
+    },
+  );
+
   test('accumulates message content and exposes current and final snapshots', async () => {
     const initialMessage = { id: 'msg_123', role: 'assistant', status: 'in_progress', content: [] };
     const finalMessage = {

--- a/tests/lib/AssistantStream.test.ts
+++ b/tests/lib/AssistantStream.test.ts
@@ -45,6 +45,62 @@ describe('AssistantStream delta accumulation', () => {
     });
   });
 
+  test('preserves accumulator identity and ordinary object prototypes', () => {
+    const nested = { text: 'hello' };
+    const accumulator = { nested };
+
+    const result = AssistantStream.accumulateDelta(accumulator, {
+      nested: { text: ' world' },
+      status: 'ready',
+    });
+
+    expect(result).toBe(accumulator);
+    expect(result['nested']).toBe(nested);
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect(Object.getPrototypeOf(result['nested'])).toBe(Object.prototype);
+    expect(result).toEqual({ nested: { text: 'hello world' }, status: 'ready' });
+    expect(Object.getOwnPropertyDescriptor(result, 'status')).toEqual({
+      configurable: true,
+      enumerable: true,
+      value: 'ready',
+      writable: true,
+    });
+  });
+
+  test('creates own fields without changing ordinary inherited values', () => {
+    const inherited = { label: 'inherited' };
+    const accumulator: Record<string, unknown> = Object.create(inherited);
+
+    const result = AssistantStream.accumulateDelta(accumulator, { label: 'updated', status: 'ready' });
+
+    expect(result).toBe(accumulator);
+    expect(Object.getPrototypeOf(result)).toBe(inherited);
+    expect(inherited.label).toBe('inherited');
+    expect(result['label']).toBe('updated');
+    expect(result['status']).toBe('ready');
+    expect(Object.getOwnPropertyDescriptor(result, 'label')).toMatchObject({ value: 'updated' });
+  });
+
+  test('preserves null-prototype accumulators during ordinary nested updates', () => {
+    const nested: Record<string, string> = Object.create(null);
+    nested['text'] = 'hello';
+
+    const accumulator: Record<string, unknown> = Object.create(null);
+    accumulator['details'] = nested;
+
+    const result = AssistantStream.accumulateDelta(accumulator, {
+      details: { text: ' world' },
+      status: 'ready',
+    });
+
+    expect(result).toBe(accumulator);
+    expect(result['details']).toBe(nested);
+    expect(Object.getPrototypeOf(result)).toBeNull();
+    expect(Object.getPrototypeOf(result['details'])).toBeNull();
+    expect(result['details']['text']).toBe('hello world');
+    expect(result['status']).toBe('ready');
+  });
+
   test('replaces null values and special index or type properties', () => {
     expect(
       AssistantStream.accumulateDelta(


### PR DESCRIPTION
## Summary

- Reject unsafe prototype-chain property names before reading, writing, or recursively merging AssistantStream deltas.
- Preserve normal accumulator identity, own-property behavior, inherited values, and null-prototype objects with focused regression coverage.
- Resolve GitHub CodeQL `js/prototype-pollution-utility` alerts [#11](https://github.com/openai/openai-node/security/code-scanning/11) and [#12](https://github.com/openai/openai-node/security/code-scanning/12).

## Why

`AssistantStream.accumulateDelta` recursively copies streamed properties into existing objects. Guarding reserved prototype-chain names before the first dynamic property access prevents those values from reaching either flagged assignment while failing explicitly with the SDK's existing `OpenAIError`.

## Verification

- `pnpm exec vitest run --config vitest.config.mts --update=none tests/lib/AssistantStream.test.ts tests/streaming/assistants/assistant.test.ts` — 44 tests passed on the final commit.
- `pnpm exec tsc --noEmit` — passed on the final commit.
- `pnpm lint` — passed on the final commit.
- `pnpm exec vitest run --config vitest.config.mts --update=none` — 1,464 tests passed before the final formatting-only rebase.
- `pnpm build` — CommonJS and ESM builds passed before the final formatting-only rebase.
- Built-package smoke test passed on supported Node.js 22.