### PR TITLE
fix(zod): prevent generated definition name collisions

### DIFF
--- a/src/_vendor/zod-to-json-schema/Options.ts
+++ b/src/_vendor/zod-to-json-schema/Options.ts
@@ -61,18 +61,32 @@ const defaultOptions: Omit<Options, 'definitions' | 'basePath'> = {
 
 export const getDefaultOptions = <Target extends Targets>(
   options: Partial<Options<Target>> | string | undefined,
-) =>
+): Options<Target> => {
   // We need to add `definitions` here as we may mutate it
-  (typeof options === 'string'
-    ? {
-        ...defaultOptions,
-        basePath: ['#'],
-        definitions: {},
-        name: options,
-      }
-    : {
-        ...defaultOptions,
-        basePath: ['#'],
-        definitions: {},
-        ...options,
-      }) as Options<Target>;
+  const resolvedOptions = (
+    typeof options === 'string'
+      ? {
+          ...defaultOptions,
+          basePath: ['#'],
+          definitions: {},
+          name: options,
+        }
+      : {
+          ...defaultOptions,
+          basePath: ['#'],
+          definitions: {},
+          ...options,
+        }
+  ) as Options<Target>;
+
+  if (
+    typeof options !== 'string' &&
+    options?.definitions &&
+    resolvedOptions.$refStrategy === 'extract-to-root' &&
+    resolvedOptions.nameStrategy === 'duplicate-ref'
+  ) {
+    resolvedOptions.definitions = { ...options.definitions };
+  }
+
+  return resolvedOptions;
+};

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -1,5 +1,6 @@
 import type { ZodTypeDef } from 'zod/v3';
 import { ZodFirstPartyTypeKind } from 'zod/v3';
+import { hasOwn } from '../../internal/utils/values';
 import type { JsonSchema7AnyType } from './parsers/any';
 import { parseAnyDef } from './parsers/any';
 import type { JsonSchema7ArrayType } from './parsers/array';
@@ -54,6 +55,7 @@ import { parseUnknownDef } from './parsers/unknown';
 import type { Refs, Seen } from './Refs';
 import { parseReadonlyDef } from './parsers/readonly';
 import { ignoreOverride } from './Options';
+import { zodDef } from './util';
 
 type JsonSchema7RefType = { $ref: string };
 type JsonSchema7Meta = {
@@ -163,18 +165,40 @@ const get$ref = (
     // `["#","definitions","contactPerson","properties","person1","properties","name"]`
     // then we'll extract it out to `contactPerson_properties_person1_properties_name`
     case 'extract-to-root': {
-      const name = item.path
+      const baseName = item.path
         .slice(refs.basePath.length + 1)
         // The first part is either the root schema name or an extracted definition
         // name that is being materialized. Keep it stable so recursive definitions
         // do not generate a new name each time they are resolved.
         .map((part, index) => (index === 0 ? part : encodeDefinitionPathPart(part)))
         .join('_');
+      let name = baseName;
 
       // we don't need to extract the root schema in this case, as it's already
       // been added to the definitions
-      if (name !== refs.name && refs.nameStrategy === 'duplicate-ref') {
-        refs.definitions[name] = item.def;
+      const isRootSchema =
+        name === refs.name &&
+        item.path.length === refs.basePath.length + 2 &&
+        item.path[refs.basePath.length] === refs.definitionPath;
+
+      if (!isRootSchema && refs.nameStrategy === 'duplicate-ref') {
+        const hasDifferentDefinition = (definitionName: string): boolean => {
+          if (!hasOwn(refs.definitions, definitionName)) {
+            return false;
+          }
+
+          const existingDefinition = refs.definitions[definitionName];
+          return existingDefinition === undefined || zodDef(existingDefinition) !== item.def;
+        };
+        let suffix = 0;
+        while (name === refs.name || hasDifferentDefinition(name)) {
+          suffix += 1;
+          name = `${baseName}_${suffix}`;
+        }
+
+        if (!hasOwn(refs.definitions, name)) {
+          refs.definitions[name] = item.def;
+        }
       }
 
       return { $ref: [...refs.basePath, refs.definitionPath, name].join('/') };

--- a/tests/helpers/zod-definition-collisions.test.ts
+++ b/tests/helpers/zod-definition-collisions.test.ts
@@ -1,0 +1,346 @@
+import { getDefaultOptions, zodToJsonSchema } from 'openai/_vendor/zod-to-json-schema';
+import {
+  zodFunction,
+  zodRealtimeFunction,
+  zodResponseFormat,
+  zodResponsesFunction,
+  zodTextFormat,
+} from 'openai/helpers/zod';
+import { z as zv3 } from 'zod/v3';
+import { z as zv4 } from 'zod/v4';
+
+interface JsonSchema {
+  $ref?: string;
+  type?: string;
+  properties?: Record<string, JsonSchema>;
+  definitions?: Record<string, JsonSchema>;
+  items?: JsonSchema;
+}
+
+interface HelperResult {
+  schema: JsonSchema;
+  parseRaw?: (content: string) => unknown;
+}
+
+interface Helper {
+  name: string;
+  convert: (schema: zv3.ZodType | zv4.ZodType) => HelperResult;
+}
+
+const helpers: Helper[] = [
+  {
+    name: 'zodResponseFormat',
+    convert: (schema) => {
+      const format = zodResponseFormat(schema, 'root');
+      return { schema: format.json_schema.schema as JsonSchema, parseRaw: format.$parseRaw };
+    },
+  },
+  {
+    name: 'zodTextFormat',
+    convert: (schema) => {
+      const format = zodTextFormat(schema, 'root');
+      return { schema: format.schema as JsonSchema, parseRaw: format.$parseRaw };
+    },
+  },
+  {
+    name: 'zodFunction',
+    convert: (schema) => {
+      const tool = zodFunction({ name: 'root', parameters: schema });
+      return { schema: tool.function.parameters as JsonSchema, parseRaw: tool.$parseRaw };
+    },
+  },
+  {
+    name: 'zodResponsesFunction',
+    convert: (schema) => {
+      const tool = zodResponsesFunction({ name: 'root', parameters: schema });
+      return { schema: tool.parameters as JsonSchema, parseRaw: tool.$parseRaw };
+    },
+  },
+  {
+    name: 'zodRealtimeFunction',
+    convert: (schema) => ({
+      schema: zodRealtimeFunction({ name: 'root', parameters: schema }).parameters as JsonSchema,
+    }),
+  },
+];
+
+function definitionFor(schema: JsonSchema, ref: string | undefined): JsonSchema {
+  if (!ref?.startsWith('#/definitions/')) {
+    throw new Error(`Expected a generated definition reference, received ${ref}`);
+  }
+
+  const definition = schema.definitions?.[ref.replace('#/definitions/', '')];
+  if (!definition) {
+    throw new Error(`Definition reference ${ref} does not resolve`);
+  }
+  return definition;
+}
+
+describe('Zod v3 generated definition names', () => {
+  it.each(helpers)('keeps colliding paths separate in $name', ({ convert }) => {
+    const sharedString = zv3.string();
+    const sharedNumber = zv3.number();
+    const root = zv3.object({
+      a: zv3.object({ b: sharedString, again: sharedString }),
+      a_properties_b: sharedNumber,
+      anotherNumber: sharedNumber,
+    });
+    const result = convert(root);
+    const nestedString = result.schema.properties?.['a']?.properties?.['again'];
+    const repeatedNumber = result.schema.properties?.['anotherNumber'];
+
+    expect(nestedString?.$ref).toBe('#/definitions/root_properties_a_properties_b');
+    expect(repeatedNumber?.$ref).toBe('#/definitions/root_properties_a_properties_b_1');
+    expect(definitionFor(result.schema, nestedString?.$ref).type).toBe('string');
+    expect(definitionFor(result.schema, repeatedNumber?.$ref).type).toBe('number');
+
+    const value = { a: { b: 'first', again: 'second' }, a_properties_b: 1, anotherNumber: 2 };
+    expect(root.parse(value)).toEqual(value);
+    if (result.parseRaw) {
+      expect(result.parseRaw(JSON.stringify(value))).toEqual(value);
+    }
+  });
+
+  it('does not overwrite a caller-provided definition with a generated collision', () => {
+    const providedNumber = zv3.number();
+    const definitions = { root_properties_first: providedNumber };
+    const sharedString = zv3.string();
+    const root = zv3.object({ first: sharedString, again: sharedString });
+    const schema = zodResponseFormat(root, 'root', {
+      schemaDefinitions: definitions,
+    }).json_schema.schema as JsonSchema;
+
+    expect(definitions).toEqual({ root_properties_first: providedNumber });
+    expect(schema.definitions?.['root_properties_first']?.type).toBe('number');
+    expect(schema.properties?.['again']?.$ref).toBe('#/definitions/root_properties_first_1');
+    expect(definitionFor(schema, schema.properties?.['again']?.$ref).type).toBe('string');
+  });
+
+  it('keeps the original readable name when no other definition occupies it', () => {
+    const shared = zv3.string();
+    const schema = zodResponseFormat(zv3.object({ first: shared, again: shared }), 'root').json_schema
+      .schema as JsonSchema;
+
+    expect(schema.properties?.['again']?.$ref).toBe('#/definitions/root_properties_first');
+    expect(schema.definitions?.['root_properties_first']?.type).toBe('string');
+  });
+
+  it('assigns deterministic suffixes to three distinct nested paths with the same flattened name', () => {
+    const sharedString = zv3.string();
+    const sharedNumber = zv3.number();
+    const sharedBoolean = zv3.boolean();
+    const root = zv3.object({
+      a: zv3.object({
+        b: zv3.object({ c: sharedString, again: sharedString }),
+        b_properties_c: sharedNumber,
+        repeatedNumber: sharedNumber,
+      }),
+      a_properties_b: zv3.object({ c: sharedBoolean, again: sharedBoolean }),
+    });
+    const schema = zodResponseFormat(root, 'root').json_schema.schema as JsonSchema;
+    const nested = schema.properties?.['a']?.properties;
+    const stringRef = nested?.['b']?.properties?.['again']?.$ref;
+    const numberRef = nested?.['repeatedNumber']?.$ref;
+    const booleanRef = schema.properties?.['a_properties_b']?.properties?.['again']?.$ref;
+
+    expect(stringRef).toBe('#/definitions/root_properties_a_properties_b_properties_c');
+    expect(numberRef).toBe('#/definitions/root_properties_a_properties_b_properties_c_1');
+    expect(booleanRef).toBe('#/definitions/root_properties_a_properties_b_properties_c_2');
+    expect(definitionFor(schema, stringRef).type).toBe('string');
+    expect(definitionFor(schema, numberRef).type).toBe('number');
+    expect(definitionFor(schema, booleanRef).type).toBe('boolean');
+  });
+
+  it('skips multiple occupied suffixes and safely handles a shadowed hasOwnProperty key', () => {
+    const providedNumber = zv3.number();
+    const providedBoolean = zv3.boolean();
+    const providedNull = zv3.null();
+    const shadowedProperty = zv3.string();
+    const definitions = {
+      root_properties_first: providedNumber,
+      root_properties_first_1: providedBoolean,
+      root_properties_first_2: providedNull,
+      hasOwnProperty: shadowedProperty,
+    };
+    const shared = zv3.string();
+    const schema = zodResponseFormat(zv3.object({ first: shared, again: shared }), 'root', {
+      schemaDefinitions: definitions,
+    }).json_schema.schema as JsonSchema;
+    const generatedRef = schema.properties?.['again']?.$ref;
+
+    expect(generatedRef).toBe('#/definitions/root_properties_first_3');
+    expect(definitionFor(schema, generatedRef).type).toBe('string');
+    expect(schema.definitions?.['root_properties_first']?.type).toBe('number');
+    expect(schema.definitions?.['root_properties_first_1']?.type).toBe('boolean');
+    expect(schema.definitions?.['root_properties_first_2']?.type).toBe('null');
+    expect(schema.definitions?.['hasOwnProperty']?.type).toBe('string');
+    expect(Object.keys(definitions)).toEqual([
+      'root_properties_first',
+      'root_properties_first_1',
+      'root_properties_first_2',
+      'hasOwnProperty',
+    ]);
+    expect(definitions.root_properties_first).toBe(providedNumber);
+  });
+
+  it('supports frozen caller definitions without adding generated names to the caller map', () => {
+    const providedNumber = zv3.number();
+    const definitions = Object.freeze({ existing: providedNumber });
+    const sharedString = zv3.string();
+    const root = zv3.object({ first: sharedString, again: sharedString });
+    const schema = zodResponseFormat(root, 'root', {
+      schemaDefinitions: definitions,
+    }).json_schema.schema as JsonSchema;
+
+    expect(Object.keys(definitions)).toEqual(['existing']);
+    expect(definitions.existing).toBe(providedNumber);
+    expect(schema.definitions?.['existing']?.type).toBe('number');
+    expect(definitionFor(schema, schema.properties?.['again']?.$ref).type).toBe('string');
+  });
+
+  it('ignores inherited definition names when checking for generated-name collisions', () => {
+    const inherited = { root_properties_first: zv3.number() };
+    const definitions = Object.create(inherited) as Record<string, zv3.ZodType>;
+    definitions['existing'] = zv3.boolean();
+    const shared = zv3.string();
+    const schema = zodResponseFormat(zv3.object({ first: shared, again: shared }), 'root', {
+      schemaDefinitions: definitions,
+    }).json_schema.schema as JsonSchema;
+
+    expect(schema.properties?.['again']?.$ref).toBe('#/definitions/root_properties_first');
+    expect(schema.definitions?.['root_properties_first']?.type).toBe('string');
+    expect(Object.keys(definitions)).toEqual(['existing']);
+  });
+
+  it('accepts null-prototype caller definitions without mutating them', () => {
+    const definitions = Object.create(null) as Record<string, zv3.ZodType>;
+    definitions['root_properties_first'] = zv3.number();
+    const shared = zv3.string();
+    const schema = zodResponseFormat(zv3.object({ first: shared, again: shared }), 'root', {
+      schemaDefinitions: definitions,
+    }).json_schema.schema as JsonSchema;
+
+    expect(schema.properties?.['again']?.$ref).toBe('#/definitions/root_properties_first_1');
+    expect(schema.definitions?.['root_properties_first']?.type).toBe('number');
+    expect(Object.keys(definitions)).toEqual(['root_properties_first']);
+  });
+
+  it.each(['schema', 'raw definition', 'schema alias'] as const)(
+    'reuses an identical caller-provided Zod %s without adding a suffix',
+    (representation) => {
+      const shared = zv3.string();
+      const definition = {
+        schema: shared,
+        'raw definition': shared._def,
+        'schema alias': new zv3.ZodString(shared._def),
+      }[representation];
+      const definitions = { root_properties_first: definition };
+      const schema = zodToJsonSchema(zv3.object({ first: shared, again: shared, third: shared }), {
+        name: 'root',
+        nameStrategy: 'duplicate-ref',
+        $refStrategy: 'extract-to-root',
+        definitions,
+      }) as JsonSchema;
+
+      expect(schema.properties?.['first']?.$ref).toBe('#/definitions/root_properties_first');
+      expect(schema.properties?.['again']?.$ref).toBe('#/definitions/root_properties_first');
+      expect(schema.properties?.['third']?.$ref).toBe('#/definitions/root_properties_first');
+      expect(schema.definitions?.['root_properties_first']?.type).toBe('string');
+      expect(definitions.root_properties_first).toBe(definition);
+      expect(Object.keys(definitions)).toEqual(['root_properties_first']);
+    },
+  );
+
+  it('keeps the response root separate from caller-provided root-name definitions', () => {
+    const providedRoot = zv3.number();
+    const providedRenamedRoot = zv3.boolean();
+    const definitions = { root: providedRoot, root_root: providedRenamedRoot };
+    const shared = zv3.string();
+    const schema = zodResponseFormat(zv3.object({ first: shared, again: shared }), 'root', {
+      schemaDefinitions: definitions,
+    }).json_schema.schema as JsonSchema;
+
+    expect(schema.properties?.['again']?.$ref).toBe('#/definitions/root_root_root_properties_first');
+    expect(schema.definitions?.['root']?.type).toBe('number');
+    expect(schema.definitions?.['root_root']?.type).toBe('boolean');
+    expect(schema.definitions?.['root_root_root']?.type).toBe('object');
+    expect(Object.keys(definitions)).toEqual(['root', 'root_root']);
+  });
+
+  it('reserves the root definition name while materializing supplied nested definitions', () => {
+    const sharedString = zv3.string();
+    const provided = zv3.object({ bar: sharedString, again: sharedString });
+    const occupiedSuffix = zv3.number();
+    const root: zv3.ZodTypeAny = zv3.lazy(() =>
+      zv3.object({ first: provided, second: provided, children: zv3.array(root) }),
+    );
+    const schema = zodResponseFormat(root, 'foo_properties_bar', {
+      schemaDefinitions: { foo: provided, foo_properties_bar_1: occupiedSuffix },
+    }).json_schema.schema as JsonSchema;
+    const nestedString = schema.definitions?.['foo']?.properties?.['again'];
+
+    expect(nestedString?.$ref).toBe('#/definitions/foo_properties_bar_2');
+    expect(definitionFor(schema, nestedString?.$ref).type).toBe('string');
+    expect(schema.definitions?.['foo_properties_bar']?.type).toBe('object');
+    expect(schema.definitions?.['foo_properties_bar_1']?.type).toBe('number');
+    expect(schema.properties?.['children']?.items?.$ref).toBe('#/definitions/foo_properties_bar');
+  });
+
+  it('preserves the caller definitions identity for converter strategies that cannot mutate it', () => {
+    const definitions = { shared: zv3.string() };
+
+    for (const $refStrategy of ['root', 'relative', 'none', 'seen'] as const) {
+      expect(
+        getDefaultOptions({ definitions, $refStrategy, nameStrategy: 'duplicate-ref' }).definitions,
+      ).toBe(definitions);
+    }
+
+    expect(
+      getDefaultOptions({ definitions, $refStrategy: 'extract-to-root', nameStrategy: 'ref' }).definitions,
+    ).toBe(definitions);
+
+    const extracted = getDefaultOptions({
+      definitions,
+      $refStrategy: 'extract-to-root',
+      nameStrategy: 'duplicate-ref',
+    }).definitions;
+    expect(extracted).not.toBe(definitions);
+    expect(extracted).toEqual(definitions);
+  });
+});
+
+describe('Zod v4 definition compatibility', () => {
+  it.each(helpers)('keeps ordinary Zod v4 conversion unchanged in $name', ({ convert }) => {
+    const sharedString = zv4.string();
+    const sharedNumber = zv4.number();
+    const root = zv4.object({
+      a: zv4.object({ b: sharedString, again: sharedString }),
+      a_properties_b: sharedNumber,
+      anotherNumber: sharedNumber,
+    });
+    const result = convert(root);
+
+    expect(result.schema.properties?.['a']?.properties?.['again']?.type).toBe('string');
+    expect(result.schema.properties?.['anotherNumber']?.type).toBe('number');
+
+    const value = { a: { b: 'first', again: 'second' }, a_properties_b: 1, anotherNumber: 2 };
+    expect(root.parse(value)).toEqual(value);
+    if (result.parseRaw) {
+      expect(result.parseRaw(JSON.stringify(value))).toEqual(value);
+    }
+  });
+
+  it('continues to accept frozen Zod v4 caller definitions without mutation', () => {
+    const shared = zv4.object({ value: zv4.string() });
+    const definitions = Object.freeze({ provided: shared });
+    const root = zv4.object({ first: shared, again: shared });
+    const schema = zodResponseFormat(root, 'root', {
+      schemaDefinitions: definitions,
+    }).json_schema.schema as JsonSchema;
+
+    expect(schema.properties?.['first']?.$ref).toBe('#/definitions/provided');
+    expect(definitionFor(schema, schema.properties?.['first']?.$ref).type).toBe('object');
+    expect(Object.keys(definitions)).toEqual(['provided']);
+    expect(definitions.provided).toBe(shared);
+  });
+});


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fix silent Zod v3 structured-output/tool schema corruption when distinct schema paths flatten to the same generated definition name. For example, repeated `a.b` string and `a_properties_b` number schemas previously both referenced the same overwritten definition, so the model-visible schema required a number while the local Zod parser required a string. This affected `zodResponseFormat`, `zodTextFormat`, `zodFunction`, `zodResponsesFunction`, and `zodRealtimeFunction`.

- Preserve existing readable names when available, reuse a name only for the identical underlying Zod definition, and choose deterministic `_1`, `_2`, ... suffixes for distinct generated or caller-provided definitions.
- Reserve the actual root definition without accidentally binding nested supplied definitions to it; retain recursive root references and safe own-key checks.
- Copy caller-provided definitions only for the `extract-to-root` + `duplicate-ref` strategy that can mutate them, supporting frozen maps while preserving identity-dependent behavior in all other converter modes.
- Add one dedicated handwritten regression suite covering every v3/v4 helper, successful parsing and correct wire-schema targets, multiple suffix collisions, identical schema/raw-definition reuse, inherited/null-prototype maps, nested/recursive/root definitions, and caller-map immutability.

Only handwritten vendored converter files and a new handwritten test file are changed; none has a Castiron generated header or appears in the generated/legacy file inventory.

## Additional context & links

Regression-first baseline on untouched `main`: the initial eight targeted tests failed, reproducing all five public-helper collisions, supplied-definition overwrite/mutation, frozen-map failure, and the reserved-root collision.

## Verification

- `pnpm test:unit tests/helpers/zod-definition-collisions.test.ts tests/helpers/zod.test.ts` — 66 passed, including 24 focused collision regressions.
- `pnpm test:unit` — 2,114 passed across 71 handwritten test files.
- `pnpm lint` — passed across 609 files.
- `pnpm exec tsc` — passed.
- `pnpm exec oxfmt --check src/_vendor/zod-to-json-schema/parseDef.ts src/_vendor/zod-to-json-schema/Options.ts tests/helpers/zod-definition-collisions.test.ts` — passed.
- `pnpm build` — passed, including CJS/ESM package import smoke checks.
- `./node_modules/typescript-4-9/bin/tsc --project dist/src/tsconfig.json --noEmit` — passed.
- `./node_modules/typescript/bin/tsc --project dist/src/tsconfig.json --noEmit` — passed.
- `pnpm exec publint dist` — passed with the existing non-fatal vendored CommonJS default-export advisory.
- Direct built-package smoke test verified all five v3 helper schemas and preservation of frozen caller definitions.