### PR TITLE
fix: preserve skill upload paths without buffering native files

### DIFF
--- a/src/internal/to-file.ts
+++ b/src/internal/to-file.ts
@@ -75,8 +75,16 @@ const isResponseLike = (value: any): value is ResponseLike =>
   typeof value.url === 'string' &&
   typeof value.blob === 'function';
 
-const hasFilePropertyOverrides = (options: FilePropertyBag | undefined): boolean =>
-  options?.type != null || options?.lastModified != null || options?.endings != null;
+const hasFilePropertyOverrides = (value: FileLike, options: FilePropertyBag | undefined): boolean =>
+  (options?.type != null && options.type !== value.type) ||
+  (options?.lastModified != null && options.lastModified !== value.lastModified) ||
+  options?.endings != null;
+
+const canReuseNativeFile = (
+  value: File,
+  name: string | null | undefined,
+  options: FilePropertyBag | undefined,
+): boolean => (name == null || name === value.name) && !hasFilePropertyOverrides(value, options);
 
 /**
  * File-compatible values that can be buffered into a native `File`.
@@ -94,12 +102,13 @@ export type ToFileInput =
 /**
  * Buffers compatible content into a native {@link File} for an SDK upload.
  *
- * Existing native `File` objects are returned unchanged when no filename or file
- * metadata override is supplied. Renamed or copied files retain their original
- * MIME type and modification time unless explicitly overridden. Other filenames
- * are inferred from response URLs or input metadata when omitted, falling back
- * to `unknown_file`. Responses, native or compatible `Blob` values, and compatible
- * non-native files supply their MIME type unless `options.type` provides an explicit override.
+ * Existing native `File` objects are returned unchanged when their effective
+ * filename and metadata are unchanged. Renamed native files reuse the original
+ * file contents without buffering and retain their MIME type and modification
+ * time unless explicitly overridden. Other filenames are inferred from response
+ * URLs or input metadata when omitted, falling back to `unknown_file`. Responses,
+ * native or compatible `Blob` values, and compatible non-native files supply
+ * their MIME type unless `options.type` provides an explicit override.
  *
  * @param value An existing file, response, binary buffer, Blob-like object, async
  * stream of file parts, or a promise resolving to one of those values.
@@ -119,17 +128,22 @@ export async function toFile(
   // If it's a promise, resolve it.
   value = await value;
 
-  // If we've been given a native `File` and no overrides, we don't need to do anything.
   if (isFileLike(value)) {
-    if (value instanceof File && name == null && !hasFilePropertyOverrides(options)) {
-      return value;
-    }
-
-    return makeFile([await value.arrayBuffer()], name ?? value.name, {
+    const fileOptions = {
       ...options,
       type: options?.type ?? value.type,
       lastModified: options?.lastModified ?? value.lastModified,
-    });
+    };
+
+    if (value instanceof File) {
+      if (canReuseNativeFile(value, name, options)) {
+        return value;
+      }
+
+      return makeFile([value], name ?? value.name, fileOptions);
+    }
+
+    return makeFile([await value.arrayBuffer()], name ?? value.name, fileOptions);
   }
 
   if (isResponseLike(value)) {

--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -146,8 +146,9 @@ export function makeFile(
  * Infers a filename from an object's `name`, `url`, `filename`, or `path` value.
  *
  * Directory components separated by either `/` or `\\` are discarded unless an
- * explicitly supplied `name` or `filename` opts into preserving its path. Paths
- * inferred from URLs and filesystem streams always discard their directories.
+ * explicitly supplied `name` or `filename` opts into preserving its path. Preserved
+ * paths use forward slashes. Paths inferred from URLs and filesystem streams always
+ * discard their directories.
  */
 export function getName(value: any, options?: { stripFilename?: boolean | undefined }): string | undefined {
   if (typeof value !== 'object' || value === null) {
@@ -158,7 +159,7 @@ export function getName(value: any, options?: { stripFilename?: boolean | undefi
     ('name' in value && value.name && String(value.name)) ||
     ('filename' in value && value.filename && String(value.filename));
   if (explicitName) {
-    return options?.stripFilename === false ? explicitName : basename(explicitName);
+    return options?.stripFilename === false ? normalizeFilenamePath(explicitName) : basename(explicitName);
   }
 
   const url = 'url' in value && value.url && String(value.url);
@@ -176,6 +177,10 @@ export function getName(value: any, options?: { stripFilename?: boolean | undefi
 
 function basename(value: string): string | undefined {
   return value.split(/[\\/]/).pop() || undefined;
+}
+
+function normalizeFilenamePath(value: string): string {
+  return value.replace(/\\/g, '/');
 }
 
 /** Identifies objects that expose a callable `Symbol.asyncIterator` method. */
@@ -442,9 +447,11 @@ async function* iterateFormValue(key: string, value: unknown): AsyncGenerator<Fo
 }
 
 function getStreamingFileName(value: Uploadable, options: CreateFormOptions): string {
-  return isStreamingFile(value)
-    ? value.name
-    : (getName(value, { stripFilename: options.stripFilenames }) ?? 'unknown_file');
+  if (isStreamingFile(value)) {
+    return options.stripFilenames === false ? normalizeFilenamePath(value.name) : value.name;
+  }
+
+  return getName(value, { stripFilename: options.stripFilenames }) ?? 'unknown_file';
 }
 
 function getStreamingFileType(value: Uploadable): string {

--- a/tests/internal/uploads-branches.test.ts
+++ b/tests/internal/uploads-branches.test.ts
@@ -43,6 +43,8 @@ describe('streaming upload metadata', () => {
   test.each([
     [{ name: 'my-skill/SKILL.md' }, 'my-skill/SKILL.md'],
     [{ filename: 'my-skill/assets/data.json' }, 'my-skill/assets/data.json'],
+    [{ name: 'my-skill\\SKILL.md' }, 'my-skill/SKILL.md'],
+    [{ filename: 'my-skill\\assets\\data.json' }, 'my-skill/assets/data.json'],
     [{ url: 'https://example.com/private/remote.txt?signature=example#fragment' }, 'remote.txt'],
     [{ path: '/private/tmp/local.txt' }, 'local.txt'],
     [{ path: 'C:\\private\\nested\\local.txt' }, 'local.txt'],

--- a/tests/lib/skills.test.ts
+++ b/tests/lib/skills.test.ts
@@ -4,6 +4,7 @@ import type { Uploadable } from 'openai';
 interface RecordedRequest {
   url: string;
   body: unknown;
+  headers: Headers;
   authorization: string | null;
 }
 
@@ -23,6 +24,7 @@ function createClient(): { client: OpenAI; requests: RecordedRequest[] } {
       requests.push({
         url: String(url),
         body: init?.body,
+        headers: new Headers(init?.headers),
         authorization: new Headers(init?.headers).get('authorization'),
       });
 
@@ -31,6 +33,18 @@ function createClient(): { client: OpenAI; requests: RecordedRequest[] } {
   });
 
   return { client, requests };
+}
+
+async function parseUploadedFiles(request: RecordedRequest | undefined): Promise<File[]> {
+  if (!request) {
+    throw new Error('Expected a recorded skill upload request');
+  }
+
+  const form = await new Response(request.body as FormData | ReadableStream, {
+    headers: request.headers,
+  }).formData();
+
+  return form.getAll('files[]') as File[];
 }
 
 const skillEndpoints = [
@@ -67,6 +81,19 @@ describe.each(skillEndpoints)('$name', ({ path, create }) => {
     ]);
   });
 
+  test('normalizes Windows-style paths in buffered multipart uploads', async () => {
+    const { client, requests } = createClient();
+
+    await create(client, [
+      new File(['manifest'], 'my-skill\\SKILL.md', { type: 'text/markdown' }),
+      new File(['asset'], 'my-skill\\assets\\data.txt', { type: 'text/plain' }),
+    ]);
+
+    const files = await parseUploadedFiles(requests[0]);
+    expect(files.map((file) => file.name)).toEqual(['my-skill/SKILL.md', 'my-skill/assets/data.txt']);
+    await expect(Promise.all(files.map((file) => file.text()))).resolves.toEqual(['manifest', 'asset']);
+  });
+
   test('preserves browser directory paths when native files are explicitly renamed', async () => {
     const { client, requests } = createClient();
     const selectedFile: File & { webkitRelativePath?: string } = new File(['manifest'], 'SKILL.md', {
@@ -99,17 +126,36 @@ describe.each(skillEndpoints)('$name', ({ path, create }) => {
     expect(body).toContain('filename="my-skill/assets/data.txt"');
     expect(body).toContain('streamed asset');
   });
-});
 
-test('continues stripping directory names for ordinary file uploads', async () => {
-  const { client, requests } = createClient();
+  test('normalizes Windows-style paths in mixed buffered and streaming multipart uploads', async () => {
+    const { client, requests } = createClient();
 
-  await client.files.create({
-    file: new File(['contents'], 'private-directory/input.jsonl'),
-    purpose: 'assistants',
+    await create(client, [
+      new File(['manifest'], 'my-skill\\SKILL.md', { type: 'text/markdown' }),
+      toStreamingFile(skillAssetChunks(), 'my-skill\\assets\\data.txt', { type: 'text/plain' }),
+    ]);
+
+    const files = await parseUploadedFiles(requests[0]);
+    expect(files.map((file) => file.name)).toEqual(['my-skill/SKILL.md', 'my-skill/assets/data.txt']);
+    await expect(Promise.all(files.map((file) => file.text()))).resolves.toEqual([
+      'manifest',
+      'streamed asset',
+    ]);
   });
-
-  expect(requests).toHaveLength(1);
-  const form = requests[0]?.body as FormData;
-  expect((form.get('file') as File).name).toBe('input.jsonl');
 });
+
+test.each(['private-directory/input.jsonl', 'private-directory\\input.jsonl'])(
+  'continues stripping directory names for ordinary file uploads: %s',
+  async (filename) => {
+    const { client, requests } = createClient();
+
+    await client.files.create({
+      file: new File(['contents'], filename),
+      purpose: 'assistants',
+    });
+
+    expect(requests).toHaveLength(1);
+    const form = requests[0]?.body as FormData;
+    expect((form.get('file') as File).name).toBe('input.jsonl');
+  },
+);

--- a/tests/uploads.test.ts
+++ b/tests/uploads.test.ts
@@ -269,6 +269,40 @@ describe('toFile', () => {
     await expect(toFile(input, null, {})).resolves.toBe(input);
   });
 
+  it('does not copy native File objects when their filename and metadata are unchanged', async () => {
+    const input = new File(['foo'], 'input.jsonl', { type: 'application/jsonl', lastModified: 1234 });
+
+    await expect(toFile(input, 'input.jsonl')).resolves.toBe(input);
+    await expect(toFile(input, undefined, { type: 'application/jsonl' })).resolves.toBe(input);
+    await expect(
+      toFile(input, 'input.jsonl', { type: 'application/jsonl', lastModified: 1234 }),
+    ).resolves.toBe(input);
+  });
+
+  it.each([
+    { label: 'filename', name: 'my-skill/SKILL.md', options: undefined },
+    { label: 'MIME type', name: undefined, options: { type: 'application/x-ndjson' } },
+    { label: 'modification time', name: undefined, options: { lastModified: 5678 } },
+    {
+      label: 'filename and metadata',
+      name: 'my-skill/SKILL.md',
+      options: { type: 'application/x-ndjson', lastModified: 5678 },
+    },
+  ])('updates a native File $label without buffering its contents', async ({ name, options }) => {
+    const input = new File(['manifest'], 'SKILL.md', { type: 'text/markdown', lastModified: 1234 });
+    const arrayBuffer = vi
+      .spyOn(input, 'arrayBuffer')
+      .mockRejectedValue(new Error('Native File contents must not be buffered'));
+
+    const file = await toFile(input, name, options);
+
+    expect(arrayBuffer).not.toHaveBeenCalled();
+    expect(file.name).toBe(name ?? 'SKILL.md');
+    expect(file.type).toBe(options?.type ?? 'text/markdown');
+    expect(file.lastModified).toBe(options?.lastModified ?? 1234);
+    await expect(file.text()).resolves.toBe('manifest');
+  });
+
   it('renames native File objects while preserving their MIME type and modification time', async () => {
     const input = new File(['manifest'], 'SKILL.md', { type: 'text/markdown', lastModified: 1234 });
 
@@ -321,6 +355,19 @@ describe('toFile', () => {
     expect(file.name).toEqual('foreign.jsonl');
     expect(file.type).toEqual('application/jsonl');
     expect(file.lastModified).toEqual(1234);
+    await expect(file.arrayBuffer()).resolves.toEqual(new Uint8Array([1, 2]).buffer);
+  });
+
+  it('continues buffering structural non-native File-compatible objects', async () => {
+    const input = foreignFileLike();
+    const arrayBuffer = vi.spyOn(input, 'arrayBuffer');
+
+    const file = await toFile(input, 'renamed.jsonl');
+
+    expect(arrayBuffer).toHaveBeenCalledTimes(1);
+    expect(file.name).toBe('renamed.jsonl');
+    expect(file.type).toBe('application/jsonl');
+    expect(file.lastModified).toBe(1234);
     await expect(file.arrayBuffer()).resolves.toEqual(new Uint8Array([1, 2]).buffer);
   });
 


### PR DESCRIPTION
## Summary
- Normalize explicitly preserved Windows-style Skills paths before buffered or streaming multipart encoding.
- Keep directory stripping unchanged for ordinary uploads and cover both Skills endpoints with parsed multipart requests.
- Rename native `File` values and apply metadata overrides without eagerly reading their contents.
- Preserve file identity when the effective name and metadata are unchanged.

## Why
The streaming encoder previously emitted `%5C` for Windows path separators, which the production Skills backend rejects. Native File renames also duplicated complete file contents in memory, including browser directory uploads.

## Verification
- Full handwritten suite: 1,596 tests passed.
- Focused upload suites: 89 tests passed.
- TypeScript, repository lint, and full CJS/ESM package build passed.
- Actual backend normalization and manifest validation accept the repaired filenames.
- A 32 MiB native File rename retains zero additional ArrayBuffer bytes.