### PR TITLE
fix(realtime): allow overriding WebSocket connection URLs

### DIFF
--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -108,6 +108,22 @@ For an Azure Realtime GA call, pass `callID` to the Azure factory instead:
 const rt = await OpenAIRealtimeWS.azure(azureClient, { callID: 'rtc_123456' });
 ```
 
+To connect to a deployment that requires an exact WebSocket URL, such as SAP AI Core, provide a `buildRealtimeURL` callback. Both `OpenAIRealtimeWS` and `OpenAIRealtimeWebSocket` accept this option in their constructors, `create()` factories, and Azure factories:
+
+```ts
+import OpenAI from 'openai';
+import { OpenAIRealtimeWS } from 'openai/realtime/ws';
+
+const client = new OpenAI();
+const rt = await OpenAIRealtimeWS.create(client, {
+  model: 'gpt-realtime',
+  buildRealtimeURL: () =>
+    new URL('wss://sap-ai-core.example.com/v2/inference/deployments/my-deployment/realtime'),
+});
+```
+
+The callback receives the client and validated connection target and returns the final `wss:` URL. Exactly one of `model`, `callID`, or transcription `intent` is still required, but the SDK does not add routing parameters such as `model` to the returned URL. Use only a trusted endpoint because connection credentials are sent to it. For native Azure WebSocket connections, the required authentication query parameter is still added before connecting and redacted from the exposed URL afterward.
+
 A full example can be found in [`examples/realtime/websocket.ts`](../examples/realtime/websocket.ts).
 
 ### Realtime error handling

--- a/src/realtime/internal-base.ts
+++ b/src/realtime/internal-base.ts
@@ -295,6 +295,8 @@ export function getAzureRealtimeConnection(
   const hasDeploymentName = connection.deploymentName !== undefined;
   const hasCallID = connection.callID !== undefined;
   const hasIntent = connection.intent !== undefined;
+  const customURLBuilder = connection.buildRealtimeURL;
+  const normalizedOptions = customURLBuilder ? { buildRealtimeURL: customURLBuilder } : {};
 
   if (
     Number(hasDeploymentName) + Number(hasCallID) + Number(hasIntent) > 1 ||
@@ -306,16 +308,16 @@ export function getAzureRealtimeConnection(
   }
 
   if (hasCallID) {
-    return { callID: connection.callID! };
+    return { ...normalizedOptions, callID: connection.callID! };
   }
 
   if (hasIntent) {
-    return { intent: 'transcription' };
+    return { ...normalizedOptions, intent: 'transcription' };
   }
 
   const model = connection.deploymentName ?? client.deploymentName;
   if (!model) {
     throw new Error('No deployment name provided');
   }
-  return { model };
+  return { ...normalizedOptions, model };
 }

--- a/src/realtime/internal-base.ts
+++ b/src/realtime/internal-base.ts
@@ -130,9 +130,23 @@ export function isAzure(client: Pick<OpenAI, 'apiKey' | 'baseURL'>): client is A
   return client instanceof AzureOpenAI;
 }
 
+interface RealtimeURLBuilderOptions {
+  /**
+   * Builds the exact WebSocket URL after the connection target has been validated.
+   *
+   * Return only a trusted `wss:` URL because the client's credentials are sent to
+   * that endpoint. Model, call ID, transcription intent, and deployment query
+   * parameters are not added to the returned URL.
+   */
+  buildRealtimeURL?: (
+    client: Pick<OpenAI, 'apiKey' | 'baseURL'>,
+    connection: RealtimeConnectionConfig,
+  ) => URL;
+}
+
 /** Starts a model or transcription session, or attaches to exactly one existing call. */
 export type RealtimeConnectionConfig =
-  | {
+  | (RealtimeURLBuilderOptions & {
       /**
        * Start a new Realtime session using the given model.
        */
@@ -143,8 +157,8 @@ export type RealtimeConnectionConfig =
 
       /** Existing call identifier; cannot be supplied when starting a model-backed session. */
       callID?: undefined;
-    }
-  | {
+    })
+  | (RealtimeURLBuilderOptions & {
       /** Starts a transcription-only Realtime session without selecting a model. */
       intent: 'transcription';
 
@@ -153,8 +167,8 @@ export type RealtimeConnectionConfig =
 
       /** Existing call identifier; cannot be supplied with transcription intent. */
       callID?: undefined;
-    }
-  | {
+    })
+  | (RealtimeURLBuilderOptions & {
       /** Model name; cannot be supplied when attaching to an existing call. */
       model?: undefined;
 
@@ -165,11 +179,11 @@ export type RealtimeConnectionConfig =
        * Attach to an in-progress Realtime call over a sideband control connection.
        */
       callID: string;
-    };
+    });
 
 /** Starts an Azure deployment or transcription session, or attaches to an existing call. */
 export type AzureRealtimeConnectionConfig =
-  | {
+  | (RealtimeURLBuilderOptions & {
       /**
        * Override the deployment configured on the Azure client.
        */
@@ -180,8 +194,8 @@ export type AzureRealtimeConnectionConfig =
 
       /** Existing call identifier; cannot be combined with `deploymentName`. */
       callID?: undefined;
-    }
-  | {
+    })
+  | (RealtimeURLBuilderOptions & {
       /** Starts an Azure transcription session; set its deployment later in `session.update`. */
       intent: 'transcription';
 
@@ -190,8 +204,8 @@ export type AzureRealtimeConnectionConfig =
 
       /** Existing call identifier; cannot be supplied with transcription intent. */
       callID?: undefined;
-    }
-  | {
+    })
+  | (RealtimeURLBuilderOptions & {
       /** Deployment override; cannot be supplied when attaching to an existing call. */
       deploymentName?: undefined;
 
@@ -202,7 +216,7 @@ export type AzureRealtimeConnectionConfig =
        * Attach to an in-progress Azure Realtime call over a sideband control connection.
        */
       callID: string;
-    };
+    });
 
 /**
  * Builds the secure WebSocket URL for a model or transcription session, or a sideband call.
@@ -211,7 +225,7 @@ export type AzureRealtimeConnectionConfig =
  * sessions select their deployment with `model`, transcription sessions use
  * `intent`, and sideband connections use `call_id`.
  *
- * @throws {Error} If exactly one valid model, transcription intent, or call ID is not supplied.
+ * @throws {Error} If the connection target is invalid or a custom URL does not use `wss:`.
  */
 export function buildRealtimeURL(
   client: Pick<OpenAI, 'apiKey' | 'baseURL'>,
@@ -234,6 +248,14 @@ export function buildRealtimeURL(
     throw new Error(
       'Pass exactly one of `model`, `callID`, or transcription `intent` when opening a Realtime WebSocket.',
     );
+  }
+
+  if (config.buildRealtimeURL) {
+    const url = new URL(config.buildRealtimeURL(client, config));
+    if (url.protocol !== 'wss:') {
+      throw new Error('Custom Realtime WebSocket URLs must use the wss: protocol.');
+    }
+    return url;
   }
 
   let url: URL;

--- a/src/realtime/websocket.ts
+++ b/src/realtime/websocket.ts
@@ -24,6 +24,17 @@ type _WebSocket = typeof globalThis extends {
     InstanceType<ws>
   : any;
 
+/** Removes Azure credential query values from the publicly exposed connection URL. */
+function redactAzureCredentials(url: URL): void {
+  const hasAuthorization = url.searchParams.has('Authorization');
+  if (url.searchParams.has('api-key') || !hasAuthorization) {
+    url.searchParams.set('api-key', '<REDACTED>');
+  }
+  if (hasAuthorization) {
+    url.searchParams.set('Authorization', '<REDACTED>');
+  }
+}
+
 /**
  * Connects to the Realtime API using the runtime's native `WebSocket` implementation.
  *
@@ -126,11 +137,7 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     });
 
     if (isAzure(client)) {
-      if (this.url.searchParams.get('Authorization') === null) {
-        this.url.searchParams.set('api-key', '<REDACTED>');
-      } else {
-        this.url.searchParams.set('Authorization', '<REDACTED>');
-      }
+      redactAzureCredentials(this.url);
     }
   }
 
@@ -187,6 +194,7 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     return new OpenAIRealtimeWebSocket(
       {
         ...connection,
+        ...(options.buildRealtimeURL ? { buildRealtimeURL: options.buildRealtimeURL } : {}),
         onURL,
         ...(dangerouslyAllowBrowser ? { dangerouslyAllowBrowser } : {}),
         __resolvedApiKey: isApiKeyProvider,

--- a/src/realtime/websocket.ts
+++ b/src/realtime/websocket.ts
@@ -194,7 +194,6 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     return new OpenAIRealtimeWebSocket(
       {
         ...connection,
-        ...(options.buildRealtimeURL ? { buildRealtimeURL: options.buildRealtimeURL } : {}),
         onURL,
         ...(dangerouslyAllowBrowser ? { dangerouslyAllowBrowser } : {}),
         __resolvedApiKey: isApiKeyProvider,

--- a/src/realtime/ws.ts
+++ b/src/realtime/ws.ts
@@ -137,7 +137,6 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
     return new OpenAIRealtimeWS(
       {
         ...connection,
-        ...(props.buildRealtimeURL ? { buildRealtimeURL: props.buildRealtimeURL } : {}),
         options: {
           ...props.options,
           headers: {

--- a/src/realtime/ws.ts
+++ b/src/realtime/ws.ts
@@ -137,6 +137,7 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
     return new OpenAIRealtimeWS(
       {
         ...connection,
+        ...(props.buildRealtimeURL ? { buildRealtimeURL: props.buildRealtimeURL } : {}),
         options: {
           ...props.options,
           headers: {

--- a/tests/realtime-websocket.test.ts
+++ b/tests/realtime-websocket.test.ts
@@ -540,3 +540,247 @@ describe('stable Node realtime transcription', () => {
     expect(nodeSocketConstructor).not.toHaveBeenCalled();
   });
 });
+
+describe('stable browser realtime custom URL builder', () => {
+  test('opens the exact custom URL while preserving authentication and its existing query', () => {
+    const client = createClient();
+    const customURL = new URL('wss://sap.example.com/deployments/custom/realtime?existing=value');
+    const customBuilder = vi.fn(() => customURL);
+
+    const realtime = new StableBrowserRealtime(
+      { model: 'gpt-realtime', buildRealtimeURL: customBuilder },
+      client,
+    );
+
+    expect(lastBrowserSocket().url).toBe(customURL.toString());
+    expect(lastBrowserSocket().protocols).toEqual(['realtime', 'openai-insecure-api-key.test-key']);
+    expect(realtime.url.toString()).toBe(customURL.toString());
+    expect(realtime.url).not.toBe(customURL);
+    expect(realtime.url.searchParams.has('model')).toBe(false);
+  });
+
+  test('rejects an insecure custom URL before opening a socket', () => {
+    expect(
+      () =>
+        new StableBrowserRealtime(
+          {
+            model: 'gpt-realtime',
+            buildRealtimeURL: () => new URL('ws://sap.example.com/realtime'),
+          },
+          createClient(),
+        ),
+    ).toThrow();
+    expect(FakeBrowserSocket.instances).toHaveLength(0);
+  });
+
+  test('preserves custom URLs when the factory resolves a rotating credential', async () => {
+    const customURL = new URL('wss://sap.example.com/custom?existing=value');
+
+    const realtime = await StableBrowserRealtime.create(
+      createClient(async () => 'rotating-key'),
+      {
+        model: 'gpt-realtime',
+        buildRealtimeURL: () => customURL,
+      },
+    );
+
+    expect(lastBrowserSocket().url).toBe(customURL.toString());
+    expect(lastBrowserSocket().protocols).toEqual(['realtime', 'openai-insecure-api-key.rotating-key']);
+    expect(realtime.url.searchParams.has('model')).toBe(false);
+  });
+
+  test('authenticates and redacts an Azure API key without modifying the caller URL', async () => {
+    const client = createAzureClient({ deployment: 'configured' });
+    const customURL = new URL('wss://sap.example.com/azure/custom?existing=value');
+    const customBuilder = vi.fn(() => customURL);
+
+    const realtime = await StableBrowserRealtime.azure(client, {
+      deploymentName: 'override',
+      buildRealtimeURL: customBuilder,
+    });
+    const connectionURL = new URL(lastBrowserSocket().url);
+
+    expect(customBuilder).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({ model: 'override', buildRealtimeURL: customBuilder }),
+    );
+    expect(connectionURL.pathname).toBe('/azure/custom');
+    expect(connectionURL.searchParams.get('existing')).toBe('value');
+    expect(connectionURL.searchParams.get('api-key')).toBe('azure-key');
+    expect(connectionURL.searchParams.has('model')).toBe(false);
+    expect(connectionURL.searchParams.has('deployment')).toBe(false);
+    expect(lastBrowserSocket().protocols).toEqual(['realtime']);
+    expect(realtime.url.searchParams.get('existing')).toBe('value');
+    expect(realtime.url.searchParams.get('api-key')).toBe('<REDACTED>');
+    expect(customURL.toString()).toBe('wss://sap.example.com/azure/custom?existing=value');
+  });
+
+  test('authenticates and redacts an Azure token without modifying the caller URL', async () => {
+    const customURL = new URL('wss://sap.example.com/azure/custom?existing=value');
+
+    const realtime = await StableBrowserRealtime.azure(
+      createAzureClient({ deployment: 'configured', tokenProvider: true }),
+      { buildRealtimeURL: () => customURL },
+    );
+    const connectionURL = new URL(lastBrowserSocket().url);
+
+    expect(connectionURL.searchParams.get('existing')).toBe('value');
+    expect(connectionURL.searchParams.get('Authorization')).toBe('Bearer azure-token');
+    expect(connectionURL.searchParams.has('model')).toBe(false);
+    expect(realtime.url.searchParams.get('Authorization')).toBe('<REDACTED>');
+    expect(customURL.toString()).toBe('wss://sap.example.com/azure/custom?existing=value');
+  });
+
+  test.each([
+    {
+      existingParameter: 'Authorization',
+      authenticationParameter: 'api-key',
+      authenticationValue: 'azure-key',
+      tokenProvider: false,
+    },
+    {
+      existingParameter: 'api-key',
+      authenticationParameter: 'Authorization',
+      authenticationValue: 'Bearer azure-token',
+      tokenProvider: true,
+    },
+  ])(
+    'redacts both Azure credential parameters when the custom URL already contains $existingParameter',
+    async ({ existingParameter, authenticationParameter, authenticationValue, tokenProvider }) => {
+      const customURL = new URL('wss://sap.example.com/azure/custom?routing=value');
+      customURL.searchParams.set(existingParameter, 'existing');
+      const callerURL = customURL.toString();
+
+      const realtime = await StableBrowserRealtime.azure(
+        createAzureClient({ deployment: 'configured', tokenProvider }),
+        { buildRealtimeURL: () => customURL },
+      );
+      const connectionURL = new URL(lastBrowserSocket().url);
+
+      expect(connectionURL.pathname).toBe('/azure/custom');
+      expect(connectionURL.searchParams.get('routing')).toBe('value');
+      expect(connectionURL.searchParams.get(existingParameter)).toBe('existing');
+      expect(connectionURL.searchParams.get(authenticationParameter)).toBe(authenticationValue);
+      expect(realtime.url.searchParams.get('routing')).toBe('value');
+      expect(realtime.url.searchParams.get('Authorization')).toBe('<REDACTED>');
+      expect(realtime.url.searchParams.get('api-key')).toBe('<REDACTED>');
+      expect(customURL.toString()).toBe(callerURL);
+    },
+  );
+
+  test('requires an Azure deployment before invoking a custom builder', async () => {
+    const customBuilder = vi.fn(() => new URL('wss://sap.example.com/realtime'));
+
+    await expect(
+      StableBrowserRealtime.azure(createAzureClient(), { buildRealtimeURL: customBuilder }),
+    ).rejects.toThrow('No deployment name provided');
+    expect(customBuilder).not.toHaveBeenCalled();
+    expect(FakeBrowserSocket.instances).toHaveLength(0);
+  });
+});
+
+describe('stable Node realtime custom URL builder', () => {
+  test('opens the exact custom URL while preserving authentication, query, and ws options', () => {
+    const client = createClient();
+    const customURL = new URL('wss://sap.example.com/deployments/custom/realtime?existing=value');
+    const customBuilder = vi.fn(() => customURL);
+
+    const realtime = new StableNodeRealtime(
+      {
+        model: 'gpt-realtime',
+        buildRealtimeURL: customBuilder,
+        options: { handshakeTimeout: 4321, headers: { 'X-Custom': 'value' } },
+      },
+      client,
+    );
+
+    expect(lastNodeSocket().url.toString()).toBe(customURL.toString());
+    expect(lastNodeSocket().options).toMatchObject({
+      handshakeTimeout: 4321,
+      headers: { Authorization: 'Bearer test-key', 'X-Custom': 'value' },
+    });
+    expect(realtime.url).not.toBe(customURL);
+    expect(realtime.url.searchParams.has('model')).toBe(false);
+  });
+
+  test('rejects a malformed custom URL before opening a socket', () => {
+    expect(
+      () =>
+        new StableNodeRealtime(
+          { model: 'gpt-realtime', buildRealtimeURL: () => 'not a valid URL' as unknown as URL },
+          createClient(),
+        ),
+    ).toThrow();
+    expect(nodeSocketConstructor).not.toHaveBeenCalled();
+  });
+
+  test('preserves custom URLs and ws options when resolving a rotating credential', async () => {
+    const customURL = new URL('wss://sap.example.com/custom?existing=value');
+
+    const realtime = await StableNodeRealtime.create(
+      createClient(async () => 'rotating-key'),
+      {
+        model: 'gpt-realtime',
+        buildRealtimeURL: () => customURL,
+        options: { headers: { 'X-Custom': 'value' } },
+      },
+    );
+
+    expect(lastNodeSocket().url.toString()).toBe(customURL.toString());
+    expect(lastNodeSocket().options.headers).toMatchObject({
+      Authorization: 'Bearer rotating-key',
+      'X-Custom': 'value',
+    });
+    expect(realtime.url.searchParams.has('model')).toBe(false);
+  });
+
+  test('preserves custom Azure URLs, API-key authentication, and ws options', async () => {
+    const client = createAzureClient({ deployment: 'configured' });
+    const customURL = new URL('wss://sap.example.com/azure/custom?existing=value');
+    const customBuilder = vi.fn(() => customURL);
+
+    await StableNodeRealtime.azure(client, {
+      deploymentName: 'override',
+      buildRealtimeURL: customBuilder,
+      options: { handshakeTimeout: 4321, headers: { 'X-Custom': 'value' } },
+    });
+    const socket = lastNodeSocket();
+
+    expect(customBuilder).toHaveBeenCalledWith(
+      client,
+      expect.objectContaining({ model: 'override', buildRealtimeURL: customBuilder }),
+    );
+    expect(socket.url.toString()).toBe(customURL.toString());
+    expect(socket.url.searchParams.has('model')).toBe(false);
+    expect(socket.url.searchParams.has('deployment')).toBe(false);
+    expect(socket.options).toMatchObject({
+      handshakeTimeout: 4321,
+      headers: { 'api-key': 'azure-key', 'X-Custom': 'value' },
+    });
+    expect(socket.options.headers).not.toHaveProperty('Authorization');
+  });
+
+  test('preserves custom Azure URLs and authenticates token providers with a bearer header', async () => {
+    const customURL = new URL('wss://sap.example.com/azure/custom?existing=value');
+
+    await StableNodeRealtime.azure(createAzureClient({ deployment: 'configured', tokenProvider: true }), {
+      buildRealtimeURL: () => customURL,
+    });
+    const socket = lastNodeSocket();
+
+    expect(socket.url.toString()).toBe(customURL.toString());
+    expect(socket.url.searchParams.has('model')).toBe(false);
+    expect(socket.options.headers).toMatchObject({ Authorization: 'Bearer azure-token' });
+    expect(socket.options.headers).not.toHaveProperty('api-key');
+  });
+
+  test('requires an Azure deployment before invoking a custom builder', async () => {
+    const customBuilder = vi.fn(() => new URL('wss://sap.example.com/realtime'));
+
+    await expect(
+      StableNodeRealtime.azure(createAzureClient(), { buildRealtimeURL: customBuilder }),
+    ).rejects.toThrow('No deployment name provided');
+    expect(customBuilder).not.toHaveBeenCalled();
+    expect(nodeSocketConstructor).not.toHaveBeenCalled();
+  });
+});

--- a/tests/realtime.test.ts
+++ b/tests/realtime.test.ts
@@ -1,3 +1,5 @@
+import { vi } from 'vitest';
+
 import OpenAI, { AzureOpenAI } from 'openai';
 import { buildRealtimeURL as buildBetaRealtimeURL } from 'openai/beta/realtime/internal-base';
 import { buildRealtimeURL, getAzureRealtimeConnection } from 'openai/realtime/internal-base';
@@ -69,6 +71,83 @@ describe.each([
       'Pass exactly one of `model`',
     );
   });
+});
+
+describe('stable realtime custom URL builder', () => {
+  test('passes the client and validated connection to the override and uses its exact URL', () => {
+    const customURL = new URL('wss://sap.example.com/deployments/custom/realtime?existing=value');
+    const customBuilder = vi.fn(() => customURL);
+    const connection = { model: 'gpt-realtime', buildRealtimeURL: customBuilder };
+
+    const result = buildRealtimeURL(openAIClient, connection);
+
+    expect(customBuilder).toHaveBeenCalledTimes(1);
+    expect(customBuilder).toHaveBeenCalledWith(openAIClient, connection);
+    expect(result.toString()).toBe('wss://sap.example.com/deployments/custom/realtime?existing=value');
+    expect(result.searchParams.has('model')).toBe(false);
+    expect(result).not.toBe(customURL);
+
+    result.searchParams.set('added', 'later');
+    expect(customURL.toString()).toBe('wss://sap.example.com/deployments/custom/realtime?existing=value');
+  });
+
+  test.each([{ callID: 'rtc_123' }, { intent: 'transcription' as const }])(
+    'does not add default routing parameters for a custom connection %#',
+    (target) => {
+      const customURL = new URL('wss://sap.example.com/custom?existing=value');
+
+      const result = buildRealtimeURL(openAIClient, {
+        ...target,
+        buildRealtimeURL: () => customURL,
+      });
+
+      expect(result.toString()).toBe(customURL.toString());
+      expect(result.searchParams.has('call_id')).toBe(false);
+      expect(result.searchParams.has('intent')).toBe(false);
+    },
+  );
+
+  test('does not add Azure deployment or API-version parameters to a custom URL', () => {
+    const customURL = new URL('wss://sap.example.com/azure/custom?existing=value');
+
+    const result = buildRealtimeURL(azureClient, {
+      model: 'my-deployment',
+      buildRealtimeURL: () => customURL,
+    });
+
+    expect(result.toString()).toBe(customURL.toString());
+    expect(result.searchParams.has('model')).toBe(false);
+    expect(result.searchParams.has('deployment')).toBe(false);
+    expect(result.searchParams.has('api-version')).toBe(false);
+  });
+
+  test.each([
+    new URL('ws://sap.example.com/realtime'),
+    new URL('https://sap.example.com/realtime'),
+    'not a valid URL' as unknown as URL,
+  ])('rejects insecure or malformed custom URLs %#', (customURL) => {
+    expect(() =>
+      buildRealtimeURL(openAIClient, {
+        model: 'gpt-realtime',
+        buildRealtimeURL: () => customURL,
+      }),
+    ).toThrow();
+  });
+
+  test.each([{}, { model: 'gpt-realtime', callID: 'rtc_123' }, { model: '', intent: 'transcription' }])(
+    'validates the connection target before invoking a custom builder %#',
+    (target) => {
+      const customBuilder = vi.fn(() => new URL('wss://sap.example.com/realtime'));
+
+      expect(() =>
+        buildRealtimeURL(openAIClient, {
+          ...target,
+          buildRealtimeURL: customBuilder,
+        } as any),
+      ).toThrow('Pass exactly one of `model`');
+      expect(customBuilder).not.toHaveBeenCalled();
+    },
+  );
 });
 
 describe('stable realtime transcription', () => {

--- a/tests/realtime.test.ts
+++ b/tests/realtime.test.ts
@@ -121,6 +121,22 @@ describe('stable realtime custom URL builder', () => {
     expect(result.searchParams.has('api-version')).toBe(false);
   });
 
+  test('preserves custom URL builders through normalized Azure connections', () => {
+    const customURL = new URL('wss://sap.example.com/azure/custom?existing=value');
+    const customBuilder = vi.fn(() => customURL);
+    const connection = getAzureRealtimeConnection(
+      { deploymentName: 'configured-deployment' },
+      { buildRealtimeURL: customBuilder },
+    );
+
+    const result = buildRealtimeURL(azureClient, connection);
+
+    expect(connection).toEqual({ model: 'configured-deployment', buildRealtimeURL: customBuilder });
+    expect(customBuilder).toHaveBeenCalledWith(azureClient, connection);
+    expect(result.toString()).toBe(customURL.toString());
+    expect(result.searchParams.has('model')).toBe(false);
+  });
+
   test.each([
     new URL('ws://sap.example.com/realtime'),
     new URL('https://sap.example.com/realtime'),


### PR DESCRIPTION
## Summary

Allow stable Realtime callers to supply a `buildRealtimeURL` callback that returns the exact trusted `wss:` endpoint. This lets SAP AI Core and other compatible deployments connect without SDK-added `model`, `call_id`, transcription-intent, deployment, or API-version query parameters.

- Expose the optional callback through the existing stable Node `ws` and native WebSocket connection options, including constructors, `create()`, and Azure factories, without adding a new named export or changing deprecated beta helpers.
- Validate the existing model/call ID/transcription target before invoking the callback, defensively copy its URL, require `wss:`, and preserve credential-provider resolution, `ws` options, and Azure deployment/authentication behavior.
- Continue adding required credentials for native Azure sockets and redact both Azure credential parameters when a custom URL already contains the other authentication parameter.
- Document the SAP AI Core usage and add focused URL-builder, transport, factory, Azure-authentication, credential-redaction, and invalid-URL regression coverage.

## Why

The built-in Realtime URL builder always appends routing query parameters such as `model=`, which SAP AI Core deployments reject. Existing base-URL customization cannot prevent those parameters from being added or choose the exact final WebSocket URL.

## Validation

- `pnpm test:unit --update=none` — 1,751 tests across 66 files passed.
- `pnpm test:unit tests/realtime.test.ts tests/realtime-websocket.test.ts` — 114 focused Realtime tests passed.
- `./scripts/lint` — repository-wide formatting and lint checks passed.
- `pnpm exec tsc` — full source TypeScript check passed.
- `./scripts/build` — CommonJS/ESM builds and package import smoke tests passed.
- `pnpm exec tsc --project dist/src/tsconfig.json --noEmit` — published-source declaration/type check passed.

Validation ran with Node 24.14.0. Reused local dependencies required temporarily resolving the already-installed `signal-exit` v4 for the build; no dependency, lockfile, or generated SDK files changed.

Fixes #2305