### PR TITLE
fix: parse empty chat content when present

### DIFF
--- a/src/lib/ChatCompletionStream.ts
+++ b/src/lib/ChatCompletionStream.ts
@@ -482,7 +482,14 @@ export class ChatCompletionStream<ParsedT = null>
   #emitContentDoneEvents(choiceSnapshot: ChatCompletionSnapshot.Choice) {
     const state = this.#getChoiceEventState(choiceSnapshot);
 
-    if (choiceSnapshot.message.content && !state.content_done) {
+    if (
+      choiceSnapshot.message.content != null &&
+      (choiceSnapshot.message.content !== '' ||
+        (!choiceSnapshot.message.refusal &&
+          !choiceSnapshot.message.tool_calls?.length &&
+          !choiceSnapshot.message.function_call)) &&
+      !state.content_done
+    ) {
       state.content_done = true;
 
       this._emit('content.done', {
@@ -738,7 +745,7 @@ export class ChatCompletionStream<ParsedT = null>
           choice.message.function_call = function_call;
         }
       }
-      if (content) {
+      if (content != null) {
         choice.message.content = (choice.message.content || '') + content;
 
         if (!choice.message.refusal && isParseableResponseFormat(this.#params?.response_format)) {

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -300,7 +300,7 @@ export function parseChatCompletion<
             }
           : undefined),
         parsed:
-          choice.message.content && !choice.message.refusal
+          choice.message.content !== null && choice.message.content !== undefined && !choice.message.refusal
             ? parseResponseFormat(params, choice.message.content)
             : null,
       },

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -300,7 +300,11 @@ export function parseChatCompletion<
             }
           : undefined),
         parsed:
-          choice.message.content !== null && choice.message.content !== undefined && !choice.message.refusal
+          choice.message.content !== null &&
+          choice.message.content !== undefined &&
+          !choice.message.refusal &&
+          (choice.message.content !== '' ||
+            (!choice.message.tool_calls?.length && !choice.message.function_call))
             ? parseResponseFormat(params, choice.message.content)
             : null,
       },

--- a/tests/lib/ChatCompletionStream.test.ts
+++ b/tests/lib/ChatCompletionStream.test.ts
@@ -5,6 +5,7 @@ import { zodResponseFormat } from 'openai/helpers/zod';
 import { ChatCompletionStream } from 'openai/lib/ChatCompletionStream';
 import type { ChatCompletionSnapshot } from 'openai/lib/ChatCompletionStream';
 import { ChatCompletionStreamingRunner } from 'openai/lib/ChatCompletionStreamingRunner';
+import { makeParseableResponseFormat } from 'openai/lib/parser';
 import type { ChatCompletionTokenLogprob } from 'openai/resources';
 import { Stream } from 'openai/streaming';
 import { z } from 'zod/v4';
@@ -1238,6 +1239,151 @@ describe('.stream()', () => {
     expect(deltaParsed).toEqual([{}, { city: 'SF' }]);
     expect(doneParsed).toEqual({ city: 'SF' });
     expect(completion.choices[0]?.message.parsed).toEqual({ city: 'SF' });
+  });
+
+  it('parses present empty assistant content when structured streaming finishes', async () => {
+    const parseRaw = vi.fn((raw: string) => ({ raw }));
+    const format = makeParseableResponseFormat(
+      { type: 'json_schema', json_schema: { name: 'empty_content', schema: {} } },
+      parseRaw,
+    );
+    const stream = ChatCompletionStream.createChatCompletion(mockStreamingClient(contentChunks('')), {
+      model: 'gpt-test',
+      messages: [{ role: 'user', content: 'Return empty content' }],
+      response_format: format,
+    });
+    const contentEvents: unknown[] = [];
+    const deltaEvents: unknown[] = [];
+    const doneEvents: unknown[] = [];
+    stream.on('content', (...event) => contentEvents.push(event));
+    stream.on('content.delta', (event) => deltaEvents.push(event));
+    stream.on('content.done', (event) => doneEvents.push(event));
+
+    const completion = await stream.finalChatCompletion();
+
+    expect(completion.choices[0]?.message).toMatchObject({ content: '', parsed: { raw: '' } });
+    expect(contentEvents).toEqual([]);
+    expect(deltaEvents).toEqual([]);
+    expect(doneEvents).toEqual([{ content: '', parsed: { raw: '' } }]);
+    expect(parseRaw).toHaveBeenCalledTimes(2);
+    expect(parseRaw).toHaveBeenNthCalledWith(1, '');
+    expect(parseRaw).toHaveBeenNthCalledWith(2, '');
+  });
+
+  it.each([undefined, null] as const)(
+    'does not emit content events when assistant content is %s',
+    async (content) => {
+      const [chunk] = contentChunks('');
+      if (!chunk?.choices[0]) {
+        throw new Error('Expected a completion choice');
+      }
+      chunk.choices[0].delta = content === undefined ? { role: 'assistant' } : { role: 'assistant', content };
+
+      const parseRaw = vi.fn((raw: string) => ({ raw }));
+      const format = makeParseableResponseFormat(
+        { type: 'json_schema', json_schema: { name: 'absent_content', schema: {} } },
+        parseRaw,
+      );
+      const stream = ChatCompletionStream.createChatCompletion(mockStreamingClient([chunk]), {
+        model: 'gpt-test',
+        messages: [{ role: 'user', content: 'Return no content' }],
+        response_format: format,
+      });
+      const contentEvents: unknown[] = [];
+      const deltaEvents: unknown[] = [];
+      const doneEvents: unknown[] = [];
+      stream.on('content', (...event) => contentEvents.push(event));
+      stream.on('content.delta', (event) => deltaEvents.push(event));
+      stream.on('content.done', (event) => doneEvents.push(event));
+
+      const completion = await stream.finalChatCompletion();
+
+      expect(completion.choices[0]?.message).toMatchObject({ content: null, parsed: null });
+      expect(contentEvents).toEqual([]);
+      expect(deltaEvents).toEqual([]);
+      expect(doneEvents).toEqual([]);
+      expect(parseRaw).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does not parse empty content preceding structured streamed tool calls', async () => {
+    const chunks = [
+      customToolChunk({ role: 'assistant', content: '' }),
+      customToolChunk({
+        tool_calls: [
+          {
+            index: 0,
+            id: 'call_function_123',
+            type: 'function',
+            function: { name: 'get_weather', arguments: '{"city":"SF"}' },
+          },
+        ],
+      }),
+      customToolChunk({}, 'tool_calls'),
+    ];
+    const stream = ChatCompletionStream.createChatCompletion(mockStreamingClient(chunks), {
+      model: 'gpt-test',
+      messages: [{ role: 'user', content: 'Check the weather' }],
+      response_format: {
+        type: 'json_schema',
+        json_schema: { name: 'location', schema: { type: 'object' } },
+      },
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'get_weather',
+            strict: true,
+            parameters: { type: 'object', properties: { city: { type: 'string' } } },
+          },
+        },
+      ],
+    });
+    const doneEvents: unknown[] = [];
+    stream.on('content.done', (event) => doneEvents.push(event));
+
+    const completion = await stream.finalChatCompletion();
+
+    expect(completion.choices[0]?.message).toMatchObject({
+      content: '',
+      parsed: null,
+      tool_calls: [{ type: 'function', function: { name: 'get_weather', parsed_arguments: { city: 'SF' } } }],
+    });
+    expect(doneEvents).toEqual([]);
+  });
+
+  it('keeps empty refusal content unparsed without emitting a content completion', async () => {
+    const [chunk] = contentChunks('');
+    if (!chunk?.choices[0]) {
+      throw new Error('Expected a completion choice');
+    }
+    chunk.choices[0].delta.refusal = 'Request refused';
+
+    const parseRaw = vi.fn((raw: string) => ({ raw }));
+    const format = makeParseableResponseFormat(
+      { type: 'json_schema', json_schema: { name: 'refused_content', schema: {} } },
+      parseRaw,
+    );
+    const stream = ChatCompletionStream.createChatCompletion(mockStreamingClient([chunk]), {
+      model: 'gpt-test',
+      messages: [{ role: 'user', content: 'Return refused content' }],
+      response_format: format,
+    });
+    const doneEvents: unknown[] = [];
+    const refusals: string[] = [];
+    stream.on('content.done', (event) => doneEvents.push(event));
+    stream.on('refusal.done', (event) => refusals.push(event.refusal));
+
+    const completion = await stream.finalChatCompletion();
+
+    expect(completion.choices[0]?.message).toMatchObject({
+      content: '',
+      parsed: null,
+      refusal: 'Request refused',
+    });
+    expect(doneEvents).toEqual([]);
+    expect(refusals).toEqual(['Request refused']);
+    expect(parseRaw).not.toHaveBeenCalled();
   });
 
   it('preserves unbranded custom parsers for structured stream completion', async () => {

--- a/tests/lib/parser.test.ts
+++ b/tests/lib/parser.test.ts
@@ -1617,6 +1617,41 @@ describe('maybeParseChatCompletion', () => {
       units: 'c',
     });
   });
+
+  it('parses present empty assistant content with the response_format parser', () => {
+    const parseRaw = vi.fn((raw: string) => ({ raw }));
+    const format = makeParseableResponseFormat(
+      { type: 'json_schema', json_schema: { name: 'empty_content', schema: {} } },
+      parseRaw,
+    );
+    const rawCompletion = {
+      id: 'chatcmpl-empty',
+      object: 'chat.completion' as const,
+      created: 1_677_652_288,
+      model: 'gpt-4o-2024-08-06',
+      choices: [
+        {
+          index: 0,
+          finish_reason: 'stop' as const,
+          logprobs: null,
+          message: {
+            role: 'assistant' as const,
+            content: '',
+            refusal: null,
+          },
+        },
+      ],
+    };
+
+    const parsed = maybeParseChatCompletion(rawCompletion, {
+      model: 'gpt-4o-2024-08-06',
+      messages: [{ role: 'user', content: 'hello' }],
+      response_format: format,
+    });
+
+    expect(parseRaw).toHaveBeenCalledWith('');
+    expect(parsed.choices[0]?.message.parsed).toEqual({ raw: '' });
+  });
 });
 
 describe('isParseableResponseFormat', () => {

--- a/tests/lib/parser.test.ts
+++ b/tests/lib/parser.test.ts
@@ -1652,6 +1652,64 @@ describe('maybeParseChatCompletion', () => {
     expect(parseRaw).toHaveBeenCalledWith('');
     expect(parsed.choices[0]?.message.parsed).toEqual({ raw: '' });
   });
+
+  it('does not parse empty assistant content on tool-call-only choices', () => {
+    const rawCompletion: OpenAI.Chat.ChatCompletion = {
+      id: 'chatcmpl-empty-tool-call',
+      object: 'chat.completion',
+      created: 1_677_652_288,
+      model: 'gpt-4o-2024-08-06',
+      choices: [
+        {
+          index: 0,
+          finish_reason: 'tool_calls',
+          logprobs: null,
+          message: {
+            role: 'assistant',
+            content: '',
+            refusal: null,
+            tool_calls: [
+              {
+                id: 'call_weather',
+                type: 'function',
+                function: { name: 'get_weather', arguments: '{"city":"SF"}' },
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    const parsed = maybeParseChatCompletion(rawCompletion, {
+      model: 'gpt-4o-2024-08-06',
+      messages: [{ role: 'user', content: 'check the weather' }],
+      response_format: {
+        type: 'json_schema',
+        json_schema: { name: 'location', schema: { type: 'object' } },
+      },
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'get_weather',
+            strict: true,
+            parameters: { type: 'object' },
+          },
+        },
+      ],
+    });
+
+    expect(parsed.choices[0]?.message.parsed).toBeNull();
+    expect(parsed.choices[0]?.message.tool_calls?.[0]).toEqual({
+      id: 'call_weather',
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        arguments: '{"city":"SF"}',
+        parsed_arguments: { city: 'SF' },
+      },
+    });
+  });
 });
 
 describe('isParseableResponseFormat', () => {


### PR DESCRIPTION
Summary:
- Treat `content: ""` as present chat content during final structured-output parsing.
- Add regression coverage that a branded `response_format` parser receives the empty string.

Reason:
The Chat Completions parser used a truthy content check before invoking the `response_format` parser, so final assistant messages with empty-string content returned `parsed: null`. Present content should be handed to the parser and let that parser decide whether empty text is valid.

Verification:
- `pnpm exec vitest run --config vitest.config.mts tests/lib/parser.test.ts -t "parses present empty assistant content"`
- `pnpm exec vitest run --config vitest.config.mts tests/lib/parser.test.ts`
- `pnpm lint`
- `pnpm build`