### PR TITLE
fix(ws): prevent duplicate listener leaks in Node and browser adapters

### DIFF
--- a/src/internal/ws-adapter-browser.ts
+++ b/src/internal/ws-adapter-browser.ts
@@ -45,7 +45,7 @@ interface CloseEvent {
  */
 export class BrowserWebSocket implements WebSocketLike {
   private _ws: WebSocket;
-  private _listenerMap = new Map<string, Map<Listener, DOMEventHandler>>();
+  private _listenerMap = new Map<string, Map<Listener, DOMEventHandler[]>>();
 
   /** Wraps an existing browser socket and configures binary frames as array buffers. */
   constructor(ws: WebSocket) {
@@ -76,35 +76,62 @@ export class BrowserWebSocket implements WebSocketLike {
   /** Registers a listener and converts browser event objects to SDK event arguments. */
   on(event: string, listener: Listener): void {
     const wrapped = BrowserWebSocket._wrapListener(event, listener);
-    this._listenersFor(event).set(listener, wrapped);
-    this._ws.addEventListener(event, wrapped);
+    this._addListener(event, listener, wrapped);
   }
 
   /** Removes the browser event wrapper associated with the original listener. */
   off(event: string, listener: Listener): void {
-    const byListener = this._listenerMap.get(event);
-    if (!byListener) {
-      return;
-    }
-    const wrapped = byListener.get(listener);
+    const wrappedListeners = this._listenerMap.get(event)?.get(listener);
+    const [wrapped] = wrappedListeners?.slice(-1) ?? [];
     if (wrapped) {
-      byListener.delete(listener);
-      this._ws.removeEventListener(event, wrapped);
+      this._removeListener(event, listener, wrapped);
     }
   }
 
   /** Registers a listener that is removed before it handles its first event. */
   once(event: string, listener: Listener): void {
-    const onceListener: Listener = (...args) => {
-      this.off(event, listener);
+    let fired = false;
+    const wrapped = BrowserWebSocket._wrapListener(event, (...args) => {
+      if (fired) {
+        return;
+      }
+      fired = true;
+      this._removeListener(event, listener, wrapped);
       listener(...args);
-    };
-    const wrapped = BrowserWebSocket._wrapListener(event, onceListener);
-    this._listenersFor(event).set(listener, wrapped);
-    this._ws.addEventListener(event, wrapped);
+    });
+    this._addListener(event, listener, wrapped);
   }
 
-  private _listenersFor(event: string): Map<Listener, DOMEventHandler> {
+  private _addListener(event: string, listener: Listener, wrapped: DOMEventHandler): void {
+    this._ws.addEventListener(event, wrapped);
+    const byListener = this._listenersFor(event);
+    const wrappedListeners = byListener.get(listener);
+    if (!wrappedListeners) {
+      byListener.set(listener, [wrapped]);
+    } else if (!wrappedListeners.includes(wrapped)) {
+      wrappedListeners.push(wrapped);
+    }
+  }
+
+  private _removeListener(event: string, listener: Listener, wrapped: DOMEventHandler): void {
+    const byListener = this._listenerMap.get(event);
+    const wrappedListeners = byListener?.get(listener);
+    const index = wrappedListeners?.lastIndexOf(wrapped) ?? -1;
+    if (!byListener || !wrappedListeners || index === -1) {
+      return;
+    }
+
+    this._ws.removeEventListener(event, wrapped);
+    wrappedListeners.splice(index, 1);
+    if (wrappedListeners.length === 0) {
+      byListener.delete(listener);
+    }
+    if (byListener.size === 0) {
+      this._listenerMap.delete(event);
+    }
+  }
+
+  private _listenersFor(event: string): Map<Listener, DOMEventHandler[]> {
     let map = this._listenerMap.get(event);
     if (!map) {
       map = new Map();

--- a/src/internal/ws-adapter-node.ts
+++ b/src/internal/ws-adapter-node.ts
@@ -13,8 +13,8 @@ type Listener = (...args: any[]) => void;
 export class NodeWebSocket implements WebSocketLike {
   private _ws: WS.WebSocket;
 
-  /** Maps `(event, originalListener)` -> wrapped listener for correct `off()` removal. */
-  private _listenerMap = new Map<string, Map<Listener, Listener>>();
+  /** Maps `(event, originalListener)` to every wrapped registration in listener order. */
+  private _listenerMap = new Map<string, Map<Listener, Listener[]>>();
 
   /** Wraps an existing socket created by the optional `ws` package. */
   constructor(ws: WS.WebSocket) {
@@ -44,35 +44,71 @@ export class NodeWebSocket implements WebSocketLike {
   /** Registers a listener with normalized message payloads and close reasons. */
   on(event: string, listener: Listener): void {
     const wrapped = NodeWebSocket._wrapListener(event, listener);
-    this._listenersFor(event).set(listener, wrapped);
-    this._ws.on(event, wrapped);
+    this._registerListener(event, listener, wrapped);
   }
 
   /** Removes the platform listener associated with the original callback. */
   off(event: string, listener: Listener): void {
-    const byListener = this._listenerMap.get(event);
-    if (!byListener) {
+    const wrappedListeners = this._listenerMap.get(event)?.get(listener);
+    const [wrapped] = wrappedListeners?.slice(-1) ?? [];
+    if (!wrapped) {
       return;
     }
-    const wrapped = byListener.get(listener);
-    if (wrapped) {
-      byListener.delete(listener);
-      this._ws.removeListener(event, wrapped);
-    }
+
+    this._removeListener(event, listener, wrapped);
   }
 
   /** Registers a listener that is removed before it handles its first event. */
   once(event: string, listener: Listener): void {
-    const onceListener: Listener = (...args) => {
-      this.off(event, listener);
+    let fired = false;
+    const wrapped = NodeWebSocket._wrapListener(event, (...args) => {
+      if (fired) {
+        return;
+      }
+
+      fired = true;
+      this._removeListener(event, listener, wrapped);
       listener(...args);
-    };
-    const wrapped = NodeWebSocket._wrapListener(event, onceListener);
-    this._listenersFor(event).set(listener, wrapped);
+    });
+    this._registerListener(event, listener, wrapped);
+  }
+
+  private _registerListener(event: string, listener: Listener, wrapped: Listener): void {
+    const byListener = this._listenersFor(event);
+    const wrappedListeners = byListener.get(listener);
+    if (wrappedListeners) {
+      wrappedListeners.push(wrapped);
+    } else {
+      byListener.set(listener, [wrapped]);
+    }
+
     this._ws.on(event, wrapped);
   }
 
-  private _listenersFor(event: string): Map<Listener, Listener> {
+  private _removeListener(event: string, listener: Listener, wrapped: Listener): void {
+    const byListener = this._listenerMap.get(event);
+    const wrappedListeners = byListener?.get(listener);
+    if (!byListener || !wrappedListeners) {
+      return;
+    }
+
+    const index = wrappedListeners.lastIndexOf(wrapped);
+    if (index === -1) {
+      return;
+    }
+
+    wrappedListeners.splice(index, 1);
+    if (wrappedListeners.length === 0) {
+      byListener.delete(listener);
+    }
+    if (byListener.size === 0) {
+      this._listenerMap.delete(event);
+    }
+
+    this._ws.removeListener(event, wrapped);
+  }
+
+  private _listenersFor(event: string): Map<Listener, Listener[]> {
     let map = this._listenerMap.get(event);
     if (!map) {
       map = new Map();

--- a/tests/internal/websocket-adapter-listeners.test.ts
+++ b/tests/internal/websocket-adapter-listeners.test.ts
@@ -1,0 +1,398 @@
+import { vi } from 'vitest';
+
+import { EventEmitter, getEventListeners } from 'node:events';
+import { BrowserWebSocket } from 'openai/internal/ws-adapter-browser';
+import { NodeWebSocket } from 'openai/internal/ws-adapter-node';
+import { ReadyState } from 'openai/internal/ws-adapter';
+import type { WebSocketLike } from 'openai/internal/ws-adapter';
+
+interface AdapterHarness {
+  adapter: WebSocketLike;
+  emitMessage: (message: string) => void;
+  emitOpen: () => void;
+  emitClose: (code: number, reason: string) => void;
+  emitError: (error: Error) => void;
+  platformListeners: (event: string) => readonly unknown[];
+}
+
+function createNodeHarness(): AdapterHarness {
+  // oxlint-disable-next-line unicorn/prefer-event-target -- Exercise real EventEmitter snapshot/removal semantics.
+  const socket = Object.assign(new EventEmitter(), {
+    readyState: ReadyState.OPEN,
+    send: vi.fn(),
+    close: vi.fn(),
+  });
+  const adapter = new NodeWebSocket(socket as unknown as ConstructorParameters<typeof NodeWebSocket>[0]);
+
+  return {
+    adapter,
+    emitMessage: (message) => {
+      socket.emit('message', Buffer.from(message), false);
+    },
+    emitOpen: () => {
+      socket.emit('open');
+    },
+    emitClose: (code, reason) => {
+      socket.emit('close', code, Buffer.from(reason));
+    },
+    emitError: (error) => {
+      socket.emit('error', error);
+    },
+    platformListeners: (event) => getEventListeners(socket, event),
+  };
+}
+
+function createBrowserHarness(): AdapterHarness {
+  const socket = Object.assign(new EventTarget(), {
+    readyState: ReadyState.OPEN,
+    binaryType: 'blob',
+    send: vi.fn(),
+    close: vi.fn(),
+  });
+  const adapter = new BrowserWebSocket(socket);
+
+  return {
+    adapter,
+    emitMessage: (message) => {
+      socket.dispatchEvent(Object.assign(new Event('message'), { data: message }));
+    },
+    emitOpen: () => {
+      socket.dispatchEvent(new Event('open'));
+    },
+    emitClose: (code, reason) => {
+      socket.dispatchEvent(Object.assign(new Event('close'), { code, reason }));
+    },
+    emitError: (error) => {
+      socket.dispatchEvent(Object.assign(new Event('error'), { error }));
+    },
+    platformListeners: (event) => getEventListeners(socket, event),
+  };
+}
+
+function listenerBookkeeping(adapter: WebSocketLike): Map<string, Map<unknown, unknown>> {
+  return (adapter as unknown as { _listenerMap: Map<string, Map<unknown, unknown>> })._listenerMap;
+}
+
+const adapterFactories = [
+  ['NodeWebSocket', createNodeHarness],
+  ['BrowserWebSocket', createBrowserHarness],
+] as const;
+
+describe.each(adapterFactories)('%s listener lifecycle', (_name, createHarness) => {
+  test('removes duplicate regular subscriptions individually without orphaning a platform listener', () => {
+    const { adapter, emitMessage, platformListeners } = createHarness();
+    const listener = vi.fn();
+
+    adapter.on('message', listener);
+    adapter.on('message', listener);
+
+    expect(platformListeners('message')).toHaveLength(2);
+    emitMessage('first');
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenNthCalledWith(1, 'first', false);
+    expect(listener).toHaveBeenNthCalledWith(2, 'first', false);
+
+    adapter.off('message', listener);
+    expect(platformListeners('message')).toHaveLength(1);
+    emitMessage('second');
+    expect(listener).toHaveBeenCalledTimes(3);
+
+    adapter.off('message', listener);
+    expect(platformListeners('message')).toHaveLength(0);
+    expect(listenerBookkeeping(adapter)).toHaveLength(0);
+
+    emitMessage('third');
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+
+  test('removes the most recent matching regular registration while preserving listener order', () => {
+    const { adapter, emitMessage, platformListeners } = createHarness();
+    const calls: string[] = [];
+    const repeated = vi.fn((message: string) => {
+      calls.push(`repeated:${message}`);
+    });
+    const middle = vi.fn((message: string) => {
+      calls.push(`middle:${message}`);
+    });
+
+    adapter.on('message', repeated);
+    adapter.on('message', middle);
+    adapter.on('message', repeated);
+    adapter.off('message', repeated);
+
+    emitMessage('first');
+
+    expect(calls).toEqual(['repeated:first', 'middle:first']);
+    expect(platformListeners('message')).toHaveLength(2);
+
+    adapter.off('message', repeated);
+    adapter.off('message', middle);
+    expect(platformListeners('message')).toHaveLength(0);
+    expect(listenerBookkeeping(adapter)).toHaveLength(0);
+  });
+
+  test.each([
+    ['regular then one-time', 'on', 'once', 2],
+    ['one-time then regular', 'once', 'on', 1],
+  ] as const)(
+    'off removes only the newest subscription when registration order is %s',
+    (_description, first, second, expectedCalls) => {
+      const { adapter, emitMessage, platformListeners } = createHarness();
+      const listener = vi.fn();
+
+      adapter[first]('message', listener);
+      adapter[second]('message', listener);
+      adapter.off('message', listener);
+
+      expect(platformListeners('message')).toHaveLength(1);
+      emitMessage('first');
+      emitMessage('second');
+
+      expect(listener).toHaveBeenCalledTimes(expectedCalls);
+
+      adapter.off('message', listener);
+      expect(platformListeners('message')).toHaveLength(0);
+      expect(listenerBookkeeping(adapter)).toHaveLength(0);
+    },
+  );
+
+  test('invokes every duplicate one-time subscription exactly once across repeated events', () => {
+    const { adapter, emitMessage, platformListeners } = createHarness();
+    const listener = vi.fn();
+
+    adapter.once('message', listener);
+    adapter.once('message', listener);
+    expect(platformListeners('message')).toHaveLength(2);
+
+    emitMessage('first');
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenNthCalledWith(1, 'first', false);
+    expect(listener).toHaveBeenNthCalledWith(2, 'first', false);
+    expect(platformListeners('message')).toHaveLength(0);
+    expect(listenerBookkeeping(adapter)).toHaveLength(0);
+
+    emitMessage('second');
+    emitMessage('third');
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  test.each([
+    ['regular then one-time', 'on', 'once'],
+    ['one-time then regular', 'once', 'on'],
+  ] as const)('preserves the regular subscription after %s registrations', (_description, first, second) => {
+    const { adapter, emitMessage, platformListeners } = createHarness();
+    const listener = vi.fn();
+
+    adapter[first]('message', listener);
+    adapter[second]('message', listener);
+
+    emitMessage('first');
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(platformListeners('message')).toHaveLength(1);
+
+    emitMessage('second');
+    emitMessage('third');
+    expect(listener.mock.calls.map(([message]) => message)).toEqual(['first', 'first', 'second', 'third']);
+
+    adapter.off('message', listener);
+    expect(platformListeners('message')).toHaveLength(0);
+    expect(listenerBookkeeping(adapter)).toHaveLength(0);
+  });
+
+  test('removes the exact one-time wrapper before reentrant dispatch with the same regular callback', () => {
+    const { adapter, emitMessage, platformListeners } = createHarness();
+    const listener = vi.fn();
+    let emittedNestedMessage = false;
+
+    listener.mockImplementation((message: string) => {
+      if (message === 'first' && !emittedNestedMessage) {
+        emittedNestedMessage = true;
+        expect(platformListeners('message')).toHaveLength(1);
+        emitMessage('nested');
+      }
+    });
+
+    adapter.once('message', listener);
+    adapter.on('message', listener);
+
+    emitMessage('first');
+    expect(listener.mock.calls.map(([message]) => message)).toEqual(['first', 'nested', 'first']);
+    expect(platformListeners('message')).toHaveLength(1);
+
+    emitMessage('later');
+    expect(listener.mock.calls.map(([message]) => message)).toEqual(['first', 'nested', 'first', 'later']);
+
+    adapter.off('message', listener);
+    expect(platformListeners('message')).toHaveLength(0);
+    expect(listenerBookkeeping(adapter)).toHaveLength(0);
+  });
+
+  test('does not invoke a one-time registration twice when another one-time callback reenters', () => {
+    const { adapter, emitMessage, platformListeners } = createHarness();
+    const listener = vi.fn();
+    let emittedNestedMessage = false;
+
+    listener.mockImplementation((message: string) => {
+      if (message === 'first' && !emittedNestedMessage) {
+        emittedNestedMessage = true;
+        emitMessage('nested');
+      }
+    });
+
+    adapter.once('message', listener);
+    adapter.once('message', listener);
+    emitMessage('first');
+
+    expect(listener.mock.calls.map(([message]) => message)).toEqual(['first', 'nested']);
+    expect(platformListeners('message')).toHaveLength(0);
+    expect(listenerBookkeeping(adapter)).toHaveLength(0);
+
+    emitMessage('later');
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  test('cleans up a one-time subscription before its callback registers itself again', () => {
+    const { adapter, emitMessage, platformListeners } = createHarness();
+    const listener = vi.fn();
+
+    listener.mockImplementation((message: string) => {
+      expect(platformListeners('message')).toHaveLength(0);
+      expect(listenerBookkeeping(adapter).has('message')).toBe(false);
+
+      if (message === 'first') {
+        adapter.once('message', listener);
+        emitMessage('nested');
+      }
+    });
+
+    adapter.once('message', listener);
+    emitMessage('first');
+    emitMessage('later');
+
+    expect(listener.mock.calls.map(([message]) => message)).toEqual(['first', 'nested']);
+    expect(platformListeners('message')).toHaveLength(0);
+    expect(listenerBookkeeping(adapter)).toHaveLength(0);
+  });
+
+  test('keeps registrations isolated by event name and normalizes close arguments', () => {
+    const { adapter, emitMessage, emitClose, platformListeners } = createHarness();
+    const listener = vi.fn();
+
+    adapter.on('message', listener);
+    adapter.on('close', listener);
+    adapter.on('close', listener);
+    adapter.off('message', listener);
+
+    expect(platformListeners('message')).toHaveLength(0);
+    expect(platformListeners('close')).toHaveLength(2);
+    emitMessage('ignored');
+    emitClose(1000, 'finished');
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenNthCalledWith(1, 1000, 'finished');
+    expect(listener).toHaveBeenNthCalledWith(2, 1000, 'finished');
+
+    adapter.off('close', listener);
+    adapter.off('close', listener);
+    expect(platformListeners('close')).toHaveLength(0);
+    expect(listenerBookkeeping(adapter)).toHaveLength(0);
+  });
+
+  test('keeps callback identity intact for pass-through events', () => {
+    const { adapter, emitOpen, platformListeners } = createHarness();
+    const listener = vi.fn();
+
+    adapter.on('open', listener);
+
+    expect(platformListeners('open')).toEqual([listener]);
+    emitOpen();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    adapter.off('open', listener);
+    expect(platformListeners('open')).toHaveLength(0);
+    expect(listenerBookkeeping(adapter)).toHaveLength(0);
+  });
+
+  test('ignores unknown callbacks and events without corrupting active registrations', () => {
+    const { adapter, emitMessage, platformListeners } = createHarness();
+    const active = vi.fn();
+    const unknown = vi.fn();
+
+    adapter.off('missing', unknown);
+    expect(listenerBookkeeping(adapter)).toHaveLength(0);
+
+    adapter.on('message', active);
+    adapter.off('missing', active);
+    adapter.off('message', unknown);
+
+    expect(platformListeners('message')).toHaveLength(1);
+    emitMessage('first');
+    expect(active).toHaveBeenCalledWith('first', false);
+    expect(unknown).not.toHaveBeenCalled();
+
+    adapter.off('message', active);
+    adapter.off('message', active);
+    expect(platformListeners('message')).toHaveLength(0);
+    expect(listenerBookkeeping(adapter)).toHaveLength(0);
+  });
+
+  test('preserves normalized error listeners while removing only their one-time registration', () => {
+    const { adapter, emitError, platformListeners } = createHarness();
+    const listener = vi.fn();
+
+    adapter.on('error', listener);
+    adapter.once('error', listener);
+    emitError(new Error('socket failed'));
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener.mock.calls.map(([error]) => (error as Error).message)).toEqual([
+      'socket failed',
+      'socket failed',
+    ]);
+    expect(platformListeners('error')).toHaveLength(1);
+
+    adapter.off('error', listener);
+    expect(platformListeners('error')).toHaveLength(0);
+    expect(listenerBookkeeping(adapter)).toHaveLength(0);
+  });
+});
+
+describe('browser-native pass-through registration', () => {
+  test('preserves EventTarget deduplication and original callback identity for duplicate open listeners', () => {
+    const { adapter, emitOpen, platformListeners } = createBrowserHarness();
+    const listener = vi.fn();
+
+    adapter.on('open', listener);
+    adapter.on('open', listener);
+
+    expect(platformListeners('open')).toEqual([listener]);
+    emitOpen();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    adapter.off('open', listener);
+    expect(platformListeners('open')).toHaveLength(0);
+    expect(listenerBookkeeping(adapter)).toHaveLength(0);
+    adapter.off('open', listener);
+    expect(listenerBookkeeping(adapter)).toHaveLength(0);
+  });
+});
+
+describe('NodeWebSocket one-time listener failures', () => {
+  test('removes and forgets a one-time registration before its callback throws', () => {
+    const { adapter, emitMessage, platformListeners } = createNodeHarness();
+    const failure = new Error('listener failed');
+    const listener = vi.fn(() => {
+      throw failure;
+    });
+
+    adapter.once('message', listener);
+
+    expect(() => emitMessage('first')).toThrow(failure);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(platformListeners('message')).toHaveLength(0);
+    expect(listenerBookkeeping(adapter)).toHaveLength(0);
+
+    emitMessage('later');
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Track every platform listener wrapper for each original callback instead of overwriting earlier registrations.
- Make `off()` remove the most recently registered matching listener, while each `once()` registration removes its own exact wrapper before invoking user code.
- Guard one-shot wrappers against reentrant Node.js `EventEmitter` dispatch, preserve native browser `EventTarget` callback identity/deduplication, and release empty listener bookkeeping immediately.
- Add a focused handwritten regression suite that exercises real `EventEmitter` and `EventTarget` behavior across both adapters.

## Impact and root cause

Both adapters previously stored only one wrapped listener per `(event, original callback)`. Re-registering the same callback overwrote that record while earlier platform listeners stayed attached. Matching `off()` calls could therefore leave subscriptions active indefinitely, and duplicate `once()` registrations could remove the wrong wrapper or fire again on later events.

The Node adapter is reachable through the customer-facing Responses WebSocket socket. Leaked subscriptions can process messages after unsubscribe, retain callbacks and their captured data, or repeat side effects that were intended to run only once. Browser behavior was additionally masked by the existing single-listener fake.

Node's `EventEmitter` snapshots listeners during dispatch, so exact-wrapper removal alone is insufficient for reentrant duplicate `once()` callbacks; each wrapper also needs its own fired guard. Browser pass-through events deliberately retain original callback identity, so duplicate native registrations must also be deduplicated in bookkeeping.

## Regression-first evidence

- Against freshly fetched `main`, all **30 new Node/browser listener-lifecycle regressions failed** while the other **2,090 handwritten tests passed**.
- A second targeted regression first reproduced retention of a duplicate browser `open` callback after one native `off()`, then passed after browser bookkeeping was aligned with `EventTarget` deduplication.
- Coverage includes duplicate `on/off`, newest-first removal ordering, duplicate `once`, both `on+once` orderings, repeated/reentrant dispatch, callback re-registration, throwing callbacks, event isolation, normalized close/error data, callback identity, and complete listener/map cleanup.

## Verification

- Focused existing + new adapter suites: `./node_modules/.bin/vitest run --config vitest.config.mts tests/internal/websocket-adapter-listeners.test.ts tests/internal/websocket-adapters.test.ts --no-cache --update=none` — **61 passed**.
- Complete handwritten suite: `env PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false ./node_modules/.bin/vitest run --config vitest.config.mts --no-cache --update=none` — **71 files / 2,120 tests passed**.
- Full generated-file checks, formatting, and lint: `./scripts/lint` — **passed; 609 files checked**.
- Full strict typecheck: `./node_modules/typescript/bin/tsc --noEmit --pretty false` — **passed**.
- Production CommonJS/ESM build and package import smoke tests: `./scripts/build` — **passed**.
- Published-source compatibility: `./node_modules/typescript-4-9/bin/tsc --project dist/src/tsconfig.json --noEmit --pretty false` and the equivalent current-TypeScript command — **both passed**.
- Additional executable checks against both built adapters verified duplicate unsubscribe, reentrant duplicate `once()`, and native-browser deduplication cleanup.

Only the two handwritten platform adapters and one new handwritten focused test change. Each path was checked for the Castiron generated header and against `scripts/generated-files.cjs`; no generated or `legacyFiles` paths are included.