### PR TITLE
fix(bedrock): safely sign inherited query parameter names

### DIFF
--- a/src/providers/bedrock/aws.ts
+++ b/src/providers/bedrock/aws.ts
@@ -101,8 +101,14 @@ function validateStaticCredentials(options: BedrockProviderOptions): AwsCredenti
 }
 
 function requestTarget(parsedURL: URL): { path: string; query: Record<string, string | string[]> } {
-  const query: Record<string, string | string[]> = {};
+  const query: Record<string, string | string[]> = Object.create(null);
   for (const [name, value] of parsedURL.searchParams) {
+    if (name === '__proto__') {
+      throw new Errors.OpenAIError(
+        'The Bedrock SigV4 signer cannot safely sign a `__proto__` query parameter.',
+      );
+    }
+
     const existing = query[name];
     if (existing === undefined) {
       query[name] = value;
@@ -217,6 +223,7 @@ class BedrockSigV4Auth implements BedrockRequestAuth {
 
     const method = (request.method ?? 'GET').toUpperCase();
     const body = signableBody(request.body);
+    const target = requestTarget(parsedURL);
 
     let signed: { headers: Record<string, string> };
     try {
@@ -225,7 +232,7 @@ class BedrockSigV4Auth implements BedrockRequestAuth {
         hostname: parsedURL.hostname,
         ...(parsedURL.port ? { port: Number(parsedURL.port) } : {}),
         method,
-        ...requestTarget(parsedURL),
+        ...target,
         headers: Object.fromEntries(headers.entries()),
         ...(body === undefined ? {} : { body }),
       });

--- a/tests/lib/bedrock-provider-query-safety.test.ts
+++ b/tests/lib/bedrock-provider-query-safety.test.ts
@@ -1,0 +1,179 @@
+import { getCanonicalQuery, SignatureV4 } from '@smithy/signature-v4';
+import { vi } from 'vitest';
+
+import OpenAI from 'openai';
+import type { RequestInfo, RequestInit } from 'openai/internal/builtin-types';
+import { configureProvider } from 'openai/internal/provider';
+import type { Provider } from 'openai/internal/provider';
+import type { FinalizedRequestInit } from 'openai/internal/types';
+import { bedrock } from 'openai/providers/bedrock/aws';
+
+type Endpoint = 'mantle' | 'runtime';
+
+const endpointCases = [
+  { endpoint: 'mantle', signingService: 'bedrock-mantle' },
+  { endpoint: 'runtime', signingService: 'bedrock' },
+] as const;
+
+const inheritedQueryNames = [
+  'constructor',
+  'toString',
+  'valueOf',
+  'hasOwnProperty',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+  'toLocaleString',
+] as const;
+
+const rejectedPrototypeQueries = [
+  '__proto__=unsafe',
+  '%5F%5Fproto%5F%5F=unsafe',
+  '%5f%5fproto%5f%5f=unsafe',
+  'ordinary=safe&__proto__=unsafe',
+] as const;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function staticProvider(endpoint: Endpoint): Provider {
+  return bedrock({
+    endpoint,
+    region: 'us-east-1',
+    baseURL: null,
+    apiKey: null,
+    accessKeyId: 'access-key',
+    secretAccessKey: 'secret-key',
+  });
+}
+
+function mockFetch() {
+  return vi.fn(async (_url: RequestInfo, _init?: RequestInit) => Response.json({ ok: true }));
+}
+
+function firstSignedRequest(calls: Parameters<SignatureV4['sign']>[]) {
+  const [firstCall] = calls;
+  if (!firstCall) {
+    throw new Error('Expected the Bedrock request to be signed.');
+  }
+  const [request] = firstCall;
+  return request;
+}
+
+describe('Bedrock SigV4 query parameter safety', () => {
+  test.each(
+    endpointCases.flatMap(({ endpoint, signingService }) =>
+      inheritedQueryNames.map((queryName) => ({ endpoint, signingService, queryName })),
+    ),
+  )(
+    'signs $endpoint requests with the inherited $queryName query name',
+    async ({ endpoint, signingService, queryName }) => {
+      const sign = vi.spyOn(SignatureV4.prototype, 'sign');
+      const fetch = mockFetch();
+      const client = new OpenAI({
+        provider: staticProvider(endpoint),
+        fetch,
+        maxRetries: 0,
+      });
+
+      await client.request({ method: 'get', path: `/models?${queryName}=safe-value` });
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(sign).toHaveBeenCalledTimes(1);
+
+      const signedRequest = firstSignedRequest(sign.mock.calls);
+      expect(signedRequest.query).toEqual({ [queryName]: 'safe-value' });
+      expect(getCanonicalQuery(signedRequest)).toBe(`${queryName}=safe-value`);
+      expect(Object.getPrototypeOf(signedRequest.query ?? {})).toBeNull();
+
+      const authorization = new Headers(fetch.mock.calls[0]?.[1]?.headers).get('authorization');
+      expect(authorization).toContain('AWS4-HMAC-SHA256');
+      expect(authorization).toContain(`/us-east-1/${signingService}/aws4_request`);
+    },
+  );
+
+  test.each(endpointCases)(
+    'preserves duplicate inherited query names at the $endpoint signing boundary',
+    async ({ endpoint, signingService }) => {
+      const sign = vi.spyOn(SignatureV4.prototype, 'sign');
+      const runtime = configureProvider(staticProvider(endpoint));
+      const request: FinalizedRequestInit = { method: 'GET', headers: new Headers() };
+
+      await runtime.prepareRequest?.(request, {
+        url: `${runtime.baseURL}/models?constructor=first&constructor=second&toString=alpha&toString=beta`,
+        options: { method: 'get', path: '/models' },
+      });
+
+      expect(sign).toHaveBeenCalledTimes(1);
+
+      const signedRequest = firstSignedRequest(sign.mock.calls);
+      expect(signedRequest.query).toEqual({
+        constructor: ['first', 'second'],
+        toString: ['alpha', 'beta'],
+      });
+      expect(getCanonicalQuery(signedRequest)).toBe(
+        'constructor=first&constructor=second&toString=alpha&toString=beta',
+      );
+      expect(request.headers.get('authorization')).toContain(`/us-east-1/${signingService}/aws4_request`);
+    },
+  );
+
+  test.each(endpointCases)(
+    'keeps ordinary query parameters and valid signatures for $endpoint',
+    async ({ endpoint, signingService }) => {
+      const sign = vi.spyOn(SignatureV4.prototype, 'sign');
+      const fetch = mockFetch();
+      const client = new OpenAI({
+        provider: staticProvider(endpoint),
+        fetch,
+        maxRetries: 0,
+      });
+
+      await client.request({
+        method: 'get',
+        path: '/models?ordinary=one&constructorSafe=two&prototype=three',
+      });
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(getCanonicalQuery(firstSignedRequest(sign.mock.calls))).toBe(
+        'constructorSafe=two&ordinary=one&prototype=three',
+      );
+      expect(new Headers(fetch.mock.calls[0]?.[1]?.headers).get('authorization')).toContain(
+        `/us-east-1/${signingService}/aws4_request`,
+      );
+    },
+  );
+
+  test.each(
+    endpointCases.flatMap(({ endpoint }) => rejectedPrototypeQueries.map((query) => ({ endpoint, query }))),
+  )(
+    'rejects $endpoint query $query before resolving AWS credentials or sending',
+    async ({ endpoint, query }) => {
+      const sign = vi.spyOn(SignatureV4.prototype, 'sign');
+      const credentialProvider = vi.fn(async () => ({
+        accessKeyId: 'rotating-access-key',
+        secretAccessKey: 'rotating-secret-key',
+      }));
+      const fetch = mockFetch();
+      const client = new OpenAI({
+        provider: bedrock({
+          endpoint,
+          region: 'us-east-1',
+          baseURL: null,
+          apiKey: null,
+          credentialProvider,
+        }),
+        fetch,
+        maxRetries: 0,
+      });
+
+      await expect(client.request({ method: 'get', path: `/models?${query}` })).rejects.toThrow(
+        'The Bedrock SigV4 signer cannot safely sign a `__proto__` query parameter.',
+      );
+
+      expect(sign).not.toHaveBeenCalled();
+      expect(credentialProvider).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalled();
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- Build Bedrock SigV4 query parameters in a null-prototype dictionary so valid query names such as `constructor`, `toString`, and `valueOf` are signed correctly instead of crashing with a misleading AWS credential error.
- Reject decoded `__proto__` parameters before invoking the signer, rotating credential provider, or fetch. Smithy's canonical query serializer cannot safely represent that name and would otherwise produce `[object Object]`.
- Resolve the request target before the credential-signing error wrapper so unsupported input produces a deterministic, actionable `OpenAIError`.
- Preserve Mantle/Runtime signing services, regions, credentials, origin checks, request bodies, headers, ordinary parameters, and repeated query values at the provider signing boundary.

## Regression coverage

The focused handwritten suite adds 26 cases covering both Mantle and Runtime, seven inherited property names, real SigV4 authorization and canonical queries, repeated signing-boundary values, ordinary controls, and raw/percent-encoded `__proto__` rejection without credential resolution or network calls.

Regression-first verification on unchanged main produced **24 failing cases and 2 passing controls**; all 26 pass with the fix.

## Verification

- Node 26 focused Bedrock suites: **213 tests passed**.
- Node 22 focused Bedrock suites: **213 tests passed**.
- `pnpm test:unit`: **96 files, 2,900 tests passed**.
- `pnpm lint`: passed.
- `pnpm exec tsc --noEmit`: passed.
- `pnpm build`: passed.
- `node ./node_modules/typescript-4-9/bin/tsc --project dist/src/tsconfig.json --noEmit`: passed.
- `node ./node_modules/typescript/bin/tsc --project dist/src/tsconfig.json --noEmit`: passed.
- `node --experimental-strip-types scripts/test-packed-package.ts`: passed CommonJS, ESM, and 266/303 source checks across 1,212 source maps.
- `pnpm exec publint dist`: passed with the existing unrelated vendored-default-export warning.
