### PR TITLE
chore: limit Dependabot to 10 open pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    open-pull-requests-limit: 5
     schedule:
       interval: weekly
     cooldown:
@@ -20,6 +21,7 @@ updates:
       - /ecosystem-tests/node-ts4.5-jest28
       - /ecosystem-tests/ts-browser-webpack
       - /ecosystem-tests/vercel-edge
+    open-pull-requests-limit: 5
     schedule:
       interval: weekly
     cooldown:


### PR DESCRIPTION
## Summary

- Limit each of the two independent npm Dependabot update configurations to five open version-update pull requests.
- Keep the combined maximum at ten without changing root dependency updates or ecosystem-test lockfile-only updates.
- Security update pull requests remain unaffected because GitHub does not apply this setting to them.

## Validation

- `git diff --check`
- Parsed `.github/dependabot.yml` with Ruby and confirmed both update-group limits sum to 10, the root directory remains `/`, and ecosystem tests retain `versioning-strategy: lockfile-only`.