### PR TITLE
fix(azure): honor explicit browser denial for Entra token providers

### DIFF
--- a/src/azure.ts
+++ b/src/azure.ts
@@ -82,7 +82,7 @@ export class AzureOpenAI extends OpenAI {
     }
 
     if (typeof azureADTokenProvider === 'function') {
-      dangerouslyAllowBrowser = true;
+      dangerouslyAllowBrowser ??= true;
     }
 
     if (!azureADTokenProvider && !apiKey) {

--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -1,5 +1,5 @@
 import { vi } from 'vitest';
-import { AzureOpenAI, APIUserAbortError, toStreamingFile } from 'openai';
+import { AzureOpenAI, APIUserAbortError, OpenAIError, toStreamingFile } from 'openai';
 import type { AzureClientOptions } from 'openai';
 import type { RequestInit, RequestInfo, Response } from 'openai/internal/builtin-types';
 
@@ -259,6 +259,92 @@ describe('instantiate azure client', () => {
   });
 
   describe('Azure Active Directory (AD)', () => {
+    describe('browser credential safety', () => {
+      beforeEach(() => {
+        delete process.env['AZURE_OPENAI_API_KEY'];
+        vi.stubGlobal('window', { document: {} });
+        vi.stubGlobal('navigator', {});
+      });
+
+      afterEach(() => {
+        vi.unstubAllGlobals();
+      });
+
+      test('honors explicit browser denial before obtaining credentials or sending requests', () => {
+        const azureADTokenProvider = vi.fn(async () => 'AZURE_ENTRA_BEARER_SECRET');
+        const customFetch = vi.fn();
+        const createClient = () =>
+          new AzureOpenAI({
+            baseURL: 'https://example.com',
+            apiVersion,
+            azureADTokenProvider,
+            dangerouslyAllowBrowser: false,
+            fetch: customFetch,
+          });
+
+        expect(createClient).toThrow(OpenAIError);
+        expect(createClient).toThrow(/running in a browser-like environment/);
+        expect(azureADTokenProvider).not.toHaveBeenCalled();
+        expect(customFetch).not.toHaveBeenCalled();
+      });
+
+      test.each([undefined, true])(
+        'preserves Microsoft Entra browser access when dangerouslyAllowBrowser is %s',
+        async (dangerouslyAllowBrowser) => {
+          const azureADTokenProvider = vi.fn(async () => 'AZURE_ENTRA_BEARER_SECRET');
+          const customFetch = vi.fn(
+            async (_url: RequestInfo, { headers }: RequestInit = {}): Promise<Response> =>
+              Response.json({ ok: true }, { headers: headers ?? [] }),
+          );
+          const client = new AzureOpenAI({
+            baseURL: 'https://example.com',
+            apiVersion,
+            azureADTokenProvider,
+            dangerouslyAllowBrowser,
+            fetch: customFetch,
+          });
+
+          expect(client).toHaveProperty('_options.dangerouslyAllowBrowser', true);
+
+          const response = await client.request({ method: 'get', path: '/foo' }).asResponse();
+
+          expect(response.headers.get('authorization')).toBe('Bearer AZURE_ENTRA_BEARER_SECRET');
+          expect(azureADTokenProvider).toHaveBeenCalledTimes(1);
+          expect(customFetch).toHaveBeenCalledTimes(1);
+        },
+      );
+
+      test('continues to reject static Azure API keys in browsers', () => {
+        const customFetch = vi.fn();
+
+        expect(
+          () =>
+            new AzureOpenAI({
+              baseURL: 'https://example.com',
+              apiVersion,
+              apiKey: 'My API Key',
+              fetch: customFetch,
+            }),
+        ).toThrow(OpenAIError);
+        expect(customFetch).not.toHaveBeenCalled();
+      });
+    });
+
+    test('preserves explicit browser denial outside browser environments', () => {
+      delete process.env['AZURE_OPENAI_API_KEY'];
+
+      const azureADTokenProvider = vi.fn(async () => 'AZURE_ENTRA_BEARER_SECRET');
+      const client = new AzureOpenAI({
+        baseURL: 'https://example.com',
+        apiVersion,
+        azureADTokenProvider,
+        dangerouslyAllowBrowser: false,
+      });
+
+      expect(client).toHaveProperty('_options.dangerouslyAllowBrowser', false);
+      expect(azureADTokenProvider).not.toHaveBeenCalled();
+    });
+
     test('with azureADTokenProvider', async () => {
       const testFetch = async (url: RequestInfo, { headers }: RequestInit = {}): Promise<Response> =>
         Response.json({ a: 1 }, { headers: headers ?? [] });

--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -294,7 +294,7 @@ describe('instantiate azure client', () => {
           const azureADTokenProvider = vi.fn(async () => 'AZURE_ENTRA_BEARER_SECRET');
           const customFetch = vi.fn(
             async (_url: RequestInfo, { headers }: RequestInit = {}): Promise<Response> =>
-              Response.json({ ok: true }, { headers: headers ?? [] }),
+              new globalThis.Response(JSON.stringify({ ok: true }), { headers: headers ?? [] }),
           );
           const client = new AzureOpenAI({
             baseURL: 'https://example.com',


### PR DESCRIPTION
## Summary

- Honor an explicitly configured `dangerouslyAllowBrowser: false` for Azure clients that use a Microsoft Entra token provider.
- Preserve the existing browser behavior when `dangerouslyAllowBrowser` is omitted or explicitly set to `true`.
- Add regression coverage for browser denial, browser opt-in compatibility, Azure static-key protections, and server-side option propagation.

## Security impact

The handwritten Azure constructor unconditionally replaced the caller's browser-security setting with `true` whenever `azureADTokenProvider` was a function. Consequently, an application that explicitly configured:

```ts
new AzureOpenAI({
  azureADTokenProvider,
  dangerouslyAllowBrowser: false,
  apiVersion,
  baseURL,
});
```

could still instantiate the client in a browser and send `Authorization: Bearer <Microsoft Entra token>`. The overwritten setting was also stored on the client and inherited by native Realtime connections.

Switching to `dangerouslyAllowBrowser ??= true` preserves the historical implicit browser allowance for existing Entra integrations while honoring an explicit denial. The existing generated OpenAI browser guard now raises its unchanged `OpenAIError` before the token provider or custom fetch can run; no generated SDK files are modified.

## Regression proof

Before the production fix, `./scripts/test tests/lib/azure.test.ts` produced **2 failing / 64 passing tests**:

- The simulated-browser constructor did not reject explicit `dangerouslyAllowBrowser: false`.
- A non-browser client incorrectly stored `dangerouslyAllowBrowser: true` instead of the caller's `false`.

The new browser fixtures stub both `window.document` and `navigator`, restore their original global-property descriptors, and clear `AZURE_OPENAI_API_KEY` before provider-based cases.

## Verification

- `./scripts/test tests/lib/azure.test.ts` — **66 passed**.
- `./scripts/test tests/lib/azure.test.ts tests/lib/azure-redirect.test.ts tests/realtime-websocket.test.ts` — **176 passed**.
- `env CI=1 COREPACK_HOME=/tmp/openai-node-responses-corepack ./node_modules/.bin/vitest run --config vitest.config.mts` — **1,943 passed across 68 handwritten test files**.
- `./scripts/lint`.
- `./node_modules/.bin/tsc`.
- `./scripts/build`.
- `./node_modules/typescript-4-9/bin/tsc --project dist/src/tsconfig.json --noEmit`.
- `./node_modules/typescript/bin/tsc --project dist/src/tsconfig.json --noEmit`.
- `env COREPACK_HOME=/tmp/openai-node-responses-corepack ./node_modules/.bin/publint dist` — passed with the existing non-blocking vendor-export warning.
