### PR TITLE
fix(realtime): remove immutable model updates from public and Azure examples

### DIFF
--- a/examples/azure/realtime/websocket.ts
+++ b/examples/azure/realtime/websocket.ts
@@ -22,7 +22,6 @@ async function main() {
       type: 'session.update',
       session: {
         output_modalities: ['text'],
-        model: 'gpt-4o-realtime-preview',
         type: 'realtime',
       },
     });

--- a/examples/azure/realtime/ws.ts
+++ b/examples/azure/realtime/ws.ts
@@ -22,7 +22,6 @@ async function main() {
       type: 'session.update',
       session: {
         output_modalities: ['text'],
-        model: 'gpt-4o-realtime-preview',
         type: 'realtime',
       },
     });

--- a/examples/realtime/websocket.ts
+++ b/examples/realtime/websocket.ts
@@ -10,7 +10,6 @@ async function main() {
       type: 'session.update',
       session: {
         output_modalities: ['text'],
-        model: 'gpt-4o-realtime-preview',
         type: 'realtime',
       },
     });

--- a/examples/realtime/ws.ts
+++ b/examples/realtime/ws.ts
@@ -10,7 +10,6 @@ async function main() {
       type: 'session.update',
       session: {
         output_modalities: ['text'],
-        model: 'gpt-4o-realtime-preview',
         type: 'realtime',
       },
     });


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Remove `model` from the initial `session.update` in all four handwritten, non-beta Realtime examples:

- OpenAI / Node `ws`: `examples/realtime/ws.ts`
- OpenAI / browser-compatible WebSocket: `examples/realtime/websocket.ts`
- Azure / Node `ws`: `examples/azure/realtime/ws.ts`
- Azure / browser-compatible WebSocket: `examples/azure/realtime/websocket.ts`

Preserve the public connection's `gpt-realtime` model, Azure's configured deployment, and each update's `output_modalities` and `type`. No generated code changes.

## Additional context & links

The authoritative [`SessionUpdateEvent` documentation](https://github.com/openai/openai-node/blob/486e1917b013c1d711dc8f1933748422bb1c3df5/src/resources/realtime/realtime.ts#L5153-L5169) explicitly forbids updating `model` after connection. These examples tried to replace the established model or deployment with `gpt-4o-realtime-preview`; the problem is immutability, not model availability.

TypeScript misses this because the update event reuses `RealtimeSessionCreateRequest`, whose create-time shape legitimately accepts `model`. The [CI examples job](https://github.com/openai/openai-node/blob/486e1917b013c1d711dc8f1933748422bb1c3df5/.github/workflows/ci.yml#L234-L240) only runs a chat-completions demo. The [contributing guide](https://github.com/openai/openai-node/blob/486e1917b013c1d711dc8f1933748422bb1c3df5/.github/CONTRIBUTING.md#L34-L41) guarantees examples are never generated; the [Realtime guide](https://github.com/openai/openai-node/blob/486e1917b013c1d711dc8f1933748422bb1c3df5/docs/realtime.md#L15-L25) already demonstrates the correct model-free update.

## Verification

- `./scripts/lint` — repository-wide lint and formatting checks passed (605 files).
- `./node_modules/.bin/oxfmt --check examples/realtime/ws.ts examples/realtime/websocket.ts examples/azure/realtime/ws.ts examples/azure/realtime/websocket.ts` — all four examples passed.
- `./node_modules/.bin/tsc --project tsconfig.json --noEmit` — passed.
- `./node_modules/.bin/tsc --project examples/tsconfig.json --noEmit` — passed.
- `./node_modules/.bin/vitest run --config vitest.config.mts tests/realtime.test.ts tests/realtime-websocket.test.ts` — 135 tests passed.
- Ephemeral TypeScript-AST contract check — all four updates omit `model`, preserve `output_modalities` and `type`, and retain the public connection model or configured Azure deployment.
- `git diff --check` — passed.

