### PR TITLE
fix: configure Bash for pnpm scripts on Windows

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -21,6 +21,12 @@ $ PNPM_VERSION=$(node -p "require('./package.json').packageManager.replace(/^pnp
 $ npm install --global "pnpm@$PNPM_VERSION"
 ```
 
+### Windows shell requirements
+
+The repository's pnpm scripts use Bash. On Windows, install [Git for Windows](https://git-scm.com/download/win)
+and run the development commands from Git Bash, where `bash` is available on `PATH`. If you run pnpm from
+PowerShell instead, add the Git for Windows `bin` directory that contains `bash.exe` to `PATH` first.
+
 To set up the repository, run:
 
 ```sh
@@ -44,7 +50,7 @@ All files in the `examples/` directory are not modified by the generator and can
 // add an example to examples/<category>/<your-example>.ts
 
 #!/usr/bin/env -S npm run tsn -- -T
-…
+?
 ```
 
 ```sh
@@ -55,7 +61,7 @@ $ npm run tsn -- -T examples/<category>/<your-example>.ts
 
 ## Using the repository from source
 
-If you’d like to use the repository from source, you can either install from git or link to a cloned repository:
+If you?d like to use the repository from source, you can either install from git or link to a cloned repository:
 
 To install via git:
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -50,7 +50,7 @@ All files in the `examples/` directory are not modified by the generator and can
 // add an example to examples/<category>/<your-example>.ts
 
 #!/usr/bin/env -S npm run tsn -- -T
-?
+…
 ```
 
 ```sh
@@ -61,7 +61,7 @@ $ npm run tsn -- -T examples/<category>/<your-example>.ts
 
 ## Using the repository from source
 
-If you?d like to use the repository from source, you can either install from git or link to a cloned repository:
+If you’d like to use the repository from source, you can either install from git or link to a cloned repository:
 
 To install via git:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,8 @@ packages:
   - examples
   - '!ecosystem-tests/**'
 
+scriptShell: bash
+
 minimumReleaseAge: 11520
 minimumReleaseAgeStrict: true
 trustPolicy: no-downgrade

--- a/tests/oxlint-config.test.ts
+++ b/tests/oxlint-config.test.ts
@@ -8,9 +8,8 @@ const oxlint = path.join(repoRoot, 'node_modules/oxlint/bin/oxlint');
 const oxfmt = path.join(repoRoot, 'node_modules/oxfmt/bin/oxfmt');
 
 function spawnPnpmScript(script: 'format' | 'lint') {
-  const command = process.platform === 'win32' ? 'bash' : 'pnpm';
-  const args =
-    process.platform === 'win32' ? ['-c', 'pnpm --config.script-shell=bash "$@"', '_', script] : [script];
+  const command = process.platform === 'win32' ? (process.env['ComSpec'] ?? 'cmd.exe') : 'pnpm';
+  const args = process.platform === 'win32' ? ['/d', '/s', '/c', `pnpm ${script}`] : [script];
 
   return spawnSync(command, args, { cwd: repoRoot, encoding: 'utf-8' });
 }


### PR DESCRIPTION
## Problem

On Windows, the documented pnpm development commands cannot launch the repository's POSIX entrypoints. For example, `pnpm build` fails immediately with `'.' is not recognized`, and `pnpm run prepare` fails while parsing the shell `if` statement.

The existing public-command regression test avoids this by passing a test-only `--config.script-shell=bash` override, so it does not verify the repository's checked-in pnpm configuration.

## Root cause

The package scripts invoke Bash scripts and use POSIX shell syntax, but pnpm defaults to `cmd.exe` for scripts on Windows. The workspace does not configure pnpm's `scriptShell` setting.

## Fix

- Configure `scriptShell: bash` in `pnpm-workspace.yaml` so pnpm uses the shell already required by the repository scripts.
- Update the public `lint` / `format` command regression test to launch pnpm through the normal Windows command processor without injecting a script-shell override.

## Tests

Validated on Windows with Node 24.19.0 and pnpm 11.5.1 against current `main`:

- baseline `pnpm build` — failed with `'.' is not recognized`
- baseline `pnpm run prepare` — failed with `then was unexpected at this time`
- `pnpm exec vitest run --config vitest.config.mts tests/oxlint-config.test.ts` — 9/9 passed
- `CI=1 pnpm test:unit` — 68 files, 1,938 tests passed
- `pnpm run prepare` — passed
- `pnpm build` — passed
- `pnpm exec tsc --pretty false` — passed
- `pnpm lint` — passed in a clean current-main snapshot
- `git diff --check` — passed

The generated Jest suite cannot start locally on Windows because `@stdy/cli@0.22.1` references an unpublished `@stdy/cli-win32-x64@0.22.1` binary; the handwritten suite completes before that unrelated tool failure.

## Compatibility / Risk

Tooling-only change. SDK runtime code, generated files, public exports, and package behavior are unchanged. The repository scripts already declare Bash in their shebangs; this makes pnpm select that same shell explicitly. Bash must remain available on `PATH` on Windows.
