### PR TITLE
fix(zod): reject non-object Zod v3 strict schema roots

### DIFF
--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -6,7 +6,13 @@ import { getRefs } from './Refs';
 import { zodDef, isEmptyObj } from './util';
 
 function validateStrictRootSerializationHook(schema: object): void {
+  const visitedPrototypes = new WeakSet<object>();
   for (let target: object | null = schema; target !== null; target = Object.getPrototypeOf(target)) {
+    if (visitedPrototypes.has(target)) {
+      throw new TypeError('Root schema cannot contain a cyclic prototype chain');
+    }
+    visitedPrototypes.add(target);
+
     const serializationHook = Object.getOwnPropertyDescriptor(target, 'toJSON');
     if (!serializationHook) {
       continue;
@@ -19,7 +25,7 @@ function validateStrictRootSerializationHook(schema: object): void {
 }
 
 function validateStrictRootShape(schema: object): void {
-  if (Array.isArray(schema)) {
+  if (typeof schema === 'function' || Array.isArray(schema)) {
     throw new TypeError('Root schema must serialize to a JSON object');
   }
 

--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -10,15 +10,23 @@ function validateStrictRootSchema(schema: object, openaiStrictMode: boolean | un
     return;
   }
 
-  const type = 'type' in schema ? schema.type : undefined;
-  const nullable = 'nullable' in schema && schema.nullable === true;
+  const descriptors = Object.getOwnPropertyDescriptors(schema);
+  for (const keyword of ['type', 'nullable', '$ref'] as const) {
+    const descriptor = descriptors[keyword];
+    if (descriptor?.enumerable && !('value' in descriptor)) {
+      throw new Error(`Root schema validation keyword '${keyword}' must be a data property`);
+    }
+  }
+
+  const type = descriptors['type']?.enumerable ? descriptors['type'].value : undefined;
+  const nullable = descriptors['nullable']?.enumerable && descriptors['nullable'].value === true;
   if (type !== 'object' || nullable) {
     const actualType = nullable && type ? `${type},null` : type;
     throw new Error(
       `Root schema must have type: 'object' but got type: ${actualType ? `'${actualType}'` : 'undefined'}`,
     );
   }
-  if ('$ref' in schema) {
+  if (descriptors['$ref']?.enumerable) {
     throw new Error("Root schema must be a concrete object and cannot contain '$ref'");
   }
 }

--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -23,7 +23,14 @@ function validateStrictRootShape(schema: object): void {
     throw new TypeError('Root schema must serialize to a JSON object');
   }
 
-  for (const unbox of [String.prototype.valueOf, Number.prototype.valueOf, Boolean.prototype.valueOf]) {
+  const primitiveUnboxers = [
+    String.prototype.valueOf,
+    Number.prototype.valueOf,
+    Boolean.prototype.valueOf,
+    ...(typeof BigInt === 'function' ? [BigInt.prototype.valueOf] : []),
+  ];
+
+  for (const unbox of primitiveUnboxers) {
     try {
       Reflect.apply(unbox, schema, []);
     } catch {

--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -10,29 +10,16 @@ function validateStrictRootSchema(schema: object, openaiStrictMode: boolean | un
     return;
   }
 
-  const typeProperty = Object.getOwnPropertyDescriptor(schema, 'type');
-  const nullableProperty = Object.getOwnPropertyDescriptor(schema, 'nullable');
-  if ((typeProperty && !('value' in typeProperty)) || (nullableProperty && !('value' in nullableProperty))) {
-    throw new Error('Accessor-backed root schema properties are not supported');
-  }
-
-  const type = typeProperty?.value;
-  const nullable = nullableProperty?.value === true;
+  const type = 'type' in schema ? schema.type : undefined;
+  const nullable = 'nullable' in schema && schema.nullable === true;
   if (type !== 'object' || nullable) {
     const actualType = nullable && type ? `${type},null` : type;
     throw new Error(
       `Root schema must have type: 'object' but got type: ${actualType ? `'${actualType}'` : 'undefined'}`,
     );
   }
-  if (Object.getOwnPropertyDescriptor(schema, '$ref')) {
+  if ('$ref' in schema) {
     throw new Error("Root schema must be a concrete object and cannot contain '$ref'");
-  }
-}
-
-function validateRootSchemaDataProperties(schema: object): void {
-  const descriptors = Reflect.ownKeys(schema).map((key) => Object.getOwnPropertyDescriptor(schema, key));
-  if (descriptors.some((descriptor) => descriptor?.enumerable && !('value' in descriptor))) {
-    throw new Error('Accessor-backed root schema properties are not supported');
   }
 }
 
@@ -40,83 +27,6 @@ function cloneStrictRootSchemaDefinitions(refs: ReturnType<typeof getRefs>): voi
   if (refs.openaiStrictMode) {
     refs.definitions = { ...refs.definitions };
   }
-}
-
-function resolveStrictRootSchemaReference(
-  schema: JsonSchema7Type,
-  definitions: Record<string, JsonSchema7Type>,
-  definitionPrefix: string,
-): JsonSchema7Type {
-  const maxReferences = Object.keys(definitions).length;
-  const visitedReferences = new Set<string>();
-  let resolved = schema;
-
-  while (true) {
-    const reference = Object.getOwnPropertyDescriptor(resolved, '$ref');
-    if (!reference) {
-      break;
-    }
-    if (!('value' in reference)) {
-      throw new Error('Accessor-backed local root schema references are not supported');
-    }
-
-    const { value } = reference;
-    if (
-      typeof value !== 'string' ||
-      !definitionPrefix.startsWith('#/') ||
-      !value.startsWith(definitionPrefix)
-    ) {
-      break;
-    }
-    if (visitedReferences.has(value)) {
-      throw new Error(`Cyclic local root schema reference: ${value}`);
-    }
-
-    const definition = Object.getOwnPropertyDescriptor(definitions, value.slice(definitionPrefix.length));
-    if (
-      !definition ||
-      !('value' in definition) ||
-      !definition.value ||
-      typeof definition.value !== 'object'
-    ) {
-      break;
-    }
-    if (visitedReferences.size >= maxReferences) {
-      throw new Error(`Cyclic local root schema reference: ${value}`);
-    }
-    visitedReferences.add(value);
-    resolved = definition.value;
-  }
-
-  return resolved;
-}
-
-function materializeStrictRootSchema(
-  schema: JsonSchema7Type,
-  definitions: Record<string, JsonSchema7Type> | undefined,
-  openaiStrictMode: boolean | undefined,
-  definitionPath: string[],
-): JsonSchema7Type {
-  if (!openaiStrictMode || !definitions) {
-    return schema;
-  }
-
-  const rootReference = Object.getOwnPropertyDescriptor(schema, '$ref');
-  if (rootReference && !('value' in rootReference)) {
-    throw new Error('Accessor-backed local root schema references are not supported');
-  }
-  if (typeof rootReference?.value !== 'string') {
-    return schema;
-  }
-
-  const resolved = resolveStrictRootSchemaReference(schema, definitions, `${definitionPath.join('/')}/`);
-  validateStrictRootSchema(resolved, openaiStrictMode);
-  validateRootSchemaDataProperties(schema);
-  validateRootSchemaDataProperties(resolved);
-
-  const rootMetadata = { ...schema } as Record<string, unknown>;
-  delete rootMetadata['$ref'];
-  return { ...resolved, ...rootMetadata };
 }
 
 const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
@@ -143,7 +53,7 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
     name = options?.name;
   }
 
-  let main =
+  const main =
     parseDef(
       schema._def,
       name === undefined
@@ -152,8 +62,10 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
             ...refs,
             currentPath: [...refs.basePath, refs.definitionPath, name],
           },
-      false,
+      refs.openaiStrictMode === true,
     ) ?? {};
+
+  validateStrictRootSchema(main, refs.openaiStrictMode);
 
   const title =
     typeof options === 'object' && options.name !== undefined && options.nameStrategy === 'title'
@@ -198,12 +110,6 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
 
     return definitions;
   })();
-
-  main = materializeStrictRootSchema(main, definitions, refs.openaiStrictMode, [
-    ...refs.basePath,
-    refs.definitionPath,
-  ]);
-  validateStrictRootSchema(main, refs.openaiStrictMode);
 
   let combined: ReturnType<typeof zodToJsonSchema<Target>>;
   if (name === undefined) {

--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -5,14 +5,18 @@ import { parseDef } from './parseDef';
 import { getRefs } from './Refs';
 import { zodDef, isEmptyObj } from './util';
 
-function validateStrictRootSchema(schema: JsonSchema7Type, openaiStrictMode: boolean | undefined): void {
+function validateStrictRootSchema(schema: object, openaiStrictMode: boolean | undefined): void {
   if (!openaiStrictMode) {
     return;
   }
 
   const type = 'type' in schema ? schema.type : undefined;
-  if (type !== 'object') {
-    throw new Error(`Root schema must have type: 'object' but got type: ${type ? `'${type}'` : 'undefined'}`);
+  const nullable = 'nullable' in schema && schema.nullable === true;
+  if (type !== 'object' || nullable) {
+    const actualType = nullable && type ? `${type},null` : type;
+    throw new Error(
+      `Root schema must have type: 'object' but got type: ${actualType ? `'${actualType}'` : 'undefined'}`,
+    );
   }
 }
 
@@ -134,6 +138,8 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
   } else if (refs.target === 'jsonSchema2019-09') {
     combined.$schema = 'https://json-schema.org/draft/2019-09/schema#';
   }
+
+  validateStrictRootSchema(combined, refs.openaiStrictMode);
 
   return combined;
 };

--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -10,14 +10,113 @@ function validateStrictRootSchema(schema: object, openaiStrictMode: boolean | un
     return;
   }
 
-  const type = 'type' in schema ? schema.type : undefined;
-  const nullable = 'nullable' in schema && schema.nullable === true;
+  const typeProperty = Object.getOwnPropertyDescriptor(schema, 'type');
+  const nullableProperty = Object.getOwnPropertyDescriptor(schema, 'nullable');
+  if ((typeProperty && !('value' in typeProperty)) || (nullableProperty && !('value' in nullableProperty))) {
+    throw new Error('Accessor-backed root schema properties are not supported');
+  }
+
+  const type = typeProperty?.value;
+  const nullable = nullableProperty?.value === true;
   if (type !== 'object' || nullable) {
     const actualType = nullable && type ? `${type},null` : type;
     throw new Error(
       `Root schema must have type: 'object' but got type: ${actualType ? `'${actualType}'` : 'undefined'}`,
     );
   }
+  if (Object.getOwnPropertyDescriptor(schema, '$ref')) {
+    throw new Error("Root schema must be a concrete object and cannot contain '$ref'");
+  }
+}
+
+function validateRootSchemaDataProperties(schema: object): void {
+  const descriptors = Reflect.ownKeys(schema).map((key) => Object.getOwnPropertyDescriptor(schema, key));
+  if (descriptors.some((descriptor) => descriptor?.enumerable && !('value' in descriptor))) {
+    throw new Error('Accessor-backed root schema properties are not supported');
+  }
+}
+
+function cloneStrictRootSchemaDefinitions(refs: ReturnType<typeof getRefs>): void {
+  if (refs.openaiStrictMode) {
+    refs.definitions = { ...refs.definitions };
+  }
+}
+
+function resolveStrictRootSchemaReference(
+  schema: JsonSchema7Type,
+  definitions: Record<string, JsonSchema7Type>,
+  definitionPrefix: string,
+): JsonSchema7Type {
+  const maxReferences = Object.keys(definitions).length;
+  const visitedReferences = new Set<string>();
+  let resolved = schema;
+
+  while (true) {
+    const reference = Object.getOwnPropertyDescriptor(resolved, '$ref');
+    if (!reference) {
+      break;
+    }
+    if (!('value' in reference)) {
+      throw new Error('Accessor-backed local root schema references are not supported');
+    }
+
+    const { value } = reference;
+    if (
+      typeof value !== 'string' ||
+      !definitionPrefix.startsWith('#/') ||
+      !value.startsWith(definitionPrefix)
+    ) {
+      break;
+    }
+    if (visitedReferences.has(value)) {
+      throw new Error(`Cyclic local root schema reference: ${value}`);
+    }
+
+    const definition = Object.getOwnPropertyDescriptor(definitions, value.slice(definitionPrefix.length));
+    if (
+      !definition ||
+      !('value' in definition) ||
+      !definition.value ||
+      typeof definition.value !== 'object'
+    ) {
+      break;
+    }
+    if (visitedReferences.size >= maxReferences) {
+      throw new Error(`Cyclic local root schema reference: ${value}`);
+    }
+    visitedReferences.add(value);
+    resolved = definition.value;
+  }
+
+  return resolved;
+}
+
+function materializeStrictRootSchema(
+  schema: JsonSchema7Type,
+  definitions: Record<string, JsonSchema7Type> | undefined,
+  openaiStrictMode: boolean | undefined,
+  definitionPath: string[],
+): JsonSchema7Type {
+  if (!openaiStrictMode || !definitions) {
+    return schema;
+  }
+
+  const rootReference = Object.getOwnPropertyDescriptor(schema, '$ref');
+  if (rootReference && !('value' in rootReference)) {
+    throw new Error('Accessor-backed local root schema references are not supported');
+  }
+  if (typeof rootReference?.value !== 'string') {
+    return schema;
+  }
+
+  const resolved = resolveStrictRootSchemaReference(schema, definitions, `${definitionPath.join('/')}/`);
+  validateStrictRootSchema(resolved, openaiStrictMode);
+  validateRootSchemaDataProperties(schema);
+  validateRootSchemaDataProperties(resolved);
+
+  const rootMetadata = { ...schema } as Record<string, unknown>;
+  delete rootMetadata['$ref'];
+  return { ...resolved, ...rootMetadata };
 }
 
 const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
@@ -35,6 +134,7 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
   >;
 } => {
   const refs = getRefs(options);
+  cloneStrictRootSchemaDefinitions(refs);
 
   let name: string | undefined;
   if (typeof options === 'string') {
@@ -43,7 +143,7 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
     name = options?.name;
   }
 
-  const main =
+  let main =
     parseDef(
       schema._def,
       name === undefined
@@ -54,8 +154,6 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
           },
       false,
     ) ?? {};
-
-  validateStrictRootSchema(main, refs.openaiStrictMode);
 
   const title =
     typeof options === 'object' && options.name !== undefined && options.nameStrategy === 'title'
@@ -100,6 +198,12 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
 
     return definitions;
   })();
+
+  main = materializeStrictRootSchema(main, definitions, refs.openaiStrictMode, [
+    ...refs.basePath,
+    refs.definitionPath,
+  ]);
+  validateStrictRootSchema(main, refs.openaiStrictMode);
 
   let combined: ReturnType<typeof zodToJsonSchema<Target>>;
   if (name === undefined) {

--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -5,6 +5,19 @@ import { parseDef } from './parseDef';
 import { getRefs } from './Refs';
 import { zodDef, isEmptyObj } from './util';
 
+function validateStrictRootSerializationHook(schema: object): void {
+  for (let target: object | null = schema; target !== null; target = Object.getPrototypeOf(target)) {
+    const serializationHook = Object.getOwnPropertyDescriptor(target, 'toJSON');
+    if (!serializationHook) {
+      continue;
+    }
+    if (!('value' in serializationHook) || typeof serializationHook.value === 'function') {
+      throw new Error("Root schema cannot contain a callable or accessor-backed 'toJSON' property");
+    }
+    break;
+  }
+}
+
 function validateStrictRootSchema(schema: object, openaiStrictMode: boolean | undefined): void {
   if (!openaiStrictMode) {
     return;
@@ -18,6 +31,8 @@ function validateStrictRootSchema(schema: object, openaiStrictMode: boolean | un
     }
   }
 
+  validateStrictRootSerializationHook(schema);
+
   const type = descriptors['type']?.enumerable ? descriptors['type'].value : undefined;
   const nullable = descriptors['nullable']?.enumerable && descriptors['nullable'].value === true;
   if (type !== 'object' || nullable) {
@@ -26,7 +41,13 @@ function validateStrictRootSchema(schema: object, openaiStrictMode: boolean | un
       `Root schema must have type: 'object' but got type: ${actualType ? `'${actualType}'` : 'undefined'}`,
     );
   }
-  if (descriptors['$ref']?.enumerable) {
+  const reference = descriptors['$ref'];
+  if (
+    reference?.enumerable &&
+    reference.value !== undefined &&
+    typeof reference.value !== 'function' &&
+    typeof reference.value !== 'symbol'
+  ) {
     throw new Error("Root schema must be a concrete object and cannot contain '$ref'");
   }
 }

--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -5,83 +5,69 @@ import { parseDef } from './parseDef';
 import { getRefs } from './Refs';
 import { zodDef, isEmptyObj } from './util';
 
-function validateStrictRootSerializationHook(schema: object): void {
-  const visitedPrototypes = new WeakSet<object>();
-  for (let target: object | null = schema; target !== null; target = Object.getPrototypeOf(target)) {
-    if (visitedPrototypes.has(target)) {
-      throw new TypeError('Root schema cannot contain a cyclic prototype chain');
-    }
-    visitedPrototypes.add(target);
+function ownStrictRootSchema(
+  schema: unknown,
+  name: string | undefined,
+  nameStrategy: string,
+): JsonSchema7Type {
+  if (schema === null || typeof schema !== 'object') {
+    throw new TypeError('Root schema must be a plain JSON-schema record');
+  }
 
-    const serializationHook = Object.getOwnPropertyDescriptor(target, 'toJSON');
-    if (!serializationHook) {
+  const prototype = Object.getPrototypeOf(schema) as object | null;
+  if (![null, Object.prototype].includes(prototype)) {
+    throw new TypeError('Root schema must be a plain JSON-schema record');
+  }
+
+  const owned: Record<string, unknown> = {};
+  for (const [key, descriptor] of Object.entries(Object.getOwnPropertyDescriptors(schema))) {
+    if (!descriptor.enumerable) {
       continue;
     }
-    if (!('value' in serializationHook) || typeof serializationHook.value === 'function') {
-      throw new Error("Root schema cannot contain a callable or accessor-backed 'toJSON' property");
+    if (!('value' in descriptor)) {
+      throw new TypeError(`Root schema property '${key}' must be a data property`);
     }
-    break;
-  }
-}
 
-function validateStrictRootShape(schema: object): void {
-  if (typeof schema === 'function' || Array.isArray(schema)) {
-    throw new TypeError('Root schema must serialize to a JSON object');
-  }
-
-  const primitiveUnboxers = [
-    String.prototype.valueOf,
-    Number.prototype.valueOf,
-    Boolean.prototype.valueOf,
-    ...(typeof BigInt === 'function' ? [BigInt.prototype.valueOf] : []),
-  ];
-
-  for (const unbox of primitiveUnboxers) {
-    try {
-      Reflect.apply(unbox, schema, []);
-    } catch {
-      // Primitive intrinsics reject objects without their matching internal slot.
+    const value: unknown = descriptor.value;
+    if (key === 'toJSON' && typeof value === 'function') {
+      throw new TypeError("Root schema cannot contain a callable 'toJSON' property");
+    }
+    if (['undefined', 'function', 'symbol'].includes(typeof value)) {
       continue;
     }
 
-    throw new TypeError('Root schema must serialize to a JSON object');
+    Object.defineProperty(owned, key, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true,
+    });
   }
-}
 
-function validateStrictRootSchema(schema: object, openaiStrictMode: boolean | undefined): void {
-  if (!openaiStrictMode) {
-    return;
+  const { type, nullable, $ref: reference } = owned;
+  if (!['undefined', 'boolean'].includes(typeof nullable)) {
+    throw new TypeError("Root schema 'nullable' must be a boolean");
   }
-
-  validateStrictRootShape(schema);
-  const descriptors = Object.getOwnPropertyDescriptors(schema);
-  for (const keyword of ['type', 'nullable', '$ref'] as const) {
-    const descriptor = descriptors[keyword];
-    if (descriptor?.enumerable && !('value' in descriptor)) {
-      throw new Error(`Root schema validation keyword '${keyword}' must be a data property`);
+  if (type !== 'object' || nullable === true) {
+    let actualType: string | undefined;
+    if (typeof type === 'string') {
+      actualType = nullable === true ? `${type},null` : type;
+    } else if (Array.isArray(type)) {
+      actualType = type.join(',');
     }
-  }
-
-  validateStrictRootSerializationHook(schema);
-
-  const type = descriptors['type']?.enumerable ? Reflect.get(schema, 'type') : undefined;
-  const nullable = descriptors['nullable']?.enumerable && Reflect.get(schema, 'nullable') === true;
-  if (type !== 'object' || nullable) {
-    const actualType = nullable && type ? `${type},null` : type;
     throw new Error(
       `Root schema must have type: 'object' but got type: ${actualType ? `'${actualType}'` : 'undefined'}`,
     );
   }
-  const reference = descriptors['$ref']?.enumerable ? Reflect.get(schema, '$ref') : undefined;
-  if (reference !== undefined && typeof reference !== 'function' && typeof reference !== 'symbol') {
+  if (reference !== undefined) {
     throw new Error("Root schema must be a concrete object and cannot contain '$ref'");
   }
-}
 
-function cloneStrictRootSchemaDefinitions(refs: ReturnType<typeof getRefs>): void {
-  if (refs.openaiStrictMode) {
-    refs.definitions = { ...refs.definitions };
+  if (name !== undefined && nameStrategy !== 'duplicate-ref') {
+    throw new Error("Root schema must have type: 'object' but got type: undefined");
   }
+
+  return owned as JsonSchema7Type;
 }
 
 const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
@@ -99,7 +85,9 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
   >;
 } => {
   const refs = getRefs(options);
-  cloneStrictRootSchemaDefinitions(refs);
+  if (refs.openaiStrictMode) {
+    refs.definitions = { ...refs.definitions };
+  }
 
   let name: string | undefined;
   if (typeof options === 'string') {
@@ -108,7 +96,7 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
     name = options?.name;
   }
 
-  const main =
+  const parsed =
     parseDef(
       schema._def,
       name === undefined
@@ -119,13 +107,9 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
           },
       refs.openaiStrictMode === true,
     ) ?? {};
+  const main = refs.openaiStrictMode ? ownStrictRootSchema(parsed, name, refs.nameStrategy) : parsed;
 
-  validateStrictRootSchema(main, refs.openaiStrictMode);
-
-  const title =
-    typeof options === 'object' && options.name !== undefined && options.nameStrategy === 'title'
-      ? options.name
-      : undefined;
+  const title = refs.nameStrategy === 'title' ? refs.name : undefined;
 
   if (title !== undefined) {
     main.title = title;
@@ -203,8 +187,6 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
   } else if (refs.target === 'jsonSchema2019-09') {
     combined.$schema = 'https://json-schema.org/draft/2019-09/schema#';
   }
-
-  validateStrictRootSchema(combined, refs.openaiStrictMode);
 
   return combined;
 };

--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -64,21 +64,16 @@ function validateStrictRootSchema(schema: object, openaiStrictMode: boolean | un
 
   validateStrictRootSerializationHook(schema);
 
-  const type = descriptors['type']?.enumerable ? descriptors['type'].value : undefined;
-  const nullable = descriptors['nullable']?.enumerable && descriptors['nullable'].value === true;
+  const type = descriptors['type']?.enumerable ? Reflect.get(schema, 'type') : undefined;
+  const nullable = descriptors['nullable']?.enumerable && Reflect.get(schema, 'nullable') === true;
   if (type !== 'object' || nullable) {
     const actualType = nullable && type ? `${type},null` : type;
     throw new Error(
       `Root schema must have type: 'object' but got type: ${actualType ? `'${actualType}'` : 'undefined'}`,
     );
   }
-  const reference = descriptors['$ref'];
-  if (
-    reference?.enumerable &&
-    reference.value !== undefined &&
-    typeof reference.value !== 'function' &&
-    typeof reference.value !== 'symbol'
-  ) {
+  const reference = descriptors['$ref']?.enumerable ? Reflect.get(schema, '$ref') : undefined;
+  if (reference !== undefined && typeof reference !== 'function' && typeof reference !== 'symbol') {
     throw new Error("Root schema must be a concrete object and cannot contain '$ref'");
   }
 }

--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -18,11 +18,29 @@ function validateStrictRootSerializationHook(schema: object): void {
   }
 }
 
+function validateStrictRootShape(schema: object): void {
+  if (Array.isArray(schema)) {
+    throw new TypeError('Root schema must serialize to a JSON object');
+  }
+
+  for (const unbox of [String.prototype.valueOf, Number.prototype.valueOf, Boolean.prototype.valueOf]) {
+    try {
+      Reflect.apply(unbox, schema, []);
+    } catch {
+      // Primitive intrinsics reject objects without their matching internal slot.
+      continue;
+    }
+
+    throw new TypeError('Root schema must serialize to a JSON object');
+  }
+}
+
 function validateStrictRootSchema(schema: object, openaiStrictMode: boolean | undefined): void {
   if (!openaiStrictMode) {
     return;
   }
 
+  validateStrictRootShape(schema);
   const descriptors = Object.getOwnPropertyDescriptors(schema);
   for (const keyword of ['type', 'nullable', '$ref'] as const) {
     const descriptor = descriptors[keyword];

--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -5,6 +5,17 @@ import { parseDef } from './parseDef';
 import { getRefs } from './Refs';
 import { zodDef, isEmptyObj } from './util';
 
+function validateStrictRootSchema(schema: JsonSchema7Type, openaiStrictMode: boolean | undefined): void {
+  if (!openaiStrictMode) {
+    return;
+  }
+
+  const type = 'type' in schema ? schema.type : undefined;
+  if (type !== 'object') {
+    throw new Error(`Root schema must have type: 'object' but got type: ${type ? `'${type}'` : 'undefined'}`);
+  }
+}
+
 const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
   schema: ZodSchema<any>,
   options?: Partial<Options<Target>> | string,
@@ -39,6 +50,8 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
           },
       false,
     ) ?? {};
+
+  validateStrictRootSchema(main, refs.openaiStrictMode);
 
   const title =
     typeof options === 'object' && options.name !== undefined && options.nameStrategy === 'title'

--- a/tests/helpers/zod-root-schema-validation.test.ts
+++ b/tests/helpers/zod-root-schema-validation.test.ts
@@ -198,6 +198,37 @@ describe('strict vendor converter root schemas', () => {
     ).toThrow('Root schema must serialize to a JSON object');
   });
 
+  it('rejects callable strict roots that JSON serialization omits', () => {
+    const overriddenRoot = Object.assign(() => null, { type: 'object' as const });
+
+    expect(JSON.stringify(overriddenRoot)).toBeUndefined();
+    expect(() =>
+      zodToJsonSchema(z3.object({ value: z3.string() }), {
+        target: 'openApi3',
+        openaiStrictMode: true,
+        override: () => overriddenRoot,
+      }),
+    ).toThrow('Root schema must serialize to a JSON object');
+  });
+
+  it('rejects cyclic proxy-reported prototypes without hanging', () => {
+    const overriddenRoot: object = new Proxy(
+      { type: 'object' as const },
+      {
+        getPrototypeOf: () => overriddenRoot,
+      },
+    );
+
+    expect(JSON.stringify(overriddenRoot)).toBe('{"type":"object"}');
+    expect(() =>
+      zodToJsonSchema(z3.object({ value: z3.string() }), {
+        target: 'openApi3',
+        openaiStrictMode: true,
+        override: () => overriddenRoot as { type: 'object' },
+      }),
+    ).toThrow('Root schema cannot contain a cyclic prototype chain');
+  });
+
   it('rejects boxed BigInt roots before JSON serialization fails', () => {
     const boxedBigInt = Reflect.construct(Object, [Reflect.apply(BigInt, undefined, [1])]) as object;
     const overriddenRoot = Object.assign(boxedBigInt, {

--- a/tests/helpers/zod-root-schema-validation.test.ts
+++ b/tests/helpers/zod-root-schema-validation.test.ts
@@ -1,0 +1,233 @@
+import { zodToJsonSchema } from 'openai/_vendor/zod-to-json-schema';
+import {
+  zodFunction,
+  zodRealtimeFunction,
+  zodResponseFormat,
+  zodResponsesFunction,
+  zodTextFormat,
+} from 'openai/helpers/zod';
+import { z as z3 } from 'zod/v3';
+import { z as z4 } from 'zod/v4';
+
+const strictHelpers = [
+  {
+    name: 'zodResponseFormat',
+    create: (schema: any) => zodResponseFormat(schema, 'root'),
+  },
+  {
+    name: 'zodTextFormat',
+    create: (schema: any) => zodTextFormat(schema, 'root'),
+  },
+  {
+    name: 'zodFunction',
+    create: (schema: any) => zodFunction({ name: 'root', parameters: schema }),
+  },
+  {
+    name: 'zodResponsesFunction',
+    create: (schema: any) => zodResponsesFunction({ name: 'root', parameters: schema }),
+  },
+];
+
+const invalidRootSchemas = [
+  {
+    name: 'a string',
+    type: 'string',
+    v3: z3.string(),
+    v4: z4.string(),
+  },
+  {
+    name: 'an array',
+    type: 'array',
+    v3: z3.array(z3.string()),
+    v4: z4.array(z4.string()),
+  },
+  {
+    name: 'a union of objects',
+    type: undefined,
+    v3: z3.union([z3.object({ first: z3.string() }), z3.object({ second: z3.number() })]),
+    v4: z4.union([z4.object({ first: z4.string() }), z4.object({ second: z4.number() })]),
+  },
+  {
+    name: 'a discriminated union of objects',
+    type: undefined,
+    v3: z3.discriminatedUnion('kind', [
+      z3.object({ kind: z3.literal('first'), first: z3.string() }),
+      z3.object({ kind: z3.literal('second'), second: z3.number() }),
+    ]),
+    v4: z4.discriminatedUnion('kind', [
+      z4.object({ kind: z4.literal('first'), first: z4.string() }),
+      z4.object({ kind: z4.literal('second'), second: z4.number() }),
+    ]),
+  },
+  {
+    name: 'a nullable object',
+    type: undefined,
+    v3: z3.object({ value: z3.string() }).nullable(),
+    v4: z4.object({ value: z4.string() }).nullable(),
+  },
+  {
+    name: 'an unrestricted schema',
+    type: undefined,
+    v3: z3.any(),
+    v4: z4.any(),
+  },
+];
+
+const expectedRootError = (type?: string) =>
+  `Root schema must have type: 'object' but got type: ${type ? `'${type}'` : 'undefined'}`;
+
+interface RecursiveObject {
+  value: string;
+  children: RecursiveObject[];
+}
+
+const recursiveObject: z3.ZodType<RecursiveObject> = z3.lazy(() =>
+  z3.object({
+    value: z3.string(),
+    children: z3.array(recursiveObject),
+  }),
+);
+
+const validObjectRoots = [
+  {
+    name: 'a plain object',
+    schema: z3.object({ value: z3.string() }),
+  },
+  {
+    name: 'a lazy object',
+    schema: z3.lazy(() => z3.object({ value: z3.string() })),
+  },
+  {
+    name: 'a recursive lazy object',
+    schema: recursiveObject,
+  },
+  {
+    name: 'a refined object',
+    schema: z3.object({ value: z3.string() }).refine(({ value }) => value.length > 0),
+  },
+  {
+    name: 'a transformed object',
+    schema: z3.object({ value: z3.string() }).transform(({ value }) => ({ value })),
+  },
+  {
+    name: 'a defaulted object',
+    schema: z3.object({ value: z3.string() }).default({ value: 'fallback' }),
+  },
+  {
+    name: 'an object containing nested unions and arrays',
+    schema: z3.object({
+      values: z3.array(z3.union([z3.string(), z3.number()])),
+      choice: z3.union([z3.object({ first: z3.string() }), z3.object({ second: z3.number() })]),
+    }),
+  },
+];
+
+describe.each(strictHelpers)('$name root schema validation', ({ create }) => {
+  it.each(invalidRootSchemas)('rejects $name equally for Zod v3 and v4', ({ type, v3, v4 }) => {
+    const expectedError = expectedRootError(type);
+
+    expect(() => create(v3)).toThrow(expectedError);
+    expect(() => create(v4)).toThrow(expectedError);
+  });
+
+  it('rejects unsupported Zod v3 object intersections', () => {
+    const intersection = z3.intersection(
+      z3.object({ first: z3.string() }),
+      z3.object({ second: z3.number() }),
+    );
+
+    expect(() => create(intersection)).toThrow(expectedRootError());
+  });
+
+  it('rejects optional Zod v3 objects that produce a root union', () => {
+    expect(() => create(z3.object({ value: z3.string() }).optional())).toThrow(expectedRootError());
+    expect(() => create(z4.object({ value: z4.string() }).optional())).not.toThrow();
+  });
+
+  it('reports every type in a Zod v3 primitive union', () => {
+    expect(() => create(z3.union([z3.string(), z3.number()]))).toThrow(expectedRootError('string,number'));
+  });
+
+  it.each(validObjectRoots)('continues accepting $name', ({ schema }) => {
+    expect(() => create(schema)).not.toThrow();
+  });
+});
+
+it('preserves named object roots and escaped references to supplied definitions', () => {
+  const shared = z3.object({ value: z3.string() });
+  const format = zodResponseFormat(
+    z3.object({ shared, values: z3.array(z3.union([z3.string(), z3.number()])) }),
+    'named-root',
+    {
+      schemaDefinitions: {
+        'shared/name~value%25': shared,
+      },
+    },
+  );
+
+  expect(format.json_schema.name).toBe('named-root');
+  expect(format.json_schema.schema).toMatchObject({
+    type: 'object',
+    properties: {
+      shared: { $ref: '#/definitions/shared~1name~0value%2525' },
+      values: { type: 'array' },
+    },
+    definitions: {
+      'shared/name~value%25': { type: 'object' },
+    },
+  });
+});
+
+describe.each(['jsonSchema7', 'jsonSchema2019-09', 'openApi3'] as const)(
+  'non-strict %s converter targets',
+  (target) => {
+    it('continues accepting unnamed non-object roots', () => {
+      expect(zodToJsonSchema(z3.array(z3.string()), { target })).toMatchObject({
+        type: 'array',
+        items: { type: 'string' },
+      });
+    });
+
+    it('preserves named root references', () => {
+      expect(zodToJsonSchema(z3.string(), { target, name: 'named-string' })).toMatchObject({
+        $ref: '#/definitions/named-string',
+        definitions: {
+          'named-string': { type: 'string' },
+        },
+      });
+    });
+
+    it('continues accepting non-object roots with explicit non-strict mode', () => {
+      expect(zodToJsonSchema(z3.string(), { target, openaiStrictMode: false })).toMatchObject({
+        type: 'string',
+      });
+    });
+  },
+);
+
+describe('zodRealtimeFunction non-strict root schemas', () => {
+  it('continues accepting a primitive Zod v3 root', () => {
+    const tool = zodRealtimeFunction({ name: 'realtime-string', parameters: z3.string() });
+
+    expect(tool.parameters).toMatchObject({ type: 'string' });
+    expect(tool).not.toHaveProperty('strict');
+  });
+
+  it('continues accepting a Zod v3 array root', () => {
+    const tool = zodRealtimeFunction({ name: 'realtime-array', parameters: z3.array(z3.string()) });
+
+    expect(tool.parameters).toMatchObject({
+      type: 'array',
+      items: { type: 'string' },
+    });
+  });
+
+  it('continues accepting a Zod v3 union root', () => {
+    const tool = zodRealtimeFunction({
+      name: 'realtime-union',
+      parameters: z3.union([z3.object({ first: z3.string() }), z3.object({ second: z3.number() })]),
+    });
+
+    expect(tool.parameters).toHaveProperty('anyOf');
+  });
+});

--- a/tests/helpers/zod-root-schema-validation.test.ts
+++ b/tests/helpers/zod-root-schema-validation.test.ts
@@ -181,6 +181,35 @@ it('preserves named object roots and escaped references to supplied definitions'
 
 describe('strict vendor converter root schemas', () => {
   it.each([
+    { name: 'an array', root: [], serialized: '[]' },
+    { name: 'a boxed string', root: Reflect.construct(String, ['value']) as object, serialized: '"value"' },
+    { name: 'a boxed number', root: Reflect.construct(Number, [42]) as object, serialized: '42' },
+    { name: 'a boxed boolean', root: Reflect.construct(Boolean, [true]) as object, serialized: 'true' },
+  ])('rejects $name roots that falsely claim to be objects', ({ root, serialized }) => {
+    const overriddenRoot = Object.assign(root, { type: 'object' as const });
+
+    expect(JSON.stringify(overriddenRoot)).toBe(serialized);
+    expect(() =>
+      zodToJsonSchema(z3.object({ value: z3.string() }), {
+        target: 'openApi3',
+        openaiStrictMode: true,
+        override: () => overriddenRoot as { type: 'object' },
+      }),
+    ).toThrow('Root schema must serialize to a JSON object');
+  });
+
+  it('preserves strict object roots without a prototype', () => {
+    const overriddenRoot = Object.assign(Object.create(null) as object, { type: 'object' as const });
+    const schema = zodToJsonSchema(z3.object({ value: z3.string() }), {
+      target: 'openApi3',
+      openaiStrictMode: true,
+      override: () => overriddenRoot,
+    });
+
+    expect(JSON.stringify(schema)).toBe('{"type":"object"}');
+  });
+
+  it.each([
     { keyword: 'type', value: 'object', visibility: 'inherited' },
     { keyword: 'type', value: 'object', visibility: 'non-enumerable' },
     { keyword: '$ref', value: '#/definitions/Root', visibility: 'inherited' },

--- a/tests/helpers/zod-root-schema-validation.test.ts
+++ b/tests/helpers/zod-root-schema-validation.test.ts
@@ -10,50 +10,25 @@ import { z as z3 } from 'zod/v3';
 import { z as z4 } from 'zod/v4';
 
 const strictHelpers = [
-  {
-    name: 'zodResponseFormat',
-    create: (schema: any) => zodResponseFormat(schema, 'root'),
-    getSchema: (result: any) => result.json_schema.schema,
-  },
-  {
-    name: 'zodTextFormat',
-    create: (schema: any) => zodTextFormat(schema, 'root'),
-    getSchema: (result: any) => result.schema,
-  },
-  {
-    name: 'zodFunction',
-    create: (schema: any) => zodFunction({ name: 'root', parameters: schema }),
-    getSchema: (result: any) => result.function.parameters,
-  },
+  { name: 'zodResponseFormat', create: (schema: any) => zodResponseFormat(schema, 'root') },
+  { name: 'zodTextFormat', create: (schema: any) => zodTextFormat(schema, 'root') },
+  { name: 'zodFunction', create: (schema: any) => zodFunction({ name: 'root', parameters: schema }) },
   {
     name: 'zodResponsesFunction',
     create: (schema: any) => zodResponsesFunction({ name: 'root', parameters: schema }),
-    getSchema: (result: any) => result.parameters,
   },
 ];
 
 const invalidRootSchemas = [
-  {
-    name: 'a string',
-    type: 'string',
-    v3: z3.string(),
-    v4: z4.string(),
-  },
-  {
-    name: 'an array',
-    type: 'array',
-    v3: z3.array(z3.string()),
-    v4: z4.array(z4.string()),
-  },
+  { name: 'a string', type: 'string', v3: z3.string(), v4: z4.string() },
+  { name: 'an array', type: 'array', v3: z3.array(z3.string()), v4: z4.array(z4.string()) },
   {
     name: 'a union of objects',
-    type: undefined,
     v3: z3.union([z3.object({ first: z3.string() }), z3.object({ second: z3.number() })]),
     v4: z4.union([z4.object({ first: z4.string() }), z4.object({ second: z4.number() })]),
   },
   {
     name: 'a discriminated union of objects',
-    type: undefined,
     v3: z3.discriminatedUnion('kind', [
       z3.object({ kind: z3.literal('first'), first: z3.string() }),
       z3.object({ kind: z3.literal('second'), second: z3.number() }),
@@ -65,16 +40,10 @@ const invalidRootSchemas = [
   },
   {
     name: 'a nullable object',
-    type: undefined,
     v3: z3.object({ value: z3.string() }).nullable(),
     v4: z4.object({ value: z4.string() }).nullable(),
   },
-  {
-    name: 'an unrestricted schema',
-    type: undefined,
-    v3: z3.any(),
-    v4: z4.any(),
-  },
+  { name: 'an unrestricted schema', v3: z3.any(), v4: z4.any() },
 ];
 
 const expectedRootError = (type?: string) =>
@@ -86,25 +55,13 @@ interface RecursiveObject {
 }
 
 const recursiveObject: z3.ZodType<RecursiveObject> = z3.lazy(() =>
-  z3.object({
-    value: z3.string(),
-    children: z3.array(recursiveObject),
-  }),
+  z3.object({ value: z3.string(), children: z3.array(recursiveObject) }),
 );
 
 const validObjectRoots = [
-  {
-    name: 'a plain object',
-    schema: z3.object({ value: z3.string() }),
-  },
-  {
-    name: 'a lazy object',
-    schema: z3.lazy(() => z3.object({ value: z3.string() })),
-  },
-  {
-    name: 'a recursive lazy object',
-    schema: recursiveObject,
-  },
+  { name: 'a plain object', schema: z3.object({ value: z3.string() }) },
+  { name: 'a lazy object', schema: z3.lazy(() => z3.object({ value: z3.string() })) },
+  { name: 'a recursive lazy object', schema: recursiveObject },
   {
     name: 'a refined object',
     schema: z3.object({ value: z3.string() }).refine(({ value }) => value.length > 0),
@@ -113,10 +70,7 @@ const validObjectRoots = [
     name: 'a transformed object',
     schema: z3.object({ value: z3.string() }).transform(({ value }) => ({ value })),
   },
-  {
-    name: 'a defaulted object',
-    schema: z3.object({ value: z3.string() }).default({ value: 'fallback' }),
-  },
+  { name: 'a defaulted object', schema: z3.object({ value: z3.string() }).default({ value: 'fallback' }) },
   {
     name: 'an object containing nested unions and arrays',
     schema: z3.object({
@@ -126,34 +80,16 @@ const validObjectRoots = [
   },
 ];
 
-const registeredRootCases = [
-  {
-    name: 'a directly registered object',
-    wrapV3: (root: z3.ZodType) => root,
-    wrapV4: (root: z4.ZodType) => root,
-  },
-  {
-    name: 'a lazy registered object',
-    wrapV3: (root: z3.ZodType) => z3.lazy(() => root),
-    wrapV4: (root: z4.ZodType) => z4.lazy(() => root),
-  },
-];
-
-describe.each(strictHelpers)('$name root schema validation', ({ create, getSchema }) => {
+describe.each(strictHelpers)('$name root schema validation', ({ create }) => {
   it.each(invalidRootSchemas)('rejects $name equally for Zod v3 and v4', ({ type, v3, v4 }) => {
-    const expectedError = expectedRootError(type);
-
-    expect(() => create(v3)).toThrow(expectedError);
-    expect(() => create(v4)).toThrow(expectedError);
+    expect(() => create(v3)).toThrow(expectedRootError(type));
+    expect(() => create(v4)).toThrow(expectedRootError(type));
   });
 
   it('rejects unsupported Zod v3 object intersections', () => {
-    const intersection = z3.intersection(
-      z3.object({ first: z3.string() }),
-      z3.object({ second: z3.number() }),
-    );
-
-    expect(() => create(intersection)).toThrow(expectedRootError());
+    expect(() =>
+      create(z3.intersection(z3.object({ first: z3.string() }), z3.object({ second: z3.number() }))),
+    ).toThrow(expectedRootError());
   });
 
   it('rejects optional Zod v3 objects that produce a root union', () => {
@@ -166,104 +102,63 @@ describe.each(strictHelpers)('$name root schema validation', ({ create, getSchem
   });
 
   it.each(validObjectRoots)('continues accepting $name', ({ schema }) => {
-    const generatedSchema = getSchema(create(schema));
-
-    expect(generatedSchema).toHaveProperty('type', 'object');
-    expect(generatedSchema).not.toHaveProperty('$ref');
-    expect(generatedSchema).not.toHaveProperty('nullable', true);
+    expect(() => create(schema)).not.toThrow();
   });
 });
 
-describe.each(registeredRootCases)('strict response formats with $name', ({ wrapV3, wrapV4 }) => {
-  it('materializes the registered root without mutating caller definitions', () => {
+describe.each([
+  { name: 'direct', wrapV3: (root: z3.ZodType) => root, wrapV4: (root: z4.ZodType) => root },
+  {
+    name: 'lazy',
+    wrapV3: (root: z3.ZodType) => z3.lazy(() => root),
+    wrapV4: (root: z4.ZodType) => z4.lazy(() => root),
+  },
+])('$name registered response-format roots', ({ wrapV3, wrapV4 }) => {
+  it('preserves frozen definitions and matches Zod v4 concrete-root behavior', () => {
     const root = z3.object({ value: z3.string() });
     const other = z3.object({ other: z3.number() });
-    const schemaDefinitions = { Root: root, Other: other };
-
+    const schemaDefinitions = Object.freeze({ Root: root, Other: other });
     const { schema } = zodResponseFormat(wrapV3(root), 'response', { schemaDefinitions }).json_schema;
 
     expect(schema).toMatchObject({
       type: 'object',
       properties: { value: { type: 'string' } },
-      definitions: {
-        Root: { type: 'object', properties: { value: { type: 'string' } } },
-        Other: { type: 'object', properties: { other: { type: 'number' } } },
-      },
+      additionalProperties: false,
+      definitions: { Root: { type: 'object' }, Other: { type: 'object' } },
     });
     expect(schema).not.toHaveProperty('$ref');
-    expect(schema).not.toHaveProperty('nullable', true);
     expect(schemaDefinitions).toEqual({ Root: root, Other: other });
-    expect(schemaDefinitions.Root).toBe(root);
-    expect(schemaDefinitions.Other).toBe(other);
-  });
 
-  it('accepts frozen caller definitions while preserving every schema identity', () => {
-    const root = z3.object({ value: z3.string() });
-    const other = z3.object({ other: z3.number() });
-    const schemaDefinitions = Object.freeze({ Root: root, Other: other });
+    const v4Root = z4.object({ value: z4.string() });
+    const v4Definitions = Object.freeze({ Root: v4Root });
+    const v4Schema = zodResponseFormat(wrapV4(v4Root), 'response', {
+      schemaDefinitions: v4Definitions,
+    }).json_schema.schema;
 
-    const { schema } = zodResponseFormat(wrapV3(root), 'response', { schemaDefinitions }).json_schema;
-
-    expect(schema).toMatchObject({ type: 'object', definitions: { Root: { type: 'object' } } });
-    expect(schema).not.toHaveProperty('$ref');
-    expect(schemaDefinitions.Root).toBe(root);
-    expect(schemaDefinitions.Other).toBe(other);
-    expect(Object.keys(schemaDefinitions)).toEqual(['Root', 'Other']);
-  });
-
-  it.each(['Root/part~value%25', 'Root%2Fpart', 'constructor', 'toString', 'response'])(
-    'resolves the literal registered definition name %s',
-    (definitionName) => {
-      const root = z3.object({ value: z3.string() });
-      const schemaDefinitions = Object.freeze({ [definitionName]: root });
-
-      const { schema } = zodResponseFormat(wrapV3(root), 'response', { schemaDefinitions }).json_schema;
-      const materializedDefinitions = (schema?.['definitions'] ?? {}) as Record<string, unknown>;
-
-      expect(schema).toHaveProperty('type', 'object');
-      expect(schema).not.toHaveProperty('$ref');
-      expect(Object.getOwnPropertyDescriptor(materializedDefinitions, definitionName)?.value).toHaveProperty(
-        'type',
-        'object',
-      );
-      expect(schemaDefinitions[definitionName]).toBe(root);
-    },
-  );
-
-  it('matches Zod v4 concrete-root and caller-identity behavior', () => {
-    const root = z4.object({ value: z4.string() });
-    const schemaDefinitions = Object.freeze({ Root: root });
-
-    const { schema } = zodResponseFormat(wrapV4(root), 'response', { schemaDefinitions }).json_schema;
-
-    expect(schema).toMatchObject({ type: 'object', properties: { value: { type: 'string' } } });
-    expect(schema).not.toHaveProperty('$ref');
-    expect(schemaDefinitions.Root).toBe(root);
+    expect(v4Schema).toMatchObject({ type: 'object', properties: { value: { type: 'string' } } });
+    expect(v4Schema).not.toHaveProperty('$ref');
+    expect(v4Definitions.Root).toBe(v4Root);
   });
 });
 
-it('preserves recursive references while materializing a registered lazy object root', () => {
+it('preserves recursive child references for frozen registered lazy roots', () => {
   const schemaDefinitions = Object.freeze({ Root: recursiveObject });
-
   const { schema } = zodResponseFormat(recursiveObject, 'response', { schemaDefinitions }).json_schema;
 
   expect(schema).toMatchObject({
     type: 'object',
-    properties: {
-      value: { type: 'string' },
-      children: { type: 'array', items: { $ref: '#/definitions/Root' } },
-    },
-    definitions: { Root: { type: 'object' } },
+    properties: { children: { type: 'array', items: { $ref: '#/definitions/response' } } },
+    definitions: { Root: { type: 'object' }, response: { type: 'object' } },
   });
   expect(schema).not.toHaveProperty('$ref');
   expect(schemaDefinitions.Root).toBe(recursiveObject);
 });
 
 it.each([
-  { name: 'a registered string', schema: z3.string(), type: 'string' },
-  { name: 'a registered array', schema: z3.array(z3.string()), type: 'array' },
-  { name: 'a registered nullable object', schema: z3.object({ value: z3.string() }).nullable() },
-])('rejects $name after resolving its definition', ({ schema, type }) => {
+  { name: 'a string', schema: z3.string(), type: 'string' },
+  { name: 'an array', schema: z3.array(z3.string()), type: 'array' },
+  { name: 'a nullable object', schema: z3.object({ value: z3.string() }).nullable(), type: undefined },
+])('rejects registered $name roots', ({ schema, type }) => {
   expect(() => zodResponseFormat(schema, 'response', { schemaDefinitions: { Root: schema } })).toThrow(
     expectedRootError(type),
   );
@@ -271,247 +166,53 @@ it.each([
 
 it('preserves named object roots and escaped references to supplied definitions', () => {
   const shared = z3.object({ value: z3.string() });
-  const format = zodResponseFormat(
-    z3.object({ shared, values: z3.array(z3.union([z3.string(), z3.number()])) }),
-    'named-root',
-    {
-      schemaDefinitions: {
-        'shared/name~value%25': shared,
-      },
-    },
-  );
+  const format = zodResponseFormat(z3.object({ shared }), 'named-root', {
+    schemaDefinitions: { 'shared/name~value%25': shared },
+  });
 
   expect(format.json_schema.name).toBe('named-root');
   expect(format.json_schema.schema).toMatchObject({
     type: 'object',
-    properties: {
-      shared: { $ref: '#/definitions/shared~1name~0value%2525' },
-      values: { type: 'array' },
-    },
-    definitions: {
-      'shared/name~value%25': { type: 'object' },
-    },
+    properties: { shared: { $ref: '#/definitions/shared~1name~0value%2525' } },
+    definitions: { 'shared/name~value%25': { type: 'object' } },
   });
 });
 
 describe('strict vendor converter root schemas', () => {
-  it('materializes a root alias chain while retaining its definition map and root metadata', () => {
+  it.each([
+    { name: 'conflicting properties', sibling: { properties: { injected: { type: 'number' } } } },
+    { name: 'additionalProperties: true', sibling: { additionalProperties: true } },
+  ])('does not activate root reference siblings containing $name', ({ sibling }) => {
     const root = z3.object({ value: z3.string() });
-    const alias = z3.object({ alias: z3.string() });
-    const definitions = Object.freeze({ Root: root, Alias: alias });
-
     const schema = zodToJsonSchema(root, {
-      name: 'response',
-      nameStrategy: 'duplicate-ref',
       openaiStrictMode: true,
-      definitions,
-      override: (definition, _refs, _seen, forceResolution) => {
-        if (!forceResolution) {
-          return { $ref: '#/definitions/Root', title: 'root title' };
-        }
-
-        return definition === root._def
-          ? { $ref: '#/definitions/Alias' }
-          : { type: 'object', properties: { alias: { type: 'string' } }, additionalProperties: false };
-      },
+      definitions: { Root: root },
+      override: (_definition, _refs, _seen, forceResolution) =>
+        forceResolution
+          ? { type: 'object', properties: { value: { type: 'string' } }, additionalProperties: false }
+          : { $ref: '#/definitions/Root', type: 'object', ...sibling },
     });
 
     expect(schema).toMatchObject({
       type: 'object',
-      title: 'root title',
-      properties: { alias: { type: 'string' } },
-      definitions: {
-        Root: { $ref: '#/definitions/Alias' },
-        Alias: { type: 'object' },
-      },
+      properties: { value: { type: 'string' } },
+      additionalProperties: false,
     });
-    expect(schema).not.toHaveProperty('$ref');
-    expect(definitions.Root).toBe(root);
-    expect(definitions.Alias).toBe(alias);
+    expect(schema).not.toHaveProperty('properties.injected');
   });
 
-  it.each([
-    'https://example.com/schema.json#/definitions/Root',
-    '#/different/Root',
-    '#/definitions/Missing',
-    '#/definitions/toString',
-    '#/definitions/__proto__',
-  ])('rejects unsafe or unresolved root references: %s', (reference) => {
-    const root = z3.object({ value: z3.string() });
-
+  it('rejects root references returned by forced overrides before activating assertion siblings', () => {
     expect(() =>
-      zodToJsonSchema(root, {
+      zodToJsonSchema(z3.object({ value: z3.string() }), {
         openaiStrictMode: true,
-        definitions: { Root: root },
-        override: (_definition, _refs, _seen, forceResolution) =>
-          forceResolution ? { type: 'object', additionalProperties: false } : { $ref: reference },
-      }),
-    ).toThrow(expectedRootError());
-  });
-
-  it('rejects external root references even when they have an object-typed sibling', () => {
-    const root = z3.object({ value: z3.string() });
-
-    expect(() =>
-      zodToJsonSchema(root, {
-        openaiStrictMode: true,
-        definitions: { Root: root },
-        override: (_definition, _refs, _seen, forceResolution) =>
-          forceResolution
-            ? { type: 'object', additionalProperties: false }
-            : { $ref: 'https://example.com/schema.json', type: 'object' },
+        override: () => ({ $ref: '#/definitions/Root', type: 'object', additionalProperties: true }),
       }),
     ).toThrow("Root schema must be a concrete object and cannot contain '$ref'");
-  });
-
-  it('rejects unresolved alias references even when they have an object-typed sibling', () => {
-    const root = z3.object({ value: z3.string() });
-
-    expect(() =>
-      zodToJsonSchema(root, {
-        openaiStrictMode: true,
-        definitions: { Root: root },
-        override: (_definition, _refs, _seen, forceResolution) =>
-          forceResolution
-            ? { $ref: '#/definitions/Missing', type: 'object' }
-            : { $ref: '#/definitions/Root' },
-      }),
-    ).toThrow("Root schema must be a concrete object and cannot contain '$ref'");
-  });
-
-  it('rejects cyclic local root references without recursing indefinitely', () => {
-    const root = z3.object({ value: z3.string() });
-
-    expect(() =>
-      zodToJsonSchema(root, {
-        openaiStrictMode: true,
-        definitions: { Root: root },
-        override: () => ({ $ref: '#/definitions/Root' }),
-      }),
-    ).toThrow(/cyclic.*root|root.*cyclic/iu);
-  });
-
-  it('rejects accessor-backed reference targets without invoking their getters', () => {
-    const root = z3.object({ value: z3.string() });
-    let getterInvoked = false;
-    const target = Object.defineProperty({ type: 'object' as const }, '$ref', {
-      enumerable: true,
-      get: () => {
-        getterInvoked = true;
-        return '#/definitions/Root';
-      },
-    });
-
-    expect(() =>
-      zodToJsonSchema(root, {
-        openaiStrictMode: true,
-        definitions: { Root: root },
-        override: (_definition, _refs, _seen, forceResolution) =>
-          forceResolution ? target : { $ref: '#/definitions/Root' },
-      }),
-    ).toThrow(/accessor.*root|root.*accessor/iu);
-    expect(getterInvoked).toBe(false);
-  });
-
-  it.each(['type', 'nullable'] as const)(
-    'rejects accessor-backed %s validation keywords without invoking their getters',
-    (keyword) => {
-      const root = z3.object({ value: z3.string() });
-      let getterInvoked = false;
-      const target = Object.defineProperty({ type: 'object' as const }, keyword, {
-        enumerable: true,
-        get: () => {
-          getterInvoked = true;
-          return keyword === 'type' ? 'object' : true;
-        },
-      });
-
-      expect(() =>
-        zodToJsonSchema(root, {
-          openaiStrictMode: true,
-          definitions: { Root: root },
-          override: (_definition, _refs, _seen, forceResolution) =>
-            forceResolution ? target : { $ref: '#/definitions/Root' },
-        }),
-      ).toThrow('Accessor-backed root schema properties are not supported');
-      expect(getterInvoked).toBe(false);
-    },
-  );
-
-  it.each([
-    { name: 'string', key: 'title' },
-    { name: 'symbol', key: Symbol('unsafe root metadata') },
-  ])('rejects accessor-backed $name root metadata without invoking its getter', ({ key }) => {
-    const root = z3.object({ value: z3.string() });
-    let getterInvoked = false;
-    const reference = Object.defineProperty({ $ref: '#/definitions/Root' }, key, {
-      enumerable: true,
-      get: () => {
-        getterInvoked = true;
-        return 'unsafe metadata';
-      },
-    });
-
-    expect(() =>
-      zodToJsonSchema(root, {
-        openaiStrictMode: true,
-        definitions: { Root: root },
-        override: (_definition, _refs, _seen, forceResolution) =>
-          forceResolution ? { type: 'object', additionalProperties: false } : reference,
-      }),
-    ).toThrow('Accessor-backed root schema properties are not supported');
-    expect(getterInvoked).toBe(false);
-  });
-
-  it('rejects accessor-backed root references even without supplied definitions', () => {
-    const root = z3.object({ value: z3.string() });
-    let getterInvoked = false;
-    const reference = Object.defineProperty({ type: 'object' as const }, '$ref', {
-      enumerable: true,
-      get: () => {
-        getterInvoked = true;
-        return '#/definitions/Root';
-      },
-    });
-
-    expect(() =>
-      zodToJsonSchema(root, {
-        openaiStrictMode: true,
-        override: () => reference,
-      }),
-    ).toThrow("Root schema must be a concrete object and cannot contain '$ref'");
-    expect(getterInvoked).toBe(false);
-  });
-
-  it('continues rejecting registered nullable OpenAPI3 object roots', () => {
-    const root = z3.object({ value: z3.string() }).nullable();
-
-    expect(() =>
-      zodToJsonSchema(root, {
-        target: 'openApi3',
-        openaiStrictMode: true,
-        definitions: { Root: root },
-      }),
-    ).toThrow(expectedRootError('object,null'));
-  });
-
-  it('keeps non-strict registered roots as references without changing legacy behavior', () => {
-    const root = z3.object({ value: z3.string() });
-    const definitions = { Root: root };
-
-    expect(zodToJsonSchema(root, { definitions })).toMatchObject({
-      $ref: '#/definitions/Root',
-      definitions: { Root: { type: 'object' } },
-    });
-    expect(definitions.Root).toBe(root);
   });
 
   it('rejects named object roots that resolve to a root reference', () => {
     expect(() =>
-      zodToJsonSchema(z3.object({ value: z3.string() }), {
-        name: 'named-object',
-        openaiStrictMode: true,
-      }),
+      zodToJsonSchema(z3.object({ value: z3.string() }), { name: 'named-object', openaiStrictMode: true }),
     ).toThrow(expectedRootError());
   });
 
@@ -526,17 +227,16 @@ describe('strict vendor converter root schemas', () => {
   });
 
   it('rejects nullable OpenAPI3 object roots', () => {
-    expect(() =>
-      zodToJsonSchema(z3.object({ value: z3.string() }).nullable(), {
-        target: 'openApi3',
-        openaiStrictMode: true,
-      }),
-    ).toThrow(expectedRootError('object,null'));
+    const root = z3.object({ value: z3.string() }).nullable();
+
+    expect(() => zodToJsonSchema(root, { target: 'openApi3', openaiStrictMode: true })).toThrow(
+      expectedRootError('object,null'),
+    );
   });
 });
 
 describe.each(['jsonSchema7', 'jsonSchema2019-09', 'openApi3'] as const)(
-  'non-strict %s converter targets',
+  'non-strict %s targets',
   (target) => {
     it('continues accepting unnamed non-object roots', () => {
       expect(zodToJsonSchema(z3.array(z3.string()), { target })).toMatchObject({
@@ -548,9 +248,7 @@ describe.each(['jsonSchema7', 'jsonSchema2019-09', 'openApi3'] as const)(
     it('preserves named root references', () => {
       expect(zodToJsonSchema(z3.string(), { target, name: 'named-string' })).toMatchObject({
         $ref: '#/definitions/named-string',
-        definitions: {
-          'named-string': { type: 'string' },
-        },
+        definitions: { 'named-string': { type: 'string' } },
       });
     });
 
@@ -562,13 +260,21 @@ describe.each(['jsonSchema7', 'jsonSchema2019-09', 'openApi3'] as const)(
   },
 );
 
+it('preserves non-strict registered roots without cloning or changing caller definitions', () => {
+  const root = z3.object({ value: z3.string() });
+  const definitions = { Root: root };
+
+  expect(zodToJsonSchema(root, { definitions })).toMatchObject({
+    $ref: '#/definitions/Root',
+    definitions: { Root: { type: 'object' } },
+  });
+  expect(definitions.Root).toBe(root);
+});
+
 it('preserves non-strict OpenAPI3 nullable object roots', () => {
-  expect(zodToJsonSchema(z3.object({ value: z3.string() }).nullable(), { target: 'openApi3' })).toMatchObject(
-    {
-      type: 'object',
-      nullable: true,
-    },
-  );
+  const root = z3.object({ value: z3.string() }).nullable();
+
+  expect(zodToJsonSchema(root, { target: 'openApi3' })).toMatchObject({ type: 'object', nullable: true });
 });
 
 describe('zodRealtimeFunction non-strict root schemas', () => {
@@ -582,18 +288,12 @@ describe('zodRealtimeFunction non-strict root schemas', () => {
   it('continues accepting a Zod v3 array root', () => {
     const tool = zodRealtimeFunction({ name: 'realtime-array', parameters: z3.array(z3.string()) });
 
-    expect(tool.parameters).toMatchObject({
-      type: 'array',
-      items: { type: 'string' },
-    });
+    expect(tool.parameters).toMatchObject({ type: 'array', items: { type: 'string' } });
   });
 
   it('continues accepting a Zod v3 union root', () => {
-    const tool = zodRealtimeFunction({
-      name: 'realtime-union',
-      parameters: z3.union([z3.object({ first: z3.string() }), z3.object({ second: z3.number() })]),
-    });
+    const parameters = z3.union([z3.object({ first: z3.string() }), z3.object({ second: z3.number() })]);
 
-    expect(tool.parameters).toHaveProperty('anyOf');
+    expect(zodRealtimeFunction({ name: 'realtime-union', parameters }).parameters).toHaveProperty('anyOf');
   });
 });

--- a/tests/helpers/zod-root-schema-validation.test.ts
+++ b/tests/helpers/zod-root-schema-validation.test.ts
@@ -293,6 +293,38 @@ describe('strict vendor converter root schemas', () => {
   });
 
   it.each([
+    { keyword: 'type', stored: 'object', observed: 'string', error: expectedRootError('string') },
+    { keyword: 'nullable', stored: false, observed: true, error: expectedRootError('object,null') },
+    {
+      keyword: '$ref',
+      stored: undefined,
+      observed: '#/definitions/Root',
+      error: "Root schema must be a concrete object and cannot contain '$ref'",
+    },
+    { keyword: '$ref', stored: '#/definitions/Root', observed: undefined, error: undefined },
+  ])('observes serialized Proxy-backed $keyword values', ({ keyword, stored, observed, error }) => {
+    const target = { type: 'object' as const, [keyword]: stored };
+    const overriddenRoot = new Proxy(target, {
+      get: (subject, property, receiver) =>
+        property === keyword ? observed : Reflect.get(subject, property, receiver),
+    });
+    const serialized = JSON.stringify(overriddenRoot);
+    const convert = () =>
+      zodToJsonSchema(z3.object({ value: z3.string() }), {
+        target: 'openApi3',
+        openaiStrictMode: true,
+        override: () => overriddenRoot,
+      });
+
+    expect(JSON.parse(serialized)[keyword]).toBe(observed);
+    if (error) {
+      expect(convert).toThrow(error);
+    } else {
+      expect(JSON.stringify(convert())).toBe(serialized);
+    }
+  });
+
+  it.each([
     { keyword: 'type', value: 'object' },
     { keyword: '$ref', value: '#/definitions/Root' },
     { keyword: 'nullable', value: true },

--- a/tests/helpers/zod-root-schema-validation.test.ts
+++ b/tests/helpers/zod-root-schema-validation.test.ts
@@ -1,4 +1,5 @@
 import { zodToJsonSchema } from 'openai/_vendor/zod-to-json-schema';
+import { vi } from 'vitest';
 import {
   zodFunction,
   zodRealtimeFunction,
@@ -179,6 +180,61 @@ it('preserves named object roots and escaped references to supplied definitions'
 });
 
 describe('strict vendor converter root schemas', () => {
+  it.each([
+    { keyword: 'type', value: 'object', visibility: 'inherited' },
+    { keyword: 'type', value: 'object', visibility: 'non-enumerable' },
+    { keyword: '$ref', value: '#/definitions/Root', visibility: 'inherited' },
+    { keyword: '$ref', value: '#/definitions/Root', visibility: 'non-enumerable' },
+    { keyword: 'nullable', value: true, visibility: 'inherited' },
+    { keyword: 'nullable', value: true, visibility: 'non-enumerable' },
+  ])('validates the serialized root when $keyword is $visibility', ({ keyword, value, visibility }) => {
+    const overriddenRoot = Object.create(
+      visibility === 'inherited' ? { [keyword]: value } : Object.prototype,
+    );
+
+    if (visibility === 'non-enumerable') {
+      Object.defineProperty(overriddenRoot, keyword, { value, enumerable: false });
+    }
+    if (keyword !== 'type') {
+      overriddenRoot.type = 'object';
+    }
+
+    const emittedRoot = JSON.stringify(overriddenRoot);
+    const convert = () =>
+      zodToJsonSchema(z3.object({ value: z3.string() }), {
+        target: 'openApi3',
+        openaiStrictMode: true,
+        override: () => overriddenRoot,
+      });
+
+    if (keyword === 'type') {
+      expect(emittedRoot).toBe('{}');
+      expect(convert).toThrow(expectedRootError());
+    } else {
+      expect(JSON.stringify(convert())).toBe(emittedRoot);
+      expect(JSON.parse(emittedRoot)).toEqual({ type: 'object' });
+    }
+  });
+
+  it.each([
+    { keyword: 'type', value: 'object' },
+    { keyword: '$ref', value: '#/definitions/Root' },
+    { keyword: 'nullable', value: true },
+  ])('rejects an enumerable $keyword accessor without invoking it', ({ keyword, value }) => {
+    const overriddenRoot = { type: 'object' as const };
+    const getter = vi.fn(() => value);
+
+    Object.defineProperty(overriddenRoot, keyword, { enumerable: true, get: getter });
+
+    expect(() =>
+      zodToJsonSchema(z3.object({ value: z3.string() }), {
+        openaiStrictMode: true,
+        override: () => overriddenRoot,
+      }),
+    ).toThrow(`Root schema validation keyword '${keyword}' must be a data property`);
+    expect(getter).not.toHaveBeenCalled();
+  });
+
   it.each([
     { name: 'conflicting properties', sibling: { properties: { injected: { type: 'number' } } } },
     { name: 'additionalProperties: true', sibling: { additionalProperties: true } },

--- a/tests/helpers/zod-root-schema-validation.test.ts
+++ b/tests/helpers/zod-root-schema-validation.test.ts
@@ -178,6 +178,36 @@ it('preserves named object roots and escaped references to supplied definitions'
   });
 });
 
+describe('strict vendor converter root schemas', () => {
+  it('rejects named object roots that resolve to a root reference', () => {
+    expect(() =>
+      zodToJsonSchema(z3.object({ value: z3.string() }), {
+        name: 'named-object',
+        openaiStrictMode: true,
+      }),
+    ).toThrow(expectedRootError());
+  });
+
+  it('continues accepting named object roots with duplicated references', () => {
+    expect(
+      zodToJsonSchema(z3.object({ value: z3.string() }), {
+        name: 'named-object',
+        nameStrategy: 'duplicate-ref',
+        openaiStrictMode: true,
+      }),
+    ).toMatchObject({ type: 'object', properties: { value: { type: 'string' } } });
+  });
+
+  it('rejects nullable OpenAPI3 object roots', () => {
+    expect(() =>
+      zodToJsonSchema(z3.object({ value: z3.string() }).nullable(), {
+        target: 'openApi3',
+        openaiStrictMode: true,
+      }),
+    ).toThrow(expectedRootError('object,null'));
+  });
+});
+
 describe.each(['jsonSchema7', 'jsonSchema2019-09', 'openApi3'] as const)(
   'non-strict %s converter targets',
   (target) => {
@@ -204,6 +234,15 @@ describe.each(['jsonSchema7', 'jsonSchema2019-09', 'openApi3'] as const)(
     });
   },
 );
+
+it('preserves non-strict OpenAPI3 nullable object roots', () => {
+  expect(zodToJsonSchema(z3.object({ value: z3.string() }).nullable(), { target: 'openApi3' })).toMatchObject(
+    {
+      type: 'object',
+      nullable: true,
+    },
+  );
+});
 
 describe('zodRealtimeFunction non-strict root schemas', () => {
   it('continues accepting a primitive Zod v3 root', () => {

--- a/tests/helpers/zod-root-schema-validation.test.ts
+++ b/tests/helpers/zod-root-schema-validation.test.ts
@@ -20,6 +20,18 @@ const strictHelpers = [
   },
 ];
 
+const expectedRootError = (type?: string) =>
+  `Root schema must have type: 'object' but got type: ${type ? `'${type}'` : 'undefined'}`;
+
+interface RecursiveObject {
+  value: string;
+  children: RecursiveObject[];
+}
+
+const recursiveObject: z3.ZodType<RecursiveObject> = z3.lazy(() =>
+  z3.object({ value: z3.string(), children: z3.array(recursiveObject) }),
+);
+
 const invalidRootSchemas = [
   { name: 'a string', type: 'string', v3: z3.string(), v4: z4.string() },
   { name: 'an array', type: 'array', v3: z3.array(z3.string()), v4: z4.array(z4.string()) },
@@ -47,84 +59,49 @@ const invalidRootSchemas = [
   { name: 'an unrestricted schema', v3: z3.any(), v4: z4.any() },
 ];
 
-const expectedRootError = (type?: string) =>
-  `Root schema must have type: 'object' but got type: ${type ? `'${type}'` : 'undefined'}`;
-
-interface RecursiveObject {
-  value: string;
-  children: RecursiveObject[];
-}
-
-const recursiveObject: z3.ZodType<RecursiveObject> = z3.lazy(() =>
-  z3.object({ value: z3.string(), children: z3.array(recursiveObject) }),
-);
-
-const validObjectRoots = [
-  { name: 'a plain object', schema: z3.object({ value: z3.string() }) },
-  { name: 'a lazy object', schema: z3.lazy(() => z3.object({ value: z3.string() })) },
-  { name: 'a recursive lazy object', schema: recursiveObject },
-  {
-    name: 'a refined object',
-    schema: z3.object({ value: z3.string() }).refine(({ value }) => value.length > 0),
-  },
-  {
-    name: 'a transformed object',
-    schema: z3.object({ value: z3.string() }).transform(({ value }) => ({ value })),
-  },
-  { name: 'a defaulted object', schema: z3.object({ value: z3.string() }).default({ value: 'fallback' }) },
-  {
-    name: 'an object containing nested unions and arrays',
-    schema: z3.object({
-      values: z3.array(z3.union([z3.string(), z3.number()])),
-      choice: z3.union([z3.object({ first: z3.string() }), z3.object({ second: z3.number() })]),
-    }),
-  },
-];
-
 describe.each(strictHelpers)('$name root schema validation', ({ create }) => {
   it.each(invalidRootSchemas)('rejects $name equally for Zod v3 and v4', ({ type, v3, v4 }) => {
     expect(() => create(v3)).toThrow(expectedRootError(type));
     expect(() => create(v4)).toThrow(expectedRootError(type));
   });
 
-  it('rejects unsupported Zod v3 object intersections', () => {
+  it.each([
+    { name: 'a plain object', schema: z3.object({ value: z3.string() }) },
+    { name: 'a lazy object', schema: z3.lazy(() => z3.object({ value: z3.string() })) },
+    { name: 'a recursive lazy object', schema: recursiveObject },
+    {
+      name: 'a transformed object',
+      schema: z3.object({ value: z3.string() }).transform(({ value }) => ({ value })),
+    },
+    {
+      name: 'an object containing nested unions',
+      schema: z3.object({ values: z3.array(z3.union([z3.string(), z3.number()])) }),
+    },
+  ])('continues accepting $name', ({ schema }) => {
+    expect(() => create(schema)).not.toThrow();
+  });
+
+  it('retains intersection, optional, and primitive-union diagnostics', () => {
     expect(() =>
       create(z3.intersection(z3.object({ first: z3.string() }), z3.object({ second: z3.number() }))),
     ).toThrow(expectedRootError());
-  });
-
-  it('rejects optional Zod v3 objects that produce a root union', () => {
     expect(() => create(z3.object({ value: z3.string() }).optional())).toThrow(expectedRootError());
     expect(() => create(z4.object({ value: z4.string() }).optional())).not.toThrow();
-  });
-
-  it('reports every type in a Zod v3 primitive union', () => {
     expect(() => create(z3.union([z3.string(), z3.number()]))).toThrow(expectedRootError('string,number'));
-  });
-
-  it.each(validObjectRoots)('continues accepting $name', ({ schema }) => {
-    expect(() => create(schema)).not.toThrow();
   });
 });
 
-describe.each([
-  { name: 'direct', wrapV3: (root: z3.ZodType) => root, wrapV4: (root: z4.ZodType) => root },
-  {
-    name: 'lazy',
-    wrapV3: (root: z3.ZodType) => z3.lazy(() => root),
-    wrapV4: (root: z4.ZodType) => z4.lazy(() => root),
-  },
-])('$name registered response-format roots', ({ wrapV3, wrapV4 }) => {
+describe.each(['direct', 'lazy'] as const)('%s registered response-format roots', (kind) => {
   it('preserves frozen definitions and matches Zod v4 concrete-root behavior', () => {
     const root = z3.object({ value: z3.string() });
     const other = z3.object({ other: z3.number() });
     const schemaDefinitions = Object.freeze({ Root: root, Other: other });
-    const { schema } = zodResponseFormat(wrapV3(root), 'response', { schemaDefinitions }).json_schema;
+    const wrapped = kind === 'lazy' ? z3.lazy(() => root) : root;
+    const { schema } = zodResponseFormat(wrapped, 'response', { schemaDefinitions }).json_schema;
 
     expect(schema).toMatchObject({
       type: 'object',
       properties: { value: { type: 'string' } },
-      additionalProperties: false,
       definitions: { Root: { type: 'object' }, Other: { type: 'object' } },
     });
     expect(schema).not.toHaveProperty('$ref');
@@ -132,316 +109,174 @@ describe.each([
 
     const v4Root = z4.object({ value: z4.string() });
     const v4Definitions = Object.freeze({ Root: v4Root });
-    const v4Schema = zodResponseFormat(wrapV4(v4Root), 'response', {
+    const wrappedV4 = kind === 'lazy' ? z4.lazy(() => v4Root) : v4Root;
+    const v4Schema = zodResponseFormat(wrappedV4, 'response', {
       schemaDefinitions: v4Definitions,
     }).json_schema.schema;
-
     expect(v4Schema).toMatchObject({ type: 'object', properties: { value: { type: 'string' } } });
-    expect(v4Schema).not.toHaveProperty('$ref');
     expect(v4Definitions.Root).toBe(v4Root);
   });
 });
 
-it('preserves recursive child references for frozen registered lazy roots', () => {
+it('preserves recursive registered roots and escaped definition names', () => {
   const schemaDefinitions = Object.freeze({ Root: recursiveObject });
-  const { schema } = zodResponseFormat(recursiveObject, 'response', { schemaDefinitions }).json_schema;
-
-  expect(schema).toMatchObject({
+  const recursive = zodResponseFormat(recursiveObject, 'response', { schemaDefinitions }).json_schema.schema;
+  expect(recursive).toMatchObject({
     type: 'object',
     properties: { children: { type: 'array', items: { $ref: '#/definitions/response' } } },
     definitions: { Root: { type: 'object' }, response: { type: 'object' } },
   });
-  expect(schema).not.toHaveProperty('$ref');
   expect(schemaDefinitions.Root).toBe(recursiveObject);
-});
 
-it.each([
-  { name: 'a string', schema: z3.string(), type: 'string' },
-  { name: 'an array', schema: z3.array(z3.string()), type: 'array' },
-  { name: 'a nullable object', schema: z3.object({ value: z3.string() }).nullable(), type: undefined },
-])('rejects registered $name roots', ({ schema, type }) => {
-  expect(() => zodResponseFormat(schema, 'response', { schemaDefinitions: { Root: schema } })).toThrow(
-    expectedRootError(type),
-  );
-});
-
-it('preserves named object roots and escaped references to supplied definitions', () => {
   const shared = z3.object({ value: z3.string() });
-  const format = zodResponseFormat(z3.object({ shared }), 'named-root', {
+  const named = zodResponseFormat(z3.object({ shared }), 'named-root', {
     schemaDefinitions: { 'shared/name~value%25': shared },
-  });
-
-  expect(format.json_schema.name).toBe('named-root');
-  expect(format.json_schema.schema).toMatchObject({
-    type: 'object',
+  }).json_schema;
+  expect(named.name).toBe('named-root');
+  expect(named.schema).toMatchObject({
     properties: { shared: { $ref: '#/definitions/shared~1name~0value%2525' } },
     definitions: { 'shared/name~value%25': { type: 'object' } },
   });
 });
 
-describe('strict vendor converter root schemas', () => {
+it('rejects registered non-object roots without changing definitions', () => {
+  const root = z3.string();
+  const schemaDefinitions = Object.freeze({ Root: root });
+  expect(() => zodResponseFormat(root, 'response', { schemaDefinitions })).toThrow(
+    expectedRootError('string'),
+  );
+  expect(schemaDefinitions.Root).toBe(root);
+});
+
+const convertStrictRoot = (root: unknown) =>
+  zodToJsonSchema(z3.object({ value: z3.string() }), {
+    target: 'openApi3',
+    openaiStrictMode: true,
+    override: () => root as { type: 'object' },
+  });
+
+describe('canonical strict vendor-converter roots', () => {
   it.each([
-    { name: 'an array', root: [], serialized: '[]' },
-    { name: 'a boxed string', root: Reflect.construct(String, ['value']) as object, serialized: '"value"' },
-    { name: 'a boxed number', root: Reflect.construct(Number, [42]) as object, serialized: '42' },
-    { name: 'a boxed boolean', root: Reflect.construct(Boolean, [true]) as object, serialized: 'true' },
-  ])('rejects $name roots that falsely claim to be objects', ({ root, serialized }) => {
-    const overriddenRoot = Object.assign(root, { type: 'object' as const });
-
-    expect(JSON.stringify(overriddenRoot)).toBe(serialized);
-    expect(() =>
-      zodToJsonSchema(z3.object({ value: z3.string() }), {
-        target: 'openApi3',
-        openaiStrictMode: true,
-        override: () => overriddenRoot as { type: 'object' },
-      }),
-    ).toThrow('Root schema must serialize to a JSON object');
+    { name: 'an array', value: [] },
+    { name: 'a callable', value: () => null },
+    { name: 'a boxed string', value: Reflect.construct(String, ['value']) },
+    { name: 'a boxed number', value: Reflect.construct(Number, [42]) },
+    { name: 'a boxed boolean', value: Reflect.construct(Boolean, [true]) },
+    { name: 'a boxed BigInt', value: Reflect.construct(Object, [Reflect.apply(BigInt, undefined, [1])]) },
+    { name: 'a custom prototype', value: Object.create({ inherited: true }) as object },
+  ])('rejects $name carriers through the same plain-record boundary', ({ value }) => {
+    expect(() => convertStrictRoot(Object.assign(value, { type: 'object' as const }))).toThrow(
+      'Root schema must be a plain JSON-schema record',
+    );
   });
 
-  it('rejects callable strict roots that JSON serialization omits', () => {
-    const overriddenRoot = Object.assign(() => null, { type: 'object' as const });
-
-    expect(JSON.stringify(overriddenRoot)).toBeUndefined();
-    expect(() =>
-      zodToJsonSchema(z3.object({ value: z3.string() }), {
-        target: 'openApi3',
-        openaiStrictMode: true,
-        override: () => overriddenRoot,
-      }),
-    ).toThrow('Root schema must serialize to a JSON object');
-  });
-
-  it('rejects cyclic proxy-reported prototypes without hanging', () => {
-    const overriddenRoot: object = new Proxy(
+  it.each(['cyclic', 'fresh'] as const)('rejects a %s Proxy prototype after one inspection', (kind) => {
+    let inspections = 0;
+    const root: object = new Proxy(
       { type: 'object' as const },
       {
-        getPrototypeOf: () => overriddenRoot,
+        getPrototypeOf() {
+          inspections += 1;
+          return kind === 'cyclic' ? root : new Proxy({}, {});
+        },
       },
     );
 
-    expect(JSON.stringify(overriddenRoot)).toBe('{"type":"object"}');
-    expect(() =>
-      zodToJsonSchema(z3.object({ value: z3.string() }), {
-        target: 'openApi3',
-        openaiStrictMode: true,
-        override: () => overriddenRoot as { type: 'object' },
-      }),
-    ).toThrow('Root schema cannot contain a cyclic prototype chain');
+    expect(() => convertStrictRoot(root)).toThrow('Root schema must be a plain JSON-schema record');
+    expect(inspections).toBe(1);
   });
 
-  it('rejects boxed BigInt roots before JSON serialization fails', () => {
-    const boxedBigInt = Reflect.construct(Object, [Reflect.apply(BigInt, undefined, [1])]) as object;
-    const overriddenRoot = Object.assign(boxedBigInt, {
-      type: 'object' as const,
-    });
+  it.each(['plain', 'null prototype'] as const)('owns and returns a stable %s root snapshot', (kind) => {
+    const source: Record<string, unknown> =
+      kind === 'plain'
+        ? { type: 'object' }
+        : Object.assign(Object.create(null) as object, { type: 'object' });
+    const owned = convertStrictRoot(source);
+    source['type'] = 'string';
 
-    expect(() => JSON.stringify(overriddenRoot)).toThrow(TypeError);
-    expect(() =>
-      zodToJsonSchema(z3.object({ value: z3.string() }), {
-        target: 'openApi3',
-        openaiStrictMode: true,
-        override: () => overriddenRoot,
-      }),
-    ).toThrow('Root schema must serialize to a JSON object');
+    expect(owned).not.toBe(source);
+    expect(JSON.stringify(owned)).toBe('{"type":"object"}');
   });
 
-  it('preserves strict object roots without a prototype', () => {
-    const overriddenRoot = Object.assign(Object.create(null) as object, { type: 'object' as const });
-    const schema = zodToJsonSchema(z3.object({ value: z3.string() }), {
-      target: 'openApi3',
-      openaiStrictMode: true,
-      override: () => overriddenRoot,
-    });
-
-    expect(JSON.stringify(schema)).toBe('{"type":"object"}');
-  });
-
-  it.each([
-    { keyword: 'type', value: 'object', visibility: 'inherited' },
-    { keyword: 'type', value: 'object', visibility: 'non-enumerable' },
-    { keyword: '$ref', value: '#/definitions/Root', visibility: 'inherited' },
-    { keyword: '$ref', value: '#/definitions/Root', visibility: 'non-enumerable' },
-    { keyword: 'nullable', value: true, visibility: 'inherited' },
-    { keyword: 'nullable', value: true, visibility: 'non-enumerable' },
-  ])('validates the serialized root when $keyword is $visibility', ({ keyword, value, visibility }) => {
-    const overriddenRoot = Object.create(
-      visibility === 'inherited' ? { [keyword]: value } : Object.prototype,
+  it('neutralizes synthesized Proxy hooks and keyword reads by owning descriptor values', () => {
+    const target: Record<string, unknown> = { type: 'object', nullable: false, $ref: undefined };
+    const get = vi.fn((_subject: object, key: PropertyKey) =>
+      key === 'toJSON' ? () => ({ type: 'string' }) : 'string',
     );
+    const owned = convertStrictRoot(new Proxy(target, { get }));
+    target['type'] = 'string';
 
-    if (visibility === 'non-enumerable') {
-      Object.defineProperty(overriddenRoot, keyword, { value, enumerable: false });
-    }
-    if (keyword !== 'type') {
-      overriddenRoot.type = 'object';
-    }
-
-    const emittedRoot = JSON.stringify(overriddenRoot);
-    const convert = () =>
-      zodToJsonSchema(z3.object({ value: z3.string() }), {
-        target: 'openApi3',
-        openaiStrictMode: true,
-        override: () => overriddenRoot,
-      });
-
-    if (keyword === 'type') {
-      expect(emittedRoot).toBe('{}');
-      expect(convert).toThrow(expectedRootError());
-    } else {
-      expect(JSON.stringify(convert())).toBe(emittedRoot);
-      expect(JSON.parse(emittedRoot)).toEqual({ type: 'object' });
-    }
+    expect(get).not.toHaveBeenCalled();
+    expect(JSON.stringify(owned)).toBe('{"type":"object","nullable":false}');
   });
 
-  it.each([
-    { keyword: 'type', stored: 'object', observed: 'string', error: expectedRootError('string') },
-    { keyword: 'nullable', stored: false, observed: true, error: expectedRootError('object,null') },
-    {
-      keyword: '$ref',
-      stored: undefined,
-      observed: '#/definitions/Root',
-      error: "Root schema must be a concrete object and cannot contain '$ref'",
+  it.each(['type', 'nullable', '$ref', 'properties', 'toJSON'] as const)(
+    'rejects an enumerable %s accessor without invoking it',
+    (key) => {
+      const root = { type: 'object' as const };
+      const getter = vi.fn(() => (key === 'type' ? 'object' : true));
+      Object.defineProperty(root, key, { enumerable: true, get: getter });
+
+      expect(() => convertStrictRoot(root)).toThrow(`Root schema property '${key}' must be a data property`);
+      expect(getter).not.toHaveBeenCalled();
     },
-    { keyword: '$ref', stored: '#/definitions/Root', observed: undefined, error: undefined },
-  ])('observes serialized Proxy-backed $keyword values', ({ keyword, stored, observed, error }) => {
-    const target = { type: 'object' as const, [keyword]: stored };
-    const overriddenRoot = new Proxy(target, {
-      get: (subject, property, receiver) =>
-        property === keyword ? observed : Reflect.get(subject, property, receiver),
-    });
-    const serialized = JSON.stringify(overriddenRoot);
-    const convert = () =>
-      zodToJsonSchema(z3.object({ value: z3.string() }), {
-        target: 'openApi3',
-        openaiStrictMode: true,
-        override: () => overriddenRoot,
-      });
+  );
 
-    expect(JSON.parse(serialized)[keyword]).toBe(observed);
-    if (error) {
-      expect(convert).toThrow(error);
-    } else {
-      expect(JSON.stringify(convert())).toBe(serialized);
-    }
+  it('rejects callable own serialization hooks without invoking them', () => {
+    const toJSON = vi.fn(() => ({ type: 'string' }));
+    expect(() => convertStrictRoot({ type: 'object', toJSON })).toThrow("callable 'toJSON'");
+    expect(toJSON).not.toHaveBeenCalled();
   });
 
-  it.each([
-    { keyword: 'type', value: 'object' },
-    { keyword: '$ref', value: '#/definitions/Root' },
-    { keyword: 'nullable', value: true },
-  ])('rejects an enumerable $keyword accessor without invoking it', ({ keyword, value }) => {
-    const overriddenRoot = { type: 'object' as const };
-    const getter = vi.fn(() => value);
+  it.each([Reflect.construct(Boolean, [true]), Reflect.construct(Boolean, [false]), null])(
+    'rejects non-primitive nullable keyword %s',
+    (nullable) => {
+      expect(() => convertStrictRoot({ type: 'object', nullable })).toThrow("'nullable' must be a boolean");
+    },
+  );
 
-    Object.defineProperty(overriddenRoot, keyword, { enumerable: true, get: getter });
+  it.each([undefined, () => 'reference', Symbol('reference')])(
+    'omits non-serializable root reference values',
+    ($ref) => {
+      const owned = convertStrictRoot({ type: 'object', $ref });
+      expect(owned).not.toHaveProperty('$ref');
+      expect(JSON.stringify(owned)).toBe('{"type":"object"}');
+    },
+  );
 
+  it('rejects forced root references without activating assertion siblings', () => {
     expect(() =>
-      zodToJsonSchema(z3.object({ value: z3.string() }), {
-        openaiStrictMode: true,
-        override: () => overriddenRoot,
-      }),
-    ).toThrow(`Root schema validation keyword '${keyword}' must be a data property`);
-    expect(getter).not.toHaveBeenCalled();
-  });
-
-  it.each(['own', 'inherited'])('rejects %s toJSON hooks that serialize a non-object root', (location) => {
-    const toJSON = vi.fn().mockReturnValue({ type: 'string' });
-    const overriddenRoot =
-      location === 'own'
-        ? { type: 'object' as const, toJSON }
-        : Object.assign(Object.create({ toJSON }), { type: 'object' as const });
-
-    expect(JSON.stringify(overriddenRoot)).toBe('{"type":"string"}');
-    expect(() =>
-      zodToJsonSchema(z3.object({ value: z3.string() }), {
-        openaiStrictMode: true,
-        override: () => overriddenRoot,
-      }),
-    ).toThrow("Root schema cannot contain a callable or accessor-backed 'toJSON' property");
-    expect(toJSON).toHaveBeenCalledTimes(1);
-  });
-
-  it.each(['own', 'inherited'])('rejects %s toJSON accessors without invoking them', (location) => {
-    const prototype = {};
-    const overriddenRoot = Object.assign(Object.create(prototype), { type: 'object' as const });
-    const getter = vi.fn(() => () => ({ type: 'string' }));
-
-    Object.defineProperty(location === 'own' ? overriddenRoot : prototype, 'toJSON', { get: getter });
-
-    expect(() =>
-      zodToJsonSchema(z3.object({ value: z3.string() }), {
-        openaiStrictMode: true,
-        override: () => overriddenRoot,
-      }),
-    ).toThrow("Root schema cannot contain a callable or accessor-backed 'toJSON' property");
-    expect(getter).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    { name: 'undefined', value: undefined },
-    { name: 'a function', value: () => '#/definitions/Root' },
-    { name: 'a symbol', value: Symbol('reference') },
-  ])('ignores an enumerable root reference containing $name because JSON omits it', ({ value }) => {
-    const overriddenRoot = { type: 'object' as const, $ref: value };
-
-    expect(JSON.stringify(overriddenRoot)).toBe('{"type":"object"}');
-    const schema = zodToJsonSchema(z3.object({ value: z3.string() }), {
-      target: 'openApi3',
-      openaiStrictMode: true,
-      override: () => overriddenRoot as { type: 'object' },
-    });
-    expect(JSON.stringify(schema)).toBe('{"type":"object"}');
-  });
-
-  it.each([
-    { name: 'conflicting properties', sibling: { properties: { injected: { type: 'number' } } } },
-    { name: 'additionalProperties: true', sibling: { additionalProperties: true } },
-  ])('does not activate root reference siblings containing $name', ({ sibling }) => {
-    const root = z3.object({ value: z3.string() });
-    const schema = zodToJsonSchema(root, {
-      openaiStrictMode: true,
-      definitions: { Root: root },
-      override: (_definition, _refs, _seen, forceResolution) =>
-        forceResolution
-          ? { type: 'object', properties: { value: { type: 'string' } }, additionalProperties: false }
-          : { $ref: '#/definitions/Root', type: 'object', ...sibling },
-    });
-
-    expect(schema).toMatchObject({
-      type: 'object',
-      properties: { value: { type: 'string' } },
-      additionalProperties: false,
-    });
-    expect(schema).not.toHaveProperty('properties.injected');
-  });
-
-  it('rejects root references returned by forced overrides before activating assertion siblings', () => {
-    expect(() =>
-      zodToJsonSchema(z3.object({ value: z3.string() }), {
-        openaiStrictMode: true,
-        override: () => ({ $ref: '#/definitions/Root', type: 'object', additionalProperties: true }),
-      }),
+      convertStrictRoot({ type: 'object', $ref: '#/definitions/Root', additionalProperties: true }),
     ).toThrow("Root schema must be a concrete object and cannot contain '$ref'");
   });
 
-  it('rejects named object roots that resolve to a root reference', () => {
-    expect(() =>
-      zodToJsonSchema(z3.object({ value: z3.string() }), { name: 'named-object', openaiStrictMode: true }),
-    ).toThrow(expectedRootError());
+  it('forces canonical resolution before supplied root-reference siblings', () => {
+    const root = z3.object({ value: z3.string() });
+    const schema = zodToJsonSchema(root, {
+      openaiStrictMode: true,
+      definitions: Object.freeze({ Root: root }),
+      override: (_definition, _refs, _seen, forceResolution) =>
+        forceResolution
+          ? { type: 'object', properties: { value: { type: 'string' } } }
+          : { $ref: '#/definitions/Root', type: 'object', additionalProperties: true },
+    });
+
+    expect(schema).toMatchObject({ type: 'object', properties: { value: { type: 'string' } } });
+    expect(schema).not.toHaveProperty('$ref');
   });
 
-  it('continues accepting named object roots with duplicated references', () => {
+  it('rejects named root references while preserving duplicate-ref object roots', () => {
+    const root = z3.object({ value: z3.string() });
+    expect(() => zodToJsonSchema(root, { name: 'named', openaiStrictMode: true })).toThrow(
+      expectedRootError(),
+    );
     expect(
-      zodToJsonSchema(z3.object({ value: z3.string() }), {
-        name: 'named-object',
-        nameStrategy: 'duplicate-ref',
-        openaiStrictMode: true,
-      }),
+      zodToJsonSchema(root, { name: 'named', nameStrategy: 'duplicate-ref', openaiStrictMode: true }),
     ).toMatchObject({ type: 'object', properties: { value: { type: 'string' } } });
   });
 
-  it('rejects nullable OpenAPI3 object roots', () => {
+  it('rejects nullable OpenAPI3 roots', () => {
     const root = z3.object({ value: z3.string() }).nullable();
-
     expect(() => zodToJsonSchema(root, { target: 'openApi3', openaiStrictMode: true })).toThrow(
       expectedRootError('object,null'),
     );
@@ -451,21 +286,15 @@ describe('strict vendor converter root schemas', () => {
 describe.each(['jsonSchema7', 'jsonSchema2019-09', 'openApi3'] as const)(
   'non-strict %s targets',
   (target) => {
-    it('continues accepting unnamed non-object roots', () => {
+    it('preserves unnamed, named, and explicitly non-strict non-object roots', () => {
       expect(zodToJsonSchema(z3.array(z3.string()), { target })).toMatchObject({
         type: 'array',
         items: { type: 'string' },
       });
-    });
-
-    it('preserves named root references', () => {
       expect(zodToJsonSchema(z3.string(), { target, name: 'named-string' })).toMatchObject({
         $ref: '#/definitions/named-string',
         definitions: { 'named-string': { type: 'string' } },
       });
-    });
-
-    it('continues accepting non-object roots with explicit non-strict mode', () => {
       expect(zodToJsonSchema(z3.string(), { target, openaiStrictMode: false })).toMatchObject({
         type: 'string',
       });
@@ -473,40 +302,30 @@ describe.each(['jsonSchema7', 'jsonSchema2019-09', 'openApi3'] as const)(
   },
 );
 
-it('preserves non-strict registered roots without cloning or changing caller definitions', () => {
+it('preserves non-strict registered and nullable roots', () => {
   const root = z3.object({ value: z3.string() });
   const definitions = { Root: root };
-
   expect(zodToJsonSchema(root, { definitions })).toMatchObject({
     $ref: '#/definitions/Root',
     definitions: { Root: { type: 'object' } },
   });
   expect(definitions.Root).toBe(root);
+  expect(zodToJsonSchema(root.nullable(), { target: 'openApi3' })).toMatchObject({
+    type: 'object',
+    nullable: true,
+  });
 });
 
-it('preserves non-strict OpenAPI3 nullable object roots', () => {
-  const root = z3.object({ value: z3.string() }).nullable();
-
-  expect(zodToJsonSchema(root, { target: 'openApi3' })).toMatchObject({ type: 'object', nullable: true });
-});
-
-describe('zodRealtimeFunction non-strict root schemas', () => {
-  it('continues accepting a primitive Zod v3 root', () => {
-    const tool = zodRealtimeFunction({ name: 'realtime-string', parameters: z3.string() });
-
-    expect(tool.parameters).toMatchObject({ type: 'string' });
-    expect(tool).not.toHaveProperty('strict');
-  });
-
-  it('continues accepting a Zod v3 array root', () => {
-    const tool = zodRealtimeFunction({ name: 'realtime-array', parameters: z3.array(z3.string()) });
-
-    expect(tool.parameters).toMatchObject({ type: 'array', items: { type: 'string' } });
-  });
-
-  it('continues accepting a Zod v3 union root', () => {
-    const parameters = z3.union([z3.object({ first: z3.string() }), z3.object({ second: z3.number() })]);
-
-    expect(zodRealtimeFunction({ name: 'realtime-union', parameters }).parameters).toHaveProperty('anyOf');
-  });
+it.each([
+  { name: 'string', parameters: z3.string(), expected: { type: 'string' } },
+  { name: 'array', parameters: z3.array(z3.string()), expected: { type: 'array' } },
+  {
+    name: 'union',
+    parameters: z3.union([z3.object({ first: z3.string() }), z3.object({ second: z3.number() })]),
+    expected: { anyOf: expect.any(Array) },
+  },
+])('keeps realtime $name roots non-strict', ({ name, parameters, expected }) => {
+  const tool = zodRealtimeFunction({ name, parameters });
+  expect(tool.parameters).toMatchObject(expected);
+  expect(tool).not.toHaveProperty('strict');
 });

--- a/tests/helpers/zod-root-schema-validation.test.ts
+++ b/tests/helpers/zod-root-schema-validation.test.ts
@@ -235,6 +235,55 @@ describe('strict vendor converter root schemas', () => {
     expect(getter).not.toHaveBeenCalled();
   });
 
+  it.each(['own', 'inherited'])('rejects %s toJSON hooks that serialize a non-object root', (location) => {
+    const toJSON = vi.fn().mockReturnValue({ type: 'string' });
+    const overriddenRoot =
+      location === 'own'
+        ? { type: 'object' as const, toJSON }
+        : Object.assign(Object.create({ toJSON }), { type: 'object' as const });
+
+    expect(JSON.stringify(overriddenRoot)).toBe('{"type":"string"}');
+    expect(() =>
+      zodToJsonSchema(z3.object({ value: z3.string() }), {
+        openaiStrictMode: true,
+        override: () => overriddenRoot,
+      }),
+    ).toThrow("Root schema cannot contain a callable or accessor-backed 'toJSON' property");
+    expect(toJSON).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['own', 'inherited'])('rejects %s toJSON accessors without invoking them', (location) => {
+    const prototype = {};
+    const overriddenRoot = Object.assign(Object.create(prototype), { type: 'object' as const });
+    const getter = vi.fn(() => () => ({ type: 'string' }));
+
+    Object.defineProperty(location === 'own' ? overriddenRoot : prototype, 'toJSON', { get: getter });
+
+    expect(() =>
+      zodToJsonSchema(z3.object({ value: z3.string() }), {
+        openaiStrictMode: true,
+        override: () => overriddenRoot,
+      }),
+    ).toThrow("Root schema cannot contain a callable or accessor-backed 'toJSON' property");
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: 'undefined', value: undefined },
+    { name: 'a function', value: () => '#/definitions/Root' },
+    { name: 'a symbol', value: Symbol('reference') },
+  ])('ignores an enumerable root reference containing $name because JSON omits it', ({ value }) => {
+    const overriddenRoot = { type: 'object' as const, $ref: value };
+
+    expect(JSON.stringify(overriddenRoot)).toBe('{"type":"object"}');
+    const schema = zodToJsonSchema(z3.object({ value: z3.string() }), {
+      target: 'openApi3',
+      openaiStrictMode: true,
+      override: () => overriddenRoot as { type: 'object' },
+    });
+    expect(JSON.stringify(schema)).toBe('{"type":"object"}');
+  });
+
   it.each([
     { name: 'conflicting properties', sibling: { properties: { injected: { type: 'number' } } } },
     { name: 'additionalProperties: true', sibling: { additionalProperties: true } },

--- a/tests/helpers/zod-root-schema-validation.test.ts
+++ b/tests/helpers/zod-root-schema-validation.test.ts
@@ -13,18 +13,22 @@ const strictHelpers = [
   {
     name: 'zodResponseFormat',
     create: (schema: any) => zodResponseFormat(schema, 'root'),
+    getSchema: (result: any) => result.json_schema.schema,
   },
   {
     name: 'zodTextFormat',
     create: (schema: any) => zodTextFormat(schema, 'root'),
+    getSchema: (result: any) => result.schema,
   },
   {
     name: 'zodFunction',
     create: (schema: any) => zodFunction({ name: 'root', parameters: schema }),
+    getSchema: (result: any) => result.function.parameters,
   },
   {
     name: 'zodResponsesFunction',
     create: (schema: any) => zodResponsesFunction({ name: 'root', parameters: schema }),
+    getSchema: (result: any) => result.parameters,
   },
 ];
 
@@ -122,7 +126,20 @@ const validObjectRoots = [
   },
 ];
 
-describe.each(strictHelpers)('$name root schema validation', ({ create }) => {
+const registeredRootCases = [
+  {
+    name: 'a directly registered object',
+    wrapV3: (root: z3.ZodType) => root,
+    wrapV4: (root: z4.ZodType) => root,
+  },
+  {
+    name: 'a lazy registered object',
+    wrapV3: (root: z3.ZodType) => z3.lazy(() => root),
+    wrapV4: (root: z4.ZodType) => z4.lazy(() => root),
+  },
+];
+
+describe.each(strictHelpers)('$name root schema validation', ({ create, getSchema }) => {
   it.each(invalidRootSchemas)('rejects $name equally for Zod v3 and v4', ({ type, v3, v4 }) => {
     const expectedError = expectedRootError(type);
 
@@ -149,8 +166,107 @@ describe.each(strictHelpers)('$name root schema validation', ({ create }) => {
   });
 
   it.each(validObjectRoots)('continues accepting $name', ({ schema }) => {
-    expect(() => create(schema)).not.toThrow();
+    const generatedSchema = getSchema(create(schema));
+
+    expect(generatedSchema).toHaveProperty('type', 'object');
+    expect(generatedSchema).not.toHaveProperty('$ref');
+    expect(generatedSchema).not.toHaveProperty('nullable', true);
   });
+});
+
+describe.each(registeredRootCases)('strict response formats with $name', ({ wrapV3, wrapV4 }) => {
+  it('materializes the registered root without mutating caller definitions', () => {
+    const root = z3.object({ value: z3.string() });
+    const other = z3.object({ other: z3.number() });
+    const schemaDefinitions = { Root: root, Other: other };
+
+    const { schema } = zodResponseFormat(wrapV3(root), 'response', { schemaDefinitions }).json_schema;
+
+    expect(schema).toMatchObject({
+      type: 'object',
+      properties: { value: { type: 'string' } },
+      definitions: {
+        Root: { type: 'object', properties: { value: { type: 'string' } } },
+        Other: { type: 'object', properties: { other: { type: 'number' } } },
+      },
+    });
+    expect(schema).not.toHaveProperty('$ref');
+    expect(schema).not.toHaveProperty('nullable', true);
+    expect(schemaDefinitions).toEqual({ Root: root, Other: other });
+    expect(schemaDefinitions.Root).toBe(root);
+    expect(schemaDefinitions.Other).toBe(other);
+  });
+
+  it('accepts frozen caller definitions while preserving every schema identity', () => {
+    const root = z3.object({ value: z3.string() });
+    const other = z3.object({ other: z3.number() });
+    const schemaDefinitions = Object.freeze({ Root: root, Other: other });
+
+    const { schema } = zodResponseFormat(wrapV3(root), 'response', { schemaDefinitions }).json_schema;
+
+    expect(schema).toMatchObject({ type: 'object', definitions: { Root: { type: 'object' } } });
+    expect(schema).not.toHaveProperty('$ref');
+    expect(schemaDefinitions.Root).toBe(root);
+    expect(schemaDefinitions.Other).toBe(other);
+    expect(Object.keys(schemaDefinitions)).toEqual(['Root', 'Other']);
+  });
+
+  it.each(['Root/part~value%25', 'Root%2Fpart', 'constructor', 'toString', 'response'])(
+    'resolves the literal registered definition name %s',
+    (definitionName) => {
+      const root = z3.object({ value: z3.string() });
+      const schemaDefinitions = Object.freeze({ [definitionName]: root });
+
+      const { schema } = zodResponseFormat(wrapV3(root), 'response', { schemaDefinitions }).json_schema;
+      const materializedDefinitions = (schema?.['definitions'] ?? {}) as Record<string, unknown>;
+
+      expect(schema).toHaveProperty('type', 'object');
+      expect(schema).not.toHaveProperty('$ref');
+      expect(Object.getOwnPropertyDescriptor(materializedDefinitions, definitionName)?.value).toHaveProperty(
+        'type',
+        'object',
+      );
+      expect(schemaDefinitions[definitionName]).toBe(root);
+    },
+  );
+
+  it('matches Zod v4 concrete-root and caller-identity behavior', () => {
+    const root = z4.object({ value: z4.string() });
+    const schemaDefinitions = Object.freeze({ Root: root });
+
+    const { schema } = zodResponseFormat(wrapV4(root), 'response', { schemaDefinitions }).json_schema;
+
+    expect(schema).toMatchObject({ type: 'object', properties: { value: { type: 'string' } } });
+    expect(schema).not.toHaveProperty('$ref');
+    expect(schemaDefinitions.Root).toBe(root);
+  });
+});
+
+it('preserves recursive references while materializing a registered lazy object root', () => {
+  const schemaDefinitions = Object.freeze({ Root: recursiveObject });
+
+  const { schema } = zodResponseFormat(recursiveObject, 'response', { schemaDefinitions }).json_schema;
+
+  expect(schema).toMatchObject({
+    type: 'object',
+    properties: {
+      value: { type: 'string' },
+      children: { type: 'array', items: { $ref: '#/definitions/Root' } },
+    },
+    definitions: { Root: { type: 'object' } },
+  });
+  expect(schema).not.toHaveProperty('$ref');
+  expect(schemaDefinitions.Root).toBe(recursiveObject);
+});
+
+it.each([
+  { name: 'a registered string', schema: z3.string(), type: 'string' },
+  { name: 'a registered array', schema: z3.array(z3.string()), type: 'array' },
+  { name: 'a registered nullable object', schema: z3.object({ value: z3.string() }).nullable() },
+])('rejects $name after resolving its definition', ({ schema, type }) => {
+  expect(() => zodResponseFormat(schema, 'response', { schemaDefinitions: { Root: schema } })).toThrow(
+    expectedRootError(type),
+  );
 });
 
 it('preserves named object roots and escaped references to supplied definitions', () => {
@@ -179,6 +295,217 @@ it('preserves named object roots and escaped references to supplied definitions'
 });
 
 describe('strict vendor converter root schemas', () => {
+  it('materializes a root alias chain while retaining its definition map and root metadata', () => {
+    const root = z3.object({ value: z3.string() });
+    const alias = z3.object({ alias: z3.string() });
+    const definitions = Object.freeze({ Root: root, Alias: alias });
+
+    const schema = zodToJsonSchema(root, {
+      name: 'response',
+      nameStrategy: 'duplicate-ref',
+      openaiStrictMode: true,
+      definitions,
+      override: (definition, _refs, _seen, forceResolution) => {
+        if (!forceResolution) {
+          return { $ref: '#/definitions/Root', title: 'root title' };
+        }
+
+        return definition === root._def
+          ? { $ref: '#/definitions/Alias' }
+          : { type: 'object', properties: { alias: { type: 'string' } }, additionalProperties: false };
+      },
+    });
+
+    expect(schema).toMatchObject({
+      type: 'object',
+      title: 'root title',
+      properties: { alias: { type: 'string' } },
+      definitions: {
+        Root: { $ref: '#/definitions/Alias' },
+        Alias: { type: 'object' },
+      },
+    });
+    expect(schema).not.toHaveProperty('$ref');
+    expect(definitions.Root).toBe(root);
+    expect(definitions.Alias).toBe(alias);
+  });
+
+  it.each([
+    'https://example.com/schema.json#/definitions/Root',
+    '#/different/Root',
+    '#/definitions/Missing',
+    '#/definitions/toString',
+    '#/definitions/__proto__',
+  ])('rejects unsafe or unresolved root references: %s', (reference) => {
+    const root = z3.object({ value: z3.string() });
+
+    expect(() =>
+      zodToJsonSchema(root, {
+        openaiStrictMode: true,
+        definitions: { Root: root },
+        override: (_definition, _refs, _seen, forceResolution) =>
+          forceResolution ? { type: 'object', additionalProperties: false } : { $ref: reference },
+      }),
+    ).toThrow(expectedRootError());
+  });
+
+  it('rejects external root references even when they have an object-typed sibling', () => {
+    const root = z3.object({ value: z3.string() });
+
+    expect(() =>
+      zodToJsonSchema(root, {
+        openaiStrictMode: true,
+        definitions: { Root: root },
+        override: (_definition, _refs, _seen, forceResolution) =>
+          forceResolution
+            ? { type: 'object', additionalProperties: false }
+            : { $ref: 'https://example.com/schema.json', type: 'object' },
+      }),
+    ).toThrow("Root schema must be a concrete object and cannot contain '$ref'");
+  });
+
+  it('rejects unresolved alias references even when they have an object-typed sibling', () => {
+    const root = z3.object({ value: z3.string() });
+
+    expect(() =>
+      zodToJsonSchema(root, {
+        openaiStrictMode: true,
+        definitions: { Root: root },
+        override: (_definition, _refs, _seen, forceResolution) =>
+          forceResolution
+            ? { $ref: '#/definitions/Missing', type: 'object' }
+            : { $ref: '#/definitions/Root' },
+      }),
+    ).toThrow("Root schema must be a concrete object and cannot contain '$ref'");
+  });
+
+  it('rejects cyclic local root references without recursing indefinitely', () => {
+    const root = z3.object({ value: z3.string() });
+
+    expect(() =>
+      zodToJsonSchema(root, {
+        openaiStrictMode: true,
+        definitions: { Root: root },
+        override: () => ({ $ref: '#/definitions/Root' }),
+      }),
+    ).toThrow(/cyclic.*root|root.*cyclic/iu);
+  });
+
+  it('rejects accessor-backed reference targets without invoking their getters', () => {
+    const root = z3.object({ value: z3.string() });
+    let getterInvoked = false;
+    const target = Object.defineProperty({ type: 'object' as const }, '$ref', {
+      enumerable: true,
+      get: () => {
+        getterInvoked = true;
+        return '#/definitions/Root';
+      },
+    });
+
+    expect(() =>
+      zodToJsonSchema(root, {
+        openaiStrictMode: true,
+        definitions: { Root: root },
+        override: (_definition, _refs, _seen, forceResolution) =>
+          forceResolution ? target : { $ref: '#/definitions/Root' },
+      }),
+    ).toThrow(/accessor.*root|root.*accessor/iu);
+    expect(getterInvoked).toBe(false);
+  });
+
+  it.each(['type', 'nullable'] as const)(
+    'rejects accessor-backed %s validation keywords without invoking their getters',
+    (keyword) => {
+      const root = z3.object({ value: z3.string() });
+      let getterInvoked = false;
+      const target = Object.defineProperty({ type: 'object' as const }, keyword, {
+        enumerable: true,
+        get: () => {
+          getterInvoked = true;
+          return keyword === 'type' ? 'object' : true;
+        },
+      });
+
+      expect(() =>
+        zodToJsonSchema(root, {
+          openaiStrictMode: true,
+          definitions: { Root: root },
+          override: (_definition, _refs, _seen, forceResolution) =>
+            forceResolution ? target : { $ref: '#/definitions/Root' },
+        }),
+      ).toThrow('Accessor-backed root schema properties are not supported');
+      expect(getterInvoked).toBe(false);
+    },
+  );
+
+  it.each([
+    { name: 'string', key: 'title' },
+    { name: 'symbol', key: Symbol('unsafe root metadata') },
+  ])('rejects accessor-backed $name root metadata without invoking its getter', ({ key }) => {
+    const root = z3.object({ value: z3.string() });
+    let getterInvoked = false;
+    const reference = Object.defineProperty({ $ref: '#/definitions/Root' }, key, {
+      enumerable: true,
+      get: () => {
+        getterInvoked = true;
+        return 'unsafe metadata';
+      },
+    });
+
+    expect(() =>
+      zodToJsonSchema(root, {
+        openaiStrictMode: true,
+        definitions: { Root: root },
+        override: (_definition, _refs, _seen, forceResolution) =>
+          forceResolution ? { type: 'object', additionalProperties: false } : reference,
+      }),
+    ).toThrow('Accessor-backed root schema properties are not supported');
+    expect(getterInvoked).toBe(false);
+  });
+
+  it('rejects accessor-backed root references even without supplied definitions', () => {
+    const root = z3.object({ value: z3.string() });
+    let getterInvoked = false;
+    const reference = Object.defineProperty({ type: 'object' as const }, '$ref', {
+      enumerable: true,
+      get: () => {
+        getterInvoked = true;
+        return '#/definitions/Root';
+      },
+    });
+
+    expect(() =>
+      zodToJsonSchema(root, {
+        openaiStrictMode: true,
+        override: () => reference,
+      }),
+    ).toThrow("Root schema must be a concrete object and cannot contain '$ref'");
+    expect(getterInvoked).toBe(false);
+  });
+
+  it('continues rejecting registered nullable OpenAPI3 object roots', () => {
+    const root = z3.object({ value: z3.string() }).nullable();
+
+    expect(() =>
+      zodToJsonSchema(root, {
+        target: 'openApi3',
+        openaiStrictMode: true,
+        definitions: { Root: root },
+      }),
+    ).toThrow(expectedRootError('object,null'));
+  });
+
+  it('keeps non-strict registered roots as references without changing legacy behavior', () => {
+    const root = z3.object({ value: z3.string() });
+    const definitions = { Root: root };
+
+    expect(zodToJsonSchema(root, { definitions })).toMatchObject({
+      $ref: '#/definitions/Root',
+      definitions: { Root: { type: 'object' } },
+    });
+    expect(definitions.Root).toBe(root);
+  });
+
   it('rejects named object roots that resolve to a root reference', () => {
     expect(() =>
       zodToJsonSchema(z3.object({ value: z3.string() }), {

--- a/tests/helpers/zod-root-schema-validation.test.ts
+++ b/tests/helpers/zod-root-schema-validation.test.ts
@@ -198,6 +198,22 @@ describe('strict vendor converter root schemas', () => {
     ).toThrow('Root schema must serialize to a JSON object');
   });
 
+  it('rejects boxed BigInt roots before JSON serialization fails', () => {
+    const boxedBigInt = Reflect.construct(Object, [Reflect.apply(BigInt, undefined, [1])]) as object;
+    const overriddenRoot = Object.assign(boxedBigInt, {
+      type: 'object' as const,
+    });
+
+    expect(() => JSON.stringify(overriddenRoot)).toThrow(TypeError);
+    expect(() =>
+      zodToJsonSchema(z3.object({ value: z3.string() }), {
+        target: 'openApi3',
+        openaiStrictMode: true,
+        override: () => overriddenRoot,
+      }),
+    ).toThrow('Root schema must serialize to a JSON object');
+  });
+
   it('preserves strict object roots without a prototype', () => {
     const overriddenRoot = Object.assign(Object.create(null) as object, { type: 'object' as const });
     const schema = zodToJsonSchema(z3.object({ value: z3.string() }), {


### PR DESCRIPTION
## Summary

- Reject Zod v3 Structured Outputs schemas whose parsed root is not `type: "object"`, using the same synchronous error as the existing Zod v4 path across `zodResponseFormat`, `zodTextFormat`, `zodFunction`, and `zodResponsesFunction`.
- Gate validation exclusively on `openaiStrictMode` and perform it before root naming, schema-definition expansion, or `$ref` wrapping, preserving valid named, lazy, recursive, refined, transformed, and defaulted object roots.
- Add a focused 77-case regression matrix covering primitive/array/object-union/discriminated-union/nullable/optional/intersection/any roots, Zod v3/v4 behavior, nested unions and arrays, escaped schema definitions, every generic converter target, and unchanged Realtime behavior.

## Why

The vendored Zod v3 converter previously returned invalid strict root schemas unchecked. The four strict public helpers therefore emitted schemas that Structured Outputs cannot accept, while the equivalent Zod v4 conversion already failed synchronously. Valid Zod v4 optional object roots remain accepted because v4 normalizes them to an actual root object; the unsupported Zod v3 representation is correctly rejected.

## Validation

- Regression-first: the new focused suite produced **36 failures** against unchanged `main` before the fix.
- `pnpm test -- tests/helpers/zod-root-schema-validation.test.ts` — **77 passing tests**.
- `pnpm test:unit` — **2,167 passing tests across 71 files**.
- `pnpm format` and `pnpm lint`.
- `pnpm exec tsc`.
- `pnpm build`, including CommonJS/ESM SDK and Bedrock import checks.
- `./node_modules/typescript-4-9/bin/tsc --project dist/src/tsconfig.json --noEmit`.
- `./node_modules/typescript/bin/tsc --project dist/src/tsconfig.json --noEmit`.
- `pnpm exec publint dist`.
- CI-equivalent ATTW package analysis and `node scripts/utils/attw-report.cjs` — `Types ok!`.
- `node --experimental-strip-types scripts/test-packed-package.ts` — offline CommonJS/ESM consumer and both compiler versions; **263/300 source checks across 1,200 source maps**.
- Built-package smoke check confirms all four strict helpers reject primitive roots while `zodRealtimeFunction` remains non-strict.
- Both changed files are handwritten, have no generated marker, and are outside the generated/legacy allowlist.