### PR TITLE
fix: await webhook verification in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,9 @@ await client.files.create({
 
 Verifying webhook signatures is _optional but encouraged_.
 
+Webhook verification is asynchronous. Always `await` `unwrap()` or `verifySignature()` before trusting
+the event.
+
 For more information about webhooks, see [the API docs](https://platform.openai.com/docs/guides/webhooks).
 
 ### Parsing webhook payloads
@@ -290,7 +293,7 @@ export async function webhook(request: Request) {
   const body = await request.text();
 
   try {
-    const event = client.webhooks.unwrap(body, headersList);
+    const event = await client.webhooks.unwrap(body, headersList);
 
     switch (event.type) {
       case 'response.completed':
@@ -330,7 +333,7 @@ export async function webhook(request: Request) {
   const body = await request.text();
 
   try {
-    client.webhooks.verifySignature(body, headersList);
+    await client.webhooks.verifySignature(body, headersList);
 
     // Parse the body after verification
     const event = JSON.parse(body);

--- a/tests/lib/webhooks.test.ts
+++ b/tests/lib/webhooks.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { vi } from 'vitest';
 import OpenAI, { InvalidWebhookSignatureError } from 'openai';
 
@@ -128,5 +129,23 @@ describe('portable webhook verification', () => {
         }
       }
     });
+  });
+});
+
+describe('webhook documentation', () => {
+  test('README awaits webhook verification before processing events', () => {
+    const readme = readFileSync('README.md', 'utf-8');
+    const examples = readme.match(/```(?:ts|typescript)\r?\n[\s\S]*?\r?\n```/gu) ?? [];
+    const calls = examples.flatMap((example) => [
+      ...example.matchAll(/(?:await\s+)?client\.webhooks\.(?<method>unwrap|verifySignature)\s*\(/gu),
+    ]);
+
+    expect(calls.map((call) => call.groups?.['method'])).toEqual(
+      expect.arrayContaining(['unwrap', 'verifySignature']),
+    );
+
+    for (const [call] of calls) {
+      expect(call).toMatch(/^await\s+/u);
+    }
   });
 });


### PR DESCRIPTION
## Summary\n- Await asynchronous webhook signature verification before parsing or trusting events in both root README examples.\n- Explain that webhook verification is asynchronous.\n- Add a regression test that checks every documented webhook verification call is awaited.\n\n## Why\nThe previous examples processed events and could return HTTP 200 before signature verification rejected, bypassing the surrounding error handler. The dedicated webhook guide already documents the correct await requirement.\n\n## Verification\n- Full handwritten SDK suite: 1,584 tests passed.\n- Focused webhook tests: 7 passed.\n- Repository lint, TypeScript compilation, and Node version policy check passed.