### PR TITLE
fix: preserve zero retry-after-ms precedence

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1078,7 +1078,7 @@ export class OpenAI {
 
     // About the Retry-After header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
     const retryAfterHeader = responseHeaders?.get('retry-after');
-    if (retryAfterHeader && !timeoutMillis) {
+    if (retryAfterHeader && timeoutMillis === undefined) {
       const timeoutSeconds = parseFloat(retryAfterHeader);
       if (!Number.isNaN(timeoutSeconds)) {
         timeoutMillis = timeoutSeconds * 1000;

--- a/tests/client-behavior.test.ts
+++ b/tests/client-behavior.test.ts
@@ -126,6 +126,34 @@ describe('OpenAI client request behavior', () => {
     }
   });
 
+  test('prefers retry-after-ms over retry-after even when retry-after-ms is zero', async () => {
+    const parseDate = vi.spyOn(Date, 'parse');
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(
+          { error: { message: 'rate limited' } },
+          {
+            status: 429,
+            headers: {
+              'retry-after-ms': '0',
+              'retry-after': new Date(0).toUTCString(),
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(jsonResponse({ recovered: true }));
+    const client = new OpenAI({ apiKey: 'test-key', maxRetries: 1, fetch });
+
+    try {
+      await expect(client.get('/items')).resolves.toEqual({ recovered: true });
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(parseDate).not.toHaveBeenCalled();
+    } finally {
+      parseDate.mockRestore();
+    }
+  });
+
   test.each([
     [new Error('network unavailable'), APIConnectionError],
     [new Error('connection timed out'), APIConnectionTimeoutError],


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

This fixes retry delay precedence when a response includes both `retry-after-ms: 0` and `retry-after`. The SDK already gives `retry-after-ms` priority for positive values, but `0` was treated as absent because the fallback check used truthiness.

The change keeps the parsed millisecond value whenever it is defined, so an explicit zero millisecond retry remains an immediate retry.

## Additional context & links

Added a regression test that verifies the `retry-after` HTTP-date parser is not consulted when `retry-after-ms` is present with value `0`.

Verification:

- `pnpm test:unit tests/client-behavior.test.ts`
- `pnpm test:unit tests/client-behavior.test.ts tests/index.test.ts tests/lib/azure.test.ts tests/lib/provider.test.ts tests/lib/workload-identity.test.ts`
- `pnpm lint`
- `pnpm build`
