### PR TITLE
test: stabilize Node 22 multipart mock-server 404 checks

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,6 +4,7 @@ import generatedTestPatterns from './scripts/generated-test-patterns.json';
 const config: JestConfigWithTsJest = {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
+  setupFiles: ['<rootDir>/scripts/jest-setup.ts'],
   testMatch: generatedTestPatterns.map(
     (pattern) => `<rootDir>/${pattern}${pattern.endsWith('.test.ts') ? '' : '/**/*.test.ts'}`,
   ),

--- a/scripts/jest-setup.ts
+++ b/scripts/jest-setup.ts
@@ -1,0 +1,3 @@
+import { bufferSteadyMultipartUploads } from './mock-server-fetch';
+
+globalThis.fetch = bufferSteadyMultipartUploads(globalThis.fetch);

--- a/scripts/mock-server-fetch.ts
+++ b/scripts/mock-server-fetch.ts
@@ -1,0 +1,25 @@
+const steadyOrigin = 'http://127.0.0.1:4010';
+const unknownPath = '/_stainless_unknown_path';
+
+export function bufferSteadyMultipartUploads(
+  fetchImplementation: typeof globalThis.fetch,
+): typeof globalThis.fetch {
+  return async (input, init) => {
+    if (!(init?.body instanceof FormData)) {
+      return fetchImplementation(input, init);
+    }
+
+    const url = new URL(input instanceof Request ? input.url : input);
+    if (url.origin !== steadyOrigin || url.pathname !== unknownPath) {
+      return fetchImplementation(input, init);
+    }
+
+    // Steady returns 404 before consuming unknown-route uploads, which can cause EPIPE.
+    const request = new Request(input, init);
+    return fetchImplementation(input, {
+      ...init,
+      headers: request.headers,
+      body: await request.arrayBuffer(),
+    });
+  };
+}

--- a/tests/mock-server-fetch.test.ts
+++ b/tests/mock-server-fetch.test.ts
@@ -1,0 +1,122 @@
+import { vi } from 'vitest';
+
+import { bufferSteadyMultipartUploads } from '../scripts/mock-server-fetch';
+
+const unknownMockRoute = 'http://127.0.0.1:4010/_stainless_unknown_path';
+
+function createMultipartBody(): FormData {
+  const body = new FormData();
+  body.append('default', 'true');
+  body.append('files[]', new File([Uint8Array.from([0, 1, 2, 255])], 'README.md', { type: 'text/plain' }));
+  return body;
+}
+
+describe('bufferSteadyMultipartUploads', () => {
+  test('buffers multipart uploads to the local unknown route without changing their contents or options', async () => {
+    const fetchImplementation = vi.fn<typeof fetch>(async () => new Response(null, { status: 404 }));
+    const fetch = bufferSteadyMultipartUploads(fetchImplementation);
+    const body = createMultipartBody();
+    const controller = new AbortController();
+    const init: RequestInit = {
+      method: 'POST',
+      body,
+      headers: { authorization: 'Bearer test-key', 'x-custom': 'retained' },
+      signal: controller.signal,
+      redirect: 'manual',
+      cache: 'no-store',
+    };
+
+    const response = await fetch(`${unknownMockRoute}?source=test`, init);
+
+    expect(response.status).toBe(404);
+    expect(fetchImplementation).toHaveBeenCalledTimes(1);
+    const [forwardedInput, forwardedInit] = fetchImplementation.mock.calls[0] ?? [];
+    expect(forwardedInput).toBe(`${unknownMockRoute}?source=test`);
+    expect(forwardedInit).toMatchObject({
+      method: 'POST',
+      signal: controller.signal,
+      redirect: 'manual',
+      cache: 'no-store',
+    });
+    expect(forwardedInit?.body).toBeInstanceOf(ArrayBuffer);
+
+    const forwardedHeaders = new Headers(forwardedInit?.headers);
+    expect(forwardedHeaders.get('authorization')).toBe('Bearer test-key');
+    expect(forwardedHeaders.get('x-custom')).toBe('retained');
+    expect(forwardedHeaders.get('content-type')).toMatch(/^multipart\/form-data; boundary=/u);
+
+    const forwardedBody = await new Response(forwardedInit?.body, { headers: forwardedHeaders }).formData();
+    expect(forwardedBody.get('default')).toBe('true');
+    const file = forwardedBody.get('files[]') as File;
+    expect(file.name).toBe('README.md');
+    expect(file.type).toBe('text/plain');
+    expect([...new Uint8Array(await file.arrayBuffer())]).toEqual([0, 1, 2, 255]);
+
+    expect(init.body).toBe(body);
+    expect(init.headers).toEqual({ authorization: 'Bearer test-key', 'x-custom': 'retained' });
+  });
+
+  test.each([
+    ['valid local route', 'http://127.0.0.1:4010/skills'],
+    ['different origin', 'https://example.com/_stainless_unknown_path'],
+    ['different loopback hostname', 'http://localhost:4010/_stainless_unknown_path'],
+    ['different port', 'http://127.0.0.1:4011/_stainless_unknown_path'],
+  ])('forwards multipart uploads unchanged for a %s', async (_description, url) => {
+    const fetchImplementation = vi.fn<typeof fetch>(async () => new Response(null, { status: 204 }));
+    const fetch = bufferSteadyMultipartUploads(fetchImplementation);
+    const init: RequestInit = { method: 'POST', body: createMultipartBody() };
+
+    await fetch(url, init);
+
+    expect(fetchImplementation).toHaveBeenCalledTimes(1);
+    const [forwardedInput, forwardedInit] = fetchImplementation.mock.calls[0] ?? [];
+    expect(forwardedInput).toBe(url);
+    expect(forwardedInit).toBe(init);
+  });
+
+  test('forwards non-multipart requests to the unknown route unchanged', async () => {
+    const fetchImplementation = vi.fn<typeof fetch>(async () => new Response(null, { status: 404 }));
+    const fetch = bufferSteadyMultipartUploads(fetchImplementation);
+    const init: RequestInit = {
+      method: 'POST',
+      body: '{"default":true}',
+      headers: { 'content-type': 'application/json' },
+    };
+
+    await fetch(unknownMockRoute, init);
+
+    expect(fetchImplementation).toHaveBeenCalledWith(unknownMockRoute, init);
+    expect(fetchImplementation.mock.calls[0]?.[1]).toBe(init);
+  });
+
+  test('forwards data URLs unchanged', async () => {
+    const fetchImplementation = vi.fn<typeof fetch>(async () => new Response(''));
+    const fetch = bufferSteadyMultipartUploads(fetchImplementation);
+
+    await fetch('data:,');
+
+    expect(fetchImplementation).toHaveBeenCalledWith('data:,', undefined);
+  });
+
+  test('preserves Request inputs and their existing headers when buffering multipart bodies', async () => {
+    const fetchImplementation = vi.fn<typeof fetch>(async () => new Response(null, { status: 404 }));
+    const fetch = bufferSteadyMultipartUploads(fetchImplementation);
+    const input = new Request(unknownMockRoute, {
+      method: 'POST',
+      headers: { 'x-request-header': 'retained' },
+      redirect: 'manual',
+    });
+    const init: RequestInit = { body: createMultipartBody() };
+
+    await fetch(input, init);
+
+    const [forwardedInput, forwardedInit] = fetchImplementation.mock.calls[0] ?? [];
+    expect(forwardedInput).toBe(input);
+    expect(new Headers(forwardedInit?.headers).get('x-request-header')).toBe('retained');
+    expect(forwardedInit?.body).toBeInstanceOf(ArrayBuffer);
+
+    const forwardedRequest = new Request(input, forwardedInit);
+    expect(forwardedRequest.method).toBe('POST');
+    expect(forwardedRequest.redirect).toBe('manual');
+  });
+});

--- a/tests/test-script.test.ts
+++ b/tests/test-script.test.ts
@@ -118,6 +118,7 @@ printf '%s\\0' "$@" > "$VITEST_ARGS_FILE"
   }
 
   test('keeps Jest limited to the canonical generated suites without a Vitest compatibility layer', () => {
+    expect(jestConfig.setupFiles).toEqual(['<rootDir>/scripts/jest-setup.ts']);
     expect(jestConfig.testMatch).toEqual(
       generatedTestPatterns.map(
         (pattern) => `<rootDir>/${pattern}${pattern.endsWith('.test.ts') ? '' : '/**/*.test.ts'}`,


### PR DESCRIPTION
## Summary

- Stabilize the generated Skills and Skill Versions request-options tests on Node.js 22.
- Buffer multipart uploads only for Steady's intentional `http://127.0.0.1:4010/_stainless_unknown_path` endpoint before forwarding them to the real `fetch` implementation.
- Keep generated tests, production SDK behavior, normal mock-server requests, and external test servers unchanged.

## Root cause

The generated Skills creation tests upload multipart `FormData` to an intentionally nonexistent route and expect `OpenAI.NotFoundError`. Steady sends HTTP 404 immediately when route matching fails, without consuming the request body.

On Node.js 22, Undici can still be writing the multipart upload when Steady closes the connection. That race produces `write EPIPE`, which the SDK correctly surfaces as `APIConnectionError` instead of the expected 404. The suite already runs with `--runInBand`, so limiting Jest workers does not fix the underlying transport race.

Example failure: https://github.com/openai/openai-node/actions/runs/31858956264/job/94948704693

## Fix

Register a generated-Jest-only setup file that wraps `globalThis.fetch`. The wrapper buffers the request only when its body is `FormData`, its origin is exactly `http://127.0.0.1:4010`, and its pathname is exactly `/_stainless_unknown_path`.

It builds a `Request`, reads the complete multipart payload into an `ArrayBuffer`, preserves the generated multipart boundary and original headers/options, and forwards the buffered bytes to the original fetch implementation. Steady still receives the real HTTP request and returns its real HTTP 404.

Handwritten regression coverage verifies multipart file bytes, fields, filenames, MIME types, headers, boundaries, query strings, request options, existing `Request` inputs, and unchanged handling of other routes, hosts, ports, JSON bodies, and `data:` requests.

## Verification

- Node.js 22.23.2 transport stress test: **17 failures / 200 requests before; 1,000 successful requests / 1,000 after**.
- Both previously flaky generated test suites: **16 consecutive Node.js 22 runs passed**.
- Full `./scripts/test` on Node.js 22.23.2 against current `main`: **2,704 handwritten tests and 559 generated tests passed**; one existing generated test remains skipped.
- Focused harness regression suite: **35 tests passed**.
- `pnpm lint` passed.
- `pnpm exec tsc --noEmit` passed.