### PR TITLE
fix(streaming): eliminate quadratic SSE buffer copying

### DIFF
--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -334,6 +334,8 @@ const DOUBLE_NEWLINE_DELIMITER_MAX_OVERLAP_BYTES = 3;
  */
 async function* iterSSEChunks(iterator: AsyncIterableIterator<Bytes>): AsyncGenerator<Uint8Array> {
   let data = new Uint8Array();
+  let dataStart = 0;
+  let dataEnd = 0;
   let searchStartIndex = 0;
 
   for await (const chunk of iterator) {
@@ -350,24 +352,39 @@ async function* iterSSEChunks(iterator: AsyncIterableIterator<Bytes>): AsyncGene
       binaryChunk = chunk;
     }
 
-    const newData = new Uint8Array(data.length + binaryChunk.length);
-    newData.set(data);
-    newData.set(binaryChunk, data.length);
-    data = newData;
+    if (dataEnd + binaryChunk.length > data.length) {
+      const bufferedLength = dataEnd - dataStart;
 
-    let patternIndex;
-    while ((patternIndex = findDoubleNewlineIndex(data.subarray(searchStartIndex))) !== -1) {
-      patternIndex += searchStartIndex;
-      yield data.slice(0, patternIndex);
-      data = data.slice(patternIndex);
-      searchStartIndex = 0;
+      // Compact only when it reclaims substantial space without moving a large live tail repeatedly.
+      if (dataStart >= data.length / 2 && bufferedLength + binaryChunk.length <= data.length) {
+        data.copyWithin(0, dataStart, dataEnd);
+      } else {
+        const newData = new Uint8Array(Math.max(data.length * 2, bufferedLength + binaryChunk.length));
+        newData.set(data.subarray(dataStart, dataEnd));
+        data = newData;
+      }
+
+      searchStartIndex -= dataStart;
+      dataStart = 0;
+      dataEnd = bufferedLength;
     }
 
-    searchStartIndex = Math.max(0, data.length - DOUBLE_NEWLINE_DELIMITER_MAX_OVERLAP_BYTES);
+    data.set(binaryChunk, dataEnd);
+    dataEnd += binaryChunk.length;
+
+    let patternIndex;
+    while ((patternIndex = findDoubleNewlineIndex(data.subarray(searchStartIndex, dataEnd))) !== -1) {
+      patternIndex += searchStartIndex;
+      yield data.slice(dataStart, patternIndex);
+      dataStart = patternIndex;
+      searchStartIndex = dataStart;
+    }
+
+    searchStartIndex = Math.max(dataStart, dataEnd - DOUBLE_NEWLINE_DELIMITER_MAX_OVERLAP_BYTES);
   }
 
-  if (data.length > 0) {
-    yield data;
+  if (dataEnd > dataStart) {
+    yield data.slice(dataStart, dataEnd);
   }
 }
 

--- a/tests/lib/streaming-core.test.ts
+++ b/tests/lib/streaming-core.test.ts
@@ -484,6 +484,70 @@ describe('_iterSSEMessages', () => {
     }
   });
 
+  test('copies fragmented SSE data a linear number of times', async () => {
+    const payload = 'x'.repeat(4096);
+    const event = encoder.encode(`data: ${payload}\n\n`);
+    const response = new Response(ReadableStreamFrom(Array.from(event, (byte) => Uint8Array.of(byte))));
+    const copyBytes = vi.spyOn(Uint8Array.prototype, 'set');
+
+    try {
+      await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toMatchObject([
+        { event: null, data: payload },
+      ]);
+
+      const copiedBytes = copyBytes.mock.calls.reduce((total, [source]) => total + source.length, 0);
+      expect(copiedBytes).toBeLessThan(event.byteLength * 8);
+    } finally {
+      copyBytes.mockRestore();
+    }
+  });
+
+  test('compacts consumed prefixes without overwriting retained SSE frames', async () => {
+    const firstFrame = encoder.encode('data: first\r\n\r\n');
+    const response = new Response(
+      ReadableStreamFrom([
+        encoder.encode('data: first\r\n\r\ndata: second\r\n\r'),
+        encoder.encode('\n'),
+        encoder.encode('data: third\r\n\r\n'),
+      ]),
+    );
+    const compactBytes = vi.spyOn(Uint8Array.prototype, 'copyWithin');
+    const decodeLines = vi.spyOn(lineDecoders.LineDecoder.prototype, 'decode');
+
+    try {
+      await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toMatchObject([
+        { event: null, data: 'first' },
+        { event: null, data: 'second' },
+        { event: null, data: 'third' },
+      ]);
+
+      expect(compactBytes).toHaveBeenCalled();
+      expect(decodeLines.mock.calls[0]?.[0]).toEqual(firstFrame);
+    } finally {
+      decodeLines.mockRestore();
+      compactBytes.mockRestore();
+    }
+  });
+
+  test('does not compact a large live event to reclaim a small consumed prefix', async () => {
+    const payload = 'x'.repeat(4096);
+    const response = new Response(
+      ReadableStreamFrom([encoder.encode(`data: first\n\ndata: ${payload}`), encoder.encode('\n\n')]),
+    );
+    const compactBytes = vi.spyOn(Uint8Array.prototype, 'copyWithin');
+
+    try {
+      await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toMatchObject([
+        { event: null, data: 'first' },
+        { event: null, data: payload },
+      ]);
+
+      expect(compactBytes).not.toHaveBeenCalled();
+    } finally {
+      compactBytes.mockRestore();
+    }
+  });
+
   test('ignores an SSE message that ends without its required blank-line delimiter', async () => {
     const response = responseForSSE('data: {"flushed":true}\n');
 


### PR DESCRIPTION
## Production impact

Merged #1913 documented production Node.js event-loop utilization reaching 100% while decoding fragmented SSE responses; roughly 95% of delimiter scans were redundant. That change fixed quadratic delimiter **rescanning**, but the immediately adjacent `iterSSEChunks` append path still allocated an exact-size `Uint8Array` and recopied every previously buffered byte for every transport fragment.

For `n` one-byte fragments, copying the existing prefix alone costs `n(n - 1) / 2` bytes:

- 16 KiB: **134,209,536 bytes** copied for one 16,384-byte event.
- 1 MiB: **549,755,289,600 bytes** copied for one 1,048,576-byte event.

Fragmented upstream responses, slow custom transports, or large audio/structured-output events can therefore create avoidable CPU and GC pressure and exhaust the event loop even after #1913.

## Change

- Keep a geometrically growing `Uint8Array` and track its active start/end plus the absolute delimiter scan cursor.
- Compact only when the consumed prefix occupies at least half the capacity **and** the live event plus incoming fragment still fit; otherwise grow geometrically. This avoids repeatedly copying a huge live tail to reclaim a tiny consumed prefix.
- Preserve #1913's three-byte delimiter overlap, consecutive events, mixed CR/LF separators split across fragments, null chunks, strings/`ArrayBuffer`/`Uint8Array`, and trailing incomplete events.
- Yield defensive frame copies so later buffer reuse cannot mutate retained consumer data; do not impose an arbitrary event-size limit.
- Leave merged #2317 completion-sentinel cancellation and reader-cleanup behavior unchanged. Open #2086 and #1648 modify separate earlier regions of this file and do not overlap this patch.

Only the handwritten streaming implementation and handwritten streaming-core tests are changed; no generated SDK files, resources, types, or benchmarks are modified.

## Regression-first evidence

The new deterministic regression feeds a 4,104-byte SSE event one byte at a time and instruments `Uint8Array.prototype.set`; the assertion requires total copied bytes to remain below `8n = 32,832`.

Before this change, the focused test failed with:

```text
AssertionError: expected 8427564 to be less than 32832
```

After this change, the same actual decoder copies **16,399 bytes** (~514x less). Additional focused regressions force compaction across a split CRLF delimiter while retaining an earlier frame, and verify that a tiny consumed prefix never compacts a large live event. The existing no-rescan regression and both #2317 sentinel/cancellation regressions continue to pass.

## Existing repository benchmarks

Medians from the existing `tests/benchmarks/streaming.bench.ts` fixtures on the same remote devbox, Node.js 26.7.0, Vitest 4.1.10, and one-byte transport fragments; each baseline used 10 samples and optimized runs used 10-18 samples:

| Fixture | Operation | Before | After | Improvement |
| --- | --- | ---: | ---: | ---: |
| 8 KiB | Decode SSE frames | 31.43 ms | 6.44 ms | **4.88x** |
| 8 KiB | Decode and parse SSE JSON | 36.95 ms | 5.72 ms | **6.46x** |
| 16 KiB | Decode SSE frames | 60.47 ms | 11.60 ms | **5.21x** |
| 16 KiB | Decode and parse SSE JSON | 62.05 ms | 11.45 ms | **5.42x** |

Benchmark measurements are informational; the regression asserts deterministic copied-byte complexity, not wall-clock timing.

## Verification

- `pnpm test:unit tests/lib/streaming-core.test.ts` — **45 passed**.
- `pnpm test:unit` — **1,941 passed across 68 handwritten test files**.
- `pnpm lint` — passed.
- `pnpm exec tsc` — passed.
- `pnpm build` — passed, including CommonJS/ESM and Bedrock package smoke tests.
- `./node_modules/typescript-4-9/bin/tsc --project dist/src/tsconfig.json --noEmit` — passed.
- `./node_modules/typescript/bin/tsc --project dist/src/tsconfig.json --noEmit` — passed.
- `pnpm bench tests/benchmarks/streaming.bench.ts --testNamePattern='(8|16) KiB event / 1-byte chunks'` — before/after measurements above.
- `git diff --check` — passed.
