### PR TITLE
fix: export workload identity helpers from openai/auth

### DIFF
--- a/scripts/test-packed-package.ts
+++ b/scripts/test-packed-package.ts
@@ -32,6 +32,13 @@ const packedPackagePath = require('node:path');
   const dist = path.join(root, 'dist');
   const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'openai-node-packed-'));
   const npmCache = path.join(temporaryDirectory, '.npm-cache');
+  const authExportNames = [
+    'k8sServiceAccountTokenProvider',
+    'azureManagedIdentityTokenProvider',
+    'gcpIDTokenProvider',
+    'OAuthError',
+    'SubjectTokenProviderError',
+  ];
   const run = (command: string, args: string[], options: RunOptions = {}): string =>
     childProcess.execFileSync(command, args, {
       cwd: temporaryDirectory,
@@ -91,8 +98,13 @@ const packedPackagePath = require('node:path');
       [
         "const OpenAI = require('openai');",
         "const { bedrock } = require('openai/providers/bedrock');",
+        "const auth = require('openai/auth');",
         "if (typeof OpenAI !== 'function') throw new Error('CommonJS default export is not constructable');",
         "if (typeof bedrock !== 'function') throw new Error('CommonJS Bedrock export is unavailable');",
+        ...authExportNames.map(
+          (name) =>
+            `if (typeof auth.${name} !== 'function') throw new Error('CommonJS auth export ${name} is unavailable');`,
+        ),
         "new OpenAI({ apiKey: 'test' });",
       ].join('\n'),
     );
@@ -101,8 +113,13 @@ const packedPackagePath = require('node:path');
       [
         "import OpenAI from 'openai';",
         "import { bedrock } from 'openai/providers/bedrock';",
+        `import { ${authExportNames.join(', ')} } from 'openai/auth';`,
         "if (typeof OpenAI !== 'function') throw new Error('ESM default export is not constructable');",
         "if (typeof bedrock !== 'function') throw new Error('ESM Bedrock export is unavailable');",
+        ...authExportNames.map(
+          (name) =>
+            `if (typeof ${name} !== 'function') throw new Error('ESM auth export ${name} is unavailable');`,
+        ),
         "new OpenAI({ apiKey: 'test' });",
       ].join('\n'),
     );
@@ -110,13 +127,26 @@ const packedPackagePath = require('node:path');
       path.join(temporaryDirectory, 'consumer.ts'),
       [
         "import OpenAI, { AzureOpenAI } from 'openai';",
+        `import { ${authExportNames.join(', ')} } from 'openai/auth';`,
+        "import type { WorkloadIdentity } from 'openai/auth';",
         "import type { ResponsesWS } from 'openai/resources/responses/ws';",
         "import type { ResponsesWS as BetaResponsesWS } from 'openai/resources/beta/responses/ws';",
         "import type { OpenAIRealtimeWS as RealtimeWS } from 'openai/realtime/ws';",
         "import type { OpenAIRealtimeWS as BetaRealtimeWS } from 'openai/beta/realtime/ws';",
         "new OpenAI({ apiKey: 'test', dangerouslyAllowBrowser: true });",
         'void AzureOpenAI;',
+        ...authExportNames.map((name) => `void ${name};`),
+        'void (null as unknown as WorkloadIdentity);',
         'void (null as unknown as ResponsesWS | BetaResponsesWS | RealtimeWS | BetaRealtimeWS);',
+      ].join('\n'),
+    );
+    fs.writeFileSync(
+      path.join(temporaryDirectory, 'consumer.cts'),
+      [
+        `import { ${authExportNames.join(', ')} } from 'openai/auth';`,
+        "import type { WorkloadIdentity } from 'openai/auth';",
+        ...authExportNames.map((name) => `void ${name};`),
+        'void (null as unknown as WorkloadIdentity);',
       ].join('\n'),
     );
     const websocketPeer = path.join(temporaryDirectory, 'websocket-peer.d.ts');
@@ -143,7 +173,7 @@ const packedPackagePath = require('node:path');
     fs.writeFileSync(
       path.join(temporaryDirectory, 'tsconfig.json'),
       JSON.stringify({
-        files: ['consumer.ts', 'websocket-peer.d.ts'],
+        files: ['consumer.ts', 'consumer.cts', 'websocket-peer.d.ts'],
         compilerOptions: {
           target: 'ES2020',
           lib: ['DOM', 'DOM.Iterable', 'ES2020'],
@@ -153,6 +183,18 @@ const packedPackagePath = require('node:path');
           strict: true,
           skipLibCheck: false,
           noEmit: true,
+        },
+      }),
+    );
+    const bundlerConfig = path.join(temporaryDirectory, 'bundler.tsconfig.json');
+    fs.writeFileSync(
+      bundlerConfig,
+      JSON.stringify({
+        extends: './tsconfig.json',
+        files: ['consumer.ts', 'websocket-peer.d.ts'],
+        compilerOptions: {
+          module: 'ESNext',
+          moduleResolution: 'Bundler',
         },
       }),
     );
@@ -270,6 +312,9 @@ const packedPackagePath = require('node:path');
         env: isolatedEnvironment,
       });
     }
+    run(process.execPath, [path.join(root, 'node_modules/typescript/bin/tsc'), '--project', bundlerConfig], {
+      env: isolatedEnvironment,
+    });
 
     run(process.execPath, ['consumer.cjs']);
     run(process.execPath, ['consumer.mjs']);

--- a/scripts/utils/postprocess-files.cjs
+++ b/scripts/utils/postprocess-files.cjs
@@ -55,6 +55,14 @@ async function postprocess() {
       types: './index.d.mts',
       default: './index.mjs',
     },
+    './auth': {
+      require: {
+        types: './auth/index.d.ts',
+        default: './auth/index.js',
+      },
+      types: './auth/index.d.mts',
+      default: './auth/index.mjs',
+    },
   };
 
   for (const entry of await fs.promises.readdir(distDir, { withFileTypes: true })) {


### PR DESCRIPTION
## Summary

- Restore the documented `openai/auth` package entrypoint for Kubernetes, Azure managed identity, and Google Cloud workload identity users.
- Publish the existing auth index through one explicit conditional export with the correct CommonJS/ESM declaration and runtime files.
- Cover the real packed-and-installed npm artifact across CommonJS, ESM, TypeScript 4.9/6 Node16, and TypeScript 6 Bundler consumers.

## Customer impact

Eight examples in `README.md` and `docs/authentication.md` import workload-identity helpers from `openai/auth`, but sampled published OpenAI Node packages 6.35, 6.40, 6.45, and 7.0–7.4 expose only `./auth/*`, not `./auth`. Consequently, every documented Kubernetes, Azure, and GCP workload-identity onboarding path fails after installation:

```text
require('openai/auth') -> ERR_PACKAGE_PATH_NOT_EXPORTED
import ... from 'openai/auth' -> ERR_PACKAGE_PATH_NOT_EXPORTED
TypeScript import from 'openai/auth' -> TS2307
```

The auth implementation and all four compiled `auth/index` artifacts are already present in the npm package. The handwritten postprocessor reconstructs the distribution export map but only adds wildcard entries for directories, leaving the auth index unreachable.

## Fix

Add only the missing, narrowly scoped `./auth` conditional export alongside the existing root export:

```js
'./auth': {
  require: {
    types: './auth/index.d.ts',
    default: './auth/index.js',
  },
  types: './auth/index.d.mts',
  default: './auth/index.mjs',
}
```

This intentionally does not change `package.json`, release metadata, generated SDK code, existing directory exports, or published source files.

## Regression coverage

The existing smoke test now runs against an actual `npm pack` + isolated offline `npm install` and verifies:

- CommonJS `require('openai/auth')` exposes `k8sServiceAccountTokenProvider`, `azureManagedIdentityTokenProvider`, `gcpIDTokenProvider`, `OAuthError`, and `SubjectTokenProviderError`.
- ESM named imports expose the same five runtime exports.
- TypeScript **4.9.5 and 6.0.3** resolve all value exports and `import type { WorkloadIdentity }` under **Node16**, in both ESM `.ts` and CommonJS `.cts` consumers.
- TypeScript **6.0.3** also resolves those imports under **Bundler** module resolution; TypeScript 4.9 predates Bundler support.
- Every compiler run retains `skipLibCheck: false`, `types: []`, and the existing isolated consumer without `@types/node`.
- Existing root exports, Bedrock exports, published-source checks, and all **1,200 source maps** continue to pass.

The new packed regression test was run before the fix and failed with `TS2307` in both `.ts` and `.cts` consumers; separate CommonJS and ESM runtime checks reproduced `ERR_PACKAGE_PATH_NOT_EXPORTED`.

## Validation

- `pnpm --config.verify-deps-before-run=false build`
- `node --experimental-strip-types scripts/test-packed-package.ts`
- `pnpm --config.verify-deps-before-run=false lint`
- `pnpm --config.verify-deps-before-run=false exec tsc`
- `./node_modules/typescript-4-9/bin/tsc --project dist/src/tsconfig.json --noEmit`
- `./node_modules/typescript/bin/tsc --project dist/src/tsconfig.json --noEmit`
- `CI=1 pnpm --config.verify-deps-before-run=false test:unit --no-cache --update=none` — **70 files, 2,090 tests passed**
- `./node_modules/.bin/publint dist` — passes with the existing unrelated `_vendor` warning
- `npm_config_cache=<task-local-cache> ./node_modules/.bin/attw --pack dist --entrypoints ./auth --profile node16` — clean Node16 CJS, Node16 ESM, and Bundler resolutions
- Full CI package-type report via `scripts/utils/attw-report.cjs` — `Types ok!`