### PR TITLE
fix(streaming): make fragmented line decoding amortized linear

### DIFF
--- a/src/internal/decoders/line.ts
+++ b/src/internal/decoders/line.ts
@@ -102,18 +102,20 @@ export class LineDecoder {
       if (this.#buffer.length > MAX_RETAINED_BUFFER_BYTES) {
         this.#buffer = new Uint8Array();
       }
-    } else if (
-      lines.length > 0 &&
-      this.#buffer.length > MAX_RETAINED_BUFFER_BYTES &&
-      this.#end - this.#start <= MAX_RETAINED_BUFFER_BYTES
-    ) {
+    } else if (lines.length > 0 && this.#buffer.length > MAX_RETAINED_BUFFER_BYTES) {
       const length = this.#end - this.#start;
-      const buffer = new Uint8Array(Math.max(length, 256));
-      buffer.set(this.#buffer.subarray(this.#start, this.#end));
-      this.#buffer = buffer;
-      this.#start = 0;
-      this.#end = length;
-      this.#searchIndex = length;
+      if (length <= MAX_RETAINED_BUFFER_BYTES || this.#buffer.length > length * 4) {
+        const capacity =
+          length <= MAX_RETAINED_BUFFER_BYTES
+            ? Math.min(Math.max(length * 2, 256), MAX_RETAINED_BUFFER_BYTES)
+            : length * 2;
+        const buffer = new Uint8Array(capacity);
+        buffer.set(this.#buffer.subarray(this.#start, this.#end));
+        this.#buffer = buffer;
+        this.#start = 0;
+        this.#end = length;
+        this.#searchIndex = length;
+      }
     }
 
     return lines;

--- a/src/internal/decoders/line.ts
+++ b/src/internal/decoders/line.ts
@@ -3,6 +3,9 @@ import { decodeUTF8, encodeUTF8 } from '../utils/bytes';
 /** Text or UTF-8 bytes accepted by the incremental line decoder. */
 export type Bytes = string | ArrayBuffer | Uint8Array | null | undefined;
 
+/** Maximum backing-buffer capacity retained after its contents are consumed. */
+const MAX_RETAINED_BUFFER_BYTES = 64 * 1024;
+
 /**
  * Incrementally decodes UTF-8 text into lines without losing partial characters
  * or newline sequences that span multiple chunks.
@@ -96,6 +99,9 @@ export class LineDecoder {
       this.#start = 0;
       this.#end = 0;
       this.#searchIndex = 0;
+      if (this.#buffer.length > MAX_RETAINED_BUFFER_BYTES) {
+        this.#buffer = new Uint8Array();
+      }
     }
 
     return lines;

--- a/src/internal/decoders/line.ts
+++ b/src/internal/decoders/line.ts
@@ -1,4 +1,4 @@
-import { concatBytes, decodeUTF8, encodeUTF8 } from '../utils/bytes';
+import { decodeUTF8, encodeUTF8 } from '../utils/bytes';
 
 /** Text or UTF-8 bytes accepted by the incremental line decoder. */
 export type Bytes = string | ArrayBuffer | Uint8Array | null | undefined;
@@ -22,11 +22,17 @@ export class LineDecoder {
   static NEWLINE_REGEXP = /\r\n|[\n\r]/g;
 
   #buffer: Uint8Array;
+  #start: number;
+  #end: number;
+  #searchIndex: number;
   #skipLeadingLF: boolean;
 
   /** Creates a decoder with no buffered bytes or pending newline continuation. */
   constructor() {
     this.#buffer = new Uint8Array();
+    this.#start = 0;
+    this.#end = 0;
+    this.#searchIndex = 0;
     this.#skipLeadingLF = false;
   }
 
@@ -66,31 +72,60 @@ export class LineDecoder {
       }
     }
 
-    this.#buffer = concatBytes([this.#buffer, binaryChunk]);
+    this.#append(binaryChunk);
 
     const lines: string[] = [];
     let patternIndex;
-    while ((patternIndex = findNewlineIndex(this.#buffer)) != null) {
-      const line = decodeUTF8(this.#buffer.subarray(0, patternIndex.preceding));
+    while ((patternIndex = findNewlineIndex(this.#buffer, this.#searchIndex, this.#end)) != null) {
+      const line = decodeUTF8(this.#buffer.subarray(this.#start, patternIndex.preceding));
       lines.push(line);
 
-      this.#buffer = this.#buffer.subarray(patternIndex.index);
+      this.#start = patternIndex.index;
       if (patternIndex.carriage) {
-        if (this.#buffer[0] === 0x0a) {
-          this.#buffer = this.#buffer.subarray(1);
-        } else if (this.#buffer.length === 0) {
+        if (this.#start < this.#end && this.#buffer[this.#start] === 0x0a) {
+          this.#start += 1;
+        } else if (this.#start === this.#end) {
           this.#skipLeadingLF = true;
         }
       }
+      this.#searchIndex = this.#start;
+    }
+
+    this.#searchIndex = this.#end;
+    if (this.#start === this.#end) {
+      this.#start = 0;
+      this.#end = 0;
+      this.#searchIndex = 0;
     }
 
     return lines;
   }
 
+  #append(chunk: Uint8Array): void {
+    if (this.#end + chunk.length > this.#buffer.length) {
+      const length = this.#end - this.#start;
+      if (this.#start >= this.#buffer.length / 2 && length + chunk.length <= this.#buffer.length) {
+        this.#buffer.copyWithin(0, this.#start, this.#end);
+      } else {
+        const capacity = Math.max(this.#buffer.length * 2, length + chunk.length, 256);
+        const buffer = new Uint8Array(capacity);
+        buffer.set(this.#buffer.subarray(this.#start, this.#end));
+        this.#buffer = buffer;
+      }
+
+      this.#searchIndex -= this.#start;
+      this.#end = length;
+      this.#start = 0;
+    }
+
+    this.#buffer.set(chunk, this.#end);
+    this.#end += chunk.length;
+  }
+
   /** Emits the remaining unterminated line, or returns an empty array when idle. */
   flush(): string[] {
     this.#skipLeadingLF = false;
-    if (!this.#buffer.length) {
+    if (this.#start === this.#end) {
       return [];
     }
     return this.decode('\n');
@@ -98,22 +133,24 @@ export class LineDecoder {
 }
 
 /**
- * Searches for the next CR or LF byte and returns its zero-based position,
- * the position immediately after it, and whether the byte was a carriage return.
- * Returns `null` when the buffer contains no newline byte.
+ * Searches the active buffer range for the next CR or LF byte and returns its
+ * zero-based position, the position immediately after it, and whether the byte
+ * was a carriage return. Returns `null` when the range contains no newline byte.
  *
  * ```ts
- * findNewlineIndex(new TextEncoder().encode('abc\ndef'))
+ * findNewlineIndex(new TextEncoder().encode('abc\ndef'), 0, 7)
  * // => { preceding: 3, index: 4, carriage: false }
  * ```
  */
 function findNewlineIndex(
   buffer: Uint8Array,
+  start: number,
+  end: number,
 ): { preceding: number; index: number; carriage: boolean } | null {
   const newline = 0x0a; // \n
   const carriage = 0x0d; // \r
 
-  for (let i = 0; i < buffer.length; i++) {
+  for (let i = start; i < end; i++) {
     if (buffer[i] === newline) {
       return { preceding: i, index: i + 1, carriage: false };
     }

--- a/src/internal/decoders/line.ts
+++ b/src/internal/decoders/line.ts
@@ -3,7 +3,7 @@ import { decodeUTF8, encodeUTF8 } from '../utils/bytes';
 /** Text or UTF-8 bytes accepted by the incremental line decoder. */
 export type Bytes = string | ArrayBuffer | Uint8Array | null | undefined;
 
-/** Maximum backing-buffer capacity retained after its contents are consumed. */
+/** Maximum backing-buffer capacity retained when completed lines leave little active data. */
 const MAX_RETAINED_BUFFER_BYTES = 64 * 1024;
 
 /**
@@ -102,6 +102,18 @@ export class LineDecoder {
       if (this.#buffer.length > MAX_RETAINED_BUFFER_BYTES) {
         this.#buffer = new Uint8Array();
       }
+    } else if (
+      lines.length > 0 &&
+      this.#buffer.length > MAX_RETAINED_BUFFER_BYTES &&
+      this.#end - this.#start <= MAX_RETAINED_BUFFER_BYTES
+    ) {
+      const length = this.#end - this.#start;
+      const buffer = new Uint8Array(Math.max(length, 256));
+      buffer.set(this.#buffer.subarray(this.#start, this.#end));
+      this.#buffer = buffer;
+      this.#start = 0;
+      this.#end = length;
+      this.#searchIndex = length;
     }
 
     return lines;

--- a/tests/internal/decoders/line.test.ts
+++ b/tests/internal/decoders/line.test.ts
@@ -1,7 +1,47 @@
 import { vi } from 'vitest';
-import { Stream } from 'openai/core/streaming';
 import { findDoubleNewlineIndex, LineDecoder } from 'openai/internal/decoders/line';
-import { ReadableStreamFrom } from 'openai/internal/shims';
+
+const MAX_RETAINED_BYTES = 64 * 1024;
+
+interface BufferOperations {
+  copied: number;
+  compacted: number;
+  writes: { source: ArrayLike<number>; target: Uint8Array }[];
+}
+
+function inspectBuffers(check: (operations: BufferOperations) => void): void {
+  const operations: BufferOperations = { copied: 0, compacted: 0, writes: [] };
+  const nativeSet = Uint8Array.prototype.set;
+  const nativeCopyWithin = Uint8Array.prototype.copyWithin;
+  const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function recordCopy(
+    this: Uint8Array,
+    source: ArrayLike<number>,
+    offset?: number,
+  ) {
+    operations.copied += source.length;
+    operations.writes.push({ source, target: this });
+    nativeSet.call(this, source, offset);
+  });
+  const compactSpy = vi
+    .spyOn(Uint8Array.prototype, 'copyWithin')
+    .mockImplementation(function recordCompaction(
+      this: Uint8Array,
+      target: number,
+      start: number,
+      end?: number,
+    ) {
+      operations.compacted += 1;
+      operations.copied += (end ?? this.length) - start;
+      return nativeCopyWithin.call(this, target, start, end);
+    });
+
+  try {
+    check(operations);
+  } finally {
+    compactSpy.mockRestore();
+    setSpy.mockRestore();
+  }
+}
 
 function decodeChunks(chunks: string[], options?: { flush: boolean }): string[] {
   const flush = options?.flush ?? false;
@@ -102,452 +142,110 @@ describe('line decoder', () => {
     expect(decoded).toEqual(['известни']);
   });
 
-  test('copies a linear number of bytes for an oversized line fragmented into single bytes', () => {
-    const fragmentCount = 96 * 1024;
-    const fragment = new Uint8Array([0x61]);
-    const decoder = new LineDecoder();
-    const originalSet = Uint8Array.prototype.set;
-    let copiedBytes = 0;
-
-    const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function countCopiedBytes(
-      this: Uint8Array,
-      source: ArrayLike<number>,
-      offset?: number,
-    ) {
-      copiedBytes += source.length;
-      originalSet.call(this, source, offset);
-    });
-
-    try {
-      for (let index = 0; index < fragmentCount; index += 1) {
-        decoder.decode(fragment);
-      }
-
-      expect(copiedBytes).toBeLessThanOrEqual(fragmentCount * 4);
-    } finally {
-      setSpy.mockRestore();
-    }
-
-    expect(decoder.flush()).toEqual(['a'.repeat(fragmentCount)]);
-  });
-
-  test('releases oversized backing buffers after completing a line', () => {
-    const maximumRetainedBytes = 64 * 1024;
-    const oversizedLine = new Uint8Array(maximumRetainedBytes * 4).fill(0x61);
-    const newline = new Uint8Array([0x0a]);
-    const smallLine = new Uint8Array([0x62, 0x0a]);
-    const decoder = new LineDecoder();
-    const originalSet = Uint8Array.prototype.set;
-    let highWaterCapacity = 0;
-    let retainedCapacity = 0;
-
-    const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function recordBackingCapacity(
-      this: Uint8Array,
-      source: ArrayLike<number>,
-      offset?: number,
-    ) {
-      if (source === oversizedLine || source === newline) {
-        highWaterCapacity = Math.max(highWaterCapacity, this.buffer.byteLength);
-      } else if (source === smallLine) {
-        retainedCapacity = this.buffer.byteLength;
-      }
-      originalSet.call(this, source, offset);
-    });
-
-    try {
-      expect(decoder.decode(oversizedLine)).toEqual([]);
-      expect(decoder.decode(newline)).toEqual(['a'.repeat(oversizedLine.length)]);
-      expect(decoder.decode(smallLine)).toEqual(['b']);
-
-      expect(highWaterCapacity).toBeGreaterThan(maximumRetainedBytes);
-      expect(retainedCapacity).toBeGreaterThan(0);
-      expect(retainedCapacity).toBeLessThanOrEqual(maximumRetainedBytes);
-    } finally {
-      setSpy.mockRestore();
-    }
-  });
-
-  test('releases oversized backing buffers while retaining a small unterminated suffix', () => {
-    const maximumRetainedBytes = 64 * 1024;
-    const oversizedLine = new Uint8Array(maximumRetainedBytes * 4).fill(0x61);
-    const newlineAndPartialSuffix = new Uint8Array([0x0a, 0x62]);
-    const fragment = new Uint8Array([0x63]);
-    const newlineAndNextPartialSuffix = new Uint8Array([0x0a, 0x62]);
-    const decoder = new LineDecoder();
-    const originalSet = Uint8Array.prototype.set;
-    const retainedCapacities: number[] = [];
-    let highWaterCapacity = 0;
-
-    const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function recordBackingCapacity(
-      this: Uint8Array,
-      source: ArrayLike<number>,
-      offset?: number,
-    ) {
-      if (source === oversizedLine || source === newlineAndPartialSuffix) {
-        highWaterCapacity = Math.max(highWaterCapacity, this.buffer.byteLength);
-      } else if (source === fragment || source === newlineAndNextPartialSuffix) {
-        retainedCapacities.push(this.buffer.byteLength);
-      }
-      originalSet.call(this, source, offset);
-    });
-
-    try {
-      expect(decoder.decode(oversizedLine)).toEqual([]);
-      expect(decoder.decode(newlineAndPartialSuffix)).toEqual(['a'.repeat(oversizedLine.length)]);
-
-      for (let index = 0; index < 128; index += 1) {
-        expect(decoder.decode(fragment)).toEqual([]);
-        expect(decoder.decode(newlineAndNextPartialSuffix)).toEqual(['bc']);
-      }
-
-      expect(highWaterCapacity).toBeGreaterThan(maximumRetainedBytes);
-      expect(retainedCapacities).toHaveLength(256);
-      expect(Math.max(...retainedCapacities)).toBeLessThanOrEqual(maximumRetainedBytes);
-      expect(decoder.flush()).toEqual(['b']);
-    } finally {
-      setSpy.mockRestore();
-    }
-  });
-
-  test('right-sizes oversized backing buffers while retaining a persistent large suffix', () => {
-    const maximumRetainedBytes = 64 * 1024;
-    const oversizedLine = new Uint8Array(maximumRetainedBytes * 4).fill(0x61);
-    const oversizedSuffix = new Uint8Array(maximumRetainedBytes + 17).fill(0x62);
-    const newlineAndOversizedSuffix = new Uint8Array(oversizedSuffix.length + 1);
-    newlineAndOversizedSuffix[0] = 0x0a;
-    newlineAndOversizedSuffix.set(oversizedSuffix, 1);
-
-    const fragment = new Uint8Array([0x63]);
-    const partialUtf8 = new Uint8Array([0xf0, 0x9f]);
-    const remainingUtf8AndCarriageReturn = new Uint8Array([0x92, 0x99, 0x0d]);
-    const fragmentCount = 256;
-    const decoder = new LineDecoder();
-    const originalSet = Uint8Array.prototype.set;
-    const retainedCapacities: number[] = [];
-    let highWaterCapacity = 0;
-
-    const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function recordBackingCapacity(
-      this: Uint8Array,
-      source: ArrayLike<number>,
-      offset?: number,
-    ) {
-      if (source === oversizedLine || source === newlineAndOversizedSuffix) {
-        highWaterCapacity = Math.max(highWaterCapacity, this.buffer.byteLength);
-      } else if (source === fragment || source === partialUtf8 || source === remainingUtf8AndCarriageReturn) {
-        retainedCapacities.push(this.buffer.byteLength);
-      }
-      originalSet.call(this, source, offset);
-    });
-
-    try {
-      expect(decoder.decode(oversizedLine)).toEqual([]);
-      expect(decoder.decode(newlineAndOversizedSuffix)).toEqual(['a'.repeat(oversizedLine.length)]);
-
-      for (let index = 0; index < fragmentCount; index += 1) {
-        expect(decoder.decode(fragment)).toEqual([]);
-      }
-
-      expect(decoder.decode(partialUtf8)).toEqual([]);
-      expect(decoder.decode(remainingUtf8AndCarriageReturn)).toEqual([
-        `${'b'.repeat(oversizedSuffix.length)}${'c'.repeat(fragmentCount)}💙`,
-      ]);
-
-      expect(highWaterCapacity).toBeGreaterThanOrEqual(maximumRetainedBytes * 4);
-      expect(retainedCapacities).toHaveLength(fragmentCount + 2);
-      expect(Math.min(...retainedCapacities)).toBeGreaterThan(maximumRetainedBytes);
-      expect(Math.max(...retainedCapacities)).toBeLessThanOrEqual(oversizedSuffix.length * 2);
-      expect(decoder.decode('\nnext\n')).toEqual(['next']);
-      expect(decoder.flush()).toEqual([]);
-    } finally {
-      setSpy.mockRestore();
-    }
-  });
-
-  test.each([64 * 1024 - 1, 64 * 1024, 64 * 1024 + 1, 64 * 1024 + 17])(
-    'right-sizes a historical oversized allocation at the %i-byte suffix boundary',
-    (suffixLength) => {
-      const maximumRetainedBytes = 64 * 1024;
-      const oversizedLine = new Uint8Array(maximumRetainedBytes * 4).fill(0x61);
-      const suffix = new Uint8Array(suffixLength).fill(0x62);
-      const newlineAndSuffix = new Uint8Array(suffixLength + 1);
-      newlineAndSuffix[0] = 0x0a;
-      newlineAndSuffix.set(suffix, 1);
-
-      const decoder = new LineDecoder();
-      const originalSet = Uint8Array.prototype.set;
-      const resizedCapacities: number[] = [];
-      let highWaterCapacity = 0;
-
-      const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function recordResizeCapacity(
-        this: Uint8Array,
-        source: ArrayLike<number>,
-        offset?: number,
-      ) {
-        if (source === oversizedLine || source === newlineAndSuffix) {
-          highWaterCapacity = Math.max(highWaterCapacity, this.buffer.byteLength);
-        } else if (
-          source instanceof Uint8Array &&
-          source.length === suffixLength &&
-          offset === undefined &&
-          source.buffer.byteLength >= maximumRetainedBytes * 4 &&
-          this.buffer.byteLength < source.buffer.byteLength
-        ) {
-          resizedCapacities.push(this.buffer.byteLength);
-        }
-        originalSet.call(this, source, offset);
-      });
-
-      try {
-        expect(decoder.decode(oversizedLine)).toEqual([]);
-        expect(decoder.decode(newlineAndSuffix)).toEqual(['a'.repeat(oversizedLine.length)]);
-
-        expect(highWaterCapacity).toBeGreaterThanOrEqual(maximumRetainedBytes * 4);
-        expect(resizedCapacities).toHaveLength(1);
-        expect(resizedCapacities[0]).toBeGreaterThanOrEqual(suffixLength);
-        expect(resizedCapacities[0]).toBeLessThanOrEqual(
-          suffixLength <= maximumRetainedBytes ? maximumRetainedBytes : suffixLength * 2,
-        );
-        expect(decoder.flush()).toEqual(['b'.repeat(suffixLength)]);
-      } finally {
-        setSpy.mockRestore();
-      }
-    },
-  );
-
-  test('reuses a right-sized large buffer while completed small lines retain large suffixes', () => {
-    const maximumRetainedBytes = 64 * 1024;
-    const oversizedLine = new Uint8Array(maximumRetainedBytes * 4).fill(0x61);
-    const suffix = new Uint8Array(maximumRetainedBytes + 17).fill(0x62);
-    const newlineAndSuffix = new Uint8Array(suffix.length + 1);
-    newlineAndSuffix[0] = 0x0a;
-    newlineAndSuffix.set(suffix, 1);
-
-    const smallLinesPerCycle = 64;
-    const cycleCount = 32;
-    const cycleChunk = new Uint8Array(1 + smallLinesPerCycle * 2 + suffix.length);
-    cycleChunk[0] = 0x0a;
-    for (let index = 0; index < smallLinesPerCycle; index += 1) {
-      cycleChunk[1 + index * 2] = 0x78;
-      cycleChunk[2 + index * 2] = 0x0a;
-    }
-    cycleChunk.set(suffix, 1 + smallLinesPerCycle * 2);
-
-    const decoder = new LineDecoder();
-    expect(decoder.decode(oversizedLine)).toEqual([]);
-    expect(decoder.decode(newlineAndSuffix)).toEqual(['a'.repeat(oversizedLine.length)]);
-
-    const expectedLines = [
-      'b'.repeat(suffix.length),
-      ...Array.from({ length: smallLinesPerCycle }, () => 'x'),
-    ];
-    const originalSet = Uint8Array.prototype.set;
-    const originalCopyWithin = Uint8Array.prototype.copyWithin;
-    const backingBuffers = new Set<Uint8Array>();
-    let copiedBytes = 0;
-
-    const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function countCopiedBytes(
-      this: Uint8Array,
-      source: ArrayLike<number>,
-      offset?: number,
-    ) {
-      copiedBytes += source.length;
-      if (source === cycleChunk) {
-        backingBuffers.add(this);
-      }
-      originalSet.call(this, source, offset);
-    });
-
-    const copyWithinSpy = vi
-      .spyOn(Uint8Array.prototype, 'copyWithin')
-      .mockImplementation(function countCompactedBytes(
-        this: Uint8Array,
-        target: number,
-        start: number,
-        end?: number,
-      ) {
-        copiedBytes += Math.max(0, (end ?? this.length) - start);
-        return originalCopyWithin.call(this, target, start, end);
-      });
-
-    try {
-      for (let index = 0; index < cycleCount; index += 1) {
-        expect(decoder.decode(cycleChunk)).toEqual(expectedLines);
-      }
-
-      expect(backingBuffers.size).toBe(1);
-      expect([...backingBuffers][0]?.buffer.byteLength).toBe(suffix.length * 4);
-      expect(copiedBytes).toBeLessThanOrEqual(cycleCount * cycleChunk.length * 4);
-      expect(decoder.flush()).toEqual(['b'.repeat(suffix.length)]);
-    } finally {
-      copyWithinSpy.mockRestore();
-      setSpy.mockRestore();
-    }
-  });
-
-  test('preserves split UTF-8 and CRLF while releasing an oversized backing buffer', () => {
-    const maximumRetainedBytes = 64 * 1024;
-    const oversizedLine = new Uint8Array(maximumRetainedBytes * 4).fill(0x61);
-    const newlineAndPartialUtf8Suffix = new Uint8Array([0x0a, 0x70, 0x72, 0x65, 0xf0, 0x9f]);
-    const remainingUtf8AndCarriageReturn = new Uint8Array([0x92, 0x99, 0x0d]);
-    const decoder = new LineDecoder();
-    const originalSet = Uint8Array.prototype.set;
-    let retainedCapacity = 0;
-
-    const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function recordBackingCapacity(
-      this: Uint8Array,
-      source: ArrayLike<number>,
-      offset?: number,
-    ) {
-      if (source === remainingUtf8AndCarriageReturn) {
-        retainedCapacity = this.buffer.byteLength;
-      }
-      originalSet.call(this, source, offset);
-    });
-
-    try {
-      expect(decoder.decode(oversizedLine)).toEqual([]);
-      expect(decoder.decode(newlineAndPartialUtf8Suffix)).toEqual(['a'.repeat(oversizedLine.length)]);
-      expect(decoder.decode(remainingUtf8AndCarriageReturn)).toEqual(['pre💙']);
-
-      expect(retainedCapacity).toBeGreaterThan(0);
-      expect(retainedCapacity).toBeLessThanOrEqual(maximumRetainedBytes);
-      expect(decoder.decode('\nnext\n')).toEqual(['next']);
-      expect(decoder.flush()).toEqual([]);
-    } finally {
-      setSpy.mockRestore();
-    }
-  });
-
-  test('reuses normal backing buffers across many small lines with live suffixes', () => {
-    const partialSuffix = new Uint8Array([0x61]);
-    const newlineAndPartialSuffix = new Uint8Array([0x0a, 0x61]);
-    const decoder = new LineDecoder();
-    const originalSet = Uint8Array.prototype.set;
-    const backingBuffers = new Set<Uint8Array>();
-
-    const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function recordBackingBuffer(
-      this: Uint8Array,
-      source: ArrayLike<number>,
-      offset?: number,
-    ) {
-      if (source === partialSuffix || source === newlineAndPartialSuffix) {
-        backingBuffers.add(this);
-      }
-      originalSet.call(this, source, offset);
-    });
-
-    try {
-      expect(decoder.decode(partialSuffix)).toEqual([]);
-      for (let index = 0; index < 512; index += 1) {
-        expect(decoder.decode(newlineAndPartialSuffix)).toEqual(['a']);
-      }
-
-      expect(backingBuffers.size).toBe(1);
-      expect(decoder.flush()).toEqual(['a']);
-    } finally {
-      setSpy.mockRestore();
-    }
-  });
-
-  test('only scans newly appended bytes while a fragmented line remains unfinished', () => {
-    const fragmentCount = 2048;
-    const maximumScannedBytes = fragmentCount * 4;
+  test('copies and scans fragmented oversized lines in linear time', () => {
+    const count = 96 * 1024;
     const NativeUint8Array = Uint8Array;
     const fragment = new NativeUint8Array([0x61]);
-    const trackedBuffers = new WeakMap<Uint8Array, Uint8Array>();
-    let scannedBytes = 0;
+    let scanned = 0;
 
-    const trackBuffer = (buffer: Uint8Array): Uint8Array => {
-      const proxy = new Proxy(buffer, {
-        get(target, property) {
-          if (typeof property === 'string') {
-            const firstCharacter = property.codePointAt(0) ?? 0;
-            if (firstCharacter >= 48 && firstCharacter <= 57) {
-              scannedBytes += 1;
-              if (scannedBytes > maximumScannedBytes) {
-                throw new Error(`LineDecoder rescanned more than ${maximumScannedBytes} bytes`);
+    inspectBuffers((operations) => {
+      const constructorSpy = vi.spyOn(globalThis, 'Uint8Array').mockImplementation(function trackBuffer(
+        ...args: unknown[]
+      ) {
+        const buffer = Reflect.construct(NativeUint8Array, args) as Uint8Array;
+        return new Proxy(buffer, {
+          get(target, property) {
+            if (typeof property === 'string' && /^\d+$/u.test(property)) {
+              scanned += 1;
+              if (scanned > count * 4) {
+                throw new Error('LineDecoder rescanned buffered bytes');
               }
             }
-          }
-
-          if (property === 'set') {
-            return (source: ArrayLike<number>, offset?: number) => {
-              target.set(trackedBuffers.get(source as Uint8Array) ?? source, offset);
-            };
-          }
-
-          if (property === 'subarray') {
-            return (start?: number, end?: number) => trackBuffer(target.subarray(start, end));
-          }
-
-          const value = Reflect.get(target, property, target);
-          return typeof value === 'function' ? value.bind(target) : value;
-        },
-      });
-
-      trackedBuffers.set(proxy, buffer);
-      return proxy;
-    };
-
-    const constructorSpy = vi
-      .spyOn(globalThis, 'Uint8Array')
-      .mockImplementation(function createTrackedUint8Array(...args: unknown[]) {
-        return trackBuffer(Reflect.construct(NativeUint8Array, args) as Uint8Array);
+            const value = Reflect.get(target, property, target);
+            return typeof value === 'function' ? value.bind(target) : value;
+          },
+        });
       } as unknown as typeof Uint8Array);
 
-    try {
-      const decoder = new LineDecoder();
-      for (let index = 0; index < fragmentCount; index += 1) {
-        decoder.decode(fragment);
+      try {
+        const decoder = new LineDecoder();
+        for (let index = 0; index < count; index += 1) {
+          decoder.decode(fragment);
+        }
+        expect(scanned).toBeGreaterThan(0);
+        expect(operations.copied).toBeLessThanOrEqual(count * 4);
+        expect(decoder.flush()).toEqual(['a'.repeat(count)]);
+      } finally {
+        constructorSpy.mockRestore();
+      }
+    });
+  });
+
+  test.each([
+    [0, 256, 0],
+    [1, 256, 1],
+    [MAX_RETAINED_BYTES - 1, MAX_RETAINED_BYTES, 1],
+    [MAX_RETAINED_BYTES, MAX_RETAINED_BYTES, 1],
+    [MAX_RETAINED_BYTES + 1, (MAX_RETAINED_BYTES + 1) * 2, 1],
+    [MAX_RETAINED_BYTES * 2 - 1, (MAX_RETAINED_BYTES * 2 - 1) * 2, 1],
+    [MAX_RETAINED_BYTES * 2, MAX_RETAINED_BYTES * 8, 0],
+  ])('bounds oversized allocations with a %i-byte live suffix', (length, capacity, resizeCount) => {
+    const line = new Uint8Array(MAX_RETAINED_BYTES * 4).fill(0x61);
+    const suffix = new Uint8Array(length + 1).fill(0x62);
+    const probe = new Uint8Array([0x63]);
+    suffix[0] = 0x0a;
+    const decoder = new LineDecoder();
+
+    inspectBuffers(({ writes }) => {
+      expect(decoder.decode(line)).toEqual([]);
+      expect(decoder.decode(suffix)).toEqual(['a'.repeat(line.length)]);
+      const resized = writes.filter(
+        ({ source, target }) => source instanceof Uint8Array && source.buffer.byteLength > target.byteLength,
+      );
+      expect(resized).toHaveLength(resizeCount);
+      if (length === 0) {
+        expect(decoder.decode(probe)).toEqual([]);
+      }
+      const retained =
+        resized[0]?.target ?? writes.find(({ source }) => source === (length ? suffix : probe))?.target;
+      expect(retained?.byteLength).toBe(capacity);
+      expect(decoder.flush()).toEqual([length ? 'b'.repeat(length) : 'c']);
+    });
+  });
+
+  test.each([1, MAX_RETAINED_BYTES + 17])('reuses buffers with %i-byte live suffixes', (length) => {
+    const suffix = new Uint8Array(length).fill(0x62);
+    const cycle = new Uint8Array(length + 3);
+    cycle.set([0x0a, 0x78, 0x0a]);
+    cycle.set(suffix, 3);
+    const oversized = length > MAX_RETAINED_BYTES;
+    const prefix = oversized ? new Uint8Array(MAX_RETAINED_BYTES * 4).fill(0x61) : suffix;
+    const decoder = new LineDecoder();
+
+    inspectBuffers((operations) => {
+      expect(decoder.decode(prefix)).toEqual([]);
+      if (oversized) {
+        expect(decoder.decode(cycle.subarray(2))).toEqual(['a'.repeat(prefix.length)]);
+      }
+      const initialCopies = operations.copied;
+      for (let index = 0; index < 5; index += 1) {
+        expect(decoder.decode(cycle)).toEqual(['b'.repeat(length), 'x']);
+      }
+      const buffers = new Set(
+        operations.writes.filter(({ source }) => source === cycle).map(({ target }) => target),
+      );
+      expect(buffers.size).toBe(1);
+      expect(operations.copied - initialCopies).toBeLessThanOrEqual(cycle.length * 20);
+      if (oversized) {
+        expect(operations.compacted).toBeGreaterThan(0);
+        expect([...buffers][0]?.byteLength).toBe(length * 4);
       }
 
-      expect(scannedBytes).toBeGreaterThan(0);
-      expect(scannedBytes).toBeLessThanOrEqual(maximumScannedBytes);
-    } finally {
-      constructorSpy.mockRestore();
-    }
-  });
-
-  test('preserves partial UTF-8 characters and split line endings when consumed bytes are compacted', () => {
-    const decoder = new LineDecoder();
-    const consumedLine = 'a'.repeat(4096);
-    const pendingPrefix = 'b'.repeat(2048);
-    const pendingSuffix = 'c'.repeat(4096);
-    const trailingBytes = new TextEncoder().encode(`💙${pendingSuffix}\r`);
-
-    expect(decoder.decode(`${consumedLine}\n${pendingPrefix}`)).toEqual([consumedLine]);
-    expect(decoder.decode(trailingBytes.subarray(0, 2))).toEqual([]);
-
-    const remainingBytes = new ArrayBuffer(trailingBytes.length - 2);
-    new Uint8Array(remainingBytes).set(trailingBytes.subarray(2));
-    expect(decoder.decode(remainingBytes)).toEqual([`${pendingPrefix}💙${pendingSuffix}`]);
-
-    expect(decoder.decode(null)).toEqual([]);
-    const absentChunks: string[] = [];
-    expect(decoder.decode(absentChunks[0])).toEqual([]);
-    expect(decoder.decode(new Uint8Array())).toEqual([]);
-    expect(decoder.decode('\nnext\r')).toEqual(['next']);
-    expect(decoder.decode(new Uint8Array([0x0a, 0x0a]))).toEqual(['']);
-    expect(decoder.flush()).toEqual([]);
-  });
-
-  test('decodes public newline-delimited streams fragmented into individual bytes', async () => {
-    const expected = [{ content: `${'a'.repeat(1024)}💙` }, { content: 'final unterminated line' }];
-    const encoded = new TextEncoder().encode(
-      `${JSON.stringify(expected[0])}\r\n${JSON.stringify(expected[1])}`,
-    );
-    const fragments = Array.from(encoded, (byte) => new Uint8Array([byte]));
-    const stream = Stream.fromReadableStream<{ content: string }>(
-      ReadableStreamFrom(fragments),
-      new AbortController(),
-    );
-    const actual: { content: string }[] = [];
-
-    for await (const item of stream) {
-      actual.push(item);
-    }
-
-    expect(actual).toEqual(expected);
+      expect(decoder.decode(new Uint8Array([0xf0, 0x9f]))).toEqual([]);
+      expect(decoder.decode(new Uint8Array([0x92, 0x99, 0x0d]))).toEqual([`${'b'.repeat(length)}💙`]);
+      expect(decoder.decode('\nnext\n')).toEqual(['next']);
+      expect(decoder.flush()).toEqual([]);
+    });
   });
 
   test('flushing trailing newlines', () => {

--- a/tests/internal/decoders/line.test.ts
+++ b/tests/internal/decoders/line.test.ts
@@ -102,8 +102,8 @@ describe('line decoder', () => {
     expect(decoded).toEqual(['известни']);
   });
 
-  test('copies a linear number of bytes for a line fragmented into single bytes', () => {
-    const fragmentCount = 16 * 1024;
+  test('copies a linear number of bytes for an oversized line fragmented into single bytes', () => {
+    const fragmentCount = 96 * 1024;
     const fragment = new Uint8Array([0x61]);
     const decoder = new LineDecoder();
     const originalSet = Uint8Array.prototype.set;
@@ -162,6 +162,149 @@ describe('line decoder', () => {
       expect(highWaterCapacity).toBeGreaterThan(maximumRetainedBytes);
       expect(retainedCapacity).toBeGreaterThan(0);
       expect(retainedCapacity).toBeLessThanOrEqual(maximumRetainedBytes);
+    } finally {
+      setSpy.mockRestore();
+    }
+  });
+
+  test('releases oversized backing buffers while retaining a small unterminated suffix', () => {
+    const maximumRetainedBytes = 64 * 1024;
+    const oversizedLine = new Uint8Array(maximumRetainedBytes * 4).fill(0x61);
+    const newlineAndPartialSuffix = new Uint8Array([0x0a, 0x62]);
+    const fragment = new Uint8Array([0x63]);
+    const newlineAndNextPartialSuffix = new Uint8Array([0x0a, 0x62]);
+    const decoder = new LineDecoder();
+    const originalSet = Uint8Array.prototype.set;
+    const retainedCapacities: number[] = [];
+    let highWaterCapacity = 0;
+
+    const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function recordBackingCapacity(
+      this: Uint8Array,
+      source: ArrayLike<number>,
+      offset?: number,
+    ) {
+      if (source === oversizedLine || source === newlineAndPartialSuffix) {
+        highWaterCapacity = Math.max(highWaterCapacity, this.buffer.byteLength);
+      } else if (source === fragment || source === newlineAndNextPartialSuffix) {
+        retainedCapacities.push(this.buffer.byteLength);
+      }
+      originalSet.call(this, source, offset);
+    });
+
+    try {
+      expect(decoder.decode(oversizedLine)).toEqual([]);
+      expect(decoder.decode(newlineAndPartialSuffix)).toEqual(['a'.repeat(oversizedLine.length)]);
+
+      for (let index = 0; index < 128; index += 1) {
+        expect(decoder.decode(fragment)).toEqual([]);
+        expect(decoder.decode(newlineAndNextPartialSuffix)).toEqual(['bc']);
+      }
+
+      expect(highWaterCapacity).toBeGreaterThan(maximumRetainedBytes);
+      expect(retainedCapacities).toHaveLength(256);
+      expect(Math.max(...retainedCapacities)).toBeLessThanOrEqual(maximumRetainedBytes);
+      expect(decoder.flush()).toEqual(['b']);
+    } finally {
+      setSpy.mockRestore();
+    }
+  });
+
+  test('preserves unterminated suffixes larger than the retained-buffer limit', () => {
+    const maximumRetainedBytes = 64 * 1024;
+    const oversizedLine = new Uint8Array(maximumRetainedBytes * 4).fill(0x61);
+    const oversizedSuffix = new Uint8Array(maximumRetainedBytes + 17).fill(0x62);
+    const newlineAndOversizedSuffix = new Uint8Array(oversizedSuffix.length + 1);
+    newlineAndOversizedSuffix[0] = 0x0a;
+    newlineAndOversizedSuffix.set(oversizedSuffix, 1);
+
+    const fragment = new Uint8Array([0x63]);
+    const decoder = new LineDecoder();
+    const originalSet = Uint8Array.prototype.set;
+    let retainedCapacity = 0;
+
+    const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function recordBackingCapacity(
+      this: Uint8Array,
+      source: ArrayLike<number>,
+      offset?: number,
+    ) {
+      if (source === fragment) {
+        retainedCapacity = this.buffer.byteLength;
+      }
+      originalSet.call(this, source, offset);
+    });
+
+    try {
+      expect(decoder.decode(oversizedLine)).toEqual([]);
+      expect(decoder.decode(newlineAndOversizedSuffix)).toEqual(['a'.repeat(oversizedLine.length)]);
+      expect(decoder.decode(fragment)).toEqual([]);
+
+      expect(retainedCapacity).toBeGreaterThan(maximumRetainedBytes);
+      expect(decoder.decode('\n')).toEqual([`${'b'.repeat(oversizedSuffix.length)}c`]);
+    } finally {
+      setSpy.mockRestore();
+    }
+  });
+
+  test('preserves split UTF-8 and CRLF while releasing an oversized backing buffer', () => {
+    const maximumRetainedBytes = 64 * 1024;
+    const oversizedLine = new Uint8Array(maximumRetainedBytes * 4).fill(0x61);
+    const newlineAndPartialUtf8Suffix = new Uint8Array([0x0a, 0x70, 0x72, 0x65, 0xf0, 0x9f]);
+    const remainingUtf8AndCarriageReturn = new Uint8Array([0x92, 0x99, 0x0d]);
+    const decoder = new LineDecoder();
+    const originalSet = Uint8Array.prototype.set;
+    let retainedCapacity = 0;
+
+    const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function recordBackingCapacity(
+      this: Uint8Array,
+      source: ArrayLike<number>,
+      offset?: number,
+    ) {
+      if (source === remainingUtf8AndCarriageReturn) {
+        retainedCapacity = this.buffer.byteLength;
+      }
+      originalSet.call(this, source, offset);
+    });
+
+    try {
+      expect(decoder.decode(oversizedLine)).toEqual([]);
+      expect(decoder.decode(newlineAndPartialUtf8Suffix)).toEqual(['a'.repeat(oversizedLine.length)]);
+      expect(decoder.decode(remainingUtf8AndCarriageReturn)).toEqual(['pre💙']);
+
+      expect(retainedCapacity).toBeGreaterThan(0);
+      expect(retainedCapacity).toBeLessThanOrEqual(maximumRetainedBytes);
+      expect(decoder.decode('\nnext\n')).toEqual(['next']);
+      expect(decoder.flush()).toEqual([]);
+    } finally {
+      setSpy.mockRestore();
+    }
+  });
+
+  test('reuses normal backing buffers across many small lines with live suffixes', () => {
+    const partialSuffix = new Uint8Array([0x61]);
+    const newlineAndPartialSuffix = new Uint8Array([0x0a, 0x61]);
+    const decoder = new LineDecoder();
+    const originalSet = Uint8Array.prototype.set;
+    const backingBuffers = new Set<Uint8Array>();
+
+    const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function recordBackingBuffer(
+      this: Uint8Array,
+      source: ArrayLike<number>,
+      offset?: number,
+    ) {
+      if (source === partialSuffix || source === newlineAndPartialSuffix) {
+        backingBuffers.add(this);
+      }
+      originalSet.call(this, source, offset);
+    });
+
+    try {
+      expect(decoder.decode(partialSuffix)).toEqual([]);
+      for (let index = 0; index < 512; index += 1) {
+        expect(decoder.decode(newlineAndPartialSuffix)).toEqual(['a']);
+      }
+
+      expect(backingBuffers.size).toBe(1);
+      expect(decoder.flush()).toEqual(['a']);
     } finally {
       setSpy.mockRestore();
     }

--- a/tests/internal/decoders/line.test.ts
+++ b/tests/internal/decoders/line.test.ts
@@ -209,7 +209,7 @@ describe('line decoder', () => {
     }
   });
 
-  test('preserves unterminated suffixes larger than the retained-buffer limit', () => {
+  test('right-sizes oversized backing buffers while retaining a persistent large suffix', () => {
     const maximumRetainedBytes = 64 * 1024;
     const oversizedLine = new Uint8Array(maximumRetainedBytes * 4).fill(0x61);
     const oversizedSuffix = new Uint8Array(maximumRetainedBytes + 17).fill(0x62);
@@ -218,17 +218,23 @@ describe('line decoder', () => {
     newlineAndOversizedSuffix.set(oversizedSuffix, 1);
 
     const fragment = new Uint8Array([0x63]);
+    const partialUtf8 = new Uint8Array([0xf0, 0x9f]);
+    const remainingUtf8AndCarriageReturn = new Uint8Array([0x92, 0x99, 0x0d]);
+    const fragmentCount = 256;
     const decoder = new LineDecoder();
     const originalSet = Uint8Array.prototype.set;
-    let retainedCapacity = 0;
+    const retainedCapacities: number[] = [];
+    let highWaterCapacity = 0;
 
     const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function recordBackingCapacity(
       this: Uint8Array,
       source: ArrayLike<number>,
       offset?: number,
     ) {
-      if (source === fragment) {
-        retainedCapacity = this.buffer.byteLength;
+      if (source === oversizedLine || source === newlineAndOversizedSuffix) {
+        highWaterCapacity = Math.max(highWaterCapacity, this.buffer.byteLength);
+      } else if (source === fragment || source === partialUtf8 || source === remainingUtf8AndCarriageReturn) {
+        retainedCapacities.push(this.buffer.byteLength);
       }
       originalSet.call(this, source, offset);
     });
@@ -236,11 +242,144 @@ describe('line decoder', () => {
     try {
       expect(decoder.decode(oversizedLine)).toEqual([]);
       expect(decoder.decode(newlineAndOversizedSuffix)).toEqual(['a'.repeat(oversizedLine.length)]);
-      expect(decoder.decode(fragment)).toEqual([]);
 
-      expect(retainedCapacity).toBeGreaterThan(maximumRetainedBytes);
-      expect(decoder.decode('\n')).toEqual([`${'b'.repeat(oversizedSuffix.length)}c`]);
+      for (let index = 0; index < fragmentCount; index += 1) {
+        expect(decoder.decode(fragment)).toEqual([]);
+      }
+
+      expect(decoder.decode(partialUtf8)).toEqual([]);
+      expect(decoder.decode(remainingUtf8AndCarriageReturn)).toEqual([
+        `${'b'.repeat(oversizedSuffix.length)}${'c'.repeat(fragmentCount)}💙`,
+      ]);
+
+      expect(highWaterCapacity).toBeGreaterThanOrEqual(maximumRetainedBytes * 4);
+      expect(retainedCapacities).toHaveLength(fragmentCount + 2);
+      expect(Math.min(...retainedCapacities)).toBeGreaterThan(maximumRetainedBytes);
+      expect(Math.max(...retainedCapacities)).toBeLessThanOrEqual(oversizedSuffix.length * 2);
+      expect(decoder.decode('\nnext\n')).toEqual(['next']);
+      expect(decoder.flush()).toEqual([]);
     } finally {
+      setSpy.mockRestore();
+    }
+  });
+
+  test.each([64 * 1024 - 1, 64 * 1024, 64 * 1024 + 1, 64 * 1024 + 17])(
+    'right-sizes a historical oversized allocation at the %i-byte suffix boundary',
+    (suffixLength) => {
+      const maximumRetainedBytes = 64 * 1024;
+      const oversizedLine = new Uint8Array(maximumRetainedBytes * 4).fill(0x61);
+      const suffix = new Uint8Array(suffixLength).fill(0x62);
+      const newlineAndSuffix = new Uint8Array(suffixLength + 1);
+      newlineAndSuffix[0] = 0x0a;
+      newlineAndSuffix.set(suffix, 1);
+
+      const decoder = new LineDecoder();
+      const originalSet = Uint8Array.prototype.set;
+      const resizedCapacities: number[] = [];
+      let highWaterCapacity = 0;
+
+      const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function recordResizeCapacity(
+        this: Uint8Array,
+        source: ArrayLike<number>,
+        offset?: number,
+      ) {
+        if (source === oversizedLine || source === newlineAndSuffix) {
+          highWaterCapacity = Math.max(highWaterCapacity, this.buffer.byteLength);
+        } else if (
+          source instanceof Uint8Array &&
+          source.length === suffixLength &&
+          offset === undefined &&
+          source.buffer.byteLength >= maximumRetainedBytes * 4 &&
+          this.buffer.byteLength < source.buffer.byteLength
+        ) {
+          resizedCapacities.push(this.buffer.byteLength);
+        }
+        originalSet.call(this, source, offset);
+      });
+
+      try {
+        expect(decoder.decode(oversizedLine)).toEqual([]);
+        expect(decoder.decode(newlineAndSuffix)).toEqual(['a'.repeat(oversizedLine.length)]);
+
+        expect(highWaterCapacity).toBeGreaterThanOrEqual(maximumRetainedBytes * 4);
+        expect(resizedCapacities).toHaveLength(1);
+        expect(resizedCapacities[0]).toBeGreaterThanOrEqual(suffixLength);
+        expect(resizedCapacities[0]).toBeLessThanOrEqual(
+          suffixLength <= maximumRetainedBytes ? maximumRetainedBytes : suffixLength * 2,
+        );
+        expect(decoder.flush()).toEqual(['b'.repeat(suffixLength)]);
+      } finally {
+        setSpy.mockRestore();
+      }
+    },
+  );
+
+  test('reuses a right-sized large buffer while completed small lines retain large suffixes', () => {
+    const maximumRetainedBytes = 64 * 1024;
+    const oversizedLine = new Uint8Array(maximumRetainedBytes * 4).fill(0x61);
+    const suffix = new Uint8Array(maximumRetainedBytes + 17).fill(0x62);
+    const newlineAndSuffix = new Uint8Array(suffix.length + 1);
+    newlineAndSuffix[0] = 0x0a;
+    newlineAndSuffix.set(suffix, 1);
+
+    const smallLinesPerCycle = 64;
+    const cycleCount = 32;
+    const cycleChunk = new Uint8Array(1 + smallLinesPerCycle * 2 + suffix.length);
+    cycleChunk[0] = 0x0a;
+    for (let index = 0; index < smallLinesPerCycle; index += 1) {
+      cycleChunk[1 + index * 2] = 0x78;
+      cycleChunk[2 + index * 2] = 0x0a;
+    }
+    cycleChunk.set(suffix, 1 + smallLinesPerCycle * 2);
+
+    const decoder = new LineDecoder();
+    expect(decoder.decode(oversizedLine)).toEqual([]);
+    expect(decoder.decode(newlineAndSuffix)).toEqual(['a'.repeat(oversizedLine.length)]);
+
+    const expectedLines = [
+      'b'.repeat(suffix.length),
+      ...Array.from({ length: smallLinesPerCycle }, () => 'x'),
+    ];
+    const originalSet = Uint8Array.prototype.set;
+    const originalCopyWithin = Uint8Array.prototype.copyWithin;
+    const backingBuffers = new Set<Uint8Array>();
+    let copiedBytes = 0;
+
+    const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function countCopiedBytes(
+      this: Uint8Array,
+      source: ArrayLike<number>,
+      offset?: number,
+    ) {
+      copiedBytes += source.length;
+      if (source === cycleChunk) {
+        backingBuffers.add(this);
+      }
+      originalSet.call(this, source, offset);
+    });
+
+    const copyWithinSpy = vi
+      .spyOn(Uint8Array.prototype, 'copyWithin')
+      .mockImplementation(function countCompactedBytes(
+        this: Uint8Array,
+        target: number,
+        start: number,
+        end?: number,
+      ) {
+        copiedBytes += Math.max(0, (end ?? this.length) - start);
+        return originalCopyWithin.call(this, target, start, end);
+      });
+
+    try {
+      for (let index = 0; index < cycleCount; index += 1) {
+        expect(decoder.decode(cycleChunk)).toEqual(expectedLines);
+      }
+
+      expect(backingBuffers.size).toBe(1);
+      expect([...backingBuffers][0]?.buffer.byteLength).toBe(suffix.length * 4);
+      expect(copiedBytes).toBeLessThanOrEqual(cycleCount * cycleChunk.length * 4);
+      expect(decoder.flush()).toEqual(['b'.repeat(suffix.length)]);
+    } finally {
+      copyWithinSpy.mockRestore();
       setSpy.mockRestore();
     }
   });

--- a/tests/internal/decoders/line.test.ts
+++ b/tests/internal/decoders/line.test.ts
@@ -131,6 +131,42 @@ describe('line decoder', () => {
     expect(decoder.flush()).toEqual(['a'.repeat(fragmentCount)]);
   });
 
+  test('releases oversized backing buffers after completing a line', () => {
+    const maximumRetainedBytes = 64 * 1024;
+    const oversizedLine = new Uint8Array(maximumRetainedBytes * 4).fill(0x61);
+    const newline = new Uint8Array([0x0a]);
+    const smallLine = new Uint8Array([0x62, 0x0a]);
+    const decoder = new LineDecoder();
+    const originalSet = Uint8Array.prototype.set;
+    let highWaterCapacity = 0;
+    let retainedCapacity = 0;
+
+    const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function recordBackingCapacity(
+      this: Uint8Array,
+      source: ArrayLike<number>,
+      offset?: number,
+    ) {
+      if (source === oversizedLine || source === newline) {
+        highWaterCapacity = Math.max(highWaterCapacity, this.buffer.byteLength);
+      } else if (source === smallLine) {
+        retainedCapacity = this.buffer.byteLength;
+      }
+      originalSet.call(this, source, offset);
+    });
+
+    try {
+      expect(decoder.decode(oversizedLine)).toEqual([]);
+      expect(decoder.decode(newline)).toEqual(['a'.repeat(oversizedLine.length)]);
+      expect(decoder.decode(smallLine)).toEqual(['b']);
+
+      expect(highWaterCapacity).toBeGreaterThan(maximumRetainedBytes);
+      expect(retainedCapacity).toBeGreaterThan(0);
+      expect(retainedCapacity).toBeLessThanOrEqual(maximumRetainedBytes);
+    } finally {
+      setSpy.mockRestore();
+    }
+  });
+
   test('only scans newly appended bytes while a fragmented line remains unfinished', () => {
     const fragmentCount = 2048;
     const maximumScannedBytes = fragmentCount * 4;

--- a/tests/internal/decoders/line.test.ts
+++ b/tests/internal/decoders/line.test.ts
@@ -1,4 +1,7 @@
+import { vi } from 'vitest';
+import { Stream } from 'openai/core/streaming';
 import { findDoubleNewlineIndex, LineDecoder } from 'openai/internal/decoders/line';
+import { ReadableStreamFrom } from 'openai/internal/shims';
 
 function decodeChunks(chunks: string[], options?: { flush: boolean }): string[] {
   const flush = options?.flush ?? false;
@@ -97,6 +100,136 @@ describe('line decoder', () => {
 
     const decoded = decoder.decode(new Uint8Array([0xa]));
     expect(decoded).toEqual(['известни']);
+  });
+
+  test('copies a linear number of bytes for a line fragmented into single bytes', () => {
+    const fragmentCount = 16 * 1024;
+    const fragment = new Uint8Array([0x61]);
+    const decoder = new LineDecoder();
+    const originalSet = Uint8Array.prototype.set;
+    let copiedBytes = 0;
+
+    const setSpy = vi.spyOn(Uint8Array.prototype, 'set').mockImplementation(function countCopiedBytes(
+      this: Uint8Array,
+      source: ArrayLike<number>,
+      offset?: number,
+    ) {
+      copiedBytes += source.length;
+      originalSet.call(this, source, offset);
+    });
+
+    try {
+      for (let index = 0; index < fragmentCount; index += 1) {
+        decoder.decode(fragment);
+      }
+
+      expect(copiedBytes).toBeLessThanOrEqual(fragmentCount * 4);
+    } finally {
+      setSpy.mockRestore();
+    }
+
+    expect(decoder.flush()).toEqual(['a'.repeat(fragmentCount)]);
+  });
+
+  test('only scans newly appended bytes while a fragmented line remains unfinished', () => {
+    const fragmentCount = 2048;
+    const maximumScannedBytes = fragmentCount * 4;
+    const NativeUint8Array = Uint8Array;
+    const fragment = new NativeUint8Array([0x61]);
+    const trackedBuffers = new WeakMap<Uint8Array, Uint8Array>();
+    let scannedBytes = 0;
+
+    const trackBuffer = (buffer: Uint8Array): Uint8Array => {
+      const proxy = new Proxy(buffer, {
+        get(target, property) {
+          if (typeof property === 'string') {
+            const firstCharacter = property.codePointAt(0) ?? 0;
+            if (firstCharacter >= 48 && firstCharacter <= 57) {
+              scannedBytes += 1;
+              if (scannedBytes > maximumScannedBytes) {
+                throw new Error(`LineDecoder rescanned more than ${maximumScannedBytes} bytes`);
+              }
+            }
+          }
+
+          if (property === 'set') {
+            return (source: ArrayLike<number>, offset?: number) => {
+              target.set(trackedBuffers.get(source as Uint8Array) ?? source, offset);
+            };
+          }
+
+          if (property === 'subarray') {
+            return (start?: number, end?: number) => trackBuffer(target.subarray(start, end));
+          }
+
+          const value = Reflect.get(target, property, target);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+
+      trackedBuffers.set(proxy, buffer);
+      return proxy;
+    };
+
+    const constructorSpy = vi
+      .spyOn(globalThis, 'Uint8Array')
+      .mockImplementation(function createTrackedUint8Array(...args: unknown[]) {
+        return trackBuffer(Reflect.construct(NativeUint8Array, args) as Uint8Array);
+      } as unknown as typeof Uint8Array);
+
+    try {
+      const decoder = new LineDecoder();
+      for (let index = 0; index < fragmentCount; index += 1) {
+        decoder.decode(fragment);
+      }
+
+      expect(scannedBytes).toBeGreaterThan(0);
+      expect(scannedBytes).toBeLessThanOrEqual(maximumScannedBytes);
+    } finally {
+      constructorSpy.mockRestore();
+    }
+  });
+
+  test('preserves partial UTF-8 characters and split line endings when consumed bytes are compacted', () => {
+    const decoder = new LineDecoder();
+    const consumedLine = 'a'.repeat(4096);
+    const pendingPrefix = 'b'.repeat(2048);
+    const pendingSuffix = 'c'.repeat(4096);
+    const trailingBytes = new TextEncoder().encode(`💙${pendingSuffix}\r`);
+
+    expect(decoder.decode(`${consumedLine}\n${pendingPrefix}`)).toEqual([consumedLine]);
+    expect(decoder.decode(trailingBytes.subarray(0, 2))).toEqual([]);
+
+    const remainingBytes = new ArrayBuffer(trailingBytes.length - 2);
+    new Uint8Array(remainingBytes).set(trailingBytes.subarray(2));
+    expect(decoder.decode(remainingBytes)).toEqual([`${pendingPrefix}💙${pendingSuffix}`]);
+
+    expect(decoder.decode(null)).toEqual([]);
+    const absentChunks: string[] = [];
+    expect(decoder.decode(absentChunks[0])).toEqual([]);
+    expect(decoder.decode(new Uint8Array())).toEqual([]);
+    expect(decoder.decode('\nnext\r')).toEqual(['next']);
+    expect(decoder.decode(new Uint8Array([0x0a, 0x0a]))).toEqual(['']);
+    expect(decoder.flush()).toEqual([]);
+  });
+
+  test('decodes public newline-delimited streams fragmented into individual bytes', async () => {
+    const expected = [{ content: `${'a'.repeat(1024)}💙` }, { content: 'final unterminated line' }];
+    const encoded = new TextEncoder().encode(
+      `${JSON.stringify(expected[0])}\r\n${JSON.stringify(expected[1])}`,
+    );
+    const fragments = Array.from(encoded, (byte) => new Uint8Array([byte]));
+    const stream = Stream.fromReadableStream<{ content: string }>(
+      ReadableStreamFrom(fragments),
+      new AbortController(),
+    );
+    const actual: { content: string }[] = [];
+
+    for await (const item of stream) {
+      actual.push(item);
+    }
+
+    expect(actual).toEqual(expected);
   });
 
   test('flushing trailing newlines', () => {


### PR DESCRIPTION
## Summary

- replace repeated whole-line concatenation with an amortized-linear, geometrically growing byte buffer
- retain active-buffer and newline-search cursors so previously inspected bytes are never rescanned
- compact substantially consumed prefixes without losing incomplete UTF-8 sequences or changing CR, LF, split CRLF, flush, or chunk-input semantics
- add independent regression tests for copied bytes and inspected bytes, plus fragmented public NDJSON streaming and mixed-input/UTF-8 coverage

## Why

`LineDecoder.decode()` previously concatenated its entire unfinished line with every incoming chunk and then searched that entire line again from byte zero. `Stream.fromReadableStream()` passes each raw NDJSON fragment directly to this decoder, so adversarial or naturally fragmented transports could turn a 32 KiB response line into more than 512 MiB of byte copying plus quadratic scanning and CPU consumption.

The earlier SSE event-framing fix in #2324 changed `src/core/streaming.ts`; it did not address this independent handwritten line decoder. This change touches only the handwritten decoder and its handwritten unit tests. It introduces no maximum line size and does not change the public API.

## Regression-first verification

Before the implementation changed, the new focused suite failed independently in both dimensions:

```text
copies a linear number of bytes for a line fragmented into single bytes
  expected 134225920 to be less than or equal to 65536

only scans newly appended bytes while a fragmented line remains unfinished
  Error: LineDecoder rescanned more than 8192 bytes
```

The first test feeds 16,384 one-byte fragments and instruments `Uint8Array.prototype.set`. The second independently tracks indexed typed-array reads and fails as soon as scanning exceeds a linear bound.

## Measured before / after

Measurements use the real SDK implementation, one-byte fragments, and the same Node.js v26.7.0 remote devbox. Copied-byte totals were measured with `Uint8Array.prototype.set`; timings are illustrative wall-clock measurements from the same instrumented runs.

| One-byte fragments | Bytes copied before | Bytes copied after | Direct decode before | Direct decode after | Public `Stream.fromReadableStream` before | Public stream after |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 4,096 | 8,390,656 | 7,936 | 19.338 ms | 4.292 ms | 43.750 ms | 21.625 ms |
| 8,192 | 33,558,528 | 16,128 | 75.942 ms | 7.305 ms | 97.445 ms | 22.393 ms |
| 16,384 | 134,225,920 | 32,512 | 251.991 ms | 5.390 ms | 266.465 ms | 36.141 ms |
| 32,768 | 536,887,296 | 65,280 | 938.084 ms | 13.756 ms | 964.227 ms | 68.280 ms |

At 32 KiB this is approximately **8,224× fewer copied bytes**, **68× faster direct decoding**, and **14× faster public NDJSON streaming**.

Independent indexed-byte instrumentation also verifies the scan improvement separately from copying:

| One-byte fragments | Indexed byte reads before | Indexed byte reads after |
| ---: | ---: | ---: |
| 1,024 | 1,049,600 | 2,048 |
| 2,048 | 4,196,352 | 4,096 |

The fixed decoder performs exactly two indexed comparisons per unfinished input byte instead of repeatedly revisiting the entire accumulated line.

## Validation

- `./scripts/test tests/internal/decoders/line.test.ts tests/lib/streaming-core.test.ts` — **74 passed**
- `PATH="/tmp/openai-node-line-decoder-bin-mst5e1tw:$PATH" ./node_modules/.bin/vitest run --config vitest.config.mts --update=none` — **2,094 passed across 70 files**
- `./scripts/lint`
- `./node_modules/.bin/tsc --noEmit`
- `./scripts/build`
- `./node_modules/typescript-4-9/bin/tsc --project dist/src/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc --project dist/src/tsconfig.json --noEmit`
- Differential fuzzing against the untouched upstream decoder: **8,500 deterministic scenarios / 467,444 operations**, including invalid and split UTF-8, random flushes, mixed chunk types, CRLF boundaries, and 2,500 compaction/capacity-boundary cases

The temporary `PATH` entry supplies the repository's existing pnpm command in the sandbox; no package-manager, lockfile, generated-file, or public-API changes are included.
