### PR TITLE
fix(realtime): enforce Azure browser denial and redact all credentials

### DIFF
--- a/src/beta/realtime/websocket.ts
+++ b/src/beta/realtime/websocket.ts
@@ -19,6 +19,17 @@ type _WebSocket = typeof globalThis extends {
     InstanceType<ws>
   : any;
 
+/** Removes Azure credential query values from the publicly exposed connection URL. */
+function redactAzureCredentials(url: URL): void {
+  const hasAuthorization = url.searchParams.has('Authorization');
+  if (url.searchParams.has('api-key') || !hasAuthorization) {
+    url.searchParams.set('api-key', '<REDACTED>');
+  }
+  if (hasAuthorization) {
+    url.searchParams.set('Authorization', '<REDACTED>');
+  }
+}
+
 /**
  * Connects to the beta Realtime API using the runtime's native `WebSocket` implementation.
  *
@@ -121,11 +132,7 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     });
 
     if (isAzure(client)) {
-      if (this.url.searchParams.get('Authorization') === null) {
-        this.url.searchParams.set('api-key', '<REDACTED>');
-      } else {
-        this.url.searchParams.set('Authorization', '<REDACTED>');
-      }
+      redactAzureCredentials(this.url);
     }
   }
 
@@ -190,7 +197,7 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
       {
         model: deploymentName,
         onURL,
-        ...(dangerouslyAllowBrowser ? { dangerouslyAllowBrowser } : {}),
+        ...(dangerouslyAllowBrowser === undefined ? {} : { dangerouslyAllowBrowser }),
         __resolvedApiKey: isApiKeyProvider,
       },
       client,

--- a/src/realtime/websocket.ts
+++ b/src/realtime/websocket.ts
@@ -195,7 +195,7 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
       {
         ...connection,
         onURL,
-        ...(dangerouslyAllowBrowser ? { dangerouslyAllowBrowser } : {}),
+        ...(dangerouslyAllowBrowser === undefined ? {} : { dangerouslyAllowBrowser }),
         __resolvedApiKey: isApiKeyProvider,
       },
       client,

--- a/tests/realtime-websocket.test.ts
+++ b/tests/realtime-websocket.test.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import type { Mock } from 'vitest';
 
-import OpenAI, { AzureOpenAI } from 'openai';
+import OpenAI, { AzureOpenAI, OpenAIError } from 'openai';
 import { OpenAIRealtimeWebSocket as StableBrowserRealtime } from 'openai/realtime/websocket';
 import { OpenAIRealtimeWS as StableNodeRealtime } from 'openai/realtime/ws';
 import { OpenAIRealtimeWebSocket as BetaBrowserRealtime } from 'openai/beta/realtime/websocket';
@@ -60,6 +60,20 @@ class FakeBrowserSocket {
 
 const originalWebSocket = globalThis.WebSocket;
 const nodeSocketConstructor = WS.WebSocket as unknown as Mock;
+const azureCredentialCases = [
+  {
+    authentication: 'an Azure API key',
+    tokenProvider: false,
+    queryParameter: 'api-key',
+    credential: 'azure-key',
+  },
+  {
+    authentication: 'an Entra bearer token',
+    tokenProvider: true,
+    queryParameter: 'Authorization',
+    credential: 'Bearer azure-token',
+  },
+] as const;
 
 function lastBrowserSocket(): FakeBrowserSocket {
   return FakeBrowserSocket.instances[FakeBrowserSocket.instances.length - 1]!;
@@ -78,14 +92,24 @@ function createClient(apiKey: string | (() => Promise<string>) = 'test-key'): Op
   return new OpenAI({ apiKey, baseURL: 'https://example.com/v1/' });
 }
 
-function createAzureClient(options: { tokenProvider?: boolean; deployment?: string } = {}): AzureOpenAI {
+function createAzureClient(
+  options: {
+    tokenProvider?: boolean;
+    deployment?: string;
+    dangerouslyAllowBrowser?: boolean;
+    baseURL?: string;
+  } = {},
+): AzureOpenAI {
   return new AzureOpenAI({
     apiVersion: '2024-10-01-preview',
-    baseURL: 'https://azure.example.com/openai/',
+    baseURL: options.baseURL ?? 'https://azure.example.com/openai/',
     ...(options.tokenProvider
       ? { azureADTokenProvider: async () => 'azure-token' }
       : { apiKey: 'azure-key' }),
     ...(options.deployment === undefined ? {} : { deployment: options.deployment }),
+    ...(options.dangerouslyAllowBrowser === undefined
+      ? {}
+      : { dangerouslyAllowBrowser: options.dangerouslyAllowBrowser }),
   });
 }
 
@@ -260,6 +284,98 @@ describe.each([
     expect(connectionURL.pathname).toBe(beta ? '/openai/realtime' : '/openai/v1/realtime');
     expect(connectionURL.searchParams.get(beta ? 'deployment' : 'model')).toBe('chat');
     expect(connectionURL.searchParams.has('api-version')).toBe(beta);
+  });
+
+  test.each(azureCredentialCases)(
+    'redacts both Azure query credentials when the URL already contains another credential with $authentication',
+    async ({ tokenProvider, queryParameter, credential }) => {
+      const existingParameter = queryParameter === 'api-key' ? 'Authorization' : 'api-key';
+      const existingCredential = tokenProvider ? 'existing-gateway-key' : 'existing-gateway-token';
+      const baseURL = `https://azure.example.com/openai/?${existingParameter}=${existingCredential}&routing=value`;
+      const client = createAzureClient({ deployment: 'chat', tokenProvider, baseURL });
+
+      const realtime = beta
+        ? await Realtime.azure(client)
+        : await StableBrowserRealtime.azure(client, {
+            buildRealtimeURL: () => {
+              const url = new URL(client.baseURL);
+              url.protocol = 'wss:';
+              return url;
+            },
+          });
+      const connectionURL = new URL(lastBrowserSocket().url);
+
+      expect(connectionURL.searchParams.get(existingParameter)).toBe(existingCredential);
+      expect(connectionURL.searchParams.get(queryParameter)).toBe(credential);
+      expect(realtime.url.searchParams.get('Authorization')).toBe('<REDACTED>');
+      expect(realtime.url.searchParams.get('api-key')).toBe('<REDACTED>');
+      expect(realtime.url.toString()).not.toContain(existingCredential);
+      expect(realtime.url.toString()).not.toContain(tokenProvider ? 'azure-token' : 'azure-key');
+    },
+  );
+
+  test.each(azureCredentialCases)(
+    'opens outside a browser when browser access is explicitly disabled with $authentication',
+    async ({ tokenProvider, queryParameter, credential }) => {
+      const client = createAzureClient({
+        deployment: 'chat',
+        tokenProvider,
+        dangerouslyAllowBrowser: true,
+      });
+
+      const realtime = await Realtime.azure(client, { dangerouslyAllowBrowser: false });
+
+      expect(realtime.socket).toBe(lastBrowserSocket());
+      expect(new URL(lastBrowserSocket().url).searchParams.get(queryParameter)).toBe(credential);
+    },
+  );
+
+  describe('Azure browser security', () => {
+    beforeEach(() => {
+      vi.stubGlobal('window', { document: {} });
+      vi.stubGlobal('navigator', {});
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    describe.each(azureCredentialCases)(
+      'with $authentication',
+      ({ tokenProvider, queryParameter, credential }) => {
+        test('rejects an explicit browser denial before opening a WebSocket', async () => {
+          const client = createAzureClient({
+            deployment: 'chat',
+            tokenProvider,
+            dangerouslyAllowBrowser: true,
+          });
+
+          await expect(Realtime.azure(client, { dangerouslyAllowBrowser: false })).rejects.toThrow(
+            OpenAIError,
+          );
+          expect(FakeBrowserSocket.instances).toHaveLength(0);
+        });
+
+        test.each([
+          { setting: 'explicitly enabled', dangerouslyAllowBrowser: true },
+          { setting: 'inherited from the client', dangerouslyAllowBrowser: undefined },
+        ])('opens a WebSocket when browser access is $setting', async ({ dangerouslyAllowBrowser }) => {
+          const client = createAzureClient({
+            deployment: 'chat',
+            tokenProvider,
+            dangerouslyAllowBrowser: true,
+          });
+
+          const realtime = await Realtime.azure(
+            client,
+            dangerouslyAllowBrowser === undefined ? {} : { dangerouslyAllowBrowser },
+          );
+
+          expect(realtime.socket).toBe(lastBrowserSocket());
+          expect(new URL(lastBrowserSocket().url).searchParams.get(queryParameter)).toBe(credential);
+        });
+      },
+    );
   });
 
   test('rejects Azure connections without a deployment', async () => {


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Summary

Close two credential-exposure paths in the handwritten Azure Realtime browser WebSocket helpers:

1. **Stable and beta ignored an explicit per-connection browser denial.** Both `.azure()` factories conditionally forwarded `dangerouslyAllowBrowser` only when it was truthy. An Azure client configured with `dangerouslyAllowBrowser: true` therefore still opened a browser WebSocket when the connection explicitly requested `dangerouslyAllowBrowser: false`, exposing either an Azure API key or an Entra bearer token in the handshake URL.
2. **Beta redacted only one Azure credential query parameter.** When a caller-provided URL already contained `Authorization` or `api-key` and the Azure factory added the other credential, `realtime.url` retained a live API key or gateway credential. The stable helper already redacted both independently.

## Changes

- Forward every defined `dangerouslyAllowBrowser` value, including `false`, from both stable and beta Azure factories to the existing browser-safety guard.
- Port stable's existing dual-credential redaction helper to beta so both `Authorization` and `api-key` are independently redacted from the public URL while the actual authorized handshake remains unchanged.
- Add parameterized stable/beta coverage for static Azure API keys and Entra token providers:
  - Explicit browser denial rejects with `OpenAIError` before constructing any WebSocket.
  - Explicit browser opt-in and omitted/inherited settings retain their existing behavior.
  - Explicit denial does not prevent supported non-browser connections.
  - Both credential query parameters are redacted when pre-existing gateway credentials share the URL.
- Preserve existing token-provider resolution and validation order; change only three handwritten files.

## Regression evidence

Before the fixes:

- All four explicit-denial combinations (stable/beta × API key/Entra token) incorrectly opened a WebSocket with real test credentials in its captured handshake URL.
- Both beta dual-credential combinations leaked an Azure API key or pre-existing gateway key through the public `realtime.url`; the corresponding stable cases already passed.

After the fixes, all eight targeted security regressions pass.

## Validation

- `./scripts/test tests/realtime-websocket.test.ts --update none` — **112 passed**
- `OPENAI_TEST_SUITE=unit ./scripts/test --update none --maxWorkers 2` — **2,110 passed across 70 handwritten test files**
- `./scripts/lint`
- `./node_modules/.bin/tsc`
- `./scripts/build` — ESM/CJS compilation and OpenAI/Bedrock import smoke tests
- `./node_modules/.bin/tsc --project dist/src/tsconfig.json --noEmit`
- `node ./node_modules/typescript-4-9/bin/tsc --project dist/src/tsconfig.json --noEmit`
