### PR TITLE
test: run pnpm scripts through Bash on Windows

### DIFF
--- a/tests/oxlint-config.test.ts
+++ b/tests/oxlint-config.test.ts
@@ -7,6 +7,14 @@ const repoRoot = process.cwd();
 const oxlint = path.join(repoRoot, 'node_modules/oxlint/bin/oxlint');
 const oxfmt = path.join(repoRoot, 'node_modules/oxfmt/bin/oxfmt');
 
+function spawnPnpmScript(script: 'format' | 'lint') {
+  const command = process.platform === 'win32' ? 'bash' : 'pnpm';
+  const args =
+    process.platform === 'win32' ? ['-c', 'pnpm --config.script-shell=bash "$@"', '_', script] : [script];
+
+  return spawnSync(command, args, { cwd: repoRoot, encoding: 'utf-8' });
+}
+
 test('inherits Ultracite native plugins and enforces their rules', () => {
   const printed = spawnSync(process.execPath, [oxlint, '--print-config', 'src/internal/uploads.ts'], {
     cwd: repoRoot,
@@ -325,19 +333,19 @@ test('checks and fixes generated imports through the public package commands', (
       ].join('\n'),
     );
 
-    const rejected = spawnSync('pnpm', ['lint'], { cwd: repoRoot, encoding: 'utf-8' });
+    const rejected = spawnPnpmScript('lint');
 
     expect(rejected.status).toBe(1);
     expect(`${rejected.stdout}${rejected.stderr}`).toContain(
       "Identifier 'Unused' is imported but never used.",
     );
 
-    const fixed = spawnSync('pnpm', ['format'], { cwd: repoRoot, encoding: 'utf-8' });
+    const fixed = spawnPnpmScript('format');
 
     expect(fixed.status).toBe(0);
     expect(readFileSync(generatedPath, 'utf-8')).not.toContain('Unused');
 
-    const accepted = spawnSync('pnpm', ['lint'], { cwd: repoRoot, encoding: 'utf-8' });
+    const accepted = spawnPnpmScript('lint');
 
     expect(accepted.status).toBe(0);
   } finally {


### PR DESCRIPTION
## Problem

The handwritten unit suite fails on Windows in `tests/oxlint-config.test.ts`. The public package-command regression test launches `pnpm lint` and `pnpm format` directly with `spawnSync('pnpm', ...)`, which returns `status: null` / `ENOENT` instead of exercising the commands.

## Root cause

On Windows, Node does not execute the extensionless pnpm shell shim the same way as POSIX. Invoking pnpm through `cmd.exe` is also insufficient because this repository's package scripts call POSIX entrypoints such as `./scripts/lint`.

## Fix

Add a small test-only `spawnPnpmScript()` helper:

- keep the existing direct `pnpm <script>` invocation on non-Windows platforms
- invoke pnpm through Bash on Windows
- set pnpm's `script-shell` to Bash so the repository's POSIX package scripts run correctly
- keep the script name positional and quoted

The test still verifies the full public-command lifecycle: lint rejects the generated fixture, format fixes it, and lint then accepts it.

## Tests

Validated on Windows with Node 24.19.0 and pnpm 11.5.1:

- baseline `CI=1 pnpm test:unit` — 1,726 passed / 1 failed with `spawnSync pnpm ENOENT`
- `pnpm exec vitest run --config vitest.config.mts tests/oxlint-config.test.ts` — 9/9 passed
- `CI=1 pnpm test:unit` — 66 files, 1,727 tests passed
- `pnpm exec oxfmt --check tests/oxlint-config.test.ts`
- `pnpm exec ultracite check tests/oxlint-config.test.ts`
- `bash ./scripts/lint` — passed after normalizing the Windows checkout's line endings
- `pnpm exec tsc --pretty false`
- `bash ./scripts/build`
- `git diff --check`

## Compatibility / Risk

Test-only change. SDK runtime code, generated files, public exports, and package behavior are unchanged. Non-Windows execution retains the existing direct pnpm invocation.