### PR TITLE
fix: prevent prototype manipulation in strict Structured Outputs schemas

### DIFF
--- a/src/lib/transform.ts
+++ b/src/lib/transform.ts
@@ -90,6 +90,24 @@ const MERGEABLE_OBJECT_ALL_OF_KEYWORDS = new Set([
 /** Visits a nested schema together with its root-relative path and containing schema keyword. */
 type JSONSchemaChildVisitor = (schema: unknown, path: string[], keyword: string) => void;
 
+/** Assigns schema keywords without invoking the inherited `__proto__` setter. */
+function assignSchema<T extends object>(target: T, ...sources: object[]): T {
+  for (const source of sources) {
+    if (Object.prototype.propertyIsEnumerable.call(source, '__proto__') && !hasOwn(target, '__proto__')) {
+      Object.defineProperty(target, '__proto__', {
+        value: undefined,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    }
+
+    Object.assign(target, source);
+  }
+
+  return target;
+}
+
 /**
  * Visits only values carried by JSON Schema keywords that contain schemas.
  * Literal payloads such as enum, const, and default deliberately do not
@@ -318,7 +336,7 @@ function inlineRootRefObject(schema: JSONSchema): void {
   for (const keyword of Object.keys(schema)) {
     delete schemaRecord[keyword];
   }
-  Object.assign(schema, inlined, inheritedAnnotations, rootMetadata);
+  assignSchema(schema, inlined, inheritedAnnotations, rootMetadata);
   if (rootDefinitions !== undefined) {
     schema.$defs = rootDefinitions;
   }
@@ -368,7 +386,7 @@ function normalizeRootAllOf(schema: JSONSchema): void {
     for (const keyword of Object.keys(schema)) {
       delete schemaRecord[keyword];
     }
-    Object.assign(schema, normalized, rootMetadata);
+    assignSchema(schema, normalized, rootMetadata);
   }
 }
 
@@ -415,7 +433,12 @@ function normalizeRootAnyOf(schema: JSONSchema): boolean {
     const renames = definitionRenames.get(keyword);
     const mergedDefinitions: Record<string, JSONSchemaDefinition> = { ...rootDefinitions };
     for (const [name, definition] of Object.entries(branchDefinitions)) {
-      mergedDefinitions[renames?.get(name) ?? name] = definition as JSONSchemaDefinition;
+      Object.defineProperty(mergedDefinitions, renames?.get(name) ?? name, {
+        value: definition,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
     }
     normalized[keyword] = mergedDefinitions;
     delete rootMetadata[keyword];
@@ -426,7 +449,7 @@ function normalizeRootAnyOf(schema: JSONSchema): boolean {
   for (const keyword of Object.keys(schema)) {
     delete schemaRecord[keyword];
   }
-  Object.assign(schema, normalized, rootMetadata);
+  assignSchema(schema, normalized, rootMetadata);
   return true;
 }
 
@@ -684,7 +707,7 @@ function ensureStrictJsonSchema(
   // the same strict handling as type: 'object'. Explicitly open object schemas
   // cannot be represented in Structured Outputs strict mode.
   if (hasObjectShape(jsonSchema)) {
-    if (!('additionalProperties' in jsonSchema)) {
+    if (!hasOwn(jsonSchema, 'additionalProperties')) {
       jsonSchema.additionalProperties = false;
     } else if (jsonSchema.additionalProperties !== false) {
       throw new Error(
@@ -767,7 +790,7 @@ function ensureStrictJsonSchema(
       const resolved = ensureStrictJsonSchema(branch, [...path, 'allOf', '0'], root);
       const annotations = { ...jsonSchema };
       delete annotations.allOf;
-      Object.assign(jsonSchema, resolved, annotations);
+      assignSchema(jsonSchema, resolved, annotations);
       delete jsonSchema.allOf;
     }
   }
@@ -1689,7 +1712,7 @@ export function normalizeObjectAllOfForExclusivity(
       for (const keyword of Object.keys(normalized)) {
         delete (normalized as Record<string, unknown>)[keyword];
       }
-      Object.assign(normalized, flattened, siblings);
+      assignSchema(normalized, flattened, siblings);
     }
 
     return normalized;
@@ -1956,7 +1979,7 @@ function mergeObjectAllOf(
       for (const keyword of Object.keys(jsonSchema)) {
         delete (jsonSchema as any)[keyword];
       }
-      Object.assign(jsonSchema, merged);
+      assignSchema(jsonSchema, merged);
       return true;
     }
     fail();
@@ -1988,7 +2011,7 @@ function mergeObjectAllOf(
   for (const keyword of Object.keys(jsonSchema)) {
     delete (jsonSchema as any)[keyword];
   }
-  Object.assign(jsonSchema, merged);
+  assignSchema(jsonSchema, merged);
   return true;
 }
 

--- a/tests/helpers/standard-schema-security.test.ts
+++ b/tests/helpers/standard-schema-security.test.ts
@@ -1,0 +1,212 @@
+import {
+  standardFunction,
+  standardResponseFormat,
+  standardResponsesFunction,
+  standardTextFormat,
+} from 'openai/helpers/standard-schema';
+import { hasOwn } from 'openai/internal/utils/values';
+
+const prototypePropertyName = '__proto__';
+
+function strictSchemasForAllHelpers(jsonSchema: Record<string, unknown>) {
+  const standardSchema = {
+    '~standard': {
+      version: 1 as const,
+      vendor: 'test',
+      validate: (value: unknown) => ({ value }),
+      jsonSchema: { input: () => jsonSchema },
+    },
+  };
+
+  return [
+    standardResponseFormat(standardSchema, 'weather').json_schema.schema,
+    standardTextFormat(standardSchema, 'weather').schema,
+    standardFunction({
+      name: 'get_weather',
+      parameters: standardSchema,
+    }).function.parameters,
+    standardResponsesFunction({
+      name: 'get_weather',
+      parameters: standardSchema,
+    }).parameters,
+  ];
+}
+
+function makePrototypeManipulationSchema(): Record<string, unknown> {
+  return JSON.parse(
+    '{"type":"object","properties":{"safe":{"type":"string"}},"required":["safe"],' +
+      '"__proto__":{"additionalProperties":false,"polluted":"YES"}}',
+  ) as Record<string, unknown>;
+}
+
+function expectPrototypeSafeClosedSchema(schema: Record<string, unknown>) {
+  const serializedSchema = JSON.stringify(schema);
+
+  expect(schema['additionalProperties']).toBe(false);
+  expect(hasOwn(schema, 'additionalProperties')).toBe(true);
+  expect(Object.getPrototypeOf(schema)).toBe(Object.prototype);
+  expect(hasOwn(schema, prototypePropertyName)).toBe(true);
+  expect(schema[prototypePropertyName]).toEqual({ additionalProperties: false, polluted: 'YES' });
+  expect(schema['polluted']).toBeUndefined();
+  expect((Object.prototype as Record<string, unknown>)['polluted']).toBeUndefined();
+  expect(JSON.parse(serializedSchema)).toMatchObject({ additionalProperties: false });
+}
+
+describe('Standard Schema prototype security', () => {
+  it.each(['$ref', 'allOf', 'anyOf'] as const)(
+    'keeps promoted root %s schemas prototype-safe and strictly closed across all helper surfaces',
+    (keyword) => {
+      const branch = makePrototypeManipulationSchema();
+      const metadata = { title: 'Ordinary root title', description: 'Ordinary root description' };
+      const rootSchemas = {
+        $ref: { ...metadata, $ref: '#/$defs/target', $defs: { target: branch } },
+        allOf: { ...metadata, allOf: [branch] },
+        anyOf: { ...metadata, type: 'object', anyOf: [branch] },
+      };
+
+      for (const schema of strictSchemasForAllHelpers(rootSchemas[keyword])) {
+        expectPrototypeSafeClosedSchema(schema as Record<string, unknown>);
+        expect(schema).toMatchObject({
+          ...metadata,
+          type: 'object',
+          properties: { safe: { type: 'string' } },
+          required: ['safe'],
+        });
+      }
+    },
+  );
+
+  it('keeps nested singleton allOf schemas prototype-safe across all helper surfaces', () => {
+    const schemas = strictSchemasForAllHelpers({
+      type: 'object',
+      properties: {
+        nested: {
+          description: 'Ordinary nested annotation',
+          allOf: [makePrototypeManipulationSchema()],
+        },
+      },
+      required: ['nested'],
+    });
+
+    for (const schema of schemas) {
+      const properties = (schema as Record<string, unknown>)['properties'] as Record<
+        string,
+        Record<string, unknown>
+      >;
+      const nested = properties['nested'] ?? {};
+      const serializedSchema = JSON.stringify(schema);
+
+      expectPrototypeSafeClosedSchema(nested);
+      expect(nested['description']).toBe('Ordinary nested annotation');
+      expect(hasOwn(schema as Record<string, unknown>, 'additionalProperties')).toBe(true);
+      expect(JSON.parse(serializedSchema)).toMatchObject({
+        additionalProperties: false,
+        properties: { nested: { additionalProperties: false } },
+      });
+    }
+  });
+
+  it('preserves legitimate __proto__ property names across all helper surfaces', () => {
+    const jsonSchema = JSON.parse(
+      '{"type":"object","properties":{"__proto__":{"type":"string"},"safe":{"type":"number"}},' +
+        '"required":["__proto__","safe"]}',
+    ) as Record<string, unknown>;
+
+    for (const schema of strictSchemasForAllHelpers(jsonSchema)) {
+      const properties = (schema as Record<string, unknown>)['properties'] as Record<string, unknown>;
+
+      expect(Object.getPrototypeOf(properties)).toBe(Object.prototype);
+      expect(hasOwn(properties, prototypePropertyName)).toBe(true);
+      expect(properties[prototypePropertyName]).toEqual({ type: 'string' });
+      expect(properties['safe']).toEqual({ type: 'number' });
+      expect(hasOwn(schema as Record<string, unknown>, 'additionalProperties')).toBe(true);
+    }
+  });
+
+  it.each(['$defs', 'definitions'] as const)(
+    'preserves own __proto__ entries in promoted root anyOf %s maps across all helper surfaces',
+    (keyword) => {
+      const branchDefinitions = JSON.parse(
+        '{"__proto__":{"type":"string"},"constructor":{"type":"number"},' +
+          '"toString":{"type":"boolean"},"BranchOnly":{"type":"integer"}}',
+      ) as Record<string, unknown>;
+      const schemas = strictSchemasForAllHelpers({
+        type: 'object',
+        description: 'Ordinary root definition metadata',
+        [keyword]: { RootOnly: { type: 'number' } },
+        anyOf: [
+          {
+            type: 'object',
+            [keyword]: branchDefinitions,
+            properties: {
+              ordinary: { $ref: `#/anyOf/0/${keyword}/BranchOnly` },
+              constructorValue: { $ref: `#/anyOf/0/${keyword}/constructor` },
+              toStringValue: { $ref: `#/anyOf/0/${keyword}/toString` },
+              rootValue: { $ref: `#/${keyword}/RootOnly` },
+            },
+            required: ['ordinary', 'constructorValue', 'toStringValue', 'rootValue'],
+          },
+        ],
+      });
+
+      for (const schema of schemas) {
+        const definitions = (schema as Record<string, unknown>)[keyword] as Record<string, unknown>;
+        const serializedSchema = JSON.stringify(schema);
+        const serialized = JSON.parse(serializedSchema) as Record<string, unknown>;
+        const serializedDefinitions = serialized[keyword] as Record<string, unknown>;
+
+        expect(Object.getPrototypeOf(definitions)).toBe(Object.prototype);
+        expect(hasOwn(definitions, prototypePropertyName)).toBe(true);
+        expect(definitions[prototypePropertyName]).toEqual({ type: 'string' });
+        expect(definitions['RootOnly']).toEqual({ type: 'number' });
+        expect(definitions['constructor']).toEqual({ type: 'number' });
+        expect(definitions['toString']).toEqual({ type: 'boolean' });
+        expect(definitions['BranchOnly']).toEqual({ type: 'integer' });
+        expect(hasOwn(serializedDefinitions, prototypePropertyName)).toBe(true);
+        expect(serialized['additionalProperties']).toBe(false);
+        expect(schema).toMatchObject({
+          description: 'Ordinary root definition metadata',
+          properties: {
+            ordinary: { $ref: `#/${keyword}/BranchOnly` },
+            constructorValue: { $ref: `#/${keyword}/constructor` },
+            toStringValue: { $ref: `#/${keyword}/toString` },
+            rootValue: { $ref: `#/${keyword}/RootOnly` },
+          },
+        });
+      }
+    },
+  );
+
+  it.each(['$defs', 'definitions'] as const)(
+    'keeps refs to promoted own __proto__ %s definitions across all helper surfaces',
+    (keyword) => {
+      const branchDefinitions = JSON.parse('{"__proto__":{"type":"string"}}') as Record<string, unknown>;
+      const schemas = strictSchemasForAllHelpers({
+        type: 'object',
+        [keyword]: { RootOnly: { type: 'number' } },
+        anyOf: [
+          {
+            type: 'object',
+            [keyword]: branchDefinitions,
+            properties: {
+              value: { $ref: `#/anyOf/0/${keyword}/__proto__` },
+            },
+            required: ['value'],
+          },
+        ],
+      });
+
+      for (const schema of schemas) {
+        const definitions = (schema as Record<string, unknown>)[keyword] as Record<string, unknown>;
+
+        expect(Object.getPrototypeOf(definitions)).toBe(Object.prototype);
+        expect(hasOwn(definitions, prototypePropertyName)).toBe(true);
+        expect(definitions[prototypePropertyName]).toEqual({ type: 'string' });
+        expect(schema).toMatchObject({
+          properties: { value: { $ref: `#/${keyword}/__proto__` } },
+          additionalProperties: false,
+        });
+      }
+    },
+  );
+});

--- a/tests/helpers/standard-schema.test.ts
+++ b/tests/helpers/standard-schema.test.ts
@@ -6,7 +6,6 @@ import {
   standardResponsesFunction,
   standardTextFormat,
 } from 'openai/helpers/standard-schema';
-import { hasOwn } from 'openai/internal/utils/values';
 import type OpenAI from 'openai';
 import type { JSONSchema } from 'openai/lib/jsonschema';
 import { compareType, expectType } from '../utils/typing';
@@ -36,8 +35,6 @@ const strictWeatherJSONSchema: JSONSchema = {
   ...weatherJSONSchema,
   additionalProperties: false,
 };
-
-const prototypePropertyName = '__proto__';
 
 function validateWeather(value: unknown) {
   if (
@@ -107,26 +104,6 @@ function makeStrictSchemaFactories(jsonSchema: Record<string, unknown>) {
 
 function strictSchemasForAllHelpers(jsonSchema: Record<string, unknown>) {
   return makeStrictSchemaFactories(jsonSchema).map((makeSchema) => makeSchema());
-}
-
-function makePrototypeManipulationSchema(): Record<string, unknown> {
-  return JSON.parse(
-    '{"type":"object","properties":{"safe":{"type":"string"}},"required":["safe"],' +
-      '"__proto__":{"additionalProperties":false,"polluted":"YES"}}',
-  ) as Record<string, unknown>;
-}
-
-function expectPrototypeSafeClosedSchema(schema: Record<string, unknown>) {
-  const serializedSchema = JSON.stringify(schema);
-
-  expect(schema['additionalProperties']).toBe(false);
-  expect(hasOwn(schema, 'additionalProperties')).toBe(true);
-  expect(Object.getPrototypeOf(schema)).toBe(Object.prototype);
-  expect(hasOwn(schema, prototypePropertyName)).toBe(true);
-  expect(schema[prototypePropertyName]).toEqual({ additionalProperties: false, polluted: 'YES' });
-  expect(schema['polluted']).toBeUndefined();
-  expect((Object.prototype as Record<string, unknown>)['polluted']).toBeUndefined();
-  expect(JSON.parse(serializedSchema)).toMatchObject({ additionalProperties: false });
 }
 
 function makeValidationOnlySchema() {
@@ -1796,76 +1773,6 @@ describe('Standard Schema helpers', () => {
     );
   });
 
-  it.each(['$ref', 'allOf', 'anyOf'] as const)(
-    'keeps promoted root %s schemas prototype-safe and strictly closed across all helper surfaces',
-    (keyword) => {
-      const branch = makePrototypeManipulationSchema();
-      const metadata = { title: 'Ordinary root title', description: 'Ordinary root description' };
-      const rootSchemas = {
-        $ref: { ...metadata, $ref: '#/$defs/target', $defs: { target: branch } },
-        allOf: { ...metadata, allOf: [branch] },
-        anyOf: { ...metadata, type: 'object', anyOf: [branch] },
-      };
-
-      for (const schema of strictSchemasForAllHelpers(rootSchemas[keyword])) {
-        expectPrototypeSafeClosedSchema(schema as Record<string, unknown>);
-        expect(schema).toMatchObject({
-          ...metadata,
-          type: 'object',
-          properties: { safe: { type: 'string' } },
-          required: ['safe'],
-        });
-      }
-    },
-  );
-
-  it('keeps nested singleton allOf schemas prototype-safe across all helper surfaces', () => {
-    const schemas = strictSchemasForAllHelpers({
-      type: 'object',
-      properties: {
-        nested: {
-          description: 'Ordinary nested annotation',
-          allOf: [makePrototypeManipulationSchema()],
-        },
-      },
-      required: ['nested'],
-    });
-
-    for (const schema of schemas) {
-      const properties = (schema as Record<string, unknown>)['properties'] as Record<
-        string,
-        Record<string, unknown>
-      >;
-      const nested = properties['nested'] ?? {};
-      const serializedSchema = JSON.stringify(schema);
-
-      expectPrototypeSafeClosedSchema(nested);
-      expect(nested['description']).toBe('Ordinary nested annotation');
-      expect(hasOwn(schema as Record<string, unknown>, 'additionalProperties')).toBe(true);
-      expect(JSON.parse(serializedSchema)).toMatchObject({
-        additionalProperties: false,
-        properties: { nested: { additionalProperties: false } },
-      });
-    }
-  });
-
-  it('preserves legitimate __proto__ property names across all helper surfaces', () => {
-    const jsonSchema = JSON.parse(
-      '{"type":"object","properties":{"__proto__":{"type":"string"},"safe":{"type":"number"}},' +
-        '"required":["__proto__","safe"]}',
-    ) as Record<string, unknown>;
-
-    for (const schema of strictSchemasForAllHelpers(jsonSchema)) {
-      const properties = (schema as Record<string, unknown>)['properties'] as Record<string, unknown>;
-
-      expect(Object.getPrototypeOf(properties)).toBe(Object.prototype);
-      expect(hasOwn(properties, prototypePropertyName)).toBe(true);
-      expect(properties[prototypePropertyName]).toEqual({ type: 'string' });
-      expect(properties['safe']).toEqual({ type: 'number' });
-      expect(hasOwn(schema as Record<string, unknown>, 'additionalProperties')).toBe(true);
-    }
-  });
-
   it('flattens singleton root anyOf object wrappers across all helper surfaces', () => {
     const schemas = strictSchemasForAllHelpers({
       type: 'object',
@@ -2017,93 +1924,6 @@ describe('Standard Schema helpers', () => {
             rootValue: { $ref: `#/${keyword}/Value` },
             rootOnly: { $ref: `#/${keyword}/RootOnly` },
           },
-        });
-      }
-    },
-  );
-
-  it.each(['$defs', 'definitions'] as const)(
-    'preserves own __proto__ entries in promoted root anyOf %s maps across all helper surfaces',
-    (keyword) => {
-      const branchDefinitions = JSON.parse(
-        '{"__proto__":{"type":"string"},"constructor":{"type":"number"},' +
-          '"toString":{"type":"boolean"},"BranchOnly":{"type":"integer"}}',
-      ) as Record<string, unknown>;
-      const schemas = strictSchemasForAllHelpers({
-        type: 'object',
-        description: 'Ordinary root definition metadata',
-        [keyword]: { RootOnly: { type: 'number' } },
-        anyOf: [
-          {
-            type: 'object',
-            [keyword]: branchDefinitions,
-            properties: {
-              ordinary: { $ref: `#/anyOf/0/${keyword}/BranchOnly` },
-              constructorValue: { $ref: `#/anyOf/0/${keyword}/constructor` },
-              toStringValue: { $ref: `#/anyOf/0/${keyword}/toString` },
-              rootValue: { $ref: `#/${keyword}/RootOnly` },
-            },
-            required: ['ordinary', 'constructorValue', 'toStringValue', 'rootValue'],
-          },
-        ],
-      });
-
-      for (const schema of schemas) {
-        const definitions = (schema as Record<string, unknown>)[keyword] as Record<string, unknown>;
-        const serializedSchema = JSON.stringify(schema);
-        const serialized = JSON.parse(serializedSchema) as Record<string, unknown>;
-        const serializedDefinitions = serialized[keyword] as Record<string, unknown>;
-
-        expect(Object.getPrototypeOf(definitions)).toBe(Object.prototype);
-        expect(hasOwn(definitions, prototypePropertyName)).toBe(true);
-        expect(definitions[prototypePropertyName]).toEqual({ type: 'string' });
-        expect(definitions['RootOnly']).toEqual({ type: 'number' });
-        expect(definitions['constructor']).toEqual({ type: 'number' });
-        expect(definitions['toString']).toEqual({ type: 'boolean' });
-        expect(definitions['BranchOnly']).toEqual({ type: 'integer' });
-        expect(hasOwn(serializedDefinitions, prototypePropertyName)).toBe(true);
-        expect(serialized['additionalProperties']).toBe(false);
-        expect(schema).toMatchObject({
-          description: 'Ordinary root definition metadata',
-          properties: {
-            ordinary: { $ref: `#/${keyword}/BranchOnly` },
-            constructorValue: { $ref: `#/${keyword}/constructor` },
-            toStringValue: { $ref: `#/${keyword}/toString` },
-            rootValue: { $ref: `#/${keyword}/RootOnly` },
-          },
-        });
-      }
-    },
-  );
-
-  it.each(['$defs', 'definitions'] as const)(
-    'keeps refs to promoted own __proto__ %s definitions across all helper surfaces',
-    (keyword) => {
-      const branchDefinitions = JSON.parse('{"__proto__":{"type":"string"}}') as Record<string, unknown>;
-      const schemas = strictSchemasForAllHelpers({
-        type: 'object',
-        [keyword]: { RootOnly: { type: 'number' } },
-        anyOf: [
-          {
-            type: 'object',
-            [keyword]: branchDefinitions,
-            properties: {
-              value: { $ref: `#/anyOf/0/${keyword}/__proto__` },
-            },
-            required: ['value'],
-          },
-        ],
-      });
-
-      for (const schema of schemas) {
-        const definitions = (schema as Record<string, unknown>)[keyword] as Record<string, unknown>;
-
-        expect(Object.getPrototypeOf(definitions)).toBe(Object.prototype);
-        expect(hasOwn(definitions, prototypePropertyName)).toBe(true);
-        expect(definitions[prototypePropertyName]).toEqual({ type: 'string' });
-        expect(schema).toMatchObject({
-          properties: { value: { $ref: `#/${keyword}/__proto__` } },
-          additionalProperties: false,
         });
       }
     },

--- a/tests/helpers/standard-schema.test.ts
+++ b/tests/helpers/standard-schema.test.ts
@@ -6,6 +6,7 @@ import {
   standardResponsesFunction,
   standardTextFormat,
 } from 'openai/helpers/standard-schema';
+import { hasOwn } from 'openai/internal/utils/values';
 import type OpenAI from 'openai';
 import type { JSONSchema } from 'openai/lib/jsonschema';
 import { compareType, expectType } from '../utils/typing';
@@ -35,6 +36,8 @@ const strictWeatherJSONSchema: JSONSchema = {
   ...weatherJSONSchema,
   additionalProperties: false,
 };
+
+const prototypePropertyName = '__proto__';
 
 function validateWeather(value: unknown) {
   if (
@@ -104,6 +107,26 @@ function makeStrictSchemaFactories(jsonSchema: Record<string, unknown>) {
 
 function strictSchemasForAllHelpers(jsonSchema: Record<string, unknown>) {
   return makeStrictSchemaFactories(jsonSchema).map((makeSchema) => makeSchema());
+}
+
+function makePrototypeManipulationSchema(): Record<string, unknown> {
+  return JSON.parse(
+    '{"type":"object","properties":{"safe":{"type":"string"}},"required":["safe"],' +
+      '"__proto__":{"additionalProperties":false,"polluted":"YES"}}',
+  ) as Record<string, unknown>;
+}
+
+function expectPrototypeSafeClosedSchema(schema: Record<string, unknown>) {
+  const serializedSchema = JSON.stringify(schema);
+
+  expect(schema['additionalProperties']).toBe(false);
+  expect(hasOwn(schema, 'additionalProperties')).toBe(true);
+  expect(Object.getPrototypeOf(schema)).toBe(Object.prototype);
+  expect(hasOwn(schema, prototypePropertyName)).toBe(true);
+  expect(schema[prototypePropertyName]).toEqual({ additionalProperties: false, polluted: 'YES' });
+  expect(schema['polluted']).toBeUndefined();
+  expect((Object.prototype as Record<string, unknown>)['polluted']).toBeUndefined();
+  expect(JSON.parse(serializedSchema)).toMatchObject({ additionalProperties: false });
 }
 
 function makeValidationOnlySchema() {
@@ -1773,6 +1796,76 @@ describe('Standard Schema helpers', () => {
     );
   });
 
+  it.each(['$ref', 'allOf', 'anyOf'] as const)(
+    'keeps promoted root %s schemas prototype-safe and strictly closed across all helper surfaces',
+    (keyword) => {
+      const branch = makePrototypeManipulationSchema();
+      const metadata = { title: 'Ordinary root title', description: 'Ordinary root description' };
+      const rootSchemas = {
+        $ref: { ...metadata, $ref: '#/$defs/target', $defs: { target: branch } },
+        allOf: { ...metadata, allOf: [branch] },
+        anyOf: { ...metadata, type: 'object', anyOf: [branch] },
+      };
+
+      for (const schema of strictSchemasForAllHelpers(rootSchemas[keyword])) {
+        expectPrototypeSafeClosedSchema(schema as Record<string, unknown>);
+        expect(schema).toMatchObject({
+          ...metadata,
+          type: 'object',
+          properties: { safe: { type: 'string' } },
+          required: ['safe'],
+        });
+      }
+    },
+  );
+
+  it('keeps nested singleton allOf schemas prototype-safe across all helper surfaces', () => {
+    const schemas = strictSchemasForAllHelpers({
+      type: 'object',
+      properties: {
+        nested: {
+          description: 'Ordinary nested annotation',
+          allOf: [makePrototypeManipulationSchema()],
+        },
+      },
+      required: ['nested'],
+    });
+
+    for (const schema of schemas) {
+      const properties = (schema as Record<string, unknown>)['properties'] as Record<
+        string,
+        Record<string, unknown>
+      >;
+      const nested = properties['nested'] ?? {};
+      const serializedSchema = JSON.stringify(schema);
+
+      expectPrototypeSafeClosedSchema(nested);
+      expect(nested['description']).toBe('Ordinary nested annotation');
+      expect(hasOwn(schema as Record<string, unknown>, 'additionalProperties')).toBe(true);
+      expect(JSON.parse(serializedSchema)).toMatchObject({
+        additionalProperties: false,
+        properties: { nested: { additionalProperties: false } },
+      });
+    }
+  });
+
+  it('preserves legitimate __proto__ property names across all helper surfaces', () => {
+    const jsonSchema = JSON.parse(
+      '{"type":"object","properties":{"__proto__":{"type":"string"},"safe":{"type":"number"}},' +
+        '"required":["__proto__","safe"]}',
+    ) as Record<string, unknown>;
+
+    for (const schema of strictSchemasForAllHelpers(jsonSchema)) {
+      const properties = (schema as Record<string, unknown>)['properties'] as Record<string, unknown>;
+
+      expect(Object.getPrototypeOf(properties)).toBe(Object.prototype);
+      expect(hasOwn(properties, prototypePropertyName)).toBe(true);
+      expect(properties[prototypePropertyName]).toEqual({ type: 'string' });
+      expect(properties['safe']).toEqual({ type: 'number' });
+      expect(hasOwn(schema as Record<string, unknown>, 'additionalProperties')).toBe(true);
+    }
+  });
+
   it('flattens singleton root anyOf object wrappers across all helper surfaces', () => {
     const schemas = strictSchemasForAllHelpers({
       type: 'object',
@@ -1924,6 +2017,93 @@ describe('Standard Schema helpers', () => {
             rootValue: { $ref: `#/${keyword}/Value` },
             rootOnly: { $ref: `#/${keyword}/RootOnly` },
           },
+        });
+      }
+    },
+  );
+
+  it.each(['$defs', 'definitions'] as const)(
+    'preserves own __proto__ entries in promoted root anyOf %s maps across all helper surfaces',
+    (keyword) => {
+      const branchDefinitions = JSON.parse(
+        '{"__proto__":{"type":"string"},"constructor":{"type":"number"},' +
+          '"toString":{"type":"boolean"},"BranchOnly":{"type":"integer"}}',
+      ) as Record<string, unknown>;
+      const schemas = strictSchemasForAllHelpers({
+        type: 'object',
+        description: 'Ordinary root definition metadata',
+        [keyword]: { RootOnly: { type: 'number' } },
+        anyOf: [
+          {
+            type: 'object',
+            [keyword]: branchDefinitions,
+            properties: {
+              ordinary: { $ref: `#/anyOf/0/${keyword}/BranchOnly` },
+              constructorValue: { $ref: `#/anyOf/0/${keyword}/constructor` },
+              toStringValue: { $ref: `#/anyOf/0/${keyword}/toString` },
+              rootValue: { $ref: `#/${keyword}/RootOnly` },
+            },
+            required: ['ordinary', 'constructorValue', 'toStringValue', 'rootValue'],
+          },
+        ],
+      });
+
+      for (const schema of schemas) {
+        const definitions = (schema as Record<string, unknown>)[keyword] as Record<string, unknown>;
+        const serializedSchema = JSON.stringify(schema);
+        const serialized = JSON.parse(serializedSchema) as Record<string, unknown>;
+        const serializedDefinitions = serialized[keyword] as Record<string, unknown>;
+
+        expect(Object.getPrototypeOf(definitions)).toBe(Object.prototype);
+        expect(hasOwn(definitions, prototypePropertyName)).toBe(true);
+        expect(definitions[prototypePropertyName]).toEqual({ type: 'string' });
+        expect(definitions['RootOnly']).toEqual({ type: 'number' });
+        expect(definitions['constructor']).toEqual({ type: 'number' });
+        expect(definitions['toString']).toEqual({ type: 'boolean' });
+        expect(definitions['BranchOnly']).toEqual({ type: 'integer' });
+        expect(hasOwn(serializedDefinitions, prototypePropertyName)).toBe(true);
+        expect(serialized['additionalProperties']).toBe(false);
+        expect(schema).toMatchObject({
+          description: 'Ordinary root definition metadata',
+          properties: {
+            ordinary: { $ref: `#/${keyword}/BranchOnly` },
+            constructorValue: { $ref: `#/${keyword}/constructor` },
+            toStringValue: { $ref: `#/${keyword}/toString` },
+            rootValue: { $ref: `#/${keyword}/RootOnly` },
+          },
+        });
+      }
+    },
+  );
+
+  it.each(['$defs', 'definitions'] as const)(
+    'keeps refs to promoted own __proto__ %s definitions across all helper surfaces',
+    (keyword) => {
+      const branchDefinitions = JSON.parse('{"__proto__":{"type":"string"}}') as Record<string, unknown>;
+      const schemas = strictSchemasForAllHelpers({
+        type: 'object',
+        [keyword]: { RootOnly: { type: 'number' } },
+        anyOf: [
+          {
+            type: 'object',
+            [keyword]: branchDefinitions,
+            properties: {
+              value: { $ref: `#/anyOf/0/${keyword}/__proto__` },
+            },
+            required: ['value'],
+          },
+        ],
+      });
+
+      for (const schema of schemas) {
+        const definitions = (schema as Record<string, unknown>)[keyword] as Record<string, unknown>;
+
+        expect(Object.getPrototypeOf(definitions)).toBe(Object.prototype);
+        expect(hasOwn(definitions, prototypePropertyName)).toBe(true);
+        expect(definitions[prototypePropertyName]).toEqual({ type: 'string' });
+        expect(schema).toMatchObject({
+          properties: { value: { $ref: `#/${keyword}/__proto__` } },
+          additionalProperties: false,
         });
       }
     },

--- a/tests/lib/transform-branches.test.ts
+++ b/tests/lib/transform-branches.test.ts
@@ -181,6 +181,28 @@ describe('object intersection normalization for exclusivity', () => {
     expect(schema).toEqual(original);
   });
 
+  test('preserves own prototype-named schema metadata while flattening an intersection', () => {
+    const branch = JSON.parse(
+      '{"type":"object","properties":{"value":{"type":"string"}},"required":["value"],"__proto__":{"polluted":"YES"}}',
+    ) as JSONSchema;
+    const schema: JSONSchema = { allOf: [branch], title: 'preserved annotation' };
+
+    const normalized = normalizeObjectAllOfForExclusivity(schema, schema);
+
+    expect(normalized).toBeDefined();
+    expect(Object.getPrototypeOf(normalized)).toBe(Object.prototype);
+    expect(Object.getOwnPropertyDescriptor(normalized, '__proto__')).toMatchObject({
+      configurable: true,
+      enumerable: true,
+      value: { polluted: 'YES' },
+      writable: true,
+    });
+    expect((normalized as Record<string, unknown>)['polluted']).toBeUndefined();
+    expect((Object.prototype as Record<string, unknown>)['polluted']).toBeUndefined();
+    expect(normalized?.title).toBe('preserved annotation');
+    expect(schema.allOf).toEqual([branch]);
+  });
+
   test.each([
     { allOf: [false] },
     { allOf: [{ type: 'object', properties: { value: { type: 'string' } } }, { type: 'string' }] },


### PR DESCRIPTION
## Summary

- Harden all seven handwritten JSON Schema merge sites with one safe-assignment helper that first installs an inert, writable, enumerable, configurable own `__proto__` data property while preserving normal `Object.assign` semantics and target identity.
- Preserve attacker-controlled `$defs` and `definitions` entry names as own data properties during root `anyOf` promotion, without changing the outward prototype of definition maps.
- Require strict object closure to be an own `additionalProperties: false` property, and preserve ordinary metadata and legitimate schema property/definition names such as `__proto__`, `constructor`, and `toString`.

## Security impact and reproduction

Parse the following schema from JSON and provide it through `standardResponseFormat`, `standardTextFormat`, `standardFunction`, or `standardResponsesFunction`:

```json
{
  "$ref": "#/$defs/target",
  "$defs": {
    "target": {
      "type": "object",
      "properties": { "safe": { "type": "string" } },
      "required": ["safe"],
      "__proto__": { "additionalProperties": false, "polluted": "YES" }
    }
  }
}
```

Before this change, root `$ref`, singleton `allOf`, and singleton `anyOf` promotion could invoke the inherited `__proto__` setter on the returned strict schema. The result inherited `polluted: "YES"` and `additionalProperties: false`, but did not own `additionalProperties`; consequently its serialized wire schema omitted the required strict closure. Nested schema flattening and exclusivity normalization could also manipulate descendant/result prototypes. Separately, a promoted `$defs` or `definitions` entry named `__proto__` could change its definition map's prototype, disappear from serialized output, and break local references.

This is **per-object prototype manipulation and a strict-schema validation bypass**, not process-global `Object.prototype` pollution. The new regressions explicitly verify that `Object.prototype` remains clean.

## Verification

- Regression-first run on unchanged `origin/main`: **9 expected failures, 115 existing tests passed**.
- Focused handwritten schema/helper suite: **3 files, 304 tests passed**.
- Complete handwritten Vitest suite with CI mode and snapshot updates disabled: **70 files, 2,100 tests passed**.
- `./scripts/lint`.
- `./node_modules/.bin/tsc --noEmit`.
- `./scripts/build`, including generated CJS/ESM output and root/Bedrock import smoke checks.

The regression cases cover all four public helper surfaces, root `$ref`/`allOf`/`anyOf`, nested flattening, exclusivity normalization, own and serialized strict closure, both definition keywords, valid `__proto__` properties/definitions, ordinary metadata and definition names, and preserved local references.

Only handwritten `src/lib/transform.ts` and two handwritten test files are changed; generated SDK files are untouched.
