### PR TITLE
fix(audio): prevent microphone leaks and playback pipe deadlocks

### DIFF
--- a/src/helpers/audio.ts
+++ b/src/helpers/audio.ts
@@ -53,6 +53,8 @@ async function nodejsPlayAudio(stream: NodeJS.ReadableStream | Response | File):
       }
 
       const ffplay = spawn('ffplay', ['-autoexit', '-nodisp', '-i', 'pipe:0']);
+      ffplay.stdout?.resume();
+      ffplay.stderr?.resume();
       ffplay.on('error', reject);
 
       pipeline(source, ffplay.stdin, (error) => {
@@ -113,8 +115,51 @@ function nodejsRecordAudio({ signal, device, timeout }: RecordAudioOptions = {})
   return new Promise((resolve, reject) => {
     const data: any[] = [];
     const provider = recordingProviders[platform];
+    let ffmpeg: ReturnType<typeof spawn> | undefined;
+    let internalSignal: AbortSignal | undefined;
+    let wasStopped = false;
+    let settled = false;
+
+    const collectData = (chunk: Buffer) => {
+      data.push(chunk);
+    };
+    const stopRecording = () => {
+      if (!settled && ffmpeg) {
+        wasStopped ||= ffmpeg.kill('SIGTERM');
+      }
+    };
+    const cleanup = () => {
+      if (settled) {
+        return false;
+      }
+
+      settled = true;
+      signal?.removeEventListener('abort', stopRecording);
+      internalSignal?.removeEventListener('abort', stopRecording);
+      ffmpeg?.stdout?.removeListener('data', collectData);
+      return true;
+    };
+    const rejectRecording = (error: unknown) => {
+      if (cleanup()) {
+        reject(error);
+      }
+    };
+    const returnData = () => {
+      if (!cleanup()) {
+        return;
+      }
+
+      const audioBuffer = Buffer.concat(data);
+      const audioFile = new File([audioBuffer], 'audio.wav', { type: 'audio/wav' });
+      resolve(audioFile);
+    };
+
     try {
-      const ffmpeg = spawn(
+      if (typeof timeout === 'number' && timeout > 0) {
+        internalSignal = AbortSignal.timeout(timeout);
+      }
+
+      ffmpeg = spawn(
         'ffmpeg',
         [
           '-f',
@@ -130,41 +175,26 @@ function nodejsRecordAudio({ signal, device, timeout }: RecordAudioOptions = {})
           'pipe:1',
         ],
         {
-          stdio: ['ignore', 'pipe', 'pipe'],
+          stdio: ['ignore', 'pipe', 'ignore'],
         },
       );
 
-      const returnData = () => {
-        const audioBuffer = Buffer.concat(data);
-        const audioFile = new File([audioBuffer], 'audio.wav', { type: 'audio/wav' });
-        resolve(audioFile);
-      };
-      let wasStopped = false;
-      const stopRecording = () => {
-        wasStopped ||= ffmpeg.kill('SIGTERM');
-      };
-
-      ffmpeg.stdout.on('data', (chunk) => {
-        data.push(chunk);
-      });
+      ffmpeg.stdout?.on('data', collectData);
 
       ffmpeg.on('error', (error) => {
         console.error(error);
-        reject(error);
+        rejectRecording(error);
       });
 
       ffmpeg.on('close', (code) => {
         if (code !== 0 && !wasStopped) {
-          reject(new Error(`ffmpeg process exited with code ${code}`));
+          rejectRecording(new Error(`ffmpeg process exited with code ${code}`));
           return;
         }
         returnData();
       });
 
-      if (typeof timeout === 'number' && timeout > 0) {
-        const internalSignal = AbortSignal.timeout(timeout);
-        internalSignal.addEventListener('abort', stopRecording, { once: true });
-      }
+      internalSignal?.addEventListener('abort', stopRecording, { once: true });
 
       if (signal) {
         if (signal.aborted) {
@@ -174,7 +204,8 @@ function nodejsRecordAudio({ signal, device, timeout }: RecordAudioOptions = {})
         }
       }
     } catch (error) {
-      reject(error);
+      stopRecording();
+      rejectRecording(error);
     }
   });
 }

--- a/src/helpers/audio.ts
+++ b/src/helpers/audio.ts
@@ -155,7 +155,7 @@ function nodejsRecordAudio({ signal, device, timeout }: RecordAudioOptions = {})
     };
 
     try {
-      if (typeof timeout === 'number' && timeout > 0) {
+      if (typeof timeout === 'number' && (timeout > 0 || Number.isNaN(timeout))) {
         internalSignal = AbortSignal.timeout(timeout);
       }
 

--- a/tests/helpers/audio-recording.test.ts
+++ b/tests/helpers/audio-recording.test.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import type { MockedFunction } from 'vitest';
 import { spawn } from 'node:child_process';
-import { EventEmitter } from 'node:events';
+import { EventEmitter, getEventListeners } from 'node:events';
 import { PassThrough, Readable, Writable } from 'node:stream';
 import { playAudio, recordAudio } from 'openai/helpers/audio';
 
@@ -27,7 +27,12 @@ function mockFfplay(exitCode = 0) {
       callback();
     },
   });
-  const ffplay = Object.assign(new EventEmitter(), { stdin, kill: vi.fn() });
+  const ffplay = Object.assign(new EventEmitter(), {
+    stdin,
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    kill: vi.fn(),
+  });
   stdin.on('finish', () => ffplay.emit('close', exitCode));
   spawnMock.mockReturnValue(ffplay as any);
   return { chunks, ffplay };
@@ -55,7 +60,7 @@ describe('recordAudio', () => {
     expect(spawnMock).toHaveBeenCalledWith(
       'ffmpeg',
       expect.arrayContaining(['-i', ':0', '-ar', '24000', '-ac', '1', '-f', 'wav', 'pipe:1']),
-      { stdio: ['ignore', 'pipe', 'pipe'] },
+      { stdio: ['ignore', 'pipe', 'ignore'] },
     );
   });
 
@@ -73,6 +78,16 @@ describe('recordAudio', () => {
     );
   });
 
+  test.each([1.5, Number.POSITIVE_INFINITY, 4_294_967_296])(
+    'rejects an invalid positive timeout (%s) before starting ffmpeg',
+    async (timeout) => {
+      mockFfmpeg();
+
+      await expect(recordAudio({ timeout })).rejects.toBeInstanceOf(RangeError);
+      expect(spawnMock).not.toHaveBeenCalled();
+    },
+  );
+
   test('terminates ffmpeg when its external abort signal is triggered', async () => {
     const ffmpeg = mockFfmpeg();
     const controller = new AbortController();
@@ -83,6 +98,67 @@ describe('recordAudio', () => {
 
     ffmpeg.emit('close', 0);
     await recording;
+  });
+
+  test.each([
+    ['a successful exit', 0, undefined],
+    ['an unsuccessful exit', 2, undefined],
+    ['a process error', undefined, new Error('microphone unavailable')],
+  ] as const)(
+    'removes external and timeout abort listeners after %s',
+    async (_description, exitCode, failure) => {
+      const ffmpeg = mockFfmpeg();
+      const controller = new AbortController();
+      const timeoutController = new AbortController();
+      vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
+      const recording = recordAudio({ signal: controller.signal, timeout: 50 });
+
+      expect(getEventListeners(controller.signal, 'abort')).toHaveLength(1);
+      expect(getEventListeners(timeoutController.signal, 'abort')).toHaveLength(1);
+      expect(ffmpeg.stdout.listenerCount('data')).toBe(1);
+
+      if (failure) {
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        ffmpeg.emit('error', failure);
+        await expect(recording).rejects.toBe(failure);
+      } else {
+        ffmpeg.emit('close', exitCode);
+        const expectation =
+          exitCode === 0
+            ? expect(recording).resolves.toBeInstanceOf(File)
+            : expect(recording).rejects.toThrow(`ffmpeg process exited with code ${exitCode}`);
+        await expectation;
+      }
+
+      expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0);
+      expect(getEventListeners(timeoutController.signal, 'abort')).toHaveLength(0);
+      expect(ffmpeg.stdout.listenerCount('data')).toBe(0);
+    },
+  );
+
+  test('does not stop ffmpeg when an external signal aborts after recording completes', async () => {
+    const ffmpeg = mockFfmpeg();
+    const controller = new AbortController();
+    const recording = recordAudio({ signal: controller.signal });
+
+    ffmpeg.emit('close', 0);
+    await recording;
+    controller.abort();
+
+    expect(ffmpeg.kill).not.toHaveBeenCalled();
+  });
+
+  test('does not stop ffmpeg when a timeout signal aborts after recording completes', async () => {
+    const ffmpeg = mockFfmpeg();
+    const timeoutController = new AbortController();
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
+    const recording = recordAudio({ timeout: 50 });
+
+    ffmpeg.emit('close', 0);
+    await recording;
+    timeoutController.abort();
+
+    expect(ffmpeg.kill).not.toHaveBeenCalled();
   });
 
   test('retains captured audio when an intentional abort exits with a nonzero code', async () => {
@@ -182,6 +258,18 @@ describe('recordAudio', () => {
     await expect(recordAudio()).rejects.toThrow('ffmpeg was not found');
   });
 
+  test('terminates ffmpeg when recording setup fails after it starts', async () => {
+    const ffmpeg = mockFfmpeg();
+    const failure = new Error('microphone output could not be observed');
+    vi.spyOn(ffmpeg.stdout, 'on').mockImplementationOnce(() => {
+      throw failure;
+    });
+
+    await expect(recordAudio()).rejects.toBe(failure);
+    expect(ffmpeg.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(ffmpeg.stdout.listenerCount('data')).toBe(0);
+  });
+
   test('rejects an unexpected unsuccessful ffmpeg exit', async () => {
     const ffmpeg = mockFfmpeg();
     const recording = recordAudio();
@@ -207,6 +295,28 @@ describe('playAudio input and process errors', () => {
     await playAudio(Readable.from(['node audio']));
 
     expect(Buffer.concat(chunks).toString()).toBe('node audio');
+  });
+
+  test('drains ffplay output without changing its spawn arguments', async () => {
+    const { ffplay } = mockFfplay();
+
+    await playAudio(Readable.from(['audio']));
+
+    expect(spawnMock).toHaveBeenCalledWith('ffplay', ['-autoexit', '-nodisp', '-i', 'pipe:0']);
+    expect(ffplay.stdout.readableFlowing).toBe(true);
+    expect(ffplay.stderr.readableFlowing).toBe(true);
+  });
+
+  test('rejects source pipeline failures and stops ffplay', async () => {
+    const { ffplay } = mockFfplay();
+    const source = new PassThrough();
+    const failure = new Error('audio source failed');
+    const playback = playAudio(source);
+
+    source.destroy(failure);
+
+    await expect(playback).rejects.toBe(failure);
+    expect(ffplay.kill).toHaveBeenCalledTimes(1);
   });
 
   test('rejects unsuccessful ffplay exit codes', async () => {

--- a/tests/helpers/audio-recording.test.ts
+++ b/tests/helpers/audio-recording.test.ts
@@ -78,8 +78,8 @@ describe('recordAudio', () => {
     );
   });
 
-  test.each([1.5, Number.POSITIVE_INFINITY, 4_294_967_296])(
-    'rejects an invalid positive timeout (%s) before starting ffmpeg',
+  test.each([1.5, Number.NaN, Number.POSITIVE_INFINITY, 4_294_967_296])(
+    'rejects an invalid timeout (%s) before starting ffmpeg',
     async (timeout) => {
       mockFfmpeg();
 


### PR DESCRIPTION
## Summary

Fix three related subprocess-lifecycle issues in the handwritten audio helpers:

- Invalid positive recording timeouts such as `1.5`, `Infinity`, and `4294967296` previously spawned FFmpeg before `AbortSignal.timeout()` rejected the value. The returned promise rejected while the microphone process kept recording indefinitely.
- External and timeout abort listeners previously outlived recording completion, retaining the subprocess and buffered audio and allowing a later abort to signal an already-finished process.
- Unread FFmpeg stderr and FFplay stdout/stderr pipes could fill and deadlock longer recording or playback sessions.

## Changes

- Validate positive timeout values with the native `AbortSignal.timeout()` implementation before starting FFmpeg, and terminate any subprocess if later synchronous recording setup fails.
- Centralize terminal cleanup so successful exits, unsuccessful exits, and process errors remove the external abort listener, internal timeout listener, and FFmpeg stdout data listener exactly once.
- Preserve intentional-abort WAV finalization, failed-`kill()` behavior, already-aborted signals, valid integer timeouts, and disabled zero/negative timeouts.
- Ignore unused FFmpeg stderr and drain both FFplay output streams while preserving FFplay's existing two-argument `spawn()` contract.
- Add mocked public-helper regressions for invalid timeout privacy leaks, every recording termination path, late external/internal aborts, post-spawn setup failures, pipe draining, and playback source failures.

## Verification

The new focused regressions were run against unchanged `main` first: **11 failed and 21 passed**. After the fix:

- `pnpm --config.verify-deps-before-run=false test tests/helpers/audio-recording.test.ts tests/helpers/audio.test.ts` — **35 passed**
- `pnpm --config.verify-deps-before-run=false test:unit` — **2,101 passed across 70 handwritten test files**
- `pnpm --config.verify-deps-before-run=false lint` — repository-wide formatting and lint checks passed across **608 files**
- `pnpm --config.verify-deps-before-run=false exec tsc --noEmit --pretty false` — full-project TypeScript check passed
- `pnpm --config.verify-deps-before-run=false build` — CommonJS and ESM builds both reported **0 errors**, including package import smoke checks

Only `src/helpers/audio.ts` and `tests/helpers/audio-recording.test.ts` are changed; both are handwritten files outside the generated/legacy-file denylist.
