### PR TITLE
fix: avoid TypeError in toFile for Responses without a URL

### DIFF
--- a/src/internal/to-file.ts
+++ b/src/internal/to-file.ts
@@ -148,7 +148,7 @@ export async function toFile(
 
   if (isResponseLike(value)) {
     const blob = await value.blob();
-    name ||= new URL(value.url).pathname.split(/[\\/]/).pop();
+    name ||= getName(value);
 
     const responseOptions =
       options?.type === undefined && blob.type ? { ...options, type: blob.type } : options;

--- a/tests/uploads.test.ts
+++ b/tests/uploads.test.ts
@@ -63,6 +63,18 @@ describe('toFile', () => {
     expect(file.name).toEqual('audio.mp3');
   });
 
+  it('falls back to unknown_file when a Response has no URL', async () => {
+    const file = await toFile(new Response('audio contents'));
+    expect(file.name).toEqual('unknown_file');
+    await expect(file.text()).resolves.toEqual('audio contents');
+  });
+
+  it('falls back to unknown_file when a Response URL has no path segment', async () => {
+    const response = mockResponse({ url: 'https://example.com/' });
+    const file = await toFile(response);
+    expect(file.name).toEqual('unknown_file');
+  });
+
   it('infers the MIME type from a Response body', async () => {
     const response = mockResponse({
       url: 'https://example.com/my/audio.mp3',


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

`toFile()` infers a filename for a `ResponseLike` input by calling `new URL(value.url)` directly, so `await toFile(new Response('contents'))` rejects with `TypeError: Invalid URL` - a `Response` that was constructed rather than returned by `fetch` has `url === ''`. A URL with no path segment, such as `https://example.com/`, yields a `File` named `''` instead. Both contradict the fallback to `unknown_file` that `toFile()` documents.

`getName()` in `src/internal/uploads.ts` already does this inference safely, `url` case included; `toFile()` imports it for its byte and stream path, and `createForm()` uses it for `Response` values. This swaps the inline parsing for that shared helper so those paths agree, and adds coverage for both cases.

## Additional context & links

- `npx vitest run --config vitest.config.mts tests/uploads.test.ts` -> 38 passed; both added cases fail on `main`.
- `npx tsc --noEmit` and `ultracite check` pass.