### PR TITLE
fix(auth): reject unsafe workload-identity token expirations

### DIFF
--- a/src/auth/workload-identity-auth.ts
+++ b/src/auth/workload-identity-auth.ts
@@ -49,7 +49,7 @@ export class WorkloadIdentityAuth {
    *
    * @throws {OAuthError} When the token endpoint rejects the subject token or identity.
    * @throws {APIError} When another unsuccessful HTTP response prevents token exchange.
-   * @throws {OpenAIError} When a successful exchange does not include an access token.
+   * @throws {OpenAIError} When a successful exchange has an invalid access token or expiration.
    */
   async getToken(): Promise<string> {
     if (!this.cachedToken || WorkloadIdentityAuth.isTokenExpired(this.cachedToken)) {
@@ -139,7 +139,15 @@ export class WorkloadIdentityAuth {
 
     const accessToken = tokenResponse.access_token;
     const expiresIn = (tokenResponse as Partial<TokenExchangeResponse>).expires_in ?? 3600;
-    const expiresAt = Date.now() + expiresIn * 1000;
+    if (typeof expiresIn !== 'number' || !Number.isFinite(expiresIn) || expiresIn <= 0) {
+      throw new OpenAIError("Token exchange response has invalid 'expires_in' field");
+    }
+
+    const now = Date.now();
+    const expiresAt = now + expiresIn * 1000;
+    if (!Number.isSafeInteger(expiresAt) || expiresAt <= now) {
+      throw new OpenAIError("Token exchange response has invalid 'expires_in' field");
+    }
 
     if (this.tokenGeneration === generation) {
       this.cachedToken = {

--- a/tests/auth/workload-identity-expiration.test.ts
+++ b/tests/auth/workload-identity-expiration.test.ts
@@ -1,0 +1,232 @@
+import { setTimeout as delay } from 'node:timers/promises';
+import { expect, vi } from 'vitest';
+
+import OpenAI, { OpenAIError } from 'openai';
+import { WorkloadIdentityAuth } from 'openai/auth/workload-identity-auth';
+import type { WorkloadIdentity } from 'openai/auth/types';
+
+const INITIAL_TIME = 1_700_000_000_000;
+const MAXIMUM_SAFE_DURATION = Math.floor((Number.MAX_SAFE_INTEGER - INITIAL_TIME) / 1000);
+
+const workloadIdentity: WorkloadIdentity = {
+  identityProviderId: 'test-identity-provider-id',
+  serviceAccountId: 'test-service-account-id',
+  refreshBufferSeconds: 0,
+  provider: {
+    tokenType: 'jwt',
+    getToken: async () => 'subject-token',
+  },
+};
+
+function tokenExchangeResponse(expiresIn: unknown, accessToken: string): Response {
+  const body = {
+    access_token: accessToken,
+    ...(expiresIn === undefined ? {} : { expires_in: expiresIn }),
+  };
+
+  if (typeof expiresIn === 'number' && !Number.isFinite(expiresIn)) {
+    const response = Response.json({ access_token: accessToken });
+    vi.spyOn(response, 'json').mockResolvedValue(body);
+    return response;
+  }
+
+  return Response.json(body);
+}
+
+describe('workload-identity access-token expiration', () => {
+  let currentTime = INITIAL_TIME;
+
+  beforeEach(() => {
+    currentTime = INITIAL_TIME;
+    vi.spyOn(Date, 'now').mockImplementation(() => currentTime);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test.each([
+    ['a nonnumeric string', 'invalid'],
+    ['a numeric string', '3600'],
+    ['an object', {}],
+    ['an empty array', []],
+    ['a numeric array', [3600]],
+    ['a boolean', true],
+    ['zero', 0],
+    ['a negative duration', -1],
+    ['NaN', Number.NaN],
+    ['positive Infinity', Number.POSITIVE_INFINITY],
+    ['negative Infinity', Number.NEGATIVE_INFINITY],
+    ['finite multiplication overflow', 1e308],
+    ['an unsafe expiration timestamp', MAXIMUM_SAFE_DURATION + 1],
+    ['a duration that rounds down to the current time', Number.MIN_VALUE],
+  ])('rejects %s before caching or returning the access token', async (_description, expiresIn) => {
+    const customFetch = vi
+      .fn()
+      .mockResolvedValueOnce(tokenExchangeResponse(expiresIn, 'unsafe-token'))
+      .mockResolvedValueOnce(tokenExchangeResponse(3600, 'replacement-token'));
+    const auth = new WorkloadIdentityAuth(workloadIdentity, customFetch);
+    const firstAttempt = auth.getToken();
+
+    await expect(firstAttempt).rejects.toBeInstanceOf(OpenAIError);
+    await expect(firstAttempt).rejects.toThrow("invalid 'expires_in'");
+    await expect(auth.getToken()).resolves.toBe('replacement-token');
+    await expect(auth.getToken()).resolves.toBe('replacement-token');
+    expect(customFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('rejects a JSON numeric literal that parses to Infinity', async () => {
+    const customFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response('{"access_token":"unsafe-token","expires_in":1e309}', {
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(tokenExchangeResponse(3600, 'replacement-token'));
+    const auth = new WorkloadIdentityAuth(workloadIdentity, customFetch);
+
+    await expect(auth.getToken()).rejects.toThrow("invalid 'expires_in'");
+    await expect(auth.getToken()).resolves.toBe('replacement-token');
+    expect(customFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test.each([
+    ['one millisecond', 0.001],
+    ['one second', 1],
+    ['fractional seconds', 1.5],
+    ['one hour', 3600],
+    ['the largest safe whole-second duration', MAXIMUM_SAFE_DURATION],
+  ])('preserves a valid positive duration: %s', async (_description, expiresIn) => {
+    const customFetch = vi.fn().mockResolvedValue(tokenExchangeResponse(expiresIn, 'valid-token'));
+    const auth = new WorkloadIdentityAuth(workloadIdentity, customFetch);
+
+    await expect(auth.getToken()).resolves.toBe('valid-token');
+    await expect(auth.getToken()).resolves.toBe('valid-token');
+    expect(customFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([
+    ['missing', undefined],
+    ['null', null],
+  ])('preserves the one-hour fallback when expires_in is %s', async (_description, expiresIn) => {
+    let exchangeCount = 0;
+    const customFetch = vi.fn(async () => {
+      exchangeCount += 1;
+      return tokenExchangeResponse(expiresIn, `token-${exchangeCount}`);
+    });
+    const auth = new WorkloadIdentityAuth(workloadIdentity, customFetch);
+
+    await expect(auth.getToken()).resolves.toBe('token-1');
+    currentTime += 3_599_999;
+    await expect(auth.getToken()).resolves.toBe('token-1');
+    currentTime += 1;
+    await expect(auth.getToken()).resolves.toBe('token-2');
+    expect(customFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('shares a rejected refresh and resets it for the next exchange', async () => {
+    const customFetch = vi
+      .fn()
+      .mockResolvedValueOnce(tokenExchangeResponse('invalid', 'unsafe-token'))
+      .mockResolvedValueOnce(tokenExchangeResponse(3600, 'replacement-token'));
+    const auth = new WorkloadIdentityAuth(workloadIdentity, customFetch);
+    const attempts = [auth.getToken(), auth.getToken(), auth.getToken()];
+
+    for (const result of await Promise.allSettled(attempts)) {
+      expect(result.status).toBe('rejected');
+      if (result.status === 'rejected') {
+        expect(result.reason).toBeInstanceOf(OpenAIError);
+        expect(result.reason.message).toContain("invalid 'expires_in'");
+      }
+    }
+
+    expect(customFetch).toHaveBeenCalledTimes(1);
+
+    await expect(auth.getToken()).resolves.toBe('replacement-token');
+    expect(customFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('retains a usable cached token when a background refresh has an invalid expiration', async () => {
+    const customFetch = vi
+      .fn()
+      .mockResolvedValueOnce(tokenExchangeResponse(60, 'cached-token'))
+      .mockResolvedValueOnce(tokenExchangeResponse('invalid', 'unsafe-token'))
+      .mockResolvedValueOnce(tokenExchangeResponse(3600, 'replacement-token'));
+    const auth = new WorkloadIdentityAuth({ ...workloadIdentity, refreshBufferSeconds: 1200 }, customFetch);
+
+    await expect(auth.getToken()).resolves.toBe('cached-token');
+    await expect(auth.getToken()).resolves.toBe('cached-token');
+    await delay(0);
+    expect(customFetch).toHaveBeenCalledTimes(2);
+
+    await expect(auth.getToken()).resolves.toBe('cached-token');
+    await delay(0);
+
+    await expect(auth.getToken()).resolves.toBe('replacement-token');
+    expect(customFetch).toHaveBeenCalledTimes(3);
+  });
+
+  test('never returns a stale token when an expired-token refresh is malformed', async () => {
+    const customFetch = vi
+      .fn()
+      .mockResolvedValueOnce(tokenExchangeResponse(1, 'expired-token'))
+      .mockResolvedValueOnce(tokenExchangeResponse(0, 'unsafe-token'))
+      .mockResolvedValueOnce(tokenExchangeResponse(3600, 'replacement-token'));
+    const auth = new WorkloadIdentityAuth(workloadIdentity, customFetch);
+
+    await expect(auth.getToken()).resolves.toBe('expired-token');
+    currentTime += 1000;
+    await expect(auth.getToken()).rejects.toThrow("invalid 'expires_in'");
+    await expect(auth.getToken()).resolves.toBe('replacement-token');
+    expect(customFetch).toHaveBeenCalledTimes(3);
+  });
+
+  test.each([
+    ['a nonnumeric duration', 'invalid'],
+    ['a zero duration', 0],
+    ['an overflowing duration', 1e308],
+  ])('prevents the public OpenAI client from using %s', async (_description, expiresIn) => {
+    let exchangeCount = 0;
+    let apiRequestCount = 0;
+    const clientFetch = vi.fn(async (url: string | URL | Request): Promise<Response> => {
+      if (url.toString().includes('/oauth/token')) {
+        exchangeCount += 1;
+        return tokenExchangeResponse(expiresIn, `unsafe-token-${exchangeCount}`);
+      }
+
+      apiRequestCount += 1;
+      return Response.json({ data: [] });
+    });
+    const client = new OpenAI({ apiKey: null, workloadIdentity, fetch: clientFetch });
+
+    await expect(client.models.list()).rejects.toThrow("invalid 'expires_in'");
+    currentTime += 30 * 24 * 60 * 60 * 1000;
+    await expect(client.models.list()).rejects.toThrow("invalid 'expires_in'");
+
+    expect(exchangeCount).toBe(2);
+    expect(apiRequestCount).toBe(0);
+  });
+
+  test('refreshes a valid workload-identity token through the public OpenAI client', async () => {
+    let exchangeCount = 0;
+    const authorizations: (string | null)[] = [];
+    const clientFetch = vi.fn(async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      if (url.toString().includes('/oauth/token')) {
+        exchangeCount += 1;
+        return tokenExchangeResponse(3600, `valid-token-${exchangeCount}`);
+      }
+
+      authorizations.push(new Headers(init?.headers).get('Authorization'));
+      return Response.json({ data: [] });
+    });
+    const client = new OpenAI({ apiKey: null, workloadIdentity, fetch: clientFetch });
+
+    await client.models.list();
+    currentTime += 30 * 24 * 60 * 60 * 1000;
+    await client.models.list();
+
+    expect(exchangeCount).toBe(2);
+    expect(authorizations).toEqual(['Bearer valid-token-1', 'Bearer valid-token-2']);
+  });
+});


### PR DESCRIPTION
## User impact

Successful workload-identity OAuth exchanges previously trusted `expires_in` in unchecked timestamp arithmetic. Strings, objects, arrays, and non-finite values could produce `NaN`; a finite JSON value such as `1e308`, or the JSON numeric literal `1e309`, could produce `Infinity`. Both invalid timestamps make expiration comparisons permanently false, so public calls such as `new OpenAI({ apiKey: null, workloadIdentity }).models.list()` could continue reusing an expired bearer token indefinitely, even after the clock advances by 30 days. Zero and negative lifetimes were also returned and sent despite already being expired.

## Changes

- Require `expires_in` to be a primitive, finite, positive number before accepting a successful OAuth response.
- Require the resulting expiration timestamp to be a safe integer strictly after the current time, preventing multiplication overflow, unsafe epoch totals, and positive durations that round down to an already-expired timestamp.
- Reject malformed exchanges with the existing `OpenAIError` before returning or caching their access tokens.
- Preserve the existing 3,600-second fallback for both omitted and `null` values, valid fractional-second lifetimes, and large durations up to the safe JavaScript timestamp boundary without adding an arbitrary expiration cap.
- Preserve shared in-flight refreshes, retry after rejected refreshes, existing usable credentials during a failed background refresh, and the normal public workload-identity authentication flow.
- Add one dedicated handwritten regression suite; no generated or legacy-generated files are changed.

## Regression-first coverage

Before the implementation change, the new standalone suite produced **21 expected failures and 8 passing compatibility cases** on current `main`. After the fix, all **29 cases pass**, covering numeric and nonnumeric strings, objects, arrays, booleans, zero, negative values, injected `NaN`/infinities, `1e308` multiplication overflow, JSON-parsed `1e309`, unsafe total epoch expiration, representability boundaries, omitted/null defaults, concurrent refresh sharing and reset, background-refresh recovery, stale-token rejection, and real public `OpenAI.models.list()` requests.

## Verification

- `./scripts/test tests/auth/workload-identity-expiration.test.ts tests/auth/workload-identity-auth.test.ts tests/lib/workload-identity.test.ts --reporter=dot` — **64 passed across 3 focused files**.
- `env OPENAI_TEST_SUITE=unit PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false ./scripts/test --reporter=dot` — **2,119 passed across all 71 handwritten files**. The scoped pnpm setting accommodates the isolated private clone's copied workspace dependencies.
- `./scripts/lint` — passed.
- `./node_modules/.bin/tsc --noEmit` — passed.
- `./scripts/build` — passed.
