### PR TITLE
fix(streaming): handle mixed SSE line endings

### DIFF
--- a/src/internal/decoders/line.ts
+++ b/src/internal/decoders/line.ts
@@ -127,33 +127,39 @@ function findNewlineIndex(
 /**
  * Finds the first blank-line separator used to delimit streamed event records.
  *
- * @returns The byte offset immediately after the first `\n\n`, `\r\r`, or
- * `\r\n\r\n` separator, or `-1` when the buffer contains no complete separator.
+ * @returns The byte offset immediately after the first pair of consecutive
+ * line endings, or `-1` when the buffer contains no complete separator.
  */
 export function findDoubleNewlineIndex(buffer: Uint8Array): number {
-  const newline = 0x0a; // \n
-  const carriage = 0x0d; // \r
-
   for (let i = 0; i < buffer.length - 1; i++) {
-    if (buffer[i] === newline && buffer[i + 1] === newline) {
-      // \n\n
-      return i + 2;
-    }
-    if (buffer[i] === carriage && buffer[i + 1] === carriage) {
-      // \r\r
-      return i + 2;
-    }
-    if (
-      buffer[i] === carriage &&
-      buffer[i + 1] === newline &&
-      i + 3 < buffer.length &&
-      buffer[i + 2] === carriage &&
-      buffer[i + 3] === newline
-    ) {
-      // \r\n\r\n
-      return i + 4;
+    const firstEndingLength = lineEndingLength(buffer, i);
+    if (firstEndingLength > 0) {
+      const secondEndingIndex = i + firstEndingLength;
+      const secondEndingLength = lineEndingLength(buffer, secondEndingIndex);
+      if (secondEndingLength > 0) {
+        const secondEndingCouldBecomeCRLF =
+          buffer[secondEndingIndex] === 0x0d && secondEndingIndex === buffer.length - 1;
+        const isUnambiguousDoubleCR = buffer[i] === 0x0d && firstEndingLength === 1;
+        if (secondEndingCouldBecomeCRLF && !isUnambiguousDoubleCR) {
+          continue;
+        }
+        return secondEndingIndex + secondEndingLength;
+      }
     }
   }
 
   return -1;
+}
+
+function lineEndingLength(buffer: Uint8Array, index: number): number {
+  const newline = 0x0a; // \n
+  const carriage = 0x0d; // \r
+
+  if (buffer[index] === newline) {
+    return 1;
+  }
+  if (buffer[index] === carriage) {
+    return buffer[index + 1] === newline ? 2 : 1;
+  }
+  return 0;
 }

--- a/src/internal/decoders/line.ts
+++ b/src/internal/decoders/line.ts
@@ -22,19 +22,21 @@ export class LineDecoder {
   static NEWLINE_REGEXP = /\r\n|[\n\r]/g;
 
   #buffer: Uint8Array;
-  #carriageReturnIndex: number | null;
+  #skipLeadingLF: boolean;
 
-  /** Creates a decoder with no buffered bytes or pending carriage return. */
+  /** Creates a decoder with no buffered bytes or pending newline continuation. */
   constructor() {
     this.#buffer = new Uint8Array();
-    this.#carriageReturnIndex = null;
+    this.#skipLeadingLF = false;
   }
 
   /**
    * Appends a text or UTF-8 byte chunk and returns every newly completed line.
    *
-   * Incomplete lines remain buffered for the next call. `null` and `undefined`
-   * are ignored and do not flush buffered content.
+   * Incomplete lines remain buffered for the next call. A trailing `\r`
+   * completes its line immediately, and a following `\n` is consumed as its
+   * continuation. `null` and `undefined` are ignored and do not flush buffered
+   * content.
    */
   decode(chunk: Bytes): string[] {
     if (chunk == null) {
@@ -50,36 +52,36 @@ export class LineDecoder {
       binaryChunk = chunk;
     }
 
+    if (binaryChunk.length === 0) {
+      return [];
+    }
+
+    if (this.#skipLeadingLF) {
+      this.#skipLeadingLF = false;
+      if (binaryChunk[0] === 0x0a) {
+        binaryChunk = binaryChunk.subarray(1);
+      }
+      if (binaryChunk.length === 0) {
+        return [];
+      }
+    }
+
     this.#buffer = concatBytes([this.#buffer, binaryChunk]);
 
     const lines: string[] = [];
     let patternIndex;
-    while ((patternIndex = findNewlineIndex(this.#buffer, this.#carriageReturnIndex)) != null) {
-      if (patternIndex.carriage && this.#carriageReturnIndex == null) {
-        // skip until we either get a corresponding `\n`, a new `\r` or nothing
-        this.#carriageReturnIndex = patternIndex.index;
-        continue;
-      }
-
-      // we got double \r or \rtext\n
-      if (
-        this.#carriageReturnIndex != null &&
-        (patternIndex.index !== this.#carriageReturnIndex + 1 || patternIndex.carriage)
-      ) {
-        lines.push(decodeUTF8(this.#buffer.subarray(0, this.#carriageReturnIndex - 1)));
-        this.#buffer = this.#buffer.subarray(this.#carriageReturnIndex);
-        this.#carriageReturnIndex = null;
-        continue;
-      }
-
-      const endIndex =
-        this.#carriageReturnIndex === null ? patternIndex.preceding : patternIndex.preceding - 1;
-
-      const line = decodeUTF8(this.#buffer.subarray(0, endIndex));
+    while ((patternIndex = findNewlineIndex(this.#buffer)) != null) {
+      const line = decodeUTF8(this.#buffer.subarray(0, patternIndex.preceding));
       lines.push(line);
 
       this.#buffer = this.#buffer.subarray(patternIndex.index);
-      this.#carriageReturnIndex = null;
+      if (patternIndex.carriage) {
+        if (this.#buffer[0] === 0x0a) {
+          this.#buffer = this.#buffer.subarray(1);
+        } else if (this.#buffer.length === 0) {
+          this.#skipLeadingLF = true;
+        }
+      }
     }
 
     return lines;
@@ -87,6 +89,7 @@ export class LineDecoder {
 
   /** Emits the remaining unterminated line, or returns an empty array when idle. */
   flush(): string[] {
+    this.#skipLeadingLF = false;
     if (!this.#buffer.length) {
       return [];
     }
@@ -97,21 +100,20 @@ export class LineDecoder {
 /**
  * Searches for the next CR or LF byte and returns its zero-based position,
  * the position immediately after it, and whether the byte was a carriage return.
- * Returns `null` when no newline byte exists after the requested start index.
+ * Returns `null` when the buffer contains no newline byte.
  *
  * ```ts
- * findNewlineIndex(new TextEncoder().encode('abc\ndef'), null)
+ * findNewlineIndex(new TextEncoder().encode('abc\ndef'))
  * // => { preceding: 3, index: 4, carriage: false }
  * ```
  */
 function findNewlineIndex(
   buffer: Uint8Array,
-  startIndex: number | null,
 ): { preceding: number; index: number; carriage: boolean } | null {
   const newline = 0x0a; // \n
   const carriage = 0x0d; // \r
 
-  for (let i = startIndex ?? 0; i < buffer.length; i++) {
+  for (let i = 0; i < buffer.length; i++) {
     if (buffer[i] === newline) {
       return { preceding: i, index: i + 1, carriage: false };
     }
@@ -137,12 +139,6 @@ export function findDoubleNewlineIndex(buffer: Uint8Array): number {
       const secondEndingIndex = i + firstEndingLength;
       const secondEndingLength = lineEndingLength(buffer, secondEndingIndex);
       if (secondEndingLength > 0) {
-        const secondEndingCouldBecomeCRLF =
-          buffer[secondEndingIndex] === 0x0d && secondEndingIndex === buffer.length - 1;
-        const isUnambiguousDoubleCR = buffer[i] === 0x0d && firstEndingLength === 1;
-        if (secondEndingCouldBecomeCRLF && !isUnambiguousDoubleCR) {
-          continue;
-        }
         return secondEndingIndex + secondEndingLength;
       }
     }

--- a/tests/internal/decoders/line.test.ts
+++ b/tests/internal/decoders/line.test.ts
@@ -115,6 +115,15 @@ describe('findDoubleNewlineIndex', () => {
     expect(findDoubleNewlineIndex(new TextEncoder().encode('\r\n\r\n'))).toBe(4);
   });
 
+  test.each([
+    ['\\r\\n followed by \\n', 'foo\r\n\nbar', 6],
+    ['\\n followed by \\r\\n', 'foo\n\r\nbar', 6],
+    ['\\r\\n followed by \\r', 'foo\r\n\rbar', 6],
+    ['\\r followed by \\r\\n', 'foo\r\r\nbar', 6],
+  ])('finds mixed line endings: %s', (_description, input, expected) => {
+    expect(findDoubleNewlineIndex(new TextEncoder().encode(input))).toBe(expected);
+  });
+
   test('returns -1 when no double newline found', () => {
     expect(findDoubleNewlineIndex(new TextEncoder().encode('foo\nbar'))).toBe(-1);
     expect(findDoubleNewlineIndex(new TextEncoder().encode('foo\rbar'))).toBe(-1);
@@ -124,6 +133,7 @@ describe('findDoubleNewlineIndex', () => {
 
   test('handles incomplete patterns', () => {
     expect(findDoubleNewlineIndex(new TextEncoder().encode('foo\r\n\r'))).toBe(-1);
+    expect(findDoubleNewlineIndex(new TextEncoder().encode('foo\n\r'))).toBe(-1);
     expect(findDoubleNewlineIndex(new TextEncoder().encode('foo\r\n'))).toBe(-1);
   });
 });

--- a/tests/internal/decoders/line.test.ts
+++ b/tests/internal/decoders/line.test.ts
@@ -46,6 +46,22 @@ describe('line decoder', () => {
     expect(decodeChunks(['foo\r', '\n', 'bar'], { flush: true })).toEqual(['foo', 'bar']);
   });
 
+  test('emits a trailing carriage return immediately and consumes its optional following newline', () => {
+    const decoder = new LineDecoder();
+
+    expect(decoder.decode('foo\r')).toEqual(['foo']);
+    expect(decoder.decode(null)).toEqual([]);
+    expect(decoder.decode('')).toEqual([]);
+    expect(decoder.decode('\nbar\r')).toEqual(['bar']);
+    expect(decoder.decode('\n')).toEqual([]);
+    expect(decoder.flush()).toEqual([]);
+  });
+
+  test('preserves a real empty line after a fragmented carriage-return line ending', () => {
+    expect(decodeChunks(['foo\r', '\n\n', 'bar\n'])).toEqual(['foo', '', 'bar']);
+    expect(decodeChunks(['foo\r', '\n', '\nbar\n'])).toEqual(['foo', '', 'bar']);
+  });
+
   test('single \\r', () => {
     expect(decodeChunks(['foo\r', 'bar'], { flush: true })).toEqual(['foo', 'bar']);
   });
@@ -53,8 +69,7 @@ describe('line decoder', () => {
   test('double \\r', () => {
     expect(decodeChunks(['foo\r', 'bar\r'], { flush: true })).toEqual(['foo', 'bar']);
     expect(decodeChunks(['foo\r', '\r', 'bar'], { flush: true })).toEqual(['foo', '', 'bar']);
-    // implementation detail that we don't yield the single \r line until a new \r or \n is encountered
-    expect(decodeChunks(['foo\r', '\r', 'bar'], { flush: false })).toEqual(['foo']);
+    expect(decodeChunks(['foo\r', '\r', 'bar'], { flush: false })).toEqual(['foo', '']);
   });
 
   test('double \\r then \\r\\n', () => {
@@ -116,12 +131,20 @@ describe('findDoubleNewlineIndex', () => {
   });
 
   test.each([
-    ['\\r\\n followed by \\n', 'foo\r\n\nbar', 6],
-    ['\\n followed by \\r\\n', 'foo\n\r\nbar', 6],
-    ['\\r\\n followed by \\r', 'foo\r\n\rbar', 6],
-    ['\\r followed by \\r\\n', 'foo\r\r\nbar', 6],
-  ])('finds mixed line endings: %s', (_description, input, expected) => {
-    expect(findDoubleNewlineIndex(new TextEncoder().encode(input))).toBe(expected);
+    ['\\n', '\n'],
+    ['\\r', '\r'],
+    ['\\r\\n', '\r\n'],
+  ])('finds every second line ending after %s', (_description, firstEnding) => {
+    for (const secondEnding of ['\n', '\r', '\r\n']) {
+      if (firstEnding === '\r' && secondEnding === '\n') {
+        continue;
+      }
+
+      const delimiter = firstEnding + secondEnding;
+      const input = `foo${delimiter}bar`;
+
+      expect(findDoubleNewlineIndex(new TextEncoder().encode(input))).toBe(3 + delimiter.length);
+    }
   });
 
   test('returns -1 when no double newline found', () => {
@@ -131,9 +154,13 @@ describe('findDoubleNewlineIndex', () => {
     expect(findDoubleNewlineIndex(new TextEncoder().encode(''))).toBe(-1);
   });
 
+  test('recognizes standalone carriage returns at the end of a complete delimiter', () => {
+    expect(findDoubleNewlineIndex(new TextEncoder().encode('foo\r\n\r'))).toBe(6);
+    expect(findDoubleNewlineIndex(new TextEncoder().encode('foo\n\r'))).toBe(5);
+  });
+
   test('handles incomplete patterns', () => {
-    expect(findDoubleNewlineIndex(new TextEncoder().encode('foo\r\n\r'))).toBe(-1);
-    expect(findDoubleNewlineIndex(new TextEncoder().encode('foo\n\r'))).toBe(-1);
     expect(findDoubleNewlineIndex(new TextEncoder().encode('foo\r\n'))).toBe(-1);
+    expect(findDoubleNewlineIndex(new TextEncoder().encode('foo\r\nbar'))).toBe(-1);
   });
 });

--- a/tests/lib/streaming-core.test.ts
+++ b/tests/lib/streaming-core.test.ts
@@ -308,6 +308,30 @@ describe('_iterSSEMessages', () => {
     ]);
   });
 
+  test('decodes events separated by mixed line endings', async () => {
+    let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          streamController = controller;
+        },
+      }),
+    );
+    const events = _iterSSEMessages(response, new AbortController());
+    const first = events.next();
+
+    streamController?.enqueue(encoder.encode('data: first\r\n\n'));
+    await expect(first).resolves.toMatchObject({ done: false, value: { event: null, data: 'first' } });
+
+    streamController?.enqueue(encoder.encode('data: second\n\r\n'));
+    streamController?.close();
+    await expect(events.next()).resolves.toMatchObject({
+      done: false,
+      value: { event: null, data: 'second' },
+    });
+    await expect(events.next()).resolves.toMatchObject({ done: true });
+  });
+
   test('finds consecutive events after scanning an earlier fragmented prefix', async () => {
     const response = new Response(
       ReadableStreamFrom([

--- a/tests/lib/streaming-core.test.ts
+++ b/tests/lib/streaming-core.test.ts
@@ -263,11 +263,18 @@ describe('_iterSSEMessages', () => {
     ]);
   });
 
-  test.each(['\n', '\r\n'])(
-    'decodes byte-fragmented %j separators before the stream ends',
-    async (newline) => {
-      const firstEvent = encoder.encode(`data: first${newline}${newline}`);
-      const secondEvent = encoder.encode(`data: second${newline}${newline}`);
+  test.each(
+    ['\n', '\r', '\r\n'].flatMap((firstEnding) =>
+      ['\n', '\r', '\r\n']
+        .filter((secondEnding) => firstEnding !== '\r' || secondEnding !== '\n')
+        .map((secondEnding) => [firstEnding, secondEnding]),
+    ),
+  )(
+    'decodes byte-fragmented %j + %j separators before the stream ends',
+    async (firstEnding, secondEnding) => {
+      const delimiter = firstEnding + secondEnding;
+      const firstEvent = encoder.encode(`data: first${delimiter}`);
+      const secondEvent = encoder.encode(`data: second${delimiter}`);
       let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
       const response = new Response(
         new ReadableStream<Uint8Array>({
@@ -285,15 +292,17 @@ describe('_iterSSEMessages', () => {
 
       await expect(first).resolves.toMatchObject({ done: false, value: { event: null, data: 'first' } });
 
+      const second = events.next();
       for (const byte of secondEvent) {
         streamController?.enqueue(Uint8Array.of(byte));
       }
-      streamController?.close();
 
-      await expect(events.next()).resolves.toMatchObject({
+      await expect(second).resolves.toMatchObject({
         done: false,
         value: { event: null, data: 'second' },
       });
+
+      streamController?.close();
       await expect(events.next()).resolves.toMatchObject({ done: true });
     },
   );
@@ -308,7 +317,7 @@ describe('_iterSSEMessages', () => {
     ]);
   });
 
-  test('decodes events separated by mixed line endings', async () => {
+  test('delivers LF followed by CRLF before the stream closes', async () => {
     let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
     const response = new Response(
       new ReadableStream<Uint8Array>({
@@ -320,16 +329,58 @@ describe('_iterSSEMessages', () => {
     const events = _iterSSEMessages(response, new AbortController());
     const first = events.next();
 
-    streamController?.enqueue(encoder.encode('data: first\r\n\n'));
+    streamController?.enqueue(encoder.encode('data: first\n\r\n'));
     await expect(first).resolves.toMatchObject({ done: false, value: { event: null, data: 'first' } });
 
-    streamController?.enqueue(encoder.encode('data: second\n\r\n'));
-    streamController?.close();
-    await expect(events.next()).resolves.toMatchObject({
+    const second = events.next();
+    streamController?.enqueue(encoder.encode('data: second\r\n\n'));
+    await expect(second).resolves.toMatchObject({
       done: false,
       value: { event: null, data: 'second' },
     });
+
+    streamController?.close();
     await expect(events.next()).resolves.toMatchObject({ done: true });
+  });
+
+  test('does not emit a phantom event when CRLF is split after an immediate CR delimiter', async () => {
+    let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          streamController = controller;
+        },
+      }),
+    );
+    const events = _iterSSEMessages(response, new AbortController());
+    const first = events.next();
+
+    streamController?.enqueue(encoder.encode('data: first\r\r'));
+    await expect(first).resolves.toMatchObject({ done: false, value: { event: null, data: 'first' } });
+
+    const second = events.next();
+    streamController?.enqueue(encoder.encode('\ndata: second\r\r'));
+    await expect(second).resolves.toMatchObject({
+      done: false,
+      value: { event: null, data: 'second' },
+    });
+
+    streamController?.enqueue(encoder.encode('\n'));
+    streamController?.close();
+    await expect(events.next()).resolves.toMatchObject({ done: true });
+  });
+
+  test.each([
+    ['\r', '\n', '\r'],
+    ['\r\n', '\r', '\r\n'],
+    ['\n', '\r\n', '\r'],
+  ])('preserves byte-fragmented multiline data with %j, %j, and %j endings', async (first, second, third) => {
+    const bytes = encoder.encode(`data: first${first}data: second${second}${third}`);
+    const response = new Response(ReadableStreamFrom(Array.from(bytes, (byte) => Uint8Array.of(byte))));
+
+    await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toMatchObject([
+      { event: null, data: 'first\nsecond' },
+    ]);
   });
 
   test('finds consecutive events after scanning an earlier fragmented prefix', async () => {
@@ -385,5 +436,25 @@ describe('_iterSSEMessages', () => {
     const response = responseForSSE('data: {"flushed":true}\n');
 
     await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toEqual([]);
+  });
+
+  test('ignores an SSE message that ends with only a single carriage return', async () => {
+    const response = responseForSSE('data: {"flushed":true}\r');
+
+    await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toEqual([]);
+  });
+
+  test('ignores an SSE message that ends with only a single CRLF line ending', async () => {
+    const response = responseForSSE('data: {"flushed":true}\r\n');
+
+    await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toEqual([]);
+  });
+
+  test('emits exactly one SSE message that ends with two carriage returns', async () => {
+    const response = responseForSSE('data: {"flushed":true}\r\r');
+
+    await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toMatchObject([
+      { event: null, data: '{"flushed":true}' },
+    ]);
   });
 });


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->

- [x] I understand that most of this repository is generated and my pull request may not be merged as-is

## Changes being requested

Recognize SSE event delimiters formed by consecutive `LF`, standalone `CR`, or `CRLF` line endings, including valid mixed combinations. A `CR` immediately followed by `LF` is one `CRLF` line ending, not two.

The incremental line decoder now emits `CR`-terminated lines immediately and remembers whether to consume one optional following `LF`. This preserves prompt event delivery when transport chunks split `CRLF`, avoids phantom blank lines, and keeps the existing optimized SSE scan window unchanged.

This changes only the handwritten streaming decoder and its focused regression coverage.

## Why

`LineDecoder` already recognized all three SSE line-ending forms, but `findDoubleNewlineIndex()` recognized only `LF+LF`, `CR+CR`, and `CRLF+CRLF`. A valid mixed-ending stream such as `data: first\n\r\n` could therefore remain buffered on an open connection until another recognized delimiter or EOF.

Standalone-`CR` event delimiters could also be delayed because the decoder previously waited for another byte before emitting the completed line. Emitting immediately and suppressing a following optional `LF` fixes both standalone-`CR` and fragmented mixed-ending delivery.

## Verification

- Focused decoder and streaming checks: 65 tests passed, including all eight distinguishable valid delimiter combinations fragmented into individual bytes.
- `pnpm test:unit`: 66 files and 1,774 tests passed after updating the branch with the latest `main`.
- `pnpm lint` passed.
- `pnpm exec tsc --noEmit --pretty false` passed.
- `pnpm build` passed for CommonJS and ESM, including package import smoke checks.
- Regression coverage includes open-stream delivery, split `CRLF`, phantom-event prevention, mixed multiline events, and incomplete versus complete records at EOF.

Vitest can rewrite unrelated legacy Jest snapshot headers locally; those mechanical changes are not included in this PR.