### PR TITLE
docs(api): describe response stream event unions

### DIFF
--- a/.castiron.stats.yml
+++ b/.castiron.stats.yml
@@ -1,6 +1,6 @@
 schema_version: 1
-generation_id: 53692a18-b1ce-4ee1-aed3-cc5564f8e806
-openapi_spec_hash: 15849b9fe3deb3c72da0825905cc0ad9
-openapi_transformed_spec_hash: 9a60ddf3a1c752e15eb43fce666d6da8
+generation_id: dcd7b54a-1820-4d81-b34b-8f4440961311
+openapi_spec_hash: 143aa2ed6323d61a1834c74044e29d30
+openapi_transformed_spec_hash: 5af6fa4fd590fcc79ba2fdd69b9f7b82
 config_hash: fcda4ecfe265daddba6fad25a8504a3f
-codegen_sha: a7719d1598f522dc0b976b03514d458022cd2b1d
+codegen_sha: da9cffd8927d38c84c4c1be72b901d97b32f22d4

--- a/api_reference/openapi.transformed.yml
+++ b/api_reference/openapi.transformed.yml
@@ -54296,6 +54296,7 @@ components:
             "sequence_number": 1
           }
     ResponseStreamEvent:
+      description: Event emitted while a response is streamed.
       anyOf:
       - $ref: '#/components/schemas/ResponseAudioDeltaEvent'
       - $ref: '#/components/schemas/ResponseAudioDoneEvent'
@@ -77148,6 +77149,7 @@ components:
               when the originating `response.create` event supplied a
               `stream_id`.
     BetaResponseStreamEvent:
+      description: Event emitted while a response is streamed.
       anyOf:
       - $ref: '#/components/schemas/BetaResponseAudioDeltaEvent'
       - $ref: '#/components/schemas/BetaResponseAudioDoneEvent'

--- a/src/resources/beta/responses/responses.ts
+++ b/src/resources/beta/responses/responses.ts
@@ -9558,7 +9558,7 @@ export type BetaResponseStatus =
   | 'incomplete';
 
 /**
- * Emitted when there is a partial audio response.
+ * Event emitted while a response is streamed.
  */
 export type BetaResponseStreamEvent =
   | BetaResponseAudioDeltaEvent

--- a/src/resources/responses/responses.ts
+++ b/src/resources/responses/responses.ts
@@ -6895,7 +6895,7 @@ export interface ResponseRefusalDoneEvent {
 export type ResponseStatus = 'completed' | 'failed' | 'in_progress' | 'cancelled' | 'queued' | 'incomplete';
 
 /**
- * Emitted when there is a partial audio response.
+ * Event emitted while a response is streamed.
  */
 export type ResponseStreamEvent =
   | ResponseAudioDeltaEvent


### PR DESCRIPTION
## Summary
- Accurately describe stable and beta Responses streaming event unions.
- Refresh the generated OpenAPI reference using real, recoverable Castiron dry-run checkpoint provenance.
- Source: https://github.com/openai/openai/pull/1277036
- OpenAPI commit: bc61c5299f7f6fdd6061ccad0ac7e4ec0f659098

## Validation
- Focused generated-source oxlint and oxfmt checks pass; existing handwritten fixes are preserved.
- git diff --check and transformed-reference MD5 verified; no internal PR created.