### PR TITLE
ci: run Vitest performance benchmarks in CI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -121,22 +121,23 @@ $ pnpm bench:json
 ```
 
 This writes `benchmark-results.json` in the repository root. The report is ignored
-by Git and is uploaded by the separate, manually triggered or scheduled benchmark
-workflow alongside a runtime, runner, revision, and fixture-hash metadata file.
-Pass a benchmark name or file filter directly to run only part of the suite, for
-example:
+by Git and uploaded as an artifact by the performance-benchmark job in normal CI.
+The separate, manually triggered or scheduled benchmark workflow also uploads a
+runtime, runner, revision, and fixture-hash metadata file. Pass a benchmark name
+or file filter directly to run only part of the suite, for example:
 
 ```sh
 $ pnpm bench streaming
 ```
 
-Benchmarks cover SSE chunk decoding and JSON parsing, incremental structured
-output parsing, schema generation and validation, and base64-versus-float
-embedding responses. Each case prepares its fixtures before timing and uses
-explicit warmup and repeated measurements. Compare medians and tail latency only
-between runs with the same Node.js version, CPU or runner class, SDK revision,
-fixture sizes, and background load. Shared CI runners are useful for collecting
-trends but are too variable for blocking performance thresholds.
+Benchmarks cover request preparation, header merging, query serialization, SSE
+chunk decoding and JSON parsing, incremental structured output parsing, schema
+generation and validation, and base64-versus-float embedding responses. Each case
+prepares its fixtures before timing and uses explicit warmup and repeated
+measurements. Compare medians and tail latency only between runs with the same
+Node.js version, CPU or runner class, SDK revision, fixture sizes, and background
+load. Shared CI runners are useful for collecting trends but are too variable for
+blocking performance thresholds.
 
 ## Linting and formatting
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -43,6 +43,7 @@ jobs:
             const fs = require("node:fs");
             const os = require("node:os");
             const fixtures = [
+              "tests/benchmarks/request-preparation.bench.ts",
               "tests/benchmarks/streaming.bench.ts",
               "tests/benchmarks/structured-output-and-embeddings.bench.ts",
               "tests/api-resources/embeddings-base64-response.json",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Runs the repository's normal lint, build, test, example, and ecosystem checks.
+# Runs the repository's normal lint, build, test, benchmark, example, and ecosystem checks.
 # These checks catch generated-code, packaging, runtime, and integration
 # regressions; policy-document alignment lives in node-version-policy.yml.
 name: CI
@@ -160,6 +160,41 @@ jobs:
             echo "::error::Node.js test matrix result: $TEST_RESULT"
             exit 1
           fi
+
+  benchmarks:
+    timeout-minutes: 20
+    name: performance benchmarks
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - name: Bootstrap
+        run: ./scripts/bootstrap
+
+      - name: Run Vitest performance benchmarks
+        run: pnpm bench:json
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: vitest-benchmark-results-${{ github.run_id }}-${{ github.run_attempt }}
+          path: benchmark-results.json
+          if-no-files-found: error
+          retention-days: 30
 
   examples:
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,16 +148,21 @@ jobs:
   test_matrix:
     name: ${{ (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review') && 'test matrix' || 'test matrix (not run)' }}
     if: ${{ always() && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review') }}
-    needs: [test]
+    needs: [test, benchmarks]
     runs-on: ubuntu-latest
     permissions: {}
     steps:
       - name: Tests (all)
         env:
           TEST_RESULT: ${{ needs.test.result }}
+          BENCHMARKS_RESULT: ${{ needs.benchmarks.result }}
         run: |
           if [ "$TEST_RESULT" != "success" ]; then
             echo "::error::Node.js test matrix result: $TEST_RESULT"
+            exit 1
+          fi
+          if [ "$BENCHMARKS_RESULT" != "success" ]; then
+            echo "::error::Performance benchmarks result: $BENCHMARKS_RESULT"
             exit 1
           fi
 

--- a/tests/benchmarks/request-preparation.bench.ts
+++ b/tests/benchmarks/request-preparation.bench.ts
@@ -1,0 +1,253 @@
+import { bench, beforeAll, describe } from 'vitest';
+
+import OpenAI from '../../src';
+import { buildHeaders } from '../../src/internal/headers';
+import type { HeadersLike } from '../../src/internal/headers';
+import { stringifyQuery } from '../../src/internal/utils/query';
+
+const BENCHMARK_OPTIONS = {
+  iterations: 10,
+  time: 100,
+  warmupIterations: 3,
+  warmupTime: 30,
+} as const;
+
+const BASIC_HEADER_LAYERS: HeadersLike[] = [
+  {
+    Accept: 'application/json',
+    'User-Agent': 'OpenAI/JS benchmark',
+    'X-Stainless-Retry-Count': '0',
+  },
+  { Authorization: 'Bearer benchmark-api-key' },
+];
+
+const LAYERED_REQUEST_HEADERS: HeadersLike[] = [
+  ...BASIC_HEADER_LAYERS,
+  {
+    'OpenAI-Organization': 'org_benchmark',
+    'OpenAI-Project': 'proj_benchmark',
+  },
+  {
+    'OpenAI-Beta': 'assistants=v2',
+    'X-Request-Origin': 'client-default',
+    'X-Trace-ID': 'trace-default',
+  },
+  {
+    'openai-beta': null,
+    'x-request-origin': 'per-request',
+    'X-Trace-ID': 'trace-request',
+    Cookie: ['session=benchmark', 'route=primary'],
+  },
+];
+
+const FLAT_QUERY = {
+  limit: 50,
+  after: 'file_0009',
+  order: 'desc',
+  purpose: 'fine-tune',
+};
+
+const NESTED_QUERY = {
+  ...FLAT_QUERY,
+  locale: 'en-GB',
+  filters: {
+    status: ['uploaded', 'processed', 'error'],
+    created_at: { gte: 1_700_000_000, lte: 1_700_086_400 },
+    owner: { organization: 'org_benchmark', project: 'proj_benchmark' },
+  },
+  metadata: { source: 'fixture/import', trace: 'batch 001' },
+};
+
+const CHAT_REQUEST = {
+  model: 'gpt-4o-mini',
+  messages: [
+    { role: 'system' as const, content: 'Return a short deterministic benchmark response.' },
+    ...Array.from({ length: 8 }, (_, index) => ({
+      role: 'user' as const,
+      content: `Benchmark message ${index}: ${'representative SDK request payload. '.repeat(4)}`,
+    })),
+  ],
+  temperature: 0,
+  metadata: { benchmark: 'request-preparation', workload: 'deterministic' },
+};
+
+const CHAT_RESPONSE = JSON.stringify({
+  id: 'chatcmpl-request-benchmark',
+  object: 'chat.completion',
+  created: 1,
+  model: CHAT_REQUEST.model,
+  choices: [
+    {
+      index: 0,
+      message: { role: 'assistant', content: 'Benchmark complete.', refusal: null },
+      finish_reason: 'stop',
+      logprobs: null,
+    },
+  ],
+  usage: { prompt_tokens: 128, completion_tokens: 4, total_tokens: 132 },
+});
+
+const requestClient = new OpenAI({
+  apiKey: 'benchmark-api-key',
+  organization: 'org_benchmark',
+  project: 'proj_benchmark',
+  baseURL: 'https://sdk-benchmark.invalid/v1',
+  maxRetries: 0,
+  defaultQuery: { locale: 'en-US', api_version: '2026-01-01' },
+  defaultHeaders: {
+    'OpenAI-Beta': 'assistants=v2',
+    'X-Request-Origin': 'client-default',
+    'X-Trace-ID': 'trace-default',
+  },
+  fetch: async () =>
+    new Response(CHAT_RESPONSE, {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }),
+});
+
+const LIST_REQUEST_OPTIONS = {
+  method: 'get' as const,
+  path: '/files?view=active',
+  query: NESTED_QUERY,
+  headers: { 'OpenAI-Beta': null, 'X-Request-Origin': 'per-request' },
+};
+
+const CHAT_REQUEST_OPTIONS = {
+  method: 'post' as const,
+  path: '/chat/completions',
+  body: CHAT_REQUEST,
+  headers: { 'X-Request-Origin': 'per-request' },
+};
+
+let benchmarkSink = 0;
+
+beforeAll(async () => {
+  const mergedHeaders = buildHeaders(LAYERED_REQUEST_HEADERS);
+  if (
+    mergedHeaders.values.get('authorization') !== 'Bearer benchmark-api-key' ||
+    mergedHeaders.values.get('x-request-origin') !== 'per-request' ||
+    mergedHeaders.values.get('cookie') !== 'session=benchmark; route=primary' ||
+    !mergedHeaders.nulls.has('openai-beta')
+  ) {
+    throw new Error('Request header benchmark fixture did not merge correctly.');
+  }
+
+  const nestedQuery = new URLSearchParams(stringifyQuery(NESTED_QUERY));
+  if (
+    nestedQuery.getAll('filters[status][]').join(',') !== 'uploaded,processed,error' ||
+    nestedQuery.get('filters[owner][organization]') !== 'org_benchmark' ||
+    nestedQuery.get('metadata[source]') !== 'fixture/import'
+  ) {
+    throw new Error('Nested query benchmark fixture did not serialize correctly.');
+  }
+
+  const listRequest = await requestClient.buildRequest(LIST_REQUEST_OPTIONS);
+  const listURL = new URL(listRequest.url);
+  if (
+    listURL.searchParams.get('view') !== 'active' ||
+    listURL.searchParams.get('locale') !== 'en-GB' ||
+    listURL.searchParams.get('api_version') !== '2026-01-01' ||
+    listRequest.req.headers.get('x-request-origin') !== 'per-request' ||
+    listRequest.req.headers.has('openai-beta')
+  ) {
+    throw new Error('GET request benchmark fixture did not preserve request options.');
+  }
+
+  const chatRequest = await requestClient.buildRequest(CHAT_REQUEST_OPTIONS);
+  if (
+    chatRequest.req.headers.get('content-type') !== 'application/json' ||
+    typeof chatRequest.req.body !== 'string' ||
+    JSON.parse(chatRequest.req.body).messages.length !== CHAT_REQUEST.messages.length
+  ) {
+    throw new Error('JSON request benchmark fixture did not encode correctly.');
+  }
+
+  const completion = await requestClient.chat.completions.create(CHAT_REQUEST);
+  if (completion.choices[0]?.message.content !== 'Benchmark complete.') {
+    throw new Error('In-memory request benchmark fixture returned an unexpected completion.');
+  }
+});
+
+describe('request header preparation', () => {
+  bench(
+    'build standard authentication and SDK headers',
+    () => {
+      const headers = buildHeaders(BASIC_HEADER_LAYERS);
+      benchmarkSink += headers.values.get('authorization')?.length ?? 0;
+    },
+    BENCHMARK_OPTIONS,
+  );
+
+  bench(
+    'merge layered defaults, overrides, removals, and cookie values',
+    () => {
+      const headers = buildHeaders(LAYERED_REQUEST_HEADERS);
+      benchmarkSink += headers.values.get('cookie')?.length ?? 0;
+    },
+    BENCHMARK_OPTIONS,
+  );
+});
+
+describe('request query serialization', () => {
+  bench(
+    'serialize flat pagination parameters',
+    () => {
+      benchmarkSink += stringifyQuery(FLAT_QUERY).length;
+    },
+    BENCHMARK_OPTIONS,
+  );
+
+  bench(
+    'serialize nested filters and bracket-array parameters',
+    () => {
+      benchmarkSink += stringifyQuery(NESTED_QUERY).length;
+    },
+    BENCHMARK_OPTIONS,
+  );
+
+  bench(
+    'build a URL with default and flat query parameters',
+    () => {
+      benchmarkSink += requestClient.buildURL('/files', FLAT_QUERY).length;
+    },
+    BENCHMARK_OPTIONS,
+  );
+
+  bench(
+    'build a URL with existing, default, and nested query parameters',
+    () => {
+      benchmarkSink += requestClient.buildURL('/files?view=active&locale=path-default', NESTED_QUERY).length;
+    },
+    BENCHMARK_OPTIONS,
+  );
+});
+
+describe('complete request preparation', () => {
+  bench(
+    'build an authenticated GET request with nested query parameters',
+    async () => {
+      const request = await requestClient.buildRequest(LIST_REQUEST_OPTIONS);
+      benchmarkSink += request.url.length;
+    },
+    BENCHMARK_OPTIONS,
+  );
+
+  bench(
+    'build an authenticated JSON POST request',
+    async () => {
+      const request = await requestClient.buildRequest(CHAT_REQUEST_OPTIONS);
+      benchmarkSink += request.req.headers.get('content-length')?.length ?? request.url.length;
+    },
+    BENCHMARK_OPTIONS,
+  );
+
+  bench(
+    'send a public chat completions request through in-memory fetch',
+    async () => {
+      const completion = await requestClient.chat.completions.create(CHAT_REQUEST);
+      benchmarkSink += completion.choices[0]?.message.content?.length ?? 0;
+    },
+    BENCHMARK_OPTIONS,
+  );
+});


### PR DESCRIPTION
## Summary

- Run the existing Vitest performance benchmark suite in the normal CI workflow and upload its JSON report as a 30-day artifact.
- Add nine deterministic request-preparation benchmarks covering header merging, flat and nested query serialization, URL construction, authenticated GET/POST preparation, and an in-memory chat-completions request.
- Include the new benchmark in scheduled-run fixture metadata and document the expanded CI coverage.

The suite runs once with the repository tooling Node.js version, avoids external API calls, and does not introduce noisy shared-runner performance thresholds.

## Validation

- `pnpm bench:json` — 47 benchmark cases passed across three files.
- `pnpm test:unit` — 1,727 tests passed across 66 files.
- `pnpm lint`
- `pnpm exec tsc`
- Validated normal CI benchmark execution/artifact upload and scheduled benchmark fixture hashing.