### PR TITLE
fix: prevent prototype event names from crashing SDK streams

### DIFF
--- a/src/core/EventEmitter.ts
+++ b/src/core/EventEmitter.ts
@@ -16,7 +16,7 @@ export type EventParameters<Events, EventType extends keyof Events> = Record<
 export class EventEmitter<EventTypes extends Record<string, (...args: any) => any>> {
   #listeners: {
     [Event in keyof EventTypes]?: EventListeners<EventTypes, Event>;
-  } = {};
+  } = Object.create(null);
 
   /**
    * Adds the listener function to the end of the listeners array for the event.

--- a/src/lib/EventEmitter.ts
+++ b/src/lib/EventEmitter.ts
@@ -16,7 +16,7 @@ export type EventParameters<Events, EventType extends keyof Events> = Record<
 export class EventEmitter<EventTypes extends Record<string, (...args: any) => any>> {
   #listeners: {
     [Event in keyof EventTypes]?: EventListeners<EventTypes, Event>;
-  } = {};
+  } = Object.create(null);
 
   /**
    * Adds the listener function to the end of the listeners array for the event.

--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -17,7 +17,7 @@ export class EventStream<EventTypes extends BaseEvents> {
 
   #listeners: {
     [Event in keyof EventTypes]?: EventListeners<EventTypes, Event>;
-  } = {};
+  } = Object.create(null);
   #abortListeners: { signal: AbortSignal; listener: () => void }[] = [];
 
   #ended = false;

--- a/tests/lib/EventStream.test.ts
+++ b/tests/lib/EventStream.test.ts
@@ -12,6 +12,10 @@ class TestStream extends EventStream<TestEvents> {
     this._emit('foo', value, index);
   }
 
+  emitNamed(event: string, value: string, index: number) {
+    this._emit(event as 'foo', value, index);
+  }
+
   emitError(error: OpenAIError) {
     this._emit('error', error);
   }
@@ -24,6 +28,40 @@ class TestStream extends EventStream<TestEvents> {
     this._emit('end');
   }
 }
+
+describe('EventStream listeners', () => {
+  test.each(['__proto__', 'constructor', 'toString', 'hasOwnProperty', 'valueOf'])(
+    'safely emits unobserved Object.prototype event %s',
+    (eventName) => {
+      const stream = new TestStream();
+      const event = eventName as 'foo';
+
+      expect(() => stream.off(event, vi.fn())).not.toThrow();
+      expect(() => stream.emitNamed(event, 'ignored', 0)).not.toThrow();
+    },
+  );
+
+  test.each(['__proto__', 'constructor', 'toString', 'hasOwnProperty', 'valueOf'])(
+    'supports regular and one-time Object.prototype event listeners for %s',
+    (eventName) => {
+      const stream = new TestStream();
+      const event = eventName as 'foo';
+      const repeated = vi.fn();
+      const once = vi.fn();
+
+      stream.on(event, repeated);
+      stream.once(event, once);
+      stream.emitNamed(event, 'first', 1);
+      stream.emitNamed(event, 'second', 2);
+      stream.off(event, repeated);
+      stream.emitNamed(event, 'ignored', 3);
+
+      expect(repeated).toHaveBeenCalledTimes(2);
+      expect(once).toHaveBeenCalledTimes(1);
+      expect(once).toHaveBeenCalledWith('first', 1);
+    },
+  );
+});
 
 describe('EventStream.emitted', () => {
   test('resolves all arguments from a multi-argument event as a tuple', async () => {

--- a/tests/lib/core-event-emitter.test.ts
+++ b/tests/lib/core-event-emitter.test.ts
@@ -13,6 +13,10 @@ class TestEmitter extends EventEmitter<Events> {
     this._emit('message', value);
   }
 
+  emitNamed(event: string, value: string) {
+    this._emit(event as 'message', value);
+  }
+
   emitEmpty() {
     this._emit('empty');
   }
@@ -32,9 +36,49 @@ class TestEmitter extends EventEmitter<Events> {
   hasErrorListener() {
     return this._hasListener('error');
   }
+
+  hasListener(event: string) {
+    return this._hasListener(event as keyof Events);
+  }
 }
 
 describe('core EventEmitter', () => {
+  test.each(['__proto__', 'constructor', 'toString', 'hasOwnProperty', 'valueOf'])(
+    'safely emits unobserved Object.prototype event %s',
+    (eventName) => {
+      const emitter = new TestEmitter();
+      const event = eventName as keyof Events;
+
+      expect(emitter.hasListener(event)).toBeFalsy();
+      expect(() => emitter.off(event, vi.fn())).not.toThrow();
+      expect(() => emitter.emitNamed(event, 'ignored')).not.toThrow();
+    },
+  );
+
+  test.each(['__proto__', 'constructor', 'toString', 'hasOwnProperty', 'valueOf'])(
+    'supports regular and one-time Object.prototype event listeners for %s',
+    (eventName) => {
+      const emitter = new TestEmitter();
+      const event = eventName as 'message';
+      const repeated = vi.fn();
+      const once = vi.fn();
+
+      emitter.on(event, repeated);
+      emitter.once(event, once);
+      expect(emitter.hasListener(event)).toBe(true);
+
+      emitter.emitNamed(event, 'first');
+      emitter.emitNamed(event, 'second');
+      emitter.off(event, repeated);
+      emitter.emitNamed(event, 'ignored');
+
+      expect(repeated).toHaveBeenCalledTimes(2);
+      expect(once).toHaveBeenCalledTimes(1);
+      expect(once).toHaveBeenCalledWith('first');
+      expect(emitter.hasListener(event)).toBe(false);
+    },
+  );
+
   test('invokes listeners in registration order, including repeated listeners', () => {
     const emitter = new TestEmitter();
     const values: string[] = [];

--- a/tests/lib/eventEmitter.test.ts
+++ b/tests/lib/eventEmitter.test.ts
@@ -11,6 +11,9 @@ class TestEmitter extends EventEmitter<TestEvents> {
   emitFoo(value: string) {
     this._emit('foo', value);
   }
+  emitNamed(event: string, value: string) {
+    this._emit(event as 'foo', value);
+  }
   emitError(err: Error) {
     this._emit('error', err);
   }
@@ -60,6 +63,42 @@ describe('EventEmitter.emitted', () => {
 });
 
 describe('EventEmitter listeners', () => {
+  test.each(['__proto__', 'constructor', 'toString', 'hasOwnProperty', 'valueOf'])(
+    'safely emits unobserved Object.prototype event %s',
+    (eventName) => {
+      const emitter = new TestEmitter();
+      const event = eventName as keyof TestEvents;
+
+      expect(emitter.hasListener(event)).toBeFalsy();
+      expect(() => emitter.off(event, vi.fn())).not.toThrow();
+      expect(() => emitter.emitNamed(event, 'ignored')).not.toThrow();
+    },
+  );
+
+  test.each(['__proto__', 'constructor', 'toString', 'hasOwnProperty', 'valueOf'])(
+    'supports regular and one-time Object.prototype event listeners for %s',
+    (eventName) => {
+      const emitter = new TestEmitter();
+      const event = eventName as 'foo';
+      const repeated = vi.fn();
+      const once = vi.fn();
+
+      emitter.on(event, repeated);
+      emitter.once(event, once);
+      expect(emitter.hasListener(event)).toBe(true);
+
+      emitter.emitNamed(event, 'first');
+      emitter.emitNamed(event, 'second');
+      emitter.off(event, repeated);
+      emitter.emitNamed(event, 'ignored');
+
+      expect(repeated).toHaveBeenCalledTimes(2);
+      expect(once).toHaveBeenCalledTimes(1);
+      expect(once).toHaveBeenCalledWith('first');
+      expect(emitter.hasListener(event)).toBe(false);
+    },
+  );
+
   test('invokes repeated listeners in registration order', () => {
     const emitter = new TestEmitter();
     const values: string[] = [];

--- a/tests/lib/responsesWebSocket.test.ts
+++ b/tests/lib/responsesWebSocket.test.ts
@@ -183,6 +183,19 @@ describe.each(variants)('%s Responses WebSocket', (_version, Base, WebSocketErro
     ]);
   });
 
+  test.each(['__proto__', 'constructor', 'toString', 'hasOwnProperty', 'valueOf'])(
+    'dispatches Object.prototype event type %s without crashing',
+    (eventType) => {
+      const websocket = createWebSocket();
+      const events = vi.fn();
+      const event = { type: eventType };
+      websocket.on('event', events);
+
+      expect(() => websocket.socket.emit('message', JSON.stringify(event), false)).not.toThrow();
+      expect(events).toHaveBeenCalledWith(event);
+    },
+  );
+
   test.each([
     [ReadyState.CONNECTING, 'connecting'],
     [ReadyState.OPEN, 'open'],

--- a/tests/realtime-websocket.test.ts
+++ b/tests/realtime-websocket.test.ts
@@ -195,6 +195,19 @@ describe.each([
     expect(errors).toHaveBeenCalledTimes(3);
   });
 
+  test.each(['__proto__', 'constructor', 'toString', 'hasOwnProperty', 'valueOf'])(
+    'dispatches Object.prototype event type %s without crashing',
+    (eventType) => {
+      const realtime = new Realtime({ model: 'gpt-realtime' }, createClient());
+      const events = vi.fn();
+      const event = { type: eventType };
+      onRealtimeEvent(realtime, 'event', events);
+
+      expect(() => lastBrowserSocket().dispatch('message', { data: JSON.stringify(event) })).not.toThrow();
+      expect(events).toHaveBeenCalledWith(event);
+    },
+  );
+
   test('serializes outgoing events and closes with defaults and custom options', () => {
     const realtime = new Realtime({ model: 'gpt-realtime' }, createClient());
     const socket = lastBrowserSocket();
@@ -391,6 +404,19 @@ describe.each([
     socket.dispatch('error', new Error('socket failed'));
     expect(errors).toHaveBeenCalledTimes(3);
   });
+
+  test.each(['__proto__', 'constructor', 'toString', 'hasOwnProperty', 'valueOf'])(
+    'dispatches Object.prototype event type %s without crashing',
+    (eventType) => {
+      const realtime = new Realtime({ model: 'gpt-realtime' }, createClient());
+      const events = vi.fn();
+      const event = { type: eventType };
+      onRealtimeEvent(realtime, 'event', events);
+
+      expect(() => lastNodeSocket().dispatch('message', JSON.stringify(event))).not.toThrow();
+      expect(events).toHaveBeenCalledWith(event);
+    },
+  );
 
   test('sends JSON events and closes with default and custom settings', () => {
     const realtime = new Realtime({ model: 'gpt-realtime' }, createClient());


### PR DESCRIPTION
## Summary

Harden all three hand-written SDK event-listener registries against `Object.prototype` event-name collisions. Incoming WebSocket messages control their `type`, so a message such as `{"type":"__proto__"}` previously escaped its transport callback with an uncaught exception.

## Impact

A server, reverse proxy, or other upstream WebSocket peer could trigger `TypeError: listeners.filter is not a function` with otherwise valid JSON. The exception bypassed SDK error listeners and could terminate a Node.js process or break a browser connection.

Affected paths include:

- stable and beta Realtime connections using both native/browser WebSockets and Node.js `ws`;
- stable and beta Responses WebSocket connections;
- direct listener registration, removal, and event dispatch on the SDK's hand-written `EventStream` and emitter helpers.

## Root cause

The core emitter, Realtime emitter, and event-stream helper initialized their listener dictionaries with `{}`. Looking up untrusted event names such as `__proto__`, `constructor`, `toString`, `hasOwnProperty`, and `valueOf` returned inherited objects or functions instead of listener arrays. Subsequent `.filter()`, `.push()`, or `.findIndex()` calls then threw; inherited functions could also make `_hasListener()` incorrectly return `true`.

## Solution

Initialize each of the three listener dictionaries with `Object.create(null)`. This preserves the existing mapped TypeScript event types and event/listener semantics while making all event names ordinary own keys. Unknown prototype-named messages continue to reach generic `event` listeners without crashing, and explicitly registered prototype-named listeners now support `on`, `once`, `off`, and normal dispatch.

Changes are limited to three hand-written emitter implementations and their existing hand-written tests. No generated SDK resources or generated tests are modified.

## Regression coverage

- Add table-driven unit coverage for all five inherited names across the core emitter, Realtime emitter, and event-stream helper.
- Verify unobserved dispatch, safe removal, listener detection, persistent registration, one-time registration, and listener removal.
- Replay malicious JSON messages through stable and beta browser/Node Realtime transports and stable/beta Responses WebSockets.
- Confirmed the new regressions produced **60 failures before the fix** and pass after the three-line production change.

## Validation

- `pnpm test:unit` — **66 files, 1,834 tests passed**.
- `pnpm exec vitest run --config vitest.config.mts tests/lib/core-event-emitter.test.ts tests/lib/eventEmitter.test.ts tests/lib/EventStream.test.ts tests/realtime-websocket.test.ts tests/lib/responsesWebSocket.test.ts --reporter=dot` — **5 files, 204 tests passed**.
- `pnpm lint` — passed.
- `pnpm exec tsc --noEmit` — passed.
- `git diff --check` — passed.
- Repository generated-file classifier — **8 changed hand-written files; 0 generated files**.

An isolated git worktree reused the existing dependency installation; pnpm commands were run with `pnpm_config_verify_deps_before_run=false` to account for the worktree's distinct workspace path.