### PR TITLE
fix(security): prevent process-wide prototype pollution via assistant stream snapshot IDs

### DIFF
--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -101,8 +101,8 @@ export class AssistantStream
 
   //Used to accumulate deltas
   //We are accumulating many types so the value here is not strict
-  #runStepSnapshots: Record<string, Runs.RunStep> = {};
-  #messageSnapshots: Record<string, Message> = {};
+  #runStepSnapshots: Record<string, Runs.RunStep> = Object.create(null);
+  #messageSnapshots: Record<string, Message> = Object.create(null);
   #messageSnapshot: Message | undefined;
   #finalRun: Run | undefined;
   #currentContentIndex: number | undefined;

--- a/tests/lib/AssistantStream.test.ts
+++ b/tests/lib/AssistantStream.test.ts
@@ -281,6 +281,17 @@ describe('AssistantStream snapshots and message lifecycle', () => {
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith(finalRun.data);
   });
+
+  test.each(['__proto__', 'constructor', 'toString'])(
+    'retains legitimate message snapshots with the reserved %s ID',
+    async (id) => {
+      const message = { id, role: 'assistant', content: [] };
+      const runner = assistantStream([{ event: 'thread.message.created', data: message }, completedRun()]);
+
+      await expect(runner.finalMessages()).resolves.toEqual([message]);
+    },
+  );
+
   test('accumulates message content and exposes current and final snapshots', async () => {
     const initialMessage = { id: 'msg_123', role: 'assistant', status: 'in_progress', content: [] };
     const finalMessage = {
@@ -521,6 +532,59 @@ describe('AssistantStream run-step lifecycle', () => {
 
     await expect(runner.done()).rejects.toThrow('Received a RunStepDelta before creation of a snapshot');
   });
+
+  test('rejects inherited run-step snapshot IDs without polluting object prototypes', async () => {
+    const pollutionKey = '__assistantStreamSnapshotPollutionRegression_019ffd14__';
+
+    try {
+      const runner = assistantStream([
+        {
+          event: 'thread.run.step.delta',
+          data: { id: '__proto__', delta: { [pollutionKey]: 'attacker-controlled' } },
+        },
+        completedRun(),
+      ]);
+
+      await expect(runner.done()).rejects.toThrow('Received a RunStepDelta before creation of a snapshot');
+      expect(Object.getOwnPropertyDescriptor(Object.prototype, pollutionKey)).toBeUndefined();
+      expect(({} as Record<string, unknown>)[pollutionKey]).toBeUndefined();
+      expect(([] as unknown as Record<string, unknown>)[pollutionKey]).toBeUndefined();
+    } finally {
+      Reflect.deleteProperty(Object.prototype, pollutionKey);
+    }
+  });
+
+  test.each(['__proto__', 'constructor', 'toString'])(
+    'rejects a run-step delta received before the reserved %s ID has a snapshot',
+    async (id) => {
+      const runner = assistantStream([
+        { event: 'thread.run.step.delta', data: { id, delta: {} } },
+        completedRun(),
+      ]);
+
+      await expect(runner.done()).rejects.toThrow('Received a RunStepDelta before creation of a snapshot');
+    },
+  );
+
+  test.each(['__proto__', 'constructor', 'toString'])(
+    'retains legitimate run-step snapshots and deltas with the reserved %s ID',
+    async (id) => {
+      const initialStep = {
+        id,
+        status: 'in_progress',
+        step_details: { type: 'message_creation', message_creation: {} },
+      };
+      const finalStep = { ...initialStep, status: 'completed', metadata: { marker: 'received' } };
+      const runner = assistantStream([
+        { event: 'thread.run.step.created', data: initialStep },
+        { event: 'thread.run.step.delta', data: { id, delta: { metadata: { marker: 'received' } } } },
+        { event: 'thread.run.step.completed', data: finalStep },
+        completedRun(),
+      ]);
+
+      await expect(runner.finalRunSteps()).resolves.toEqual([finalStep]);
+    },
+  );
 
   test('finishes an active tool call when the run ends before its step does', async () => {
     const runner = assistantStream([


### PR DESCRIPTION
## Severity

**High — remotely triggerable, process-wide JavaScript prototype pollution.**

Assistant streaming events contain server-controlled message and run-step identifiers. A malicious run-step delta received before its matching creation event can write attacker-controlled properties directly onto the global `Object.prototype`, making those properties visible on fresh objects and arrays throughout the Node.js process. Downstream authorization, configuration, data-integrity, or application-integrity impact depends on how consuming application code interprets inherited properties.

## Root cause and relation to #2280

PR #2280 prevented prototype pollution through unsafe **delta property names** by rejecting `__proto__`, `constructor`, and `prototype` during delta accumulation. However, `AssistantStream` still initialized both snapshot registries as ordinary `{}` objects and indexed the run-step registry with the server-controlled `event.data.id` before validating that a real snapshot exists.

When the first run-step event is a delta whose identifier is `__proto__`, this lookup returns the inherited global prototype instead of `undefined`:

```ts
const snapshot = this.#runStepSnapshots[event.data.id];
```

The missing-snapshot guard is therefore bypassed, and `AssistantStream.accumulateDelta(Object.prototype, delta)` accepts any otherwise ordinary delta property and assigns it to `Object.prototype`. The delta-key checks from #2280 never see an unsafe delta key, so they do not stop this distinct attack path.

## Attack event

```ts
{
  event: 'thread.run.step.delta',
  data: {
    id: '__proto__',
    delta: { polluted: 'attacker-controlled' },
  },
}
```

Before this fix, processing that event without a preceding `thread.run.step.created` incorrectly succeeds, and both `({}).polluted` and `[].polluted` resolve to `'attacker-controlled'` across the entire process.

## Narrow fix

- Initialize both handwritten run-step and message snapshot registries with `Object.create(null)`.
- Preserve existing public APIs, missing-snapshot errors, snapshot enumeration, delta accumulation, and normal identifier behavior.
- Treat `__proto__`, `constructor`, and `toString` as valid identifiers once their actual snapshots are created, while rejecting deltas for those identifiers when no owned snapshot exists.
- Leave generated Stainless/Castiron files, emitter implementations, and the independent emitter-collision PR #2315 untouched.

## Regression evidence

The new end-to-end malicious streaming-event regression was added and executed against unmodified upstream `main` before the production change. It failed with:

```text
AssertionError: promise resolved "undefined" instead of rejecting
```

The regression uses a unique test-only property and removes exactly that property from `Object.prototype` in `finally`, so even the vulnerable baseline leaves the test process clean. After the fix it verifies the original missing-snapshot rejection, absence of the injected own prototype property, and unpolluted fresh objects and arrays.

Additional parameterized coverage verifies `__proto__`, `constructor`, and `toString` are rejected as missing run-step snapshots but retained correctly when used as legitimate message and run-step identifiers, including run-step delta accumulation and `finalMessages()` / `finalRunSteps()`.

## Verification

```sh
./scripts/test tests/lib/AssistantStream.test.ts
./scripts/lint
COREPACK_HOME=/tmp/openai-node-corepack-019ffd14 pnpm_config_verify_deps_before_run=false pnpm exec tsc --noEmit --pretty false
./scripts/build
./node_modules/typescript-4-9/bin/tsc --project dist/src/tsconfig.json --noEmit
./node_modules/typescript/bin/tsc --project dist/src/tsconfig.json --noEmit
git diff --check
```

Focused result: **66 passing AssistantStream tests**. Repository lint, full repository TypeScript checking, production build, and published-source type checks on TypeScript 4.9 and 6 all pass.