### PR TITLE
fix(realtime): prevent remote error payloads from crashing clients

### DIFF
--- a/src/beta/realtime/internal-base.ts
+++ b/src/beta/realtime/internal-base.ts
@@ -8,6 +8,14 @@ import { OpenAIError } from '../../error';
 import type OpenAI from '../../index';
 import { AzureOpenAI } from '../../index';
 
+function safeErrorValue(value: unknown): string {
+  try {
+    return String(value);
+  } catch {
+    return '[unserializable error value]';
+  }
+}
+
 /** An API-reported or client-side error encountered by a beta Realtime connection. */
 export class OpenAIRealtimeError extends OpenAIError {
   /** Stable error name used to identify Realtime connection failures. */
@@ -98,7 +106,7 @@ export abstract class OpenAIRealtimeEmitter extends EventEmitter<RealtimeEvents>
   protected _onError(event: ErrorEvent, message?: string | undefined): void;
   protected _onError(event: ErrorEvent | null, message?: string | undefined, cause?: any): void {
     message = event?.error
-      ? `${event.error.message} code=${event.error.code} param=${event.error.param} type=${event.error.type} event_id=${event.error.event_id}`
+      ? `${safeErrorValue(event.error.message)} code=${safeErrorValue(event.error.code)} param=${safeErrorValue(event.error.param)} type=${safeErrorValue(event.error.type)} event_id=${safeErrorValue(event.error.event_id)}`
       : (message ?? 'unknown error');
 
     if (!this._hasListener('error')) {

--- a/src/realtime/internal-base.ts
+++ b/src/realtime/internal-base.ts
@@ -9,6 +9,14 @@ import { OpenAIError } from '../error';
 import type OpenAI from '../index';
 import { AzureOpenAI } from '../index';
 
+function safeErrorValue(value: unknown): string {
+  try {
+    return String(value);
+  } catch {
+    return '[unserializable error value]';
+  }
+}
+
 /** An API-reported or client-side error encountered by an active Realtime connection. */
 export class OpenAIRealtimeError extends OpenAIError {
   /** Stable error name used to identify Realtime connection failures. */
@@ -102,7 +110,7 @@ export abstract class OpenAIRealtimeEmitter extends EventEmitter<RealtimeEvents>
   protected _onError(event: RealtimeErrorEvent, message?: string | undefined): void;
   protected _onError(event: RealtimeErrorEvent | null, message?: string | undefined, cause?: any): void {
     message = event?.error
-      ? `${event.error.message} code=${event.error.code} param=${event.error.param} type=${event.error.type} event_id=${event.error.event_id}`
+      ? `${safeErrorValue(event.error.message)} code=${safeErrorValue(event.error.code)} param=${safeErrorValue(event.error.param)} type=${safeErrorValue(event.error.type)} event_id=${safeErrorValue(event.error.event_id)}`
       : (message ?? 'unknown error');
 
     if (!this._hasListener('error')) {

--- a/tests/realtime-error-payload-security.test.ts
+++ b/tests/realtime-error-payload-security.test.ts
@@ -1,0 +1,240 @@
+import { vi } from 'vitest';
+
+import OpenAI from 'openai';
+import { OpenAIRealtimeError as StableRealtimeError } from 'openai/realtime';
+import { OpenAIRealtimeWebSocket as StableNativeRealtime } from 'openai/realtime/websocket';
+import { OpenAIRealtimeWS as StableNodeRealtime } from 'openai/realtime/ws';
+import { OpenAIRealtimeError as BetaRealtimeError } from 'openai/beta/realtime';
+import { OpenAIRealtimeWebSocket as BetaNativeRealtime } from 'openai/beta/realtime/websocket';
+import { OpenAIRealtimeWS as BetaNodeRealtime } from 'openai/beta/realtime/ws';
+
+type Listener = (event: any) => void;
+
+interface FakeSocket {
+  dispatch: (event: string, value: unknown) => void;
+}
+
+vi.mock('ws', () => {
+  function FakeNodeSocket() {
+    const listeners = new Map<string, Listener>();
+
+    return {
+      on: (event: string, listener: Listener) => listeners.set(event, listener),
+      send: vi.fn(),
+      close: vi.fn(),
+      dispatch: (event: string, value: unknown) => listeners.get(event)?.(value),
+    };
+  }
+
+  return { WebSocket: FakeNodeSocket };
+});
+
+class FakeNativeSocket implements FakeSocket {
+  private readonly listeners = new Map<string, Listener>();
+
+  readonly send = vi.fn();
+  readonly close = vi.fn();
+
+  addEventListener(event: string, listener: Listener): void {
+    this.listeners.set(event, listener);
+  }
+
+  dispatch(event: string, value: unknown): void {
+    this.listeners.get(event)?.(value);
+  }
+}
+
+const originalWebSocket = Object.getOwnPropertyDescriptor(globalThis, 'WebSocket');
+
+const errorFields = ['message', 'code', 'param', 'type', 'event_id'] as const;
+
+function serverError(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'error',
+    event_id: 'evt_server',
+    error: {
+      message: 'request rejected',
+      code: 'invalid_request',
+      param: null,
+      type: 'invalid_request_error',
+      event_id: 'evt_request',
+      ...overrides,
+    },
+  };
+}
+
+function dispatchFrame(socket: FakeSocket, transport: 'native' | 'node', frame: object): void {
+  const data = JSON.stringify(frame);
+  socket.dispatch('message', transport === 'native' ? { data } : data);
+}
+
+function onRealtimeEvent(realtime: unknown, event: string, listener: Listener): void {
+  (realtime as { on: (event: string, listener: Listener) => unknown }).on(event, listener);
+}
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, 'WebSocket', {
+    configurable: true,
+    value: FakeNativeSocket,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+
+  if (originalWebSocket) {
+    Object.defineProperty(globalThis, 'WebSocket', originalWebSocket);
+  } else {
+    Reflect.deleteProperty(globalThis, 'WebSocket');
+  }
+});
+
+describe.each([
+  {
+    name: 'stable native',
+    Realtime: StableNativeRealtime,
+    RealtimeError: StableRealtimeError,
+    transport: 'native' as const,
+  },
+  {
+    name: 'stable Node',
+    Realtime: StableNodeRealtime,
+    RealtimeError: StableRealtimeError,
+    transport: 'node' as const,
+  },
+  {
+    name: 'beta native',
+    Realtime: BetaNativeRealtime,
+    RealtimeError: BetaRealtimeError,
+    transport: 'native' as const,
+  },
+  {
+    name: 'beta Node',
+    Realtime: BetaNodeRealtime,
+    RealtimeError: BetaRealtimeError,
+    transport: 'node' as const,
+  },
+])('$name Realtime error payload security', ({ Realtime, RealtimeError, transport }) => {
+  function connect() {
+    const realtime = new Realtime(
+      { model: 'gpt-realtime' },
+      new OpenAI({ apiKey: 'test-key', baseURL: 'https://example.com/v1/' }),
+    );
+
+    return { realtime, socket: realtime.socket as unknown as FakeSocket };
+  }
+
+  test.each(errorFields)('delivers a noncoercible JSON %s without throwing', (field) => {
+    const { realtime, socket } = connect();
+    const errors = vi.fn();
+    const events = vi.fn();
+    const value = { toString: null, valueOf: null };
+    const event = serverError({ [field]: value });
+
+    onRealtimeEvent(realtime, 'event', events);
+    onRealtimeEvent(realtime, 'error', errors);
+
+    expect(() => dispatchFrame(socket, transport, event)).not.toThrow();
+    expect(events).toHaveBeenCalledTimes(1);
+    expect(events).toHaveBeenCalledWith(event);
+    expect(errors).toHaveBeenCalledTimes(1);
+
+    const [[error] = []] = errors.mock.calls;
+    expect(error).toBeInstanceOf(RealtimeError);
+    expect(error.name).toBe('OpenAIRealtimeError');
+    expect(error.message).toContain('[unserializable error value]');
+    expect(error.event_id).toBe('evt_server');
+    expect(error.error).toEqual(event.error);
+    expect(error.error[field]).toEqual(value);
+  });
+
+  test('preserves the exact formatting of valid server errors', () => {
+    const { realtime, socket } = connect();
+    const errors = vi.fn();
+    const event = serverError();
+
+    onRealtimeEvent(realtime, 'error', errors);
+    dispatchFrame(socket, transport, event);
+
+    expect(errors).toHaveBeenCalledTimes(1);
+    const [[error] = []] = errors.mock.calls;
+    expect(error).toMatchObject({
+      name: 'OpenAIRealtimeError',
+      message:
+        'request rejected code=invalid_request param=null type=invalid_request_error event_id=evt_request',
+      event_id: 'evt_server',
+      error: event.error,
+    });
+  });
+
+  test.each([
+    { label: 'null', value: null, formatted: 'null' },
+    { label: 'missing', value: undefined, formatted: 'undefined' },
+    { label: 'number', value: 429, formatted: '429' },
+    { label: 'ordinary nested JSON', value: { nested: { toString: null } }, formatted: '[object Object]' },
+  ])('preserves existing formatting for a $label error value', ({ value, formatted }) => {
+    const { realtime, socket } = connect();
+    const errors = vi.fn();
+
+    onRealtimeEvent(realtime, 'error', errors);
+    dispatchFrame(socket, transport, serverError({ message: value }));
+
+    expect(errors).toHaveBeenCalledTimes(1);
+    const [[error] = []] = errors.mock.calls;
+    expect(error.message).toBe(
+      `${formatted} code=invalid_request param=null type=invalid_request_error event_id=evt_request`,
+    );
+  });
+
+  test('handles nested noncoercible JSON without serializing or changing its metadata', () => {
+    const { realtime, socket } = connect();
+    const errors = vi.fn();
+    const nested = {
+      toString: { message: { toString: null, valueOf: null } },
+      valueOf: { nested: [{ toString: null, valueOf: null }] },
+    };
+    const event = serverError({ message: nested, code: nested, event_id: nested });
+
+    onRealtimeEvent(realtime, 'error', errors);
+
+    expect(() => dispatchFrame(socket, transport, event)).not.toThrow();
+    expect(errors).toHaveBeenCalledTimes(1);
+
+    const [[error] = []] = errors.mock.calls;
+    expect(error.message).toBe(
+      '[unserializable error value] code=[unserializable error value] param=null type=invalid_request_error event_id=[unserializable error value]',
+    );
+    expect(error.error).toEqual(event.error);
+    expect(error.event_id).toBe(event.event_id);
+  });
+
+  test('retains asynchronous rejection for an unhandled malformed server error', () => {
+    const { socket } = connect();
+    const reject = vi.spyOn(Promise, 'reject').mockReturnValue(Promise.resolve() as Promise<never>);
+
+    expect(() =>
+      dispatchFrame(socket, transport, serverError({ message: { toString: null, valueOf: null } })),
+    ).not.toThrow();
+    expect(reject).toHaveBeenCalledTimes(1);
+
+    const [[error] = []] = reject.mock.calls;
+    expect(error).toBeInstanceOf(RealtimeError);
+    expect(error.message).toContain('[unserializable error value]');
+    expect(error.message).toContain('bind an `error` callback');
+    expect(error.event_id).toBe('evt_server');
+  });
+
+  test('does not swallow exceptions thrown by registered error listeners', () => {
+    const { realtime, socket } = connect();
+    const listenerError = new Error('application error listener failed');
+
+    onRealtimeEvent(realtime, 'error', () => {
+      throw listenerError;
+    });
+
+    expect(() =>
+      dispatchFrame(socket, transport, serverError({ message: { toString: null, valueOf: null } })),
+    ).toThrow(listenerError);
+  });
+});


### PR DESCRIPTION
## Summary

- Protect all five server-controlled Realtime error fields (`message`, `code`, `param`, `type`, and `event_id`) with exception-safe string conversion in the stable and beta handwritten Realtime emitters.
- Preserve existing valid-error formatting, the original event/error metadata, documented asynchronous rejection for unhandled errors, and exceptions thrown by application error listeners.
- Add one dedicated handwritten regression suite covering the four public stable/beta × native/Node WebSocket clients.

## Security impact

A remote WebSocket peer that can deliver a valid JSON Realtime error frame can send a noncoercible error value, for example:

```json
{"type":"error","error":{"message":{"toString":null,"valueOf":null}}}
```

The existing formatter interpolates attacker-controlled values before invoking registered SDK error handlers. JavaScript coercion then throws `TypeError: Cannot convert object to primitive value`; Node WebSocket clients can consequently terminate through an uncaught exception even when an SDK `.on('error')` listener is registered. The same sink exists for all five error fields in both stable and beta clients. The impact is remotely triggerable client denial of service, not credential disclosure or authentication bypass.

The fix catches only conversion failures and substitutes `[unserializable error value]`. It does not serialize untrusted objects, change public APIs, swallow application listener exceptions, or modify transport/generated files.

## Verification

- Failure-first baseline on unchanged `main`: **32 failing / 20 passing** security cases, reproducing every field across all four public clients.
- `pnpm test tests/realtime-error-payload-security.test.ts --reporter=dot` — **52/52 passed**.
- `pnpm run test:unit --reporter=dot` — **2,142/2,142 passed across 71 handwritten test files**.
- `pnpm run lint` — passed.
- `pnpm exec tsc` — passed.
- `pnpm run build` — passed, including CommonJS/ESM package smoke checks.
- Verified every changed file lacks the Castiron generated-file header and is absent from the generated/legacy-file manifest.
- Refreshed all open-PR changed-file lists immediately before publication; none overlaps these three handwritten files.