### PR TITLE
fix(security): prevent multipart upload content-type header injection

### DIFF
--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -53,7 +53,7 @@ export interface StreamingFile {
  * @param data Async-iterable or readable-stream chunks containing text, binary data, or blobs.
  * @param name Non-empty filename sent in the multipart request.
  * @param options Optional MIME type for the streaming file.
- * @throws {TypeError} If `name` is empty.
+ * @throws {TypeError} If `name` is empty or the content type contains control characters.
  */
 export function toStreamingFile(
   data: StreamingFileInput,
@@ -64,11 +64,16 @@ export function toStreamingFile(
     throw new TypeError('toStreamingFile requires a non-empty file name');
   }
 
+  const type = options?.type;
+  if (type) {
+    validateStreamingFileType(type);
+  }
+
   return {
     [brand_privateStreamingFile]: true,
     data,
     name,
-    ...(options?.type ? { type: options.type } : {}),
+    ...(type ? { type } : {}),
   };
 }
 
@@ -384,10 +389,10 @@ async function* iterateMultipartBody(
   options: CreateFormOptions,
 ): AsyncGenerator<Uint8Array> {
   for await (const { key, value } of iterateFormEntries(body)) {
-    yield encodeUTF8(`--${boundary}\r\n`);
     if (isUploadable(value)) {
       const filename = getStreamingFileName(value, options);
       const type = getStreamingFileType(value);
+      yield encodeUTF8(`--${boundary}\r\n`);
       yield encodeUTF8(
         `Content-Disposition: form-data; name="${escapeHeaderValue(key)}"; filename="${escapeHeaderValue(
           filename,
@@ -395,6 +400,7 @@ async function* iterateMultipartBody(
       );
       yield* iterateBytes(getStreamingFileData(value));
     } else {
+      yield encodeUTF8(`--${boundary}\r\n`);
       yield encodeUTF8(
         `Content-Disposition: form-data; name="${escapeHeaderValue(key)}"\r\n\r\n${String(value)}`,
       );
@@ -455,16 +461,30 @@ function getStreamingFileName(value: Uploadable, options: CreateFormOptions): st
 }
 
 function getStreamingFileType(value: Uploadable): string {
-  if (isStreamingFile(value)) {
-    return value.type || 'application/octet-stream';
+  let type: string | undefined;
+
+  if (isStreamingFile(value) || isNamedBlob(value)) {
+    ({ type } = value);
+  } else if (value instanceof Response) {
+    type = value.headers.get('content-type') ?? undefined;
   }
-  if (isNamedBlob(value) && value.type) {
-    return value.type;
+
+  return validateStreamingFileType(type || 'application/octet-stream');
+}
+
+function validateStreamingFileType(type: string): string {
+  if (typeof type !== 'string') {
+    throw new TypeError('Streaming upload content type must be a string');
   }
-  if (value instanceof Response) {
-    return value.headers.get('content-type') || 'application/octet-stream';
+
+  for (let index = 0; index < type.length; index += 1) {
+    const character = type.codePointAt(index) ?? 0;
+    if (character <= 0x1f || character === 0x7f) {
+      throw new TypeError('Streaming upload content type must not contain control characters');
+    }
   }
-  return 'application/octet-stream';
+
+  return type;
 }
 
 function getStreamingFileData(value: Uploadable): unknown {

--- a/tests/internal/uploads-branches.test.ts
+++ b/tests/internal/uploads-branches.test.ts
@@ -28,6 +28,50 @@ describe('streaming upload metadata', () => {
   });
 
   test.each([
+    ['CRLF header injection', 'text/plain\r\nContent-Disposition: form-data; name="purpose"'],
+    ['CR', 'text/plain\r'],
+    ['LF', 'text/plain\n'],
+    ['NUL', 'text/plain\0'],
+    ['HTAB', 'text/plain\t'],
+    ['C0 control', 'text/plain\u001F'],
+    ['DEL', 'text/plain\u007F'],
+  ] as const)('rejects %s in streaming content types synchronously', (_, type) => {
+    async function* chunks() {
+      yield 'content';
+    }
+
+    expect(() => toStreamingFile(chunks(), 'upload.txt', { type })).toThrow(TypeError);
+    expect(() => toStreamingFile(chunks(), 'upload.txt', { type })).toThrow(/content.type/i);
+  });
+
+  test.each([
+    'TEXT/PLAIN; charset=UTF-8',
+    '  TEXT/PLAIN; charset=UTF-8  ',
+    'text/x-café; note=こんにちは',
+  ] as const)('preserves valid content types unchanged: %s', (type) => {
+    async function* chunks() {
+      yield 'content';
+    }
+
+    expect(toStreamingFile(chunks(), 'upload.txt', { type }).type).toBe(type);
+  });
+
+  test('reads streaming content type metadata only once', () => {
+    async function* chunks() {
+      yield 'content';
+    }
+
+    const getType = vi
+      .fn()
+      .mockReturnValueOnce('text/plain')
+      .mockReturnValue('text/plain\r\nContent-Disposition: form-data; name="purpose"');
+    const options = Object.defineProperty({}, 'type', { get: getType });
+
+    expect(toStreamingFile(chunks(), 'upload.txt', options)).toHaveProperty('type', 'text/plain');
+    expect(getType).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([
     [{ name: '/tmp/named.jsonl' }, 'named.jsonl'],
     [{ url: 'https://example.com/files/audio.wav' }, 'audio.wav'],
     [{ filename: 'C:\\recordings\\audio.wav' }, 'audio.wav'],
@@ -202,6 +246,166 @@ describe('buffered multipart forms', () => {
 });
 
 describe('lazy multipart stream encoding', () => {
+  test('rejects mutated content types instead of injecting duplicate form parameters', async () => {
+    async function* chunks() {
+      yield 'sensitive upload bytes';
+    }
+
+    const upload = toStreamingFile(chunks(), 'secret.txt', { type: 'text/plain' });
+    Object.defineProperty(upload, 'type', {
+      value: 'text/plain\r\nContent-Disposition: form-data; name="purpose"',
+    });
+
+    const options = await multipartFormRequestOptions({ body: { upload, purpose: 'assistants' } }, fetch);
+    const contentType = buildHeaders([options.headers]).values.get('content-type')!;
+    const outcome = await new Response(options.body as ReadableStream, {
+      headers: { 'content-type': contentType },
+    })
+      .formData()
+      .then(
+        (form) => ({ hasUpload: form.has('upload'), purposes: form.getAll('purpose') }),
+        (error: unknown) => error,
+      );
+
+    expect(outcome).toBeInstanceOf(TypeError);
+    expect(outcome).toHaveProperty('message', expect.stringMatching(/content.type/i));
+  });
+
+  test('rejects a mutated content type before emitting its multipart boundary', async () => {
+    async function* chunks() {
+      yield 'sensitive upload bytes';
+    }
+
+    const upload = toStreamingFile(chunks(), 'secret.txt', { type: 'text/plain' });
+    Object.defineProperty(upload, 'type', {
+      value: 'text/plain\r\nContent-Disposition: form-data; name="purpose"',
+    });
+
+    const options = await multipartFormRequestOptions({ body: { upload } }, fetch);
+    const reader = (options.body as ReadableStream).getReader();
+
+    await expect(reader.read()).rejects.toThrow(/content.type/i);
+  });
+
+  test('rejects mutable content types that inject headers through string coercion', async () => {
+    async function* chunks() {
+      yield 'sensitive upload bytes';
+    }
+
+    const upload = toStreamingFile(chunks(), 'secret.txt', { type: 'text/plain' });
+    Object.defineProperty(upload, 'type', {
+      value: {
+        length: 0,
+        toString: () => 'text/plain\r\nContent-Disposition: form-data; name="purpose"',
+      },
+    });
+
+    const options = await multipartFormRequestOptions({ body: { upload, purpose: 'assistants' } }, fetch);
+    const contentType = buildHeaders([options.headers]).values.get('content-type')!;
+    const outcome = await new Response(options.body as ReadableStream, {
+      headers: { 'content-type': contentType },
+    })
+      .formData()
+      .then(
+        (form) => ({ hasUpload: form.has('upload'), purposes: form.getAll('purpose') }),
+        (error: unknown) => error,
+      );
+
+    expect(outcome).toBeInstanceOf(TypeError);
+    expect(outcome).toHaveProperty('message', expect.stringMatching(/content.type/i));
+  });
+
+  test('rejects malicious File content types in mixed streaming forms before emitting a boundary', async () => {
+    const maliciousFile = new File(['sensitive upload bytes'], 'secret.txt');
+    Object.defineProperty(maliciousFile, 'type', {
+      get: () => 'text/plain\r\nContent-Disposition: form-data; name="purpose"',
+    });
+
+    async function* chunks() {
+      yield 'safe stream';
+    }
+
+    const options = await maybeMultipartFormRequestOptions(
+      {
+        body: {
+          upload: maliciousFile,
+          stream: toStreamingFile(chunks(), 'safe.txt'),
+          purpose: 'assistants',
+        },
+      },
+      fetch,
+    );
+    const reader = (options.body as ReadableStream).getReader();
+
+    await expect(reader.read()).rejects.toThrow(/content.type/i);
+  });
+
+  test('reads File content types only once while encoding mixed streaming forms', async () => {
+    const upload = new File(['sensitive upload bytes'], 'secret.txt');
+    const getType = vi
+      .fn()
+      .mockReturnValueOnce('text/plain')
+      .mockReturnValue('text/plain\r\nContent-Disposition: form-data; name="purpose"');
+    Object.defineProperty(upload, 'type', { get: getType });
+
+    async function* chunks() {
+      yield 'safe stream';
+    }
+
+    const options = await maybeMultipartFormRequestOptions(
+      {
+        body: {
+          upload,
+          stream: toStreamingFile(chunks(), 'safe.txt'),
+          purpose: 'assistants',
+        },
+      },
+      fetch,
+    );
+    const contentType = buildHeaders([options.headers]).values.get('content-type')!;
+    const form = await new Response(options.body as ReadableStream, {
+      headers: { 'content-type': contentType },
+    }).formData();
+
+    expect(getType).toHaveBeenCalledTimes(1);
+    expect(form.getAll('purpose')).toEqual(['assistants']);
+    expect(form.get('upload')).toBeInstanceOf(File);
+  });
+
+  test('preserves content type case and parameters while encoding streaming files', async () => {
+    async function* chunks() {
+      yield 'content';
+    }
+
+    const options = await multipartFormRequestOptions(
+      {
+        body: {
+          upload: toStreamingFile(chunks(), 'upload.txt', { type: 'TEXT/PLAIN; charset=UTF-8' }),
+        },
+      },
+      fetch,
+    );
+
+    await expect(new Response(options.body as ReadableStream).text()).resolves.toContain(
+      'Content-Type: TEXT/PLAIN; charset=UTF-8',
+    );
+  });
+
+  test('retains the default content type for streaming files', async () => {
+    async function* chunks() {
+      yield 'content';
+    }
+
+    const options = await multipartFormRequestOptions(
+      { body: { upload: toStreamingFile(chunks(), 'upload.bin') } },
+      fetch,
+    );
+
+    await expect(new Response(options.body as ReadableStream).text()).resolves.toContain(
+      'Content-Type: application/octet-stream',
+    );
+  });
+
   test('continues stripping ordinary File paths when streaming is enabled', async () => {
     async function* chunks() {
       yield 'streamed';


### PR DESCRIPTION
## Summary

- Reject ASCII C0 control characters (including CR, LF, NUL, and TAB), DEL, and runtime non-string MIME values both when creating a streaming upload and when resolving every multipart upload part.
- Resolve streaming-file, `File`/`Blob`, and response content types exactly once and validate them before emitting that upload part's boundary or headers.
- Preserve MIME spelling, case, parameters, printable non-ASCII/spacing, and the existing `application/octet-stream` default.

## Security impact

The handwritten streaming multipart encoder previously interpolated caller-controlled upload MIME metadata directly into a `Content-Type` part header. A MIME value such as `text/plain\r\nContent-Disposition: form-data; name="purpose"` injected a second `Content-Disposition` header without requiring knowledge of the multipart boundary.

Using Node's WHATWG `Response(...).formData()` parser on the vulnerable baseline, the intended upload disappeared and its bytes became an attacker-controlled text form parameter:

```text
upload: null
purpose: ["sensitive upload bytes", "assistants"]
```

Factory-only validation is insufficient because streaming-file objects are mutable and mixed streaming forms also serialize named `File`/`Blob` parts whose `.type` getters may be overridden. The central sink guard covers both cases, rejects coercion-based object payloads, snapshots changing getters once, and rejects invalid upload parts before even their boundary bytes are emitted.

## Regression coverage

- Seven synchronous control-character cases: CRLF header injection, bare CR, LF, NUL, TAB, U+001F, and DEL.
- Actual WHATWG multipart parsing to demonstrate and prevent duplicate injected form parameters.
- Mutated streaming-file MIME metadata and malicious non-string `toString()` payloads.
- Hostile and changing `File.type` getters in mixed streaming forms.
- No multipart-boundary output for an invalid first upload part.
- Preserved MIME case, parameters, whitespace, Unicode, and the default content type.

## Verification

- Baseline security regression run: 10 expected failures; standalone WHATWG parser reproduced `purpose=["sensitive upload bytes", "assistants"]`.
- `./scripts/test tests/internal/uploads-branches.test.ts --no-cache --update=none` — 59 passed.
- `COREPACK_HOME=/tmp/openai-node-corepack-review-9f4a72 pnpm_config_verify_deps_before_run=false OPENAI_TEST_SUITE=unit ./scripts/test --no-cache --update=none` — 66 files, 1,862 tests passed.
- `./scripts/lint` — passed.
- `./node_modules/.bin/tsc --noEmit` — passed.
- `./scripts/build` — passed, including CommonJS/ESM package smoke checks.
- `./node_modules/typescript-4-9/bin/tsc --project dist/src/tsconfig.json --noEmit` — passed.
- `./node_modules/typescript/bin/tsc --project dist/src/tsconfig.json --noEmit` — passed.
- The generated-suite wrapper could not start its Steady mock through `npm exec` because the devbox npm cache is read-only; generated tests were not run locally.