### PR TITLE
fix(responses): validate streaming event indices before array access

### DIFF
--- a/src/lib/responses/ResponseAccumulator.ts
+++ b/src/lib/responses/ResponseAccumulator.ts
@@ -1,5 +1,6 @@
 import type { Response, ResponseOutputText, ResponseStreamEvent } from '../../resources/responses/responses';
 import { OpenAIError } from '../../error';
+import { hasOwn } from '../../internal/utils';
 import { addOutputText } from '../ResponsesParser';
 
 /** A transport keepalive event that leaves the accumulated response unchanged. */
@@ -32,6 +33,7 @@ export function accumulateResponse(
 
   switch (event.type) {
     case 'response.output_item.added': {
+      validateArrayIndex(snapshot.output, event.output_index, 'output', true);
       snapshot.output.push(structuredClone(event.item));
       if (event.item.type === 'message') {
         addOutputText(snapshot);
@@ -51,15 +53,18 @@ export function accumulateResponse(
       const type = output.type;
       const part = event.part;
       if (type === 'message' && part.type !== 'reasoning_text') {
+        validateArrayIndex(output.content, event.content_index, 'content', true);
         output.content.push(structuredClone(part));
         if (part.type === 'output_text') {
           addOutputText(snapshot);
         }
       } else if (type === 'reasoning' && part.type === 'reasoning_text') {
+        const content = output.content ?? [];
+        validateArrayIndex(content, event.content_index, 'content', true);
         if (!output.content) {
-          output.content = [];
+          output.content = content;
         }
-        output.content.push(structuredClone(part));
+        content.push(structuredClone(part));
       }
       break;
     }
@@ -113,6 +118,7 @@ export function accumulateResponse(
         if (content.type !== 'output_text') {
           throw new OpenAIError(`expected content to be 'output_text', got ${content.type}`);
         }
+        validateArrayIndex(content.annotations, event.annotation_index, 'annotation', true);
         content.annotations[event.annotation_index] = structuredClone(
           event.annotation,
         ) as ResponseOutputText['annotations'][number];
@@ -186,6 +192,7 @@ export function accumulateResponse(
     case 'response.reasoning_summary_part.added': {
       const output = getOutput(snapshot, event.output_index);
       if (output.type === 'reasoning') {
+        validateArrayIndex(output.summary, event.summary_index, 'content', true);
         output.summary.push(structuredClone(event.part));
       }
       break;
@@ -400,6 +407,7 @@ function cloneResponse(response: Response): Response {
 }
 
 function getOutput(snapshot: Response, outputIndex: number): Response['output'][number] {
+  validateArrayIndex(snapshot.output, outputIndex, 'output');
   const output = snapshot.output[outputIndex];
   if (!output) {
     throw new OpenAIError(`missing output at index ${outputIndex}`);
@@ -408,11 +416,28 @@ function getOutput(snapshot: Response, outputIndex: number): Response['output'][
 }
 
 function getContent<T>(content: T[], contentIndex: number): T {
+  validateArrayIndex(content, contentIndex, 'content');
   const part = content[contentIndex];
   if (!part) {
     throw new OpenAIError(`missing content at index ${contentIndex}`);
   }
   return part;
+}
+
+function validateArrayIndex(
+  collection: readonly unknown[],
+  index: number,
+  kind: 'output' | 'content' | 'annotation',
+  allowAppend = false,
+): void {
+  if (
+    !Number.isSafeInteger(index) ||
+    index < 0 ||
+    index > collection.length ||
+    (index === collection.length ? !allowAppend || index in collection : !hasOwn(collection, index))
+  ) {
+    throw new OpenAIError(`missing ${kind} at index ${index}`);
+  }
 }
 
 function assertNever(value: never): never {

--- a/src/lib/responses/ResponseAccumulator.ts
+++ b/src/lib/responses/ResponseAccumulator.ts
@@ -33,7 +33,7 @@ export function accumulateResponse(
 
   switch (event.type) {
     case 'response.output_item.added': {
-      validateArrayIndex(snapshot.output, event.output_index, 'output', true);
+      validateArrayAppend(snapshot.output, event.output_index, 'output');
       snapshot.output.push(structuredClone(event.item));
       if (event.item.type === 'message') {
         addOutputText(snapshot);
@@ -53,14 +53,14 @@ export function accumulateResponse(
       const type = output.type;
       const part = event.part;
       if (type === 'message' && part.type !== 'reasoning_text') {
-        validateArrayIndex(output.content, event.content_index, 'content', true);
+        validateArrayAppend(output.content, event.content_index, 'content');
         output.content.push(structuredClone(part));
         if (part.type === 'output_text') {
           addOutputText(snapshot);
         }
       } else if (type === 'reasoning' && part.type === 'reasoning_text') {
         const content = output.content ?? [];
-        validateArrayIndex(content, event.content_index, 'content', true);
+        validateArrayAppend(content, event.content_index, 'content');
         if (!output.content) {
           output.content = content;
         }
@@ -192,7 +192,7 @@ export function accumulateResponse(
     case 'response.reasoning_summary_part.added': {
       const output = getOutput(snapshot, event.output_index);
       if (output.type === 'reasoning') {
-        validateArrayIndex(output.summary, event.summary_index, 'content', true);
+        validateArrayAppend(output.summary, event.summary_index, 'content');
         output.summary.push(structuredClone(event.part));
       }
       break;
@@ -422,6 +422,17 @@ function getContent<T>(content: T[], contentIndex: number): T {
     throw new OpenAIError(`missing content at index ${contentIndex}`);
   }
   return part;
+}
+
+function validateArrayAppend(
+  collection: readonly unknown[],
+  index: number,
+  kind: 'output' | 'content',
+): void {
+  if (index !== collection.length) {
+    throw new OpenAIError(`missing ${kind} at index ${index}`);
+  }
+  validateArrayIndex(collection, index, kind, true);
 }
 
 function validateArrayIndex(

--- a/tests/lib/ResponseAccumulator.events.test.ts
+++ b/tests/lib/ResponseAccumulator.events.test.ts
@@ -696,28 +696,12 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
     expect(Object.getPrototypeOf(annotations)).toBe(Array.prototype);
   });
 
-  test.each([
-    ['output', 'response.output_item.added', 'output_index', 1, 'declared append'],
-    ['content', 'response.content_part.added', 'content_index', 1, 'declared append'],
-    [
-      'summary',
-      'response.reasoning_summary_part.added',
-      'summary_index',
-      1,
-      'declared append',
-    ],
-    ['output', 'response.output_item.added', 'output_index', 0, 'replayed existing'],
-    ['content', 'response.content_part.added', 'content_index', 0, 'replayed existing'],
-    [
-      'summary',
-      'response.reasoning_summary_part.added',
-      'summary_index',
-      0,
-      'replayed existing',
-    ],
-  ])(
-    'rejects inherited numeric setters for a %s %s index',
-    (kind, type, indexField, declaredIndex) => {
+  for (const declaredIndex of [0, 1]) {
+    test.each([
+      ['output', 'response.output_item.added', 'output_index'],
+      ['content', 'response.content_part.added', 'content_index'],
+      ['summary', 'response.reasoning_summary_part.added', 'summary_index'],
+    ])(`rejects %s setter with declared index ${declaredIndex}`, (kind, type, indexField) => {
       let snapshot: Response;
       if (kind === 'output') {
         snapshot = snapshotFor({ type: 'function_call', id: 'original', arguments: '' });
@@ -734,10 +718,7 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
           summary: [{ type: 'summary_text', text: 'original' }],
         });
       }
-      const output = snapshot.output[0] as {
-        content: unknown[];
-        summary: unknown[];
-      };
+      const output = snapshot.output[0] as { content: unknown[]; summary: unknown[] };
       let collection: unknown[];
       if (kind === 'output') {
         collection = snapshot.output;
@@ -771,15 +752,13 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
             annotations: [],
           },
         }),
-      ).toThrow(
-        `missing ${kind === 'summary' ? 'content' : kind} at index ${declaredIndex}`,
-      );
+      ).toThrow(`missing ${kind === 'summary' ? 'content' : kind} at index ${declaredIndex}`);
 
       expect(inheritedSetterCalled).toBe(false);
       expect(collection).toHaveLength(1);
       expect(hasOwn(collection, 1)).toBe(false);
-    },
-  );
+    });
+  }
 
   test('rejects inherited numeric setters before appending annotations', () => {
     const snapshot = snapshotFor({

--- a/tests/lib/ResponseAccumulator.events.test.ts
+++ b/tests/lib/ResponseAccumulator.events.test.ts
@@ -699,10 +699,22 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
   test.each([
     ['output', 'response.output_item.added', 'output_index', 1, 'declared append'],
     ['content', 'response.content_part.added', 'content_index', 1, 'declared append'],
-    ['summary', 'response.reasoning_summary_part.added', 'summary_index', 1, 'declared append'],
+    [
+      'summary',
+      'response.reasoning_summary_part.added',
+      'summary_index',
+      1,
+      'declared append',
+    ],
     ['output', 'response.output_item.added', 'output_index', 0, 'replayed existing'],
     ['content', 'response.content_part.added', 'content_index', 0, 'replayed existing'],
-    ['summary', 'response.reasoning_summary_part.added', 'summary_index', 0, 'replayed existing'],
+    [
+      'summary',
+      'response.reasoning_summary_part.added',
+      'summary_index',
+      0,
+      'replayed existing',
+    ],
   ])(
     'rejects inherited numeric setters for a %s %s index',
     (kind, type, indexField, declaredIndex) => {
@@ -722,7 +734,10 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
           summary: [{ type: 'summary_text', text: 'original' }],
         });
       }
-      const output = snapshot.output[0] as { content: unknown[]; summary: unknown[] };
+      const output = snapshot.output[0] as {
+        content: unknown[];
+        summary: unknown[];
+      };
       let collection: unknown[];
       if (kind === 'output') {
         collection = snapshot.output;
@@ -756,7 +771,9 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
             annotations: [],
           },
         }),
-      ).toThrow(`missing ${kind === 'summary' ? 'content' : kind} at index ${declaredIndex}`);
+      ).toThrow(
+        `missing ${kind === 'summary' ? 'content' : kind} at index ${declaredIndex}`,
+      );
 
       expect(inheritedSetterCalled).toBe(false);
       expect(collection).toHaveLength(1);

--- a/tests/lib/ResponseAccumulator.events.test.ts
+++ b/tests/lib/ResponseAccumulator.events.test.ts
@@ -194,13 +194,13 @@ describe('ResponseAccumulator output and content events', () => {
     });
   });
 
-  test('preserves existing output, content, and summary append behavior when events are replayed', () => {
+  test('appends output, content, and summary at their declared contiguous indices', () => {
     const outputSnapshot = snapshotFor({ type: 'function_call', id: 'original', arguments: '' });
     const replayedOutput = { type: 'function_call', id: 'replayed', arguments: '' };
 
     applyEvent(outputSnapshot, {
       type: 'response.output_item.added',
-      output_index: 0,
+      output_index: 1,
       item: replayedOutput,
     });
 
@@ -216,7 +216,7 @@ describe('ResponseAccumulator output and content events', () => {
     applyEvent(contentSnapshot, {
       type: 'response.content_part.added',
       output_index: 0,
-      content_index: 0,
+      content_index: 1,
       part: replayedContent,
     });
 
@@ -233,7 +233,7 @@ describe('ResponseAccumulator output and content events', () => {
     applyEvent(summarySnapshot, {
       type: 'response.reasoning_summary_part.added',
       output_index: 0,
-      summary_index: 0,
+      summary_index: 1,
       part: replayedSummary,
     });
 
@@ -694,6 +694,54 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
 
     expect(annotations).toHaveLength(0);
     expect(Object.getPrototypeOf(annotations)).toBe(Array.prototype);
+  });
+
+  test.each([
+    ['output', 'response.output_item.added', 'output_index'],
+    ['content', 'response.content_part.added', 'content_index'],
+    ['summary', 'response.reasoning_summary_part.added', 'summary_index'],
+  ])('rejects inherited numeric setters at the declared %s append position', (kind, type, indexField) => {
+    const snapshot =
+      kind === 'output'
+        ? snapshotFor({ type: 'function_call', id: 'original', arguments: '' })
+        : snapshotFor({
+            type: kind === 'summary' ? 'reasoning' : 'message',
+            content: kind === 'content' ? [{ type: 'output_text', text: 'original', annotations: [] }] : [],
+            summary: kind === 'summary' ? [{ type: 'summary_text', text: 'original' }] : [],
+          });
+    const output = snapshot.output[0] as { content: unknown[]; summary: unknown[] };
+    const collection =
+      kind === 'output' ? snapshot.output : kind === 'content' ? output.content : output.summary;
+    let inheritedSetterCalled = false;
+    const collectionPrototype = Object.create(Array.prototype) as object;
+    Object.defineProperty(collectionPrototype, 1, {
+      configurable: true,
+      get() {
+        return null;
+      },
+      set() {
+        inheritedSetterCalled = true;
+      },
+    });
+    Object.setPrototypeOf(collection, collectionPrototype);
+
+    expect(() =>
+      applyEvent(snapshot, {
+        type,
+        output_index: 0,
+        [indexField]: 1,
+        item: { type: 'function_call', id: 'injected', arguments: '' },
+        part: {
+          type: kind === 'summary' ? 'summary_text' : 'output_text',
+          text: 'injected',
+          annotations: [],
+        },
+      }),
+    ).toThrow(`missing ${kind === 'summary' ? 'content' : kind} at index 1`);
+
+    expect(inheritedSetterCalled).toBe(false);
+    expect(collection).toHaveLength(1);
+    expect(hasOwn(collection, 1)).toBe(false);
   });
 
   test('rejects inherited numeric setters before appending annotations', () => {

--- a/tests/lib/ResponseAccumulator.events.test.ts
+++ b/tests/lib/ResponseAccumulator.events.test.ts
@@ -701,17 +701,31 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
     ['content', 'response.content_part.added', 'content_index'],
     ['summary', 'response.reasoning_summary_part.added', 'summary_index'],
   ])('rejects inherited numeric setters at the declared %s append position', (kind, type, indexField) => {
-    const snapshot =
-      kind === 'output'
-        ? snapshotFor({ type: 'function_call', id: 'original', arguments: '' })
-        : snapshotFor({
-            type: kind === 'summary' ? 'reasoning' : 'message',
-            content: kind === 'content' ? [{ type: 'output_text', text: 'original', annotations: [] }] : [],
-            summary: kind === 'summary' ? [{ type: 'summary_text', text: 'original' }] : [],
-          });
+    let snapshot: Response;
+    if (kind === 'output') {
+      snapshot = snapshotFor({ type: 'function_call', id: 'original', arguments: '' });
+    } else if (kind === 'content') {
+      snapshot = snapshotFor({
+        type: 'message',
+        content: [{ type: 'output_text', text: 'original', annotations: [] }],
+        summary: [],
+      });
+    } else {
+      snapshot = snapshotFor({
+        type: 'reasoning',
+        content: [],
+        summary: [{ type: 'summary_text', text: 'original' }],
+      });
+    }
     const output = snapshot.output[0] as { content: unknown[]; summary: unknown[] };
-    const collection =
-      kind === 'output' ? snapshot.output : kind === 'content' ? output.content : output.summary;
+    let collection: unknown[];
+    if (kind === 'output') {
+      collection = snapshot.output;
+    } else if (kind === 'content') {
+      collection = output.content;
+    } else {
+      collection = output.summary;
+    }
     let inheritedSetterCalled = false;
     const collectionPrototype = Object.create(Array.prototype) as object;
     Object.defineProperty(collectionPrototype, 1, {

--- a/tests/lib/ResponseAccumulator.events.test.ts
+++ b/tests/lib/ResponseAccumulator.events.test.ts
@@ -706,58 +706,58 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
   ])(
     'rejects inherited numeric setters for a %s %s index',
     (kind, type, indexField, declaredIndex) => {
-    let snapshot: Response;
-    if (kind === 'output') {
-      snapshot = snapshotFor({ type: 'function_call', id: 'original', arguments: '' });
-    } else if (kind === 'content') {
-      snapshot = snapshotFor({
-        type: 'message',
-        content: [{ type: 'output_text', text: 'original', annotations: [] }],
-        summary: [],
-      });
-    } else {
-      snapshot = snapshotFor({
-        type: 'reasoning',
-        content: [],
-        summary: [{ type: 'summary_text', text: 'original' }],
-      });
-    }
-    const output = snapshot.output[0] as { content: unknown[]; summary: unknown[] };
-    let collection: unknown[];
-    if (kind === 'output') {
-      collection = snapshot.output;
-    } else if (kind === 'content') {
-      collection = output.content;
-    } else {
-      collection = output.summary;
-    }
-    let inheritedSetterCalled = false;
-    const collectionPrototype = Object.create(Array.prototype) as object;
-    Object.defineProperty(collectionPrototype, 1, {
-      configurable: true,
-      get() {
-        return null;
-      },
-      set() {
-        inheritedSetterCalled = true;
-      },
-    });
-    Object.setPrototypeOf(collection, collectionPrototype);
-
-    expect(() =>
-      applyEvent(snapshot, {
-        type,
-        output_index: 0,
-        [indexField]: declaredIndex,
-        item: { type: 'function_call', id: 'injected', arguments: '' },
-        part: {
-          type: kind === 'summary' ? 'summary_text' : 'output_text',
-          text: 'injected',
-          annotations: [],
+      let snapshot: Response;
+      if (kind === 'output') {
+        snapshot = snapshotFor({ type: 'function_call', id: 'original', arguments: '' });
+      } else if (kind === 'content') {
+        snapshot = snapshotFor({
+          type: 'message',
+          content: [{ type: 'output_text', text: 'original', annotations: [] }],
+          summary: [],
+        });
+      } else {
+        snapshot = snapshotFor({
+          type: 'reasoning',
+          content: [],
+          summary: [{ type: 'summary_text', text: 'original' }],
+        });
+      }
+      const output = snapshot.output[0] as { content: unknown[]; summary: unknown[] };
+      let collection: unknown[];
+      if (kind === 'output') {
+        collection = snapshot.output;
+      } else if (kind === 'content') {
+        collection = output.content;
+      } else {
+        collection = output.summary;
+      }
+      let inheritedSetterCalled = false;
+      const collectionPrototype = Object.create(Array.prototype) as object;
+      Object.defineProperty(collectionPrototype, 1, {
+        configurable: true,
+        get() {
+          return null;
         },
-      }),
-    ).toThrow(`missing ${kind === 'summary' ? 'content' : kind} at index ${declaredIndex}`);
-
+        set() {
+          inheritedSetterCalled = true;
+        },
+      });
+      Object.setPrototypeOf(collection, collectionPrototype);
+  
+      expect(() =>
+        applyEvent(snapshot, {
+          type,
+          output_index: 0,
+          [indexField]: declaredIndex,
+          item: { type: 'function_call', id: 'injected', arguments: '' },
+          part: {
+            type: kind === 'summary' ? 'summary_text' : 'output_text',
+            text: 'injected',
+            annotations: [],
+          },
+        }),
+      ).toThrow(`missing ${kind === 'summary' ? 'content' : kind} at index ${declaredIndex}`);
+  
       expect(inheritedSetterCalled).toBe(false);
       expect(collection).toHaveLength(1);
       expect(hasOwn(collection, 1)).toBe(false);

--- a/tests/lib/ResponseAccumulator.events.test.ts
+++ b/tests/lib/ResponseAccumulator.events.test.ts
@@ -1,4 +1,5 @@
 import { OpenAIError } from 'openai/core/error';
+import { hasOwn } from 'openai/internal/utils';
 import { accumulateResponse } from 'openai/lib/responses/ResponseAccumulator';
 import type { Response, ResponseStreamEvent } from 'openai/resources/responses/responses';
 
@@ -158,6 +159,87 @@ describe('ResponseAccumulator output and content events', () => {
     expect(snapshot.output_text).toBe('final');
     expect((snapshot.output[0] as { content: unknown[] }).content[0]).toEqual(finalPart);
     expect((snapshot.output[0] as { content: unknown[] }).content[0]).not.toBe(finalPart);
+  });
+
+  test('appends annotations sequentially and allows existing annotations to be replayed', () => {
+    const snapshot = snapshotFor({
+      type: 'message',
+      content: [{ type: 'output_text', text: '', annotations: [] }],
+    });
+    const event = {
+      type: 'response.output_text.annotation.added',
+      output_index: 0,
+      content_index: 0,
+      annotation_index: 0,
+      annotation: { type: 'url_citation', url: 'https://example.com/first' },
+    };
+
+    applyEvent(snapshot, event);
+    applyEvent(snapshot, {
+      ...event,
+      annotation: { type: 'url_citation', url: 'https://example.com/replayed' },
+    });
+    applyEvent(snapshot, {
+      ...event,
+      annotation_index: 1,
+      annotation: { type: 'url_citation', url: 'https://example.com/second' },
+    });
+
+    expect(snapshot.output[0]).toMatchObject({
+      content: [
+        {
+          annotations: [{ url: 'https://example.com/replayed' }, { url: 'https://example.com/second' }],
+        },
+      ],
+    });
+  });
+
+  test('preserves existing output, content, and summary append behavior when events are replayed', () => {
+    const outputSnapshot = snapshotFor({ type: 'function_call', id: 'original', arguments: '' });
+    const replayedOutput = { type: 'function_call', id: 'replayed', arguments: '' };
+
+    applyEvent(outputSnapshot, {
+      type: 'response.output_item.added',
+      output_index: 0,
+      item: replayedOutput,
+    });
+
+    expect(outputSnapshot.output).toHaveLength(2);
+    expect(outputSnapshot.output[1]).toEqual(replayedOutput);
+
+    const contentSnapshot = snapshotFor({
+      type: 'message',
+      content: [{ type: 'output_text', text: 'original', annotations: [] }],
+    });
+    const replayedContent = { type: 'output_text', text: 'replayed', annotations: [] };
+
+    applyEvent(contentSnapshot, {
+      type: 'response.content_part.added',
+      output_index: 0,
+      content_index: 0,
+      part: replayedContent,
+    });
+
+    const contentOutput = contentSnapshot.output[0] as { content: unknown[] };
+    expect(contentOutput.content).toHaveLength(2);
+    expect(contentOutput.content[1]).toEqual(replayedContent);
+
+    const summarySnapshot = snapshotFor({
+      type: 'reasoning',
+      summary: [{ type: 'summary_text', text: 'original' }],
+    });
+    const replayedSummary = { type: 'summary_text', text: 'replayed' };
+
+    applyEvent(summarySnapshot, {
+      type: 'response.reasoning_summary_part.added',
+      output_index: 0,
+      summary_index: 0,
+      part: replayedSummary,
+    });
+
+    const summaryOutput = summarySnapshot.output[0] as { summary: unknown[] };
+    expect(summaryOutput.summary).toHaveLength(2);
+    expect(summaryOutput.summary[1]).toEqual(replayedSummary);
   });
 });
 
@@ -356,6 +438,390 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
         delta: 'missing',
       }),
     ).toThrow('missing content at index 1');
+  });
+
+  test.each(['__proto__', 'constructor', 'push'])(
+    'rejects inherited output index %s without replacing the output array prototype',
+    (index) => {
+      const snapshot = makeResponse();
+      const outputPrototype = Object.getPrototypeOf(snapshot.output);
+
+      expect(() =>
+        applyEvent(snapshot, {
+          type: 'response.output_item.done',
+          output_index: index,
+          item: { type: 'message', content: [] },
+        }),
+      ).toThrow(`missing output at index ${index}`);
+
+      expect(Object.getPrototypeOf(snapshot.output)).toBe(outputPrototype);
+      expect(Object.getPrototypeOf(snapshot.output)).toBe(Array.prototype);
+      expect(snapshot.output).toHaveLength(0);
+    },
+  );
+
+  test.each([
+    -1,
+    0.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    1,
+    4_294_967_294,
+    Number.MAX_SAFE_INTEGER + 1,
+    '0',
+  ])('rejects malformed or missing existing output index %s before mutation', (index) => {
+    const snapshot = snapshotFor({ type: 'message', content: [] });
+    const [original] = snapshot.output;
+
+    expect(() =>
+      applyEvent(snapshot, {
+        type: 'response.output_item.done',
+        output_index: index,
+        item: { type: 'message', content: [{ type: 'output_text', text: 'injected' }] },
+      }),
+    ).toThrow(`missing output at index ${index}`);
+
+    expect(snapshot.output).toHaveLength(1);
+    expect(snapshot.output[0]).toBe(original);
+    expect(Object.getPrototypeOf(snapshot.output)).toBe(Array.prototype);
+  });
+
+  test.each([
+    ['message', { type: 'output_text', text: 'injected', annotations: [] }],
+    ['reasoning', { type: 'reasoning_text', text: 'injected' }],
+  ])('rejects inherited %s content indices before replacing the content array prototype', (type, part) => {
+    const snapshot = snapshotFor({ type, summary: [], content: [] });
+    const output = snapshot.output[0] as { content: unknown[] };
+
+    expect(() =>
+      applyEvent(snapshot, {
+        type: 'response.content_part.done',
+        output_index: 0,
+        content_index: '__proto__',
+        part,
+      }),
+    ).toThrow('missing content at index __proto__');
+
+    expect(Object.getPrototypeOf(output.content)).toBe(Array.prototype);
+    expect(output.content).toHaveLength(0);
+  });
+
+  test.each([-1, 0.5, Number.NaN, Number.NEGATIVE_INFINITY, 1, 4_294_967_294, '0'])(
+    'rejects malformed or missing existing content index %s before mutation',
+    (index) => {
+      const snapshot = snapshotFor({
+        type: 'message',
+        content: [{ type: 'output_text', text: 'unchanged', annotations: [] }],
+      });
+      const output = snapshot.output[0] as { content: unknown[] };
+      const [original] = output.content;
+
+      expect(() =>
+        applyEvent(snapshot, {
+          type: 'response.content_part.done',
+          output_index: 0,
+          content_index: index,
+          part: { type: 'output_text', text: 'injected', annotations: [] },
+        }),
+      ).toThrow(`missing content at index ${index}`);
+
+      expect(output.content).toHaveLength(1);
+      expect(output.content[0]).toBe(original);
+      expect(Object.getPrototypeOf(output.content)).toBe(Array.prototype);
+    },
+  );
+
+  test('rejects inherited summary indices before replacing the summary array prototype', () => {
+    const snapshot = snapshotFor({ type: 'reasoning', summary: [] });
+    const output = snapshot.output[0] as { summary: unknown[] };
+
+    expect(() =>
+      applyEvent(snapshot, {
+        type: 'response.reasoning_summary_part.done',
+        output_index: 0,
+        summary_index: '__proto__',
+        part: { type: 'summary_text', text: 'injected' },
+      }),
+    ).toThrow('missing content at index __proto__');
+
+    expect(Object.getPrototypeOf(output.summary)).toBe(Array.prototype);
+    expect(output.summary).toHaveLength(0);
+  });
+
+  test.each([-1, 0.5, Number.NaN, Number.POSITIVE_INFINITY, 1, 4_294_967_294, '0'])(
+    'rejects malformed or missing existing summary index %s before mutation',
+    (index) => {
+      const snapshot = snapshotFor({
+        type: 'reasoning',
+        summary: [{ type: 'summary_text', text: 'unchanged' }],
+      });
+      const output = snapshot.output[0] as { summary: unknown[] };
+      const [original] = output.summary;
+
+      expect(() =>
+        applyEvent(snapshot, {
+          type: 'response.reasoning_summary_part.done',
+          output_index: 0,
+          summary_index: index,
+          part: { type: 'summary_text', text: 'injected' },
+        }),
+      ).toThrow(`missing content at index ${index}`);
+
+      expect(output.summary).toHaveLength(1);
+      expect(output.summary[0]).toBe(original);
+      expect(Object.getPrototypeOf(output.summary)).toBe(Array.prototype);
+    },
+  );
+
+  test.each([
+    ['output', 'response.output_item.added', 'output_index'],
+    ['content', 'response.content_part.added', 'content_index'],
+    ['summary', 'response.reasoning_summary_part.added', 'summary_index'],
+  ])('rejects a noncontiguous %s index before appending', (kind, type, indexField) => {
+    const snapshot =
+      kind === 'output'
+        ? makeResponse()
+        : snapshotFor({
+            type: kind === 'summary' ? 'reasoning' : 'message',
+            content: [],
+            summary: [],
+          });
+
+    expect(() =>
+      applyEvent(snapshot, {
+        type,
+        output_index: 0,
+        [indexField]: 4_294_967_294,
+        item: { type: 'message', content: [] },
+        part: {
+          type: kind === 'summary' ? 'summary_text' : 'output_text',
+          text: 'injected',
+          annotations: [],
+        },
+      }),
+    ).toThrow();
+
+    if (kind === 'output') {
+      expect(snapshot.output).toHaveLength(0);
+    } else {
+      const output = snapshot.output[0] as { content: unknown[]; summary: unknown[] };
+      expect(kind === 'content' ? output.content : output.summary).toHaveLength(0);
+    }
+  });
+
+  test('does not initialize missing reasoning content for an invalid appended content index', () => {
+    const snapshot = snapshotFor({ type: 'reasoning', summary: [] });
+
+    expect(() =>
+      applyEvent(snapshot, {
+        type: 'response.content_part.added',
+        output_index: 0,
+        content_index: 1,
+        part: { type: 'reasoning_text', text: 'injected' },
+      }),
+    ).toThrow('missing content at index 1');
+
+    expect(snapshot.output[0]).not.toHaveProperty('content');
+  });
+
+  test.each([
+    ['output', 'response.output_item.added', 'output_index'],
+    ['content', 'response.content_part.added', 'content_index'],
+    ['summary', 'response.reasoning_summary_part.added', 'summary_index'],
+  ])('rejects an inherited %s index before appending', (kind, type, indexField) => {
+    const snapshot =
+      kind === 'output'
+        ? makeResponse()
+        : snapshotFor({
+            type: kind === 'summary' ? 'reasoning' : 'message',
+            content: [],
+            summary: [],
+          });
+
+    expect(() =>
+      applyEvent(snapshot, {
+        type,
+        output_index: 0,
+        [indexField]: '__proto__',
+        item: { type: 'message', content: [] },
+        part: {
+          type: kind === 'summary' ? 'summary_text' : 'output_text',
+          text: 'injected',
+          annotations: [],
+        },
+      }),
+    ).toThrow();
+
+    if (kind === 'output') {
+      expect(snapshot.output).toHaveLength(0);
+      expect(Object.getPrototypeOf(snapshot.output)).toBe(Array.prototype);
+    } else {
+      const output = snapshot.output[0] as { content: unknown[]; summary: unknown[] };
+      const collection = kind === 'content' ? output.content : output.summary;
+      expect(collection).toHaveLength(0);
+      expect(Object.getPrototypeOf(collection)).toBe(Array.prototype);
+    }
+  });
+
+  test.each([
+    '__proto__',
+    'constructor',
+    '0',
+    -1,
+    0.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    1,
+    4_294_967_294,
+    Number.MAX_SAFE_INTEGER + 1,
+  ])('rejects invalid or noncontiguous annotation index %s without expanding the array', (index) => {
+    const snapshot = snapshotFor({
+      type: 'message',
+      content: [{ type: 'output_text', text: '', annotations: [] }],
+    });
+    const output = snapshot.output[0] as unknown as { content: [{ annotations: unknown[] }] };
+    const [{ annotations }] = output.content;
+
+    expect(() =>
+      applyEvent(snapshot, {
+        type: 'response.output_text.annotation.added',
+        output_index: 0,
+        content_index: 0,
+        annotation_index: index,
+        annotation: { type: 'url_citation', url: 'https://example.com/injected' },
+      }),
+    ).toThrow(`missing annotation at index ${index}`);
+
+    expect(annotations).toHaveLength(0);
+    expect(Object.getPrototypeOf(annotations)).toBe(Array.prototype);
+  });
+
+  test('rejects inherited numeric setters before appending annotations', () => {
+    const snapshot = snapshotFor({
+      type: 'message',
+      content: [{ type: 'output_text', text: '', annotations: [] }],
+    });
+    const output = snapshot.output[0] as unknown as { content: [{ annotations: unknown[] }] };
+    const [{ annotations }] = output.content;
+    let inheritedSetterCalled = false;
+    const annotationPrototype = Object.create(Array.prototype) as object;
+    Object.defineProperty(annotationPrototype, 0, {
+      configurable: true,
+      get() {
+        return null;
+      },
+      set() {
+        inheritedSetterCalled = true;
+      },
+    });
+    Object.setPrototypeOf(annotations, annotationPrototype);
+
+    expect(() =>
+      applyEvent(snapshot, {
+        type: 'response.output_text.annotation.added',
+        output_index: 0,
+        content_index: 0,
+        annotation_index: 0,
+        annotation: { type: 'url_citation', url: 'https://example.com/injected' },
+      }),
+    ).toThrow('missing annotation at index 0');
+
+    expect(inheritedSetterCalled).toBe(false);
+    expect(annotations).toHaveLength(0);
+    expect(hasOwn(annotations, 0)).toBe(false);
+  });
+
+  test('rejects inherited values in sparse output, content, summary, and annotation arrays', () => {
+    const inheritedOutput = { type: 'message', content: [] };
+    const outputPrototype = Object.create(Array.prototype) as Record<number, unknown>;
+    outputPrototype[0] = inheritedOutput;
+    const sparseOutput: OutputItem[] = [];
+    sparseOutput.length = 1;
+    Object.setPrototypeOf(sparseOutput, outputPrototype);
+    const outputSnapshot = makeResponse(sparseOutput);
+
+    expect(() =>
+      applyEvent(outputSnapshot, {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: { type: 'message', content: [] },
+      }),
+    ).toThrow('missing output at index 0');
+    expect(hasOwn(sparseOutput, 0)).toBe(false);
+    expect(Object.getPrototypeOf(sparseOutput)).toBe(outputPrototype);
+
+    const contentSnapshot = snapshotFor({
+      type: 'message',
+      content: [{ type: 'output_text', text: 'unchanged', annotations: [] }],
+    });
+    const contentOutput = contentSnapshot.output[0] as unknown as {
+      content: [{ type: string; text: string; annotations: unknown[] }];
+    };
+    const [inheritedContent] = contentOutput.content;
+    const contentPrototype = Object.create(Array.prototype) as Record<number, unknown>;
+    contentPrototype[0] = inheritedContent;
+    Reflect.deleteProperty(contentOutput.content, 0);
+    Object.setPrototypeOf(contentOutput.content, contentPrototype);
+
+    expect(() =>
+      applyEvent(contentSnapshot, {
+        type: 'response.content_part.done',
+        output_index: 0,
+        content_index: 0,
+        part: { type: 'output_text', text: 'injected', annotations: [] },
+      }),
+    ).toThrow('missing content at index 0');
+    expect(hasOwn(contentOutput.content, 0)).toBe(false);
+    expect(inheritedContent.text).toBe('unchanged');
+
+    const summarySnapshot = snapshotFor({
+      type: 'reasoning',
+      summary: [{ type: 'summary_text', text: 'unchanged' }],
+    });
+    const summaryOutput = summarySnapshot.output[0] as unknown as {
+      summary: [{ type: string; text: string }];
+    };
+    const [inheritedSummary] = summaryOutput.summary;
+    const summaryPrototype = Object.create(Array.prototype) as Record<number, unknown>;
+    summaryPrototype[0] = inheritedSummary;
+    Reflect.deleteProperty(summaryOutput.summary, 0);
+    Object.setPrototypeOf(summaryOutput.summary, summaryPrototype);
+
+    expect(() =>
+      applyEvent(summarySnapshot, {
+        type: 'response.reasoning_summary_part.done',
+        output_index: 0,
+        summary_index: 0,
+        part: { type: 'summary_text', text: 'injected' },
+      }),
+    ).toThrow('missing content at index 0');
+    expect(hasOwn(summaryOutput.summary, 0)).toBe(false);
+    expect(inheritedSummary.text).toBe('unchanged');
+
+    const annotationSnapshot = snapshotFor({
+      type: 'message',
+      content: [{ type: 'output_text', text: '', annotations: [{}] }],
+    });
+    const annotationOutput = annotationSnapshot.output[0] as unknown as {
+      content: [{ annotations: unknown[] }];
+    };
+    const [{ annotations }] = annotationOutput.content;
+    const annotationPrototype = Object.create(Array.prototype) as Record<number, unknown>;
+    [annotationPrototype[0]] = annotations;
+    delete annotations[0];
+    Object.setPrototypeOf(annotations, annotationPrototype);
+
+    expect(() =>
+      applyEvent(annotationSnapshot, {
+        type: 'response.output_text.annotation.added',
+        output_index: 0,
+        content_index: 0,
+        annotation_index: 0,
+        annotation: { type: 'url_citation', url: 'https://example.com/injected' },
+      }),
+    ).toThrow('missing annotation at index 0');
+    expect(annotations).toHaveLength(1);
+    expect(hasOwn(annotations, 0)).toBe(false);
   });
 
   test.each([

--- a/tests/lib/ResponseAccumulator.events.test.ts
+++ b/tests/lib/ResponseAccumulator.events.test.ts
@@ -697,10 +697,15 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
   });
 
   test.each([
-    ['output', 'response.output_item.added', 'output_index'],
-    ['content', 'response.content_part.added', 'content_index'],
-    ['summary', 'response.reasoning_summary_part.added', 'summary_index'],
-  ])('rejects inherited numeric setters at the declared %s append position', (kind, type, indexField) => {
+    ['output', 'response.output_item.added', 'output_index', 1, 'declared append'],
+    ['content', 'response.content_part.added', 'content_index', 1, 'declared append'],
+    ['summary', 'response.reasoning_summary_part.added', 'summary_index', 1, 'declared append'],
+    ['output', 'response.output_item.added', 'output_index', 0, 'replayed existing'],
+    ['content', 'response.content_part.added', 'content_index', 0, 'replayed existing'],
+    ['summary', 'response.reasoning_summary_part.added', 'summary_index', 0, 'replayed existing'],
+  ])(
+    'rejects inherited numeric setters for a %s %s index',
+    (kind, type, indexField, declaredIndex) => {
     let snapshot: Response;
     if (kind === 'output') {
       snapshot = snapshotFor({ type: 'function_call', id: 'original', arguments: '' });
@@ -743,7 +748,7 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
       applyEvent(snapshot, {
         type,
         output_index: 0,
-        [indexField]: 0,
+        [indexField]: declaredIndex,
         item: { type: 'function_call', id: 'injected', arguments: '' },
         part: {
           type: kind === 'summary' ? 'summary_text' : 'output_text',
@@ -751,12 +756,13 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
           annotations: [],
         },
       }),
-    ).toThrow(`missing ${kind === 'summary' ? 'content' : kind} at index 0`);
+    ).toThrow(`missing ${kind === 'summary' ? 'content' : kind} at index ${declaredIndex}`);
 
-    expect(inheritedSetterCalled).toBe(false);
-    expect(collection).toHaveLength(1);
-    expect(hasOwn(collection, 1)).toBe(false);
-  });
+      expect(inheritedSetterCalled).toBe(false);
+      expect(collection).toHaveLength(1);
+      expect(hasOwn(collection, 1)).toBe(false);
+    },
+  );
 
   test('rejects inherited numeric setters before appending annotations', () => {
     const snapshot = snapshotFor({

--- a/tests/lib/ResponseAccumulator.events.test.ts
+++ b/tests/lib/ResponseAccumulator.events.test.ts
@@ -743,7 +743,7 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
         },
       });
       Object.setPrototypeOf(collection, collectionPrototype);
-  
+
       expect(() =>
         applyEvent(snapshot, {
           type,
@@ -757,7 +757,7 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
           },
         }),
       ).toThrow(`missing ${kind === 'summary' ? 'content' : kind} at index ${declaredIndex}`);
-  
+
       expect(inheritedSetterCalled).toBe(false);
       expect(collection).toHaveLength(1);
       expect(hasOwn(collection, 1)).toBe(false);

--- a/tests/lib/ResponseAccumulator.events.test.ts
+++ b/tests/lib/ResponseAccumulator.events.test.ts
@@ -743,7 +743,7 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
       applyEvent(snapshot, {
         type,
         output_index: 0,
-        [indexField]: 1,
+        [indexField]: 0,
         item: { type: 'function_call', id: 'injected', arguments: '' },
         part: {
           type: kind === 'summary' ? 'summary_text' : 'output_text',
@@ -751,7 +751,7 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
           annotations: [],
         },
       }),
-    ).toThrow(`missing ${kind === 'summary' ? 'content' : kind} at index 1`);
+    ).toThrow(`missing ${kind === 'summary' ? 'content' : kind} at index 0`);
 
     expect(inheritedSetterCalled).toBe(false);
     expect(collection).toHaveLength(1);


### PR DESCRIPTION
## Summary

Harden handwritten Responses streaming accumulation against remotely controlled event indices without changing generated SDK resources, clients, or public types.

- Validate `output_index`, `content_index`, and `summary_index` before every existing-element lookup, replacement, or append.
- Require existing references to be safe nonnegative integers below the current collection length and to resolve to an own array element.
- Allow additions only at an existing own element or exactly the current collection length, preserving replay behavior while rejecting sparse gaps and inherited keys.
- Bound `annotation_index` to an existing own annotation or a single contiguous append, and reject inherited numeric append setters before assignment.
- Preserve existing `missing output at index …` / `missing content at index …` errors and avoid initializing missing reasoning content when its index is invalid.
- Reuse the existing ES2020-compatible `hasOwn` helper; no exported API, generated file, ChatCompletion streaming, generic SSE, Azure, tool runner, or Bedrock code changes.

## Security impact

Streaming event index fields arrive from the remote response stream and cannot be trusted merely because their generated TypeScript types say `number`.

Previously, an event such as `response.output_item.done` with `output_index: "__proto__"` caused `getOutput` to resolve `Array.prototype` as though it were an existing output. The subsequent assignment replaced the snapshot array's prototype, corrupted local accumulator state, and immediately failed with errors such as `rsp.output is not iterable` or `.push is not a function`. Equivalent inherited-key attacks reached completed message content, reasoning content, reasoning summaries, and annotations; inherited sparse slots and numeric append setters could also be treated as legitimate state.

Separately, `annotation_index: 4294967294` expanded an empty annotations array to length **4,294,967,295** in one assignment, creating an immediate CPU/memory denial-of-service vector. Merely restricting values to JavaScript's legal array-index range does not address this: the fix derives a practical protocol bound directly from the collection's current length and accepts only an existing own slot or one contiguous append. Negative, fractional, nonfinite, unsafe-integer, string, inherited, and out-of-range indices now fail before lookup, allocation, assignment, initialization, or append.

## Regression evidence

- The original handwritten focused suite passed **50/50** tests before new regressions were added.
- Against the unchanged vulnerable accumulator, the new exploit regressions produced **23 failing cases**, including the exact prototype-replacement crash and oversized annotation insertion.
- An independent bypass review then reproduced an inherited numeric annotation setter firing at the append position; a separate regression failed first and now proves the setter is never called.
- The final focused suite passes **99/99** cases, covering inherited names, array-prototype preservation, malformed and unsafe numeric indices, large-but-valid JavaScript indices, sparse inherited values, oversized annotations without expanding array length, inherited append setters, compatible contiguous insertion, and output/content/summary/annotation replay.

## Verification

```sh
./node_modules/.bin/vitest run --config vitest.config.mts tests/lib/ResponseAccumulator.events.test.ts
# 99 passed

COREPACK_HOME=/tmp/openai-node-responses-corepack XDG_CACHE_HOME=/tmp/openai-node-responses-xdg pnpm test:unit --update=none
# 66 test files, 1,893 tests passed; snapshots unchanged

./node_modules/.bin/tsc --noEmit
./scripts/lint
COREPACK_HOME=/tmp/openai-node-responses-corepack XDG_CACHE_HOME=/tmp/openai-node-responses-xdg pnpm build
# TypeScript, repository formatting/lint, CommonJS build, ESM build, and package smoke imports all pass
```

This is distinct from #2318, which only addresses `ChatCompletionStream` indices and does not touch Responses accumulation.
