### PR TITLE
fix: isolate Vercel ecosystem tests per request

### DIFF
--- a/ecosystem-tests/vercel-edge/src/pages/api/edge-test.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/edge-test.ts
@@ -16,10 +16,6 @@ export const config = {
 
 type Test = { description: string; handler: () => Promise<void> };
 
-const tests: Test[] = [];
-function it(description: string, handler: () => Promise<void>) {
-  tests.push({ description, handler });
-}
 function expectEqual(a: any, b: any) {
   if (!Object.is(a, b)) {
     throw new Error(`expected values to be equal: ${JSON.stringify({ a, b })}`);
@@ -42,6 +38,11 @@ function expectSimilar(received: string, expected: string, maxDistance: number) 
 }
 
 export default async function handler(request: NextRequest) {
+  const tests: Test[] = [];
+  function it(description: string, handler: () => Promise<void>) {
+    tests.push({ description, handler });
+  }
+
   try {
     console.error('creating client');
     const client = new OpenAI();

--- a/ecosystem-tests/vercel-edge/src/pages/api/node-test.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/node-test.ts
@@ -5,10 +5,6 @@ import { uploadWebApiTestCases } from '../../uploadWebApiTestCases';
 
 type Test = { description: string; handler: () => Promise<void> };
 
-const tests: Test[] = [];
-function it(description: string, handler: () => Promise<void>) {
-  tests.push({ description, handler });
-}
 function expectEqual(a: any, b: any) {
   if (!Object.is(a, b)) {
     throw new Error(`expected values to be equal: ${JSON.stringify({ a, b })}`);
@@ -31,6 +27,11 @@ function expectSimilar(received: string, expected: string, maxDistance: number) 
 }
 
 export default async function handler(request: NextApiRequest, response: NextApiResponse) {
+  const tests: Test[] = [];
+  function it(description: string, handler: () => Promise<void>) {
+    tests.push({ description, handler });
+  }
+
   try {
     console.error('creating client');
     const client = new OpenAI();

--- a/tests/ecosystem-vercel-request-isolation.test.ts
+++ b/tests/ecosystem-vercel-request-isolation.test.ts
@@ -1,0 +1,184 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { runInNewContext } from 'node:vm';
+import ts from 'typescript';
+
+type Runtime = 'edge' | 'node';
+
+interface RecordedCall {
+  clientID: number;
+  token: string;
+}
+
+interface HandlerResult {
+  body: string;
+  status: number;
+}
+
+interface HandlerHarness {
+  calls: RecordedCall[];
+  callsPerRequest: number;
+  runRequest: () => Promise<HandlerResult>;
+}
+
+interface MockNodeResponse {
+  body: string;
+  statusCode: number;
+  status: (statusCode: number) => MockNodeResponse;
+  end: (body: string) => MockNodeResponse;
+}
+
+function mockNextResponse(body: string, init: { status?: number } = {}): HandlerResult {
+  return { body, status: init.status ?? 200 };
+}
+
+function createMockNodeResponse(): MockNodeResponse {
+  return {
+    body: '',
+    statusCode: 0,
+    status(statusCode) {
+      this.statusCode = statusCode;
+      return this;
+    },
+    end(body) {
+      this.body = body;
+      return this;
+    },
+  };
+}
+
+function createHandlerHarness(runtime: Runtime, failedClientIDs: number[] = []): HandlerHarness {
+  const calls: RecordedCall[] = [];
+  const failures = new Set(failedClientIDs);
+  const callsPerRequest = runtime === 'edge' ? 8 : 7;
+  let nextClientID = 0;
+
+  class MockOpenAI {
+    readonly id: number;
+    readonly token: string;
+
+    constructor() {
+      nextClientID += 1;
+      this.id = nextClientID;
+      this.token = `synthetic-token-${this.id}`;
+    }
+  }
+
+  function uploadWebApiTestCases({
+    client,
+    it,
+  }: {
+    client: MockOpenAI;
+    it: (description: string, handler: () => Promise<void>) => void;
+  }): void {
+    for (let index = 0; index < callsPerRequest; index += 1) {
+      it(`mock API call ${index + 1}`, async () => {
+        calls.push({ clientID: client.id, token: client.token });
+
+        if (failures.has(client.id)) {
+          throw new Error(`synthetic failure for client ${client.id}`);
+        }
+      });
+    }
+  }
+
+  const dependencies: Record<string, unknown> = {
+    '../../uploadWebApiTestCases': { uploadWebApiTestCases },
+    'fastest-levenshtein': { distance: () => 0 },
+    'next/server': { NextResponse: mockNextResponse },
+    openai: { __esModule: true, default: MockOpenAI },
+  };
+
+  const handlerPath = path.resolve(
+    process.cwd(),
+    'ecosystem-tests/vercel-edge/src/pages/api',
+    `${runtime}-test.ts`,
+  );
+  const handlerSource = readFileSync(handlerPath, 'utf-8');
+  const transpiledHandler = ts.transpileModule(handlerSource, {
+    compilerOptions: {
+      esModuleInterop: true,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: handlerPath,
+  });
+
+  const handlerExports: {
+    default?: (request: unknown, response?: MockNodeResponse) => Promise<unknown>;
+  } = {};
+
+  runInNewContext(
+    transpiledHandler.outputText,
+    {
+      console: { error: () => null },
+      exports: handlerExports,
+      module: { exports: handlerExports },
+      require: (specifier: string) => {
+        const dependency = dependencies[specifier];
+
+        if (!dependency) {
+          throw new Error(`Unexpected handler dependency: ${specifier}`);
+        }
+
+        return dependency;
+      },
+    },
+    { filename: handlerPath },
+  );
+
+  const handler = handlerExports.default;
+
+  if (!handler) {
+    throw new Error(`Missing default handler export: ${handlerPath}`);
+  }
+
+  return {
+    calls,
+    callsPerRequest,
+    async runRequest(): Promise<HandlerResult> {
+      if (runtime === 'edge') {
+        const response = (await handler({})) as HandlerResult;
+        return { body: response.body, status: response.status };
+      }
+
+      const response = createMockNodeResponse();
+      await handler({}, response);
+      return { body: response.body, status: response.statusCode };
+    },
+  };
+}
+
+async function expectSuccessfulRequest(harness: HandlerHarness, clientID: number): Promise<void> {
+  const previousCallCount = harness.calls.length;
+
+  expect(await harness.runRequest()).toEqual({ body: 'Passed!', status: 200 });
+  expect(harness.calls.slice(previousCallCount)).toEqual(
+    Array.from({ length: harness.callsPerRequest }, () => ({
+      clientID,
+      token: `synthetic-token-${clientID}`,
+    })),
+  );
+}
+
+describe.each<Runtime>(['edge', 'node'])('warm Vercel %s handler', (runtime) => {
+  test('runs only the current request client and credentials', async () => {
+    const harness = createHandlerHarness(runtime);
+
+    await expectSuccessfulRequest(harness, 1);
+    await expectSuccessfulRequest(harness, 2);
+    await expectSuccessfulRequest(harness, 3);
+
+    expect(harness.calls).toHaveLength(harness.callsPerRequest * 3);
+  });
+
+  test('does not replay a failed previous request', async () => {
+    const harness = createHandlerHarness(runtime, [1]);
+
+    expect(await harness.runRequest()).toEqual({ body: 'Internal Server Error', status: 500 });
+    expect(harness.calls).toEqual([{ clientID: 1, token: 'synthetic-token-1' }]);
+
+    await expectSuccessfulRequest(harness, 2);
+    await expectSuccessfulRequest(harness, 3);
+  });
+});


### PR DESCRIPTION
## Summary

- Move the test registry and `it` registration closure inside each Vercel Edge and Node request handler while preserving existing logging, response statuses, error handling, and Edge-runtime behavior.
- Prevent warm workers from retaining and replaying previous requests' OpenAI clients, credentials, failures, and billable upload-test calls.
- Add one dependency-free Vitest regression that transpiles each real handler, evaluates it once in a mocked VM, and exercises three sequential requests plus failed-request recovery for both runtimes.

The previous module-global registry caused Edge workers to execute `8 * n * (n + 1) / 2` API calls and Node workers to execute `7 * n * (n + 1) / 2` API calls across `n` warm requests, instead of `8 * n` and `7 * n` respectively. No real API calls or credentials are used by the regression.

## Regression-first verification

- Before the fix: **4/4 regression tests failed**. The second Edge request replayed 8 stale-client calls; the second Node request replayed 7 stale-client calls; a failed prior request continued returning HTTP 500 in both runtimes.
- After the fix: **4/4 regression tests pass**, including per-request client/token isolation and recovery after an earlier failure.

## Validation

- `OPENAI_TEST_SUITE=unit ./scripts/test` — **71 handwritten test files, 2,094 tests passed**.
- `./scripts/lint`
- `./node_modules/.bin/oxfmt --check .`
- `pnpm exec tsc`
- `./scripts/build`
- `./node_modules/typescript-4-9/bin/tsc --project dist/src/tsconfig.json --noEmit`
- `./node_modules/typescript/bin/tsc --project dist/src/tsconfig.json --noEmit`
- `node --experimental-strip-types scripts/test-packed-package.ts` — packed CJS/ESM plus **263/300 source checks across 1,200 source maps**.
- `./node_modules/.bin/publint dist` — passes with its existing vendored CommonJS interop warning.
- Vercel fixture `./node_modules/.bin/tsc --noEmit --incremental false`.
- Vercel fixture filtered mocked-error Jest tests — **4/4 passed**.
- Vercel fixture `NEXT_TELEMETRY_DISABLED=1 OPENAI_API_KEY= OPENAI_ADMIN_KEY= npm run build -- --no-lint` — production **Next.js 15.5.21** build passes and compiles both affected API routes without executing them; existing upstream AI Edge-runtime warnings remain.
