### PR TITLE
fix(auth): reject redirects during workload identity token exchange

### DIFF
--- a/src/auth/workload-identity-auth.ts
+++ b/src/auth/workload-identity-auth.ts
@@ -102,6 +102,7 @@ export class WorkloadIdentityAuth {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(body),
+      redirect: 'manual',
     });
 
     if (!response.ok) {

--- a/tests/auth/workload-identity-auth.test.ts
+++ b/tests/auth/workload-identity-auth.test.ts
@@ -1,10 +1,36 @@
-import { vi } from 'vitest';
+import { once } from 'node:events';
+import { createServer } from 'node:http';
+import type { Server } from 'node:http';
+import { expect, vi } from 'vitest';
 
 import { WorkloadIdentityAuth } from 'openai/auth/workload-identity-auth';
-import { OAuthError, OpenAIError } from 'openai';
+import { APIError, OAuthError, OpenAIError } from 'openai';
 import type { WorkloadIdentity } from 'openai/auth/types';
 
 const originalFetch = global.fetch;
+
+async function listenLoopback(server: Server): Promise<string> {
+  const listening = once(server, 'listening');
+  server.listen(0, '127.0.0.1');
+  await listening;
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected a loopback TCP server address');
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function closeLoopback(server: Server): Promise<void> {
+  if (!server.listening) {
+    return;
+  }
+
+  const closed = once(server, 'close');
+  server.close();
+  server.closeAllConnections();
+  await closed;
+}
 
 function tokenExchangeResponse(accessToken: string, expiresIn: number): Response {
   return Response.json({
@@ -232,6 +258,54 @@ describe('WorkloadIdentityAuth', () => {
     expect(body.identity_provider_id).toBe('test-identity-provider-id');
     expect(body.service_account_id).toBe('test-service-account-id');
   });
+
+  test.each([307, 308])(
+    'does not expose workload credentials through an HTTP %i redirect',
+    async (status) => {
+      const attackerRequests: string[] = [];
+      const attacker = createServer((request, response) => {
+        let body = '';
+        request.setEncoding('utf-8');
+        request.on('data', (chunk: string) => {
+          body += chunk;
+        });
+        request.on('end', () => {
+          attackerRequests.push(body);
+          response.writeHead(200, { 'Content-Type': 'application/json' });
+          response.end(JSON.stringify({ access_token: 'attacker-token', expires_in: 3600 }));
+        });
+      });
+      let attackerUrl = '';
+      const tokenEndpoint = createServer((_request, response) => {
+        response.writeHead(status, { Location: `${attackerUrl}/stolen-credentials` });
+        response.end();
+      });
+
+      try {
+        attackerUrl = await listenLoopback(attacker);
+        const tokenEndpointUrl = await listenLoopback(tokenEndpoint);
+        const config: WorkloadIdentity = {
+          identityProviderId: 'sensitive-identity-provider-id',
+          serviceAccountId: 'sensitive-service-account-id',
+          provider: {
+            tokenType: 'jwt',
+            getToken: async () => 'sensitive-kubernetes-service-account-jwt',
+          },
+        };
+        const auth = new WorkloadIdentityAuth(config, async (url, init) => {
+          expect(url).toBe('https://auth.openai.com/oauth/token');
+          return await globalThis.fetch(tokenEndpointUrl, init);
+        });
+        const tokenPromise = auth.getToken();
+
+        await expect.soft(tokenPromise).rejects.toBeInstanceOf(APIError);
+        await expect.soft(tokenPromise).rejects.toHaveProperty('status', status);
+        expect(attackerRequests).toEqual([]);
+      } finally {
+        await Promise.all([closeLoopback(tokenEndpoint), closeLoopback(attacker)]);
+      }
+    },
+  );
 
   test('includes all required fields in token exchange', async () => {
     const config: WorkloadIdentity = {


### PR DESCRIPTION
## Security impact

`WorkloadIdentityAuth` exchanges a Kubernetes service-account JWT, Azure managed-identity token, or GCP identity token by POSTing it to `https://auth.openai.com/oauth/token` alongside the OpenAI identity-provider and service-account identifiers.

If that token endpoint, its gateway, or another upstream component returns an attacker-controlled HTTP 307 or 308 redirect, fetch's default redirect handling follows it cross-origin while preserving the POST method and **entire JSON request body**. The attacker receives the workload credential and identity identifiers, then can return a forged OAuth success such as `{"access_token":"attacker-token","expires_in":3600}`. The SDK accepts and caches that token for later API authorization.

Cross-origin fetch redirects can strip `Authorization` headers, but they do not strip the request body. HTTP 301/302 typically rewrite a POST to GET, and 303 explicitly switches to GET; 307/308 instead preserve the sensitive POST body, making them the critical exfiltration cases. Exploitation requires an attacker-controlled redirect from the token endpoint or an upstream gateway; this change does not assume that condition is independently achievable.

## Fix

Set `redirect: 'manual'` exclusively on the handwritten workload-identity token-exchange fetch. No redirect is followed, including a same-origin redirect that could otherwise lead to an attacker-controlled redirect chain. The existing unsuccessful-response path rejects the returned 307/308 response as an `APIError` and preserves its HTTP status under Node.

Successful exchanges, proactive refreshes, token caching, and unrelated SDK requests are unchanged. No generated SDK clients are modified.

## Regression coverage

The handwritten auth regression starts two independent `node:http` servers on different ephemeral loopback ports: one emulates the token endpoint and redirects with each of 307 and 308, and the other emulates an attacker, records the complete request body, and returns a valid-looking forged access token.

Against the vulnerable `origin/main` baseline, both new cases failed: the attacker received the subject JWT plus `identity_provider_id` and `service_account_id`, and `getToken()` resolved to `attacker-token`. With this fix, the attacker receives **zero requests** and `getToken()` rejects with the original redirect status as a typed `APIError`.

## Verification

All package-manager commands used a writable task-local `COREPACK_HOME` and reused already-installed dependencies from ignored worktree-local links.

- Vulnerable baseline, before the source fix: **17 existing auth tests passed; both new 307/308 regressions failed**, proving credential exfiltration and forged-token acceptance.
- `pnpm test:unit tests/auth/workload-identity-auth.test.ts --reporter=verbose`: **19 passed**.
- `CI=true pnpm test:unit --reporter=dot --silent=passed-only --update=none`: **1,846 passed across 66 files**.
- `pnpm lint`: passed.
- `pnpm exec tsc`: passed.
- `pnpm build`: passed.
- `./node_modules/typescript-4-9/bin/tsc --project dist/src/tsconfig.json --noEmit`: passed.
- `./node_modules/typescript/bin/tsc --project dist/src/tsconfig.json --noEmit`: passed.
