### PR TITLE
fix: reject non-JSON-native Zod v3 structured outputs

### DIFF
--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -54,6 +54,15 @@ import type { JsonSchema7UnknownType } from './parsers/unknown';
 import { parseUnknownDef } from './parsers/unknown';
 import type { Refs, Seen } from './Refs';
 import { parseReadonlyDef } from './parsers/readonly';
+import {
+  acceptsEveryJSONNumber,
+  acceptsJSONNumber,
+  acceptsUnsafeJSONInteger,
+  convertsJSONPipelineInput,
+  capturesUnsafeBigIntInput,
+  producesBigIntAtPath,
+  producesBigIntOutput,
+} from './schema-capabilities';
 import { ignoreOverride } from './Options';
 import { zodDef } from './util';
 
@@ -101,12 +110,19 @@ const hasJSONInputPreprocessor = (refs: Refs): boolean =>
   (refs as PreprocessedRefs)[jsonInputPreprocessor] === true;
 const registeredDefinitionInputContexts = new WeakMap<Seen, 'preprocessed' | 'unprocessed' | 'mixed'>();
 
-const recordDefinitionInputContext = (def: ZodTypeDef, seen: Seen, refs: Refs, preprocessed: boolean) => {
-  const definitionName = seen.path[refs.basePath.length + 1];
+const recordDefinitionInputContext = (
+  def: ZodTypeDef,
+  seen: Seen,
+  refs: Refs,
+  preprocessed: boolean,
+  extractedDefinitionName?: string,
+) => {
+  const definitionName = extractedDefinitionName ?? seen.path[refs.basePath.length + 1];
   const definition = definitionName === undefined ? undefined : refs.definitions[definitionName];
   if (
-    seen.path.length !== refs.basePath.length + 2 ||
-    seen.path[refs.basePath.length] !== refs.definitionPath ||
+    (extractedDefinitionName === undefined &&
+      (seen.path.length !== refs.basePath.length + 2 ||
+        seen.path[refs.basePath.length] !== refs.definitionPath)) ||
     definitionName === undefined ||
     definition === undefined ||
     !hasOwn(refs.definitions, definitionName) ||
@@ -153,150 +169,6 @@ const requiresJSONInputPreprocessor = (def: ZodTypeDef): boolean => {
       return false;
     }
   }
-};
-
-const producesBigIntOutput = (def: any, seen = new Set<ZodTypeDef>()): boolean => {
-  if (seen.has(def)) {
-    return false;
-  }
-  seen.add(def);
-
-  switch (def.typeName as ZodFirstPartyTypeKind) {
-    case ZodFirstPartyTypeKind.ZodBigInt: {
-      return true;
-    }
-    case ZodFirstPartyTypeKind.ZodLiteral: {
-      return typeof def.value === 'bigint';
-    }
-    case ZodFirstPartyTypeKind.ZodNullable:
-    case ZodFirstPartyTypeKind.ZodOptional:
-    case ZodFirstPartyTypeKind.ZodDefault:
-    case ZodFirstPartyTypeKind.ZodCatch:
-    case ZodFirstPartyTypeKind.ZodReadonly: {
-      return producesBigIntOutput(def.innerType._def, seen);
-    }
-    case ZodFirstPartyTypeKind.ZodBranded: {
-      return producesBigIntOutput(def.type._def, seen);
-    }
-    case ZodFirstPartyTypeKind.ZodEffects: {
-      return producesBigIntOutput(def.schema._def, seen);
-    }
-    case ZodFirstPartyTypeKind.ZodPipeline: {
-      return producesBigIntOutput(def.out._def, seen);
-    }
-    case ZodFirstPartyTypeKind.ZodLazy: {
-      return producesBigIntOutput(def.getter()._def, seen);
-    }
-    case ZodFirstPartyTypeKind.ZodIntersection: {
-      return (
-        producesBigIntOutput(def.left._def, new Set(seen)) ||
-        producesBigIntOutput(def.right._def, new Set(seen))
-      );
-    }
-    case ZodFirstPartyTypeKind.ZodUnion:
-    case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
-      const options = def.options instanceof Map ? [...def.options.values()] : def.options;
-      return options.some((option: { _def: ZodTypeDef }) => producesBigIntOutput(option._def, new Set(seen)));
-    }
-    default: {
-      return false;
-    }
-  }
-};
-
-const acceptsJSONNumber = (def: any, seen = new Set<ZodTypeDef>()): boolean => {
-  if (seen.has(def)) {
-    return false;
-  }
-  seen.add(def);
-
-  switch (def.typeName as ZodFirstPartyTypeKind) {
-    case ZodFirstPartyTypeKind.ZodNumber:
-    case ZodFirstPartyTypeKind.ZodAny:
-    case ZodFirstPartyTypeKind.ZodUnknown: {
-      return true;
-    }
-    case ZodFirstPartyTypeKind.ZodLiteral: {
-      return typeof def.value === 'number';
-    }
-    case ZodFirstPartyTypeKind.ZodNativeEnum: {
-      return Object.values(def.values).some((value) => typeof value === 'number');
-    }
-    case ZodFirstPartyTypeKind.ZodNullable:
-    case ZodFirstPartyTypeKind.ZodOptional:
-    case ZodFirstPartyTypeKind.ZodDefault:
-    case ZodFirstPartyTypeKind.ZodCatch:
-    case ZodFirstPartyTypeKind.ZodReadonly: {
-      return acceptsJSONNumber(def.innerType._def, seen);
-    }
-    case ZodFirstPartyTypeKind.ZodBranded: {
-      return acceptsJSONNumber(def.type._def, seen);
-    }
-    case ZodFirstPartyTypeKind.ZodEffects: {
-      return def.effect.type === 'preprocess' || acceptsJSONNumber(def.schema._def, seen);
-    }
-    case ZodFirstPartyTypeKind.ZodPipeline: {
-      return acceptsJSONNumber(def.in._def, seen);
-    }
-    case ZodFirstPartyTypeKind.ZodLazy: {
-      return acceptsJSONNumber(def.getter()._def, seen);
-    }
-    case ZodFirstPartyTypeKind.ZodPromise: {
-      return acceptsJSONNumber(def.type._def, seen);
-    }
-    case ZodFirstPartyTypeKind.ZodIntersection: {
-      return (
-        acceptsJSONNumber(def.left._def, new Set(seen)) && acceptsJSONNumber(def.right._def, new Set(seen))
-      );
-    }
-    case ZodFirstPartyTypeKind.ZodUnion:
-    case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
-      const options = def.options instanceof Map ? [...def.options.values()] : def.options;
-      return options.some((option: { _def: ZodTypeDef }) => acceptsJSONNumber(option._def, new Set(seen)));
-    }
-    default: {
-      return def.coerce === true;
-    }
-  }
-};
-
-const convertsJSONPipelineInput = (def: any, output: any): boolean => {
-  if (def.typeName === ZodFirstPartyTypeKind.ZodEffects) {
-    return (
-      def.effect.type === 'transform' ||
-      def.effect.type === 'preprocess' ||
-      convertsJSONPipelineInput(def.schema._def, output)
-    );
-  }
-
-  if (def.typeName === ZodFirstPartyTypeKind.ZodPipeline) {
-    return convertsJSONPipelineInput(def.in._def, output) || convertsJSONPipelineInput(def.out._def, output);
-  }
-
-  const inner = def.innerType?._def ?? def.type?._def;
-  if (inner) {
-    return convertsJSONPipelineInput(inner, output);
-  }
-
-  const outputInner = output.innerType?._def ?? output.type?._def;
-  return outputInner
-    ? convertsJSONPipelineInput(def, outputInner)
-    : def.coerce === true && def.typeName === output.typeName;
-};
-
-const hasJSONIntegerBranch = (schema: unknown): boolean => {
-  if (!schema || typeof schema !== 'object') {
-    return false;
-  }
-
-  const record = schema as Record<string, unknown>;
-  const { type } = record;
-  if (type === 'integer' || (Array.isArray(type) && type.includes('integer'))) {
-    return true;
-  }
-
-  const branches = record['anyOf'] ?? record['allOf'];
-  return Array.isArray(branches) && branches.some((branch) => hasJSONIntegerBranch(branch));
 };
 
 export function parseDef(
@@ -430,6 +302,9 @@ const get$ref = (
         if (!hasOwn(refs.definitions, name)) {
           refs.definitions[name] = item.def;
         }
+        if (refs.openaiStrictMode) {
+          recordDefinitionInputContext(item.def, item, refs, hasJSONInputPreprocessor(refs), name);
+        }
       }
 
       return { $ref: [...refs.basePath, refs.definitionPath, name].join('/') };
@@ -498,11 +373,16 @@ const normalizeStrictBigIntValue = (value: bigint, keyword: string, refs: Refs):
 
 const normalizeStrictDefaultValue = (
   value: unknown,
+  definition: ZodTypeDef,
   refs: Refs,
   keyword = 'default',
   seen = new WeakMap<object, unknown>(),
+  path: readonly (string | number)[] = [],
 ): unknown => {
   if (typeof value === 'bigint') {
+    if (!producesBigIntAtPath(definition, path)) {
+      throwUnrepresentableStrictZodType(ZodFirstPartyTypeKind.ZodBigInt, refs);
+    }
     return normalizeStrictBigIntValue(value, keyword, refs);
   }
   if (!value || typeof value !== 'object') {
@@ -520,7 +400,14 @@ const normalizeStrictDefaultValue = (
     let changed = false;
 
     for (const [index, item] of value.entries()) {
-      const normalizedItem = normalizeStrictDefaultValue(item, refs, `${keyword}[${index}]`, seen);
+      const normalizedItem = normalizeStrictDefaultValue(
+        item,
+        definition,
+        refs,
+        `${keyword}[${index}]`,
+        seen,
+        [...path, index],
+      );
       normalized.push(normalizedItem);
       changed ||= normalizedItem !== item;
     }
@@ -541,7 +428,10 @@ const normalizeStrictDefaultValue = (
   seen.set(value, normalized);
   let changed = false;
   for (const [key, item] of Object.entries(value)) {
-    const normalizedItem = normalizeStrictDefaultValue(item, refs, `${keyword}.${key}`, seen);
+    const normalizedItem = normalizeStrictDefaultValue(item, definition, refs, `${keyword}.${key}`, seen, [
+      ...path,
+      key,
+    ]);
     Object.defineProperty(normalized, key, {
       value: normalizedItem,
       configurable: true,
@@ -626,7 +516,7 @@ const selectParser = (
     case ZodFirstPartyTypeKind.ZodUnion:
     case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
       const options = (def.options instanceof Map ? [...def.options.values()] : def.options) as {
-        _def: {
+        _def: ZodTypeDef & {
           typeName: ZodFirstPartyTypeKind;
           value?: unknown;
         };
@@ -640,9 +530,14 @@ const selectParser = (
       if (refs.openaiStrictMode && (bigintIndex !== -1 || hasBigIntLiteral)) {
         const branches = options
           .map((option, index) => {
-            const boundNumber = bigintIndex !== -1 && index > bigintIndex && acceptsJSONNumber(option._def);
+            const fallibleNumber = !acceptsEveryJSONNumber(option._def);
+            const boundNumber =
+              bigintIndex !== -1 &&
+              !producesBigIntOutput(option._def) &&
+              acceptsJSONNumber(option._def) &&
+              (index > bigintIndex || fallibleNumber);
             const branch = parseDef(
-              option._def as ZodTypeDef,
+              option._def,
               {
                 ...refs,
                 currentPath: [...refs.currentPath, 'anyOf', String(index)],
@@ -654,27 +549,47 @@ const selectParser = (
               return branch;
             }
 
+            const competingBigInts = options.filter(
+              (candidate, candidateIndex) =>
+                candidateIndex !== index &&
+                producesBigIntOutput(candidate._def) &&
+                (candidateIndex < index || fallibleNumber),
+            );
+            const minimum =
+              competingBigInts.some((candidate) => capturesUnsafeBigIntInput(candidate._def, 'minimum')) &&
+              (acceptsUnsafeJSONInteger(branch, 'minimum') || (!('type' in branch) && !('$ref' in branch)));
+            const maximum =
+              competingBigInts.some((candidate) => capturesUnsafeBigIntInput(candidate._def, 'maximum')) &&
+              (acceptsUnsafeJSONInteger(branch, 'maximum') || (!('type' in branch) && !('$ref' in branch)));
+            if (!minimum && !maximum) {
+              return branch;
+            }
+
             if ('$ref' in branch) {
               return {
                 allOf: [
                   branch,
                   {
-                    minimum: Number.MIN_SAFE_INTEGER,
-                    maximum: Number.MAX_SAFE_INTEGER,
+                    ...(minimum ? { minimum: Number.MIN_SAFE_INTEGER } : undefined),
+                    ...(maximum ? { maximum: Number.MAX_SAFE_INTEGER } : undefined),
                   } as JsonSchema7Type,
                 ],
               };
             }
 
             const record = branch as unknown as Record<string, unknown>;
-            record['minimum'] = Math.max(
-              typeof record['minimum'] === 'number' ? record['minimum'] : Number.MIN_SAFE_INTEGER,
-              Number.MIN_SAFE_INTEGER,
-            );
-            record['maximum'] = Math.min(
-              typeof record['maximum'] === 'number' ? record['maximum'] : Number.MAX_SAFE_INTEGER,
-              Number.MAX_SAFE_INTEGER,
-            );
+            if (minimum) {
+              record['minimum'] = Math.max(
+                typeof record['minimum'] === 'number' ? record['minimum'] : Number.MIN_SAFE_INTEGER,
+                Number.MIN_SAFE_INTEGER,
+              );
+            }
+            if (maximum) {
+              record['maximum'] = Math.min(
+                typeof record['maximum'] === 'number' ? record['maximum'] : Number.MAX_SAFE_INTEGER,
+                Number.MAX_SAFE_INTEGER,
+              );
+            }
             return branch;
           })
           .filter(
@@ -773,15 +688,7 @@ const selectParser = (
     case ZodFirstPartyTypeKind.ZodDefault: {
       const schema = parseDefaultDef(def, refs, forceResolution);
       if (refs.openaiStrictMode) {
-        if (
-          typeof schema.default === 'bigint' &&
-          !hasJSONIntegerBranch(schema) &&
-          !producesBigIntOutput(def.innerType._def)
-        ) {
-          throwUnrepresentableStrictZodType(ZodFirstPartyTypeKind.ZodBigInt, refs);
-        }
-
-        schema.default = normalizeStrictDefaultValue(schema.default, refs);
+        schema.default = normalizeStrictDefaultValue(schema.default, def.innerType._def, refs);
       }
 
       return schema;
@@ -793,6 +700,13 @@ const selectParser = (
       return parseReadonlyDef(def, refs, forceResolution);
     }
     case ZodFirstPartyTypeKind.ZodCatch: {
+      if (refs.openaiStrictMode) {
+        const catchRefs: PreprocessedRefs = {
+          ...refs,
+          [jsonInputPreprocessor]: true,
+        };
+        return parseCatchDef(def, catchRefs, forceResolution);
+      }
       return parseCatchDef(def, refs, forceResolution);
     }
     case ZodFirstPartyTypeKind.ZodPipeline: {

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -107,8 +107,13 @@ export type JsonSchema7Type = JsonSchema7TypeUnion & JsonSchema7Meta;
 
 const jsonInputPreprocessor = Symbol('openaiJsonInputPreprocessor');
 const constrainedReferenceContext = Symbol('openaiConstrainedReferenceContext');
+const expectedPipelineOutput = Symbol('openaiExpectedPipelineOutput');
 
-type PreprocessedRefs = Refs & { [jsonInputPreprocessor]?: true; [constrainedReferenceContext]?: true };
+type PreprocessedRefs = Refs & {
+  [jsonInputPreprocessor]?: true;
+  [constrainedReferenceContext]?: true;
+  [expectedPipelineOutput]?: ZodTypeDef;
+};
 
 const hasJSONInputPreprocessor = (refs: Refs): boolean =>
   (refs as PreprocessedRefs)[jsonInputPreprocessor] === true;
@@ -468,10 +473,7 @@ const normalizeStrictDefaultValue = (
 
 const isNumericSchemaType = (type: unknown) => type === 'number' || type === 'integer';
 
-const mergeStrictScalarSchemas = (
-  left: JsonSchema7Type,
-  right: JsonSchema7Type,
-): JsonSchema7Type | undefined => {
+const mergeStrictSchemas = (left: JsonSchema7Type, right: JsonSchema7Type): JsonSchema7Type | undefined => {
   const first = left as Record<string, unknown>;
   const second = right as Record<string, unknown>;
   if (
@@ -487,10 +489,47 @@ const mergeStrictScalarSchemas = (
   for (const [keyword, value] of Object.entries(second)) {
     if (value === undefined || merged[keyword] === undefined || Object.is(merged[keyword], value)) {
       merged[keyword] = value;
-    } else if (keyword === 'minimum' || keyword === 'exclusiveMinimum' || keyword === 'minLength') {
+    } else if (
+      keyword === 'minimum' ||
+      keyword === 'exclusiveMinimum' ||
+      keyword === 'minLength' ||
+      keyword === 'minItems'
+    ) {
       merged[keyword] = Math.max(merged[keyword] as number, value as number);
-    } else if (keyword === 'maximum' || keyword === 'exclusiveMaximum' || keyword === 'maxLength') {
+    } else if (
+      keyword === 'maximum' ||
+      keyword === 'exclusiveMaximum' ||
+      keyword === 'maxLength' ||
+      keyword === 'maxItems'
+    ) {
       merged[keyword] = Math.min(merged[keyword] as number, value as number);
+    } else if (keyword === 'properties' && value && typeof value === 'object') {
+      const original = merged[keyword] as Record<string, JsonSchema7Type>;
+      const properties = value as Record<string, JsonSchema7Type>;
+      if (Object.keys(original).length !== Object.keys(properties).length) {
+        return undefined;
+      }
+      const combined: Record<string, JsonSchema7Type> = {};
+      for (const [name, property] of Object.entries(properties)) {
+        const existing = original[name];
+        if (!hasOwn(original, name) || !existing) {
+          return undefined;
+        }
+        const nested = mergeStrictSchemas(existing, property);
+        if (!nested) {
+          return undefined;
+        }
+        combined[name] = nested;
+      }
+      merged[keyword] = combined;
+    } else if (keyword === 'items' && value && typeof value === 'object' && !Array.isArray(value)) {
+      const nested = mergeStrictSchemas(merged[keyword] as JsonSchema7Type, value as JsonSchema7Type);
+      if (!nested) {
+        return undefined;
+      }
+      merged[keyword] = nested;
+    } else if (keyword === 'required' && Array.isArray(merged[keyword]) && Array.isArray(value)) {
+      merged[keyword] = [...new Set([...(merged[keyword] as string[]), ...(value as string[])])];
     } else if (keyword === 'type' && isNumericSchemaType(merged[keyword]) && isNumericSchemaType(value)) {
       merged[keyword] = 'integer';
     } else {
@@ -666,7 +705,7 @@ const selectParser = (
         if (!merged) {
           break;
         }
-        merged = mergeStrictScalarSchemas(merged, next);
+        merged = mergeStrictSchemas(merged, next);
       }
       return merged ?? schema;
     }
@@ -726,6 +765,9 @@ const selectParser = (
       return parseDef(def.getter()._def, refs, forceResolution);
     }
     case ZodFirstPartyTypeKind.ZodPromise: {
+      if (refs.openaiStrictMode && !refs.currentPath.includes('anyOf')) {
+        throwUnrepresentableStrictZodType(ZodFirstPartyTypeKind.ZodPromise, refs);
+      }
       return parsePromiseDef(def, refs, forceResolution);
     }
     case ZodFirstPartyTypeKind.ZodNaN:
@@ -742,11 +784,28 @@ const selectParser = (
         return parseEffectsDef(def, preprocessedRefs, forceResolution);
       }
 
-      const boundNumericTransform =
+      const numericTransform =
         refs.openaiStrictMode === true &&
         def.effect?.type === 'transform' &&
         acceptsJSONNumber(def.schema._def);
-      const schema = parseEffectsDef(def, refs, forceResolution || boundNumericTransform);
+      const expectedOutput = (refs as PreprocessedRefs)[expectedPipelineOutput];
+      const transform = def.effect?.transform as unknown;
+      const boundNumericTransform =
+        numericTransform &&
+        (transform === BigInt || (expectedOutput && producesBigIntOutput(expectedOutput)));
+      if (
+        numericTransform &&
+        !expectedOutput &&
+        !boundNumericTransform &&
+        transform !== String &&
+        transform !== Number &&
+        transform !== Boolean
+      ) {
+        throw new Error(
+          `ZodEffects numeric transform at \`${refs.currentPath.join('/')}\` has no inspectable output type for strict Structured Outputs.`,
+        );
+      }
+      const schema = parseEffectsDef(def, refs, forceResolution || boundNumericTransform === true);
       return boundNumericTransform && schema !== undefined ? applySafeIntegerBounds(schema) : schema;
     }
     case ZodFirstPartyTypeKind.ZodAny: {
@@ -784,14 +843,44 @@ const selectParser = (
         const outputRefs: PreprocessedRefs = convertsJSONPipelineInput(def.in._def, def.out._def)
           ? { ...refs, [jsonInputPreprocessor]: true as const }
           : refs;
-        const output = parseDef(def.out._def, {
+        const outputPathRefs: PreprocessedRefs = {
           ...outputRefs,
           currentPath: [...refs.currentPath, 'output'],
-        });
-        const input = parsePipelineDef(def, refs, forceResolution, outputRefs);
-        return input && output && outputRefs === refs
-          ? (mergeStrictScalarSchemas(input, output) ?? input)
-          : input;
+        };
+        let output = parseDef(def.out._def, outputPathRefs);
+        if (output && '$ref' in output) {
+          output = parseDef(def.out._def, outputPathRefs, true);
+        }
+        const inputRefs: PreprocessedRefs =
+          outputRefs === refs ? refs : { ...refs, [expectedPipelineOutput]: def.out._def };
+        const input = parsePipelineDef(def, inputRefs, forceResolution, outputRefs);
+        if (!input || !output) {
+          return input;
+        }
+
+        const combined = mergeStrictSchemas(input, output);
+        if (combined) {
+          return combined;
+        }
+
+        if (outputRefs !== refs) {
+          const outputDef = def.out._def as ZodTypeDef & {
+            typeName: ZodFirstPartyTypeKind;
+            checks?: unknown[];
+          };
+          const structurallyConstrained =
+            outputDef.typeName === ZodFirstPartyTypeKind.ZodLiteral ||
+            outputDef.typeName === ZodFirstPartyTypeKind.ZodObject ||
+            outputDef.typeName === ZodFirstPartyTypeKind.ZodArray ||
+            (outputDef.checks?.length ?? 0) > 0;
+          if (!structurallyConstrained) {
+            return input;
+          }
+        }
+
+        throw new Error(
+          `ZodPipeline output constraints at \`${refs.currentPath.join('/')}\` cannot be represented in strict Structured Outputs.`,
+        );
       }
 
       return parsePipelineDef(def, refs, forceResolution);

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -93,6 +93,38 @@ export type JsonSchema7TypeUnion =
 
 export type JsonSchema7Type = JsonSchema7TypeUnion & JsonSchema7Meta;
 
+const jsonInputPreprocessor = Symbol('openaiJsonInputPreprocessor');
+
+type PreprocessedRefs = Refs & { [jsonInputPreprocessor]?: true };
+
+const hasJSONInputPreprocessor = (refs: Refs): boolean =>
+  (refs as PreprocessedRefs)[jsonInputPreprocessor] === true;
+
+const requiresJSONInputPreprocessor = (def: ZodTypeDef): boolean => {
+  const schema = def as ZodTypeDef & {
+    typeName: ZodFirstPartyTypeKind;
+    coerce?: boolean;
+    value?: unknown;
+  };
+
+  switch (schema.typeName) {
+    case ZodFirstPartyTypeKind.ZodBigInt:
+    case ZodFirstPartyTypeKind.ZodDate: {
+      return !schema.coerce;
+    }
+    case ZodFirstPartyTypeKind.ZodMap:
+    case ZodFirstPartyTypeKind.ZodSet: {
+      return true;
+    }
+    case ZodFirstPartyTypeKind.ZodLiteral: {
+      return typeof schema.value === 'bigint';
+    }
+    default: {
+      return false;
+    }
+  }
+};
+
 export function parseDef(
   def: ZodTypeDef,
   refs: Refs,
@@ -108,7 +140,27 @@ export function parseDef(
     }
   }
 
-  if (seenItem && !forceResolution) {
+  const needsPreprocessing = refs.openaiStrictMode === true && requiresJSONInputPreprocessor(def);
+  const isPreprocessed = hasJSONInputPreprocessor(refs);
+  if (needsPreprocessing && !isPreprocessed) {
+    const registeredDefinitionPath =
+      seenItem?.jsonSchema === undefined &&
+      seenItem?.path.length === refs.basePath.length + 2 &&
+      seenItem.path[refs.basePath.length] === refs.definitionPath
+        ? seenItem.path
+        : undefined;
+    const diagnosticRefs = registeredDefinitionPath
+      ? { ...refs, currentPath: registeredDefinitionPath }
+      : refs;
+
+    throwUnrepresentableStrictZodType((def as { typeName: ZodFirstPartyTypeKind }).typeName, diagnosticRefs);
+  }
+
+  // A native schema reused by different preprocessors must not be extracted as
+  // a bare definition, because its input-conversion context would be lost.
+  const inlinePreprocessedType = needsPreprocessing && isPreprocessed;
+
+  if (seenItem && !forceResolution && !inlinePreprocessedType) {
     const seenSchema = get$ref(seenItem, refs);
 
     if (seenSchema !== undefined) {
@@ -135,7 +187,7 @@ export function parseDef(
 
     return jsonSchema;
   } finally {
-    if (forceResolution && seenItem) {
+    if ((forceResolution || inlinePreprocessedType) && seenItem) {
       // Materializing a definition temporarily moves it to the definition path. Restore the
       // original path so later references to a shared inner type don't inherit wrapper metadata.
       refs.seen.set(def, seenItem);
@@ -282,21 +334,17 @@ const selectParser = (
       return parseObjectDef(def, refs);
     }
     case ZodFirstPartyTypeKind.ZodBigInt: {
-      if (refs.openaiStrictMode && !def.coerce) {
-        throwUnrepresentableStrictZodType(typeName, refs);
-      }
-
       const schema = parseBigintDef(def, refs);
       if (refs.openaiStrictMode) {
+        const record = schema as unknown as Record<string, unknown>;
         for (const [keyword, value] of Object.entries(schema)) {
           if (typeof value === 'bigint') {
-            (schema as unknown as Record<string, unknown>)[keyword] = normalizeStrictBigIntValue(
-              value,
-              keyword,
-              refs,
-            );
+            record[keyword] = normalizeStrictBigIntValue(value, keyword, refs);
           }
         }
+
+        record['minimum'] ??= Number.MIN_SAFE_INTEGER;
+        record['maximum'] ??= Number.MAX_SAFE_INTEGER;
       }
 
       return schema;
@@ -305,10 +353,6 @@ const selectParser = (
       return parseBooleanDef();
     }
     case ZodFirstPartyTypeKind.ZodDate: {
-      if (refs.openaiStrictMode && !def.coerce) {
-        throwUnrepresentableStrictZodType(typeName, refs);
-      }
-
       return parseDateDef(def, refs);
     }
     case ZodFirstPartyTypeKind.ZodUndefined: {
@@ -322,6 +366,51 @@ const selectParser = (
     }
     case ZodFirstPartyTypeKind.ZodUnion:
     case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
+      const options = (def.options instanceof Map ? [...def.options.values()] : def.options) as {
+        _def: {
+          typeName: ZodFirstPartyTypeKind;
+          value?: unknown;
+        };
+      }[];
+      const bigintIndex = options.findIndex(
+        (option) => option._def.typeName === ZodFirstPartyTypeKind.ZodBigInt,
+      );
+      const hasBigIntLiteral = options.some(
+        (option) =>
+          option._def.typeName === ZodFirstPartyTypeKind.ZodLiteral && typeof option._def.value === 'bigint',
+      );
+
+      if (refs.openaiStrictMode && (bigintIndex !== -1 || hasBigIntLiteral)) {
+        const branches = options
+          .map((option, index) =>
+            parseDef(option._def as ZodTypeDef, {
+              ...refs,
+              currentPath: [...refs.currentPath, 'anyOf', String(index)],
+            }),
+          )
+          .filter(
+            (branch): branch is JsonSchema7Type =>
+              branch !== undefined && (!refs.strictUnions || Object.keys(branch).length > 0),
+          );
+        const numberWinsBeforeBigInt =
+          bigintIndex !== -1 &&
+          options
+            .slice(0, bigintIndex)
+            .some((option) => option._def.typeName === ZodFirstPartyTypeKind.ZodNumber);
+
+        if (bigintIndex !== -1 && !numberWinsBeforeBigInt) {
+          for (const branch of branches) {
+            if ('type' in branch && branch.type === 'number') {
+              const record = branch as unknown as Record<string, unknown>;
+              record['minimum'] ??= Number.MIN_SAFE_INTEGER;
+              record['maximum'] ??= Number.MAX_SAFE_INTEGER;
+            }
+          }
+        }
+
+        return branches.length > 0 ? { anyOf: branches } : undefined;
+      }
+
       return parseUnionDef(def, refs);
     }
     case ZodFirstPartyTypeKind.ZodIntersection: {
@@ -334,7 +423,19 @@ const selectParser = (
       return parseRecordDef(def, refs);
     }
     case ZodFirstPartyTypeKind.ZodLiteral: {
-      return parseLiteralDef(def, refs);
+      const schema = parseLiteralDef(def, refs);
+      if (refs.openaiStrictMode && typeof def.value === 'bigint') {
+        const record = schema as unknown as Record<string, unknown>;
+        const value = normalizeStrictBigIntValue(def.value, 'const', refs);
+        if ('const' in record) {
+          record['const'] = value;
+        }
+        if (Array.isArray(record['enum'])) {
+          record['enum'] = [value];
+        }
+      }
+
+      return schema;
     }
     case ZodFirstPartyTypeKind.ZodEnum: {
       return parseEnumDef(def);
@@ -343,23 +444,28 @@ const selectParser = (
       return parseNativeEnumDef(def);
     }
     case ZodFirstPartyTypeKind.ZodNullable: {
+      if (refs.openaiStrictMode && def.innerType._def.typeName === ZodFirstPartyTypeKind.ZodBigInt) {
+        const inner = parseDef(
+          def.innerType._def,
+          {
+            ...refs,
+            currentPath: [...refs.currentPath, 'anyOf', '0'],
+          },
+          forceResolution,
+        );
+
+        return inner && { anyOf: [inner, { type: 'null' }] };
+      }
+
       return parseNullableDef(def, refs, forceResolution);
     }
     case ZodFirstPartyTypeKind.ZodOptional: {
       return parseOptionalDef(def, refs, forceResolution);
     }
     case ZodFirstPartyTypeKind.ZodMap: {
-      if (refs.openaiStrictMode) {
-        throwUnrepresentableStrictZodType(typeName, refs);
-      }
-
       return parseMapDef(def, refs);
     }
     case ZodFirstPartyTypeKind.ZodSet: {
-      if (refs.openaiStrictMode) {
-        throwUnrepresentableStrictZodType(typeName, refs);
-      }
-
       return parseSetDef(def, refs);
     }
     case ZodFirstPartyTypeKind.ZodLazy: {
@@ -373,6 +479,15 @@ const selectParser = (
       return parseNeverDef();
     }
     case ZodFirstPartyTypeKind.ZodEffects: {
+      if (refs.openaiStrictMode && def.effect?.type === 'preprocess') {
+        const preprocessedRefs: PreprocessedRefs = {
+          ...refs,
+          [jsonInputPreprocessor]: true,
+        };
+
+        return parseEffectsDef(def, preprocessedRefs, forceResolution);
+      }
+
       return parseEffectsDef(def, refs, forceResolution);
     }
     case ZodFirstPartyTypeKind.ZodAny: {

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -504,6 +504,13 @@ const nativeCollectionDefaultType = (
 
 const trustedInternalSlotObjectMethods = [
   { type: 'RegExp', method: Object.getOwnPropertyDescriptor(RegExp.prototype, 'source')?.get },
+  {
+    type: 'URLSearchParams',
+    method:
+      typeof URLSearchParams === 'undefined'
+        ? undefined
+        : Object.getOwnPropertyDescriptor(URLSearchParams.prototype, 'size')?.get,
+  },
   { type: 'ArrayBuffer', method: Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, 'byteLength')?.get },
   {
     type: 'SharedArrayBuffer',
@@ -818,6 +825,86 @@ const mergeStrictNumericMultiples = (first: unknown, second: unknown): number | 
   return expected === actual ? combined : undefined;
 };
 
+type StrictNumberCheck = { kind: string; value?: number; inclusive?: boolean };
+
+const strictNumberBoundKeywords = {
+  min: { inclusive: 'minimum', exclusive: 'exclusiveMinimum' },
+  max: { inclusive: 'maximum', exclusive: 'exclusiveMaximum' },
+} as const;
+
+const normalizeStrictNumberMultiple = (value: number, refs: Refs): number => {
+  assertFiniteStrictSchemaValue(value, 'multipleOf', refs);
+  if (value === 0) {
+    throw new RangeError(
+      `Zod field at \`${refs.currentPath.join('/')}\` uses \`ZodNumber\` and requires a strictly positive \`multipleOf\` value for JSON Structured Outputs.`,
+    );
+  }
+  const normalized = Math.abs(value);
+  if (decimalMultiple(normalized) === undefined) {
+    throw new TypeError(
+      `Zod field at \`${refs.currentPath.join('/')}\` uses \`ZodNumber\` and cannot safely represent its notation-sensitive \`multipleOf\` value in JSON Structured Outputs.`,
+    );
+  }
+  return normalized;
+};
+
+const retainStrictNumberBound = (
+  record: Record<string, unknown>,
+  check: StrictNumberCheck,
+  refs: Refs,
+): void => {
+  if ((check.kind !== 'min' && check.kind !== 'max') || typeof check.value !== 'number') {
+    return;
+  }
+  const keyword =
+    strictNumberBoundKeywords[check.kind][check.inclusive === false ? 'exclusive' : 'inclusive'];
+  if (!Number.isFinite(check.value)) {
+    const vacuous =
+      (check.kind === 'min' && check.value === -Infinity) ||
+      (check.kind === 'max' && check.value === Infinity);
+    if (!vacuous) {
+      assertFiniteStrictSchemaValue(check.value, keyword, refs);
+    }
+    return;
+  }
+  const previous = record[keyword];
+  if (
+    typeof previous !== 'number' ||
+    (check.kind === 'min' ? check.value > previous : check.value < previous)
+  ) {
+    record[keyword] = check.value;
+  }
+};
+
+const retainStrictNumberChecks = (
+  record: Record<string, unknown>,
+  checks: readonly StrictNumberCheck[],
+  refs: Refs,
+): void => {
+  for (const keyword of ['minimum', 'exclusiveMinimum', 'maximum', 'exclusiveMaximum', 'multipleOf']) {
+    Reflect.deleteProperty(record, keyword);
+  }
+  for (const check of checks) {
+    if (check.kind !== 'multipleOf' || typeof check.value !== 'number') {
+      retainStrictNumberBound(record, check, refs);
+      continue;
+    }
+    const multiple = normalizeStrictNumberMultiple(check.value, refs);
+    const existing = record['multipleOf'];
+    if (typeof existing !== 'number') {
+      record['multipleOf'] = multiple;
+      continue;
+    }
+    const combined = mergeStrictNumericMultiples(existing, multiple);
+    if (combined === undefined) {
+      throw new TypeError(
+        `Zod field at \`${refs.currentPath.join('/')}\` uses \`ZodNumber\` and cannot safely combine its \`multipleOf\` constraints in JSON Structured Outputs.`,
+      );
+    }
+    record['multipleOf'] = combined;
+  }
+};
+
 type StrictBigIntCheck = { kind: string; value?: bigint; inclusive?: boolean };
 
 const strictBigIntBoundKeywords = {
@@ -943,15 +1030,92 @@ const mergeStrictSchemas = (left: JsonSchema7Type, right: JsonSchema7Type): Json
   return merged as JsonSchema7Type;
 };
 
+const strictSchemaTypes = (schema: JsonSchema7Type): readonly string[] | undefined => {
+  const value = (schema as Record<string, unknown>)['type'];
+  if (typeof value === 'string') {
+    return [value];
+  }
+  return Array.isArray(value) && value.length > 0 && value.every((item) => typeof item === 'string')
+    ? (value as string[])
+    : undefined;
+};
+
 const hasDisjointStrictSchemaTypes = (first: JsonSchema7Type, second: JsonSchema7Type): boolean => {
-  const left = (first as Record<string, unknown>)['type'];
-  const right = (second as Record<string, unknown>)['type'];
+  const left = strictSchemaTypes(first);
+  const right = strictSchemaTypes(second);
   return (
-    typeof left === 'string' &&
-    typeof right === 'string' &&
-    left !== right &&
-    !(isNumericSchemaType(left) && isNumericSchemaType(right))
+    left !== undefined &&
+    right !== undefined &&
+    left.every((candidate) =>
+      right.every(
+        (alternative) =>
+          candidate !== alternative && !(isNumericSchemaType(candidate) && isNumericSchemaType(alternative)),
+      ),
+    )
   );
+};
+
+type StrictPipelineAlternativeProjection = {
+  alternatives: JsonSchema7Type[];
+  discarded: boolean;
+};
+
+const applyStrictPipelineAlternativeWrapper = (
+  candidate: JsonSchema7Type,
+  wrapper: Record<string, unknown>,
+): JsonSchema7Type | undefined => {
+  if (Object.keys(wrapper).length === 0) {
+    return candidate;
+  }
+  const type = wrapper['type'] ?? (candidate as Record<string, unknown>)['type'];
+  return typeof type === 'string'
+    ? mergeStrictSchemas(candidate, { ...wrapper, type } as JsonSchema7Type)
+    : undefined;
+};
+
+const projectStrictPipelineAlternative = (
+  input: JsonSchema7Type,
+  candidate: JsonSchema7Type,
+  active = new Set<object>(),
+): StrictPipelineAlternativeProjection | undefined => {
+  const combined = mergeStrictSchemas(input, candidate);
+  if (combined) {
+    return { alternatives: [combined], discarded: false };
+  }
+  if (hasDisjointStrictSchemaTypes(input, candidate)) {
+    return { alternatives: [], discarded: true };
+  }
+  const record = candidate as Record<string, unknown>;
+  const nested = record['anyOf'];
+  if (!Array.isArray(nested) || active.has(candidate)) {
+    return undefined;
+  }
+  active.add(candidate);
+  try {
+    const wrapper = Object.fromEntries(Object.entries(record).filter(([key]) => key !== 'anyOf'));
+    const projected: JsonSchema7Type[] = [];
+    let discarded = false;
+    for (const alternative of nested) {
+      if (!alternative || typeof alternative !== 'object' || Array.isArray(alternative)) {
+        return undefined;
+      }
+      const result = projectStrictPipelineAlternative(input, alternative as JsonSchema7Type, active);
+      if (!result) {
+        return undefined;
+      }
+      discarded ||= result.discarded;
+      for (const item of result.alternatives) {
+        const wrapped = applyStrictPipelineAlternativeWrapper(item, wrapper);
+        if (!wrapped) {
+          return undefined;
+        }
+        projected.push(wrapped);
+      }
+    }
+    return { alternatives: projected, discarded };
+  } finally {
+    active.delete(candidate);
+  }
 };
 
 const selectParser = (
@@ -967,6 +1131,7 @@ const selectParser = (
     case ZodFirstPartyTypeKind.ZodNumber: {
       const schema = parseNumberDef(def, refs);
       if (refs.openaiStrictMode) {
+        retainStrictNumberChecks(schema as Record<string, unknown>, def.checks ?? [], refs);
         for (const keyword of [
           'minimum',
           'exclusiveMinimum',
@@ -1440,16 +1605,13 @@ const selectParser = (
           let discarded = false;
           let unprojectable = false;
           for (const alternative of alternatives) {
-            const candidate = alternative as JsonSchema7Type;
-            const combinedAlternative = mergeStrictSchemas(input, candidate);
-            if (combinedAlternative) {
-              projected.push(combinedAlternative);
-            } else if (hasDisjointStrictSchemaTypes(input, candidate)) {
-              discarded = true;
-            } else {
+            const result = projectStrictPipelineAlternative(input, alternative as JsonSchema7Type);
+            if (!result) {
               unprojectable = true;
               break;
             }
+            projected.push(...result.alternatives);
+            discarded ||= result.discarded;
           }
           const [first] = projected;
           if (!unprojectable && first !== undefined) {

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -1278,6 +1278,9 @@ const selectParser = (
         if (output && '$ref' in output) {
           output = parseDef(def.out._def, outputPathRefs, true);
         }
+        if (output === undefined) {
+          return throwUnrepresentableStrictZodType(def.out._def.typeName, outputPathRefs);
+        }
         const inputRefs: PreprocessedRefs =
           outputRefs === refs ? refs : { ...refs, [expectedPipelineOutput]: def.out._def };
         let input = parsePipelineDef(def, inputRefs, forceResolution, outputRefs);
@@ -1288,7 +1291,7 @@ const selectParser = (
           };
           input = parseDef(def.in._def, materializedInputRefs, true);
         }
-        if (!input || !output) {
+        if (!input) {
           return input;
         }
 

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -59,6 +59,7 @@ import {
   acceptsJSONNumber,
   acceptsJSONString,
   applyBigIntStringFallbackBounds,
+  applyFractionalBigIntFallbackBounds,
   applyNestedNumericOverlaps,
   applySafeIntegerBounds,
   applyUnsafeBigIntBounds,
@@ -75,7 +76,6 @@ import {
   producesDateAtPath,
   producesBigIntOutput,
   requiresAsynchronousJSONInput,
-  throwsOnFractionalBigIntInput,
 } from './schema-capabilities';
 import { ignoreOverride } from './Options';
 import { zodDef } from './util';
@@ -747,7 +747,30 @@ const selectParser = (
       return parseStringDef(def, refs);
     }
     case ZodFirstPartyTypeKind.ZodNumber: {
-      return parseNumberDef(def, refs);
+      const schema = parseNumberDef(def, refs);
+      if (refs.openaiStrictMode) {
+        for (const keyword of [
+          'minimum',
+          'exclusiveMinimum',
+          'maximum',
+          'exclusiveMaximum',
+          'multipleOf',
+        ] as const) {
+          const value = schema[keyword];
+          if (typeof value !== 'number' || Number.isFinite(value)) {
+            continue;
+          }
+          const vacuous =
+            ((keyword === 'minimum' || keyword === 'exclusiveMinimum') && value === -Infinity) ||
+            ((keyword === 'maximum' || keyword === 'exclusiveMaximum') && value === Infinity);
+          if (vacuous) {
+            Reflect.deleteProperty(schema, keyword);
+          } else {
+            assertFiniteStrictSchemaValue(value, keyword, refs);
+          }
+        }
+      }
+      return schema;
     }
     case ZodFirstPartyTypeKind.ZodObject: {
       return parseObjectDef(def, refs);
@@ -927,11 +950,10 @@ const selectParser = (
               boundedBranch,
               competingBigInts.map((candidate) => candidate._def),
             );
-            const fractionalTransform = options.some(
-              (candidate, candidateIndex) =>
-                candidateIndex < index && throwsOnFractionalBigIntInput(candidate._def, bounded),
-            );
-            return fractionalTransform ? ({ ...bounded, type: 'integer' } as JsonSchema7Type) : bounded;
+            const precedingProducers = options
+              .filter((_, candidateIndex) => candidateIndex < index)
+              .map((candidate) => candidate._def);
+            return applyFractionalBigIntFallbackBounds(bounded, precedingProducers);
           })
           .filter(
             (branch): branch is JsonSchema7Type =>

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -62,7 +62,9 @@ import {
   applyUnsafeBigIntBounds,
   convertsJSONPipelineInput,
   findNestedNumericOverlaps,
+  hasConstrainedPipelineOutput,
   hasOpaqueJSONValidation,
+  hasOpaquePipelineTransform,
   producesBigIntAtPath,
   producesDateAtPath,
   producesBigIntOutput,
@@ -385,6 +387,46 @@ const normalizeStrictBigIntValue = (value: bigint, keyword: string, refs: Refs):
   return normalized;
 };
 
+const strictDefaultDescriptors = (
+  value: object,
+  keyword: string,
+  refs: Refs,
+): [string, PropertyDescriptor][] => {
+  const descriptors = Object.entries(Object.getOwnPropertyDescriptors(value));
+  for (const [key, descriptor] of descriptors) {
+    if (descriptor.get || descriptor.set) {
+      throw new TypeError(
+        `Zod field at \`${refs.currentPath.join('/')}\` cannot safely represent the \`${keyword}.${key}\` accessor in JSON Structured Outputs.`,
+      );
+    }
+    if (key === 'toJSON' && typeof descriptor.value === 'function') {
+      throw new TypeError(
+        `Zod field at \`${refs.currentPath.join('/')}\` cannot safely represent a callable \`${keyword}.toJSON\` serializer in JSON Structured Outputs.`,
+      );
+    }
+  }
+
+  let prototype: object | null = Object.getPrototypeOf(value) as object | null;
+  while (prototype) {
+    const serializer = Object.getOwnPropertyDescriptor(prototype, 'toJSON');
+    if (serializer && (serializer.get || serializer.set || typeof serializer.value === 'function')) {
+      throw new TypeError(
+        `Zod field at \`${refs.currentPath.join('/')}\` cannot safely represent an inherited \`${keyword}.toJSON\` serializer in JSON Structured Outputs.`,
+      );
+    }
+    prototype = Object.getPrototypeOf(prototype) as object | null;
+  }
+  return descriptors;
+};
+
+const isCanonicalDateDefault = (value: Date): boolean =>
+  Object.getPrototypeOf(value) === Date.prototype &&
+  Number.isFinite(Date.prototype.getTime.call(value)) &&
+  ['toJSON', 'toISOString', 'valueOf'].every(
+    (property) => !Object.getOwnPropertyDescriptor(value, property),
+  ) &&
+  !Object.getOwnPropertyDescriptor(value, Symbol.toPrimitive);
+
 const normalizeStrictDefaultValue = (
   value: unknown,
   definition: ZodTypeDef,
@@ -406,6 +448,11 @@ const normalizeStrictDefaultValue = (
     }
     return normalizeStrictBigIntValue(value, keyword, refs);
   }
+  if (value === undefined || typeof value === 'symbol' || typeof value === 'function') {
+    throw new TypeError(
+      `Zod field at \`${refs.currentPath.join('/')}\` cannot represent the non-JSON \`${keyword}\` value in JSON Structured Outputs.`,
+    );
+  }
   if (!value || typeof value !== 'object') {
     return value;
   }
@@ -426,6 +473,19 @@ const normalizeStrictDefaultValue = (
 
   active.add(value);
   try {
+    if (value instanceof Date) {
+      if (!isCanonicalDateDefault(value)) {
+        throw new TypeError(
+          `Zod field at \`${refs.currentPath.join('/')}\` cannot safely represent the invalid or customized \`${keyword}\` Date in JSON Structured Outputs.`,
+        );
+      }
+      if (!producesDateAtPath(definition, path, rootValue)) {
+        throwUnrepresentableStrictZodType(ZodFirstPartyTypeKind.ZodDate, refs);
+      }
+      return value;
+    }
+
+    const descriptors = strictDefaultDescriptors(value, keyword, refs);
     if (Array.isArray(value)) {
       const normalized: unknown[] = [];
       seen.set(value, normalized);
@@ -454,22 +514,12 @@ const normalizeStrictDefaultValue = (
     }
 
     const prototype: unknown = Object.getPrototypeOf(value);
-    if (prototype !== Object.prototype && prototype !== null) {
-      if (value instanceof Date) {
-        if (!producesDateAtPath(definition, path, rootValue)) {
-          throwUnrepresentableStrictZodType(ZodFirstPartyTypeKind.ZodDate, refs);
-        }
-        return value;
-      }
-      throw new TypeError(
-        `Zod field at \`${refs.currentPath.join('/')}\` cannot safely represent the \`${keyword}\` custom-prototype value in JSON Structured Outputs.`,
-      );
-    }
-
-    const normalized = Object.create(prototype) as Record<string, unknown>;
+    const plainPrototype = prototype === null ? null : Object.prototype;
+    const normalized = Object.create(plainPrototype) as Record<string, unknown>;
     seen.set(value, normalized);
-    let changed = false;
-    for (const [key, item] of Object.entries(value)) {
+    let changed = prototype !== plainPrototype;
+    for (const [key, descriptor] of descriptors.filter(([, item]) => item.enumerable)) {
+      const item: unknown = descriptor.value;
       const normalizedItem = normalizeStrictDefaultValue(
         item,
         definition,
@@ -856,18 +906,6 @@ const selectParser = (
       const boundNumericTransform =
         numericTransform &&
         (transform === BigInt || (expectedOutput && producesBigIntOutput(expectedOutput)));
-      if (
-        numericTransform &&
-        !expectedOutput &&
-        !boundNumericTransform &&
-        transform !== String &&
-        transform !== Number &&
-        transform !== Boolean
-      ) {
-        throw new Error(
-          `ZodEffects numeric transform at \`${refs.currentPath.join('/')}\` has no inspectable output type for strict Structured Outputs.`,
-        );
-      }
       const schema = parseEffectsDef(def, refs, forceResolution || boundNumericTransform === true);
       if (!boundNumericTransform || schema === undefined) {
         return schema;
@@ -938,6 +976,15 @@ const selectParser = (
           input = parseDef(def.in._def, materializedInputRefs, true);
         }
         if (!input || !output) {
+          return input;
+        }
+
+        if (hasOpaquePipelineTransform(def.in._def)) {
+          if (hasConstrainedPipelineOutput(def.out._def)) {
+            throw new Error(
+              `ZodPipeline output constraints at \`${refs.currentPath.join('/')}\` cannot be safely projected across an opaque transform in strict Structured Outputs.`,
+            );
+          }
           return input;
         }
 

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -64,6 +64,7 @@ import {
   findNestedNumericOverlaps,
   hasOpaqueJSONValidation,
   producesBigIntAtPath,
+  producesDateAtPath,
   producesBigIntOutput,
   requiresAsynchronousJSONInput,
 } from './schema-capabilities';
@@ -392,7 +393,13 @@ const normalizeStrictDefaultValue = (
   seen = new WeakMap<object, unknown>(),
   path: readonly (string | number)[] = [],
   rootValue: unknown = value,
+  active = new WeakSet<object>(),
 ): unknown => {
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    throw new TypeError(
+      `Zod field at \`${refs.currentPath.join('/')}\` cannot represent the non-finite \`${keyword}\` value in JSON Structured Outputs.`,
+    );
+  }
   if (typeof value === 'bigint') {
     if (!producesBigIntAtPath(definition, path, rootValue)) {
       throwUnrepresentableStrictZodType(ZodFirstPartyTypeKind.ZodBigInt, refs);
@@ -407,27 +414,78 @@ const normalizeStrictDefaultValue = (
     throwUnrepresentableStrictZodType(typeName, refs);
   }
 
+  if (active.has(value)) {
+    throw new TypeError(
+      `Zod field at \`${refs.currentPath.join('/')}\` cannot represent the cyclic \`${keyword}\` value in JSON Structured Outputs.`,
+    );
+  }
   const previous = seen.get(value);
   if (previous !== undefined) {
     return previous;
   }
 
-  if (Array.isArray(value)) {
-    const normalized: unknown[] = [];
+  active.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const normalized: unknown[] = [];
+      seen.set(value, normalized);
+      let changed = false;
+
+      for (const [index, item] of value.entries()) {
+        const normalizedItem = normalizeStrictDefaultValue(
+          item,
+          definition,
+          refs,
+          `${keyword}[${index}]`,
+          seen,
+          [...path, index],
+          rootValue,
+          active,
+        );
+        normalized.push(normalizedItem);
+        changed ||= normalizedItem !== item;
+      }
+
+      if (!changed) {
+        seen.set(value, value);
+        return value;
+      }
+      return normalized;
+    }
+
+    const prototype: unknown = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      if (value instanceof Date) {
+        if (!producesDateAtPath(definition, path, rootValue)) {
+          throwUnrepresentableStrictZodType(ZodFirstPartyTypeKind.ZodDate, refs);
+        }
+        return value;
+      }
+      throw new TypeError(
+        `Zod field at \`${refs.currentPath.join('/')}\` cannot safely represent the \`${keyword}\` custom-prototype value in JSON Structured Outputs.`,
+      );
+    }
+
+    const normalized = Object.create(prototype) as Record<string, unknown>;
     seen.set(value, normalized);
     let changed = false;
-
-    for (const [index, item] of value.entries()) {
+    for (const [key, item] of Object.entries(value)) {
       const normalizedItem = normalizeStrictDefaultValue(
         item,
         definition,
         refs,
-        `${keyword}[${index}]`,
+        `${keyword}.${key}`,
         seen,
-        [...path, index],
+        [...path, key],
         rootValue,
+        active,
       );
-      normalized.push(normalizedItem);
+      Object.defineProperty(normalized, key, {
+        value: normalizedItem,
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      });
       changed ||= normalizedItem !== item;
     }
 
@@ -436,45 +494,9 @@ const normalizeStrictDefaultValue = (
       return value;
     }
     return normalized;
+  } finally {
+    active.delete(value);
   }
-
-  const prototype: unknown = Object.getPrototypeOf(value);
-  if (prototype !== Object.prototype && prototype !== null) {
-    if (value instanceof Date) {
-      return value;
-    }
-    throw new TypeError(
-      `Zod field at \`${refs.currentPath.join('/')}\` cannot safely represent the \`${keyword}\` custom-prototype value in JSON Structured Outputs.`,
-    );
-  }
-
-  const normalized = Object.create(prototype) as Record<string, unknown>;
-  seen.set(value, normalized);
-  let changed = false;
-  for (const [key, item] of Object.entries(value)) {
-    const normalizedItem = normalizeStrictDefaultValue(
-      item,
-      definition,
-      refs,
-      `${keyword}.${key}`,
-      seen,
-      [...path, key],
-      rootValue,
-    );
-    Object.defineProperty(normalized, key, {
-      value: normalizedItem,
-      configurable: true,
-      enumerable: true,
-      writable: true,
-    });
-    changed ||= normalizedItem !== item;
-  }
-
-  if (!changed) {
-    seen.set(value, value);
-    return value;
-  }
-  return normalized;
 };
 
 const isNumericSchemaType = (type: unknown) => type === 'number' || type === 'integer';
@@ -851,6 +873,11 @@ const selectParser = (
         return schema;
       }
 
+      if (transform === BigInt && (!('type' in schema) || !isNumericSchemaType(schema.type))) {
+        throw new Error(
+          `ZodEffects BigInt transform at \`${refs.currentPath.join('/')}\` requires a directly representable numeric JSON input in strict Structured Outputs.`,
+        );
+      }
       const bounded = applySafeIntegerBounds(schema);
       if (transform === BigInt && 'type' in bounded && bounded.type === 'number') {
         bounded.type = 'integer';
@@ -917,6 +944,18 @@ const selectParser = (
         const combined = mergeStrictSchemas(input, output);
         if (combined) {
           return combined;
+        }
+        const alternatives = (output as Record<string, unknown>)['anyOf'];
+        if (Array.isArray(alternatives)) {
+          const projected = alternatives.map((alternative) =>
+            mergeStrictSchemas(input, alternative as JsonSchema7Type),
+          );
+          if (projected.every((alternative) => alternative !== undefined)) {
+            return { anyOf: projected } as JsonSchema7Type;
+          }
+          throw new Error(
+            `ZodPipeline output constraints at \`${refs.currentPath.join('/')}\` cannot be represented in strict Structured Outputs.`,
+          );
         }
 
         if (outputRefs !== refs) {

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -165,6 +165,9 @@ const producesBigIntOutput = (def: any, seen = new Set<ZodTypeDef>()): boolean =
     case ZodFirstPartyTypeKind.ZodBigInt: {
       return true;
     }
+    case ZodFirstPartyTypeKind.ZodLiteral: {
+      return typeof def.value === 'bigint';
+    }
     case ZodFirstPartyTypeKind.ZodNullable:
     case ZodFirstPartyTypeKind.ZodOptional:
     case ZodFirstPartyTypeKind.ZodDefault:
@@ -181,10 +184,19 @@ const producesBigIntOutput = (def: any, seen = new Set<ZodTypeDef>()): boolean =
     case ZodFirstPartyTypeKind.ZodPipeline: {
       return producesBigIntOutput(def.out._def, seen);
     }
+    case ZodFirstPartyTypeKind.ZodLazy: {
+      return producesBigIntOutput(def.getter()._def, seen);
+    }
+    case ZodFirstPartyTypeKind.ZodIntersection: {
+      return (
+        producesBigIntOutput(def.left._def, new Set(seen)) ||
+        producesBigIntOutput(def.right._def, new Set(seen))
+      );
+    }
     case ZodFirstPartyTypeKind.ZodUnion:
     case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
       const options = def.options instanceof Map ? [...def.options.values()] : def.options;
-      return options.some((option: { _def: ZodTypeDef }) => producesBigIntOutput(option._def, seen));
+      return options.some((option: { _def: ZodTypeDef }) => producesBigIntOutput(option._def, new Set(seen)));
     }
     default: {
       return false;
@@ -207,6 +219,9 @@ const acceptsJSONNumber = (def: any, seen = new Set<ZodTypeDef>()): boolean => {
     case ZodFirstPartyTypeKind.ZodLiteral: {
       return typeof def.value === 'number';
     }
+    case ZodFirstPartyTypeKind.ZodNativeEnum: {
+      return Object.values(def.values).some((value) => typeof value === 'number');
+    }
     case ZodFirstPartyTypeKind.ZodNullable:
     case ZodFirstPartyTypeKind.ZodOptional:
     case ZodFirstPartyTypeKind.ZodDefault:
@@ -223,10 +238,21 @@ const acceptsJSONNumber = (def: any, seen = new Set<ZodTypeDef>()): boolean => {
     case ZodFirstPartyTypeKind.ZodPipeline: {
       return acceptsJSONNumber(def.in._def, seen);
     }
+    case ZodFirstPartyTypeKind.ZodLazy: {
+      return acceptsJSONNumber(def.getter()._def, seen);
+    }
+    case ZodFirstPartyTypeKind.ZodPromise: {
+      return acceptsJSONNumber(def.type._def, seen);
+    }
+    case ZodFirstPartyTypeKind.ZodIntersection: {
+      return (
+        acceptsJSONNumber(def.left._def, new Set(seen)) && acceptsJSONNumber(def.right._def, new Set(seen))
+      );
+    }
     case ZodFirstPartyTypeKind.ZodUnion:
     case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
       const options = def.options instanceof Map ? [...def.options.values()] : def.options;
-      return options.some((option: { _def: ZodTypeDef }) => acceptsJSONNumber(option._def, seen));
+      return options.some((option: { _def: ZodTypeDef }) => acceptsJSONNumber(option._def, new Set(seen)));
     }
     default: {
       return def.coerce === true;
@@ -747,7 +773,11 @@ const selectParser = (
     case ZodFirstPartyTypeKind.ZodDefault: {
       const schema = parseDefaultDef(def, refs, forceResolution);
       if (refs.openaiStrictMode) {
-        if (typeof schema.default === 'bigint' && !hasJSONIntegerBranch(schema)) {
+        if (
+          typeof schema.default === 'bigint' &&
+          !hasJSONIntegerBranch(schema) &&
+          !producesBigIntOutput(def.innerType._def)
+        ) {
           throwUnrepresentableStrictZodType(ZodFirstPartyTypeKind.ZodBigInt, refs);
         }
 

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -523,7 +523,8 @@ const normalizeStrictDefaultValue = (
       seen.set(value, normalized);
       let changed = false;
 
-      for (const [index, item] of value.entries()) {
+      for (let index = 0; index < value.length; index += 1) {
+        const item: unknown = value[index];
         const normalizedItem = normalizeStrictDefaultValue(
           item,
           definition,

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -65,10 +65,12 @@ import {
   hasConstrainedPipelineOutput,
   hasOpaqueJSONValidation,
   hasOpaquePipelineTransform,
+  knownParsedOutputType,
   producesBigIntAtPath,
   producesDateAtPath,
   producesBigIntOutput,
   requiresAsynchronousJSONInput,
+  throwsOnFractionalBigIntInput,
 } from './schema-capabilities';
 import { ignoreOverride } from './Options';
 import { zodDef } from './util';
@@ -440,13 +442,23 @@ const strictDefaultDescriptors = (
   return descriptors;
 };
 
+const trustedDatePrototypeMethods = new Map<PropertyKey, unknown>([
+  ['getTime', Date.prototype.getTime],
+  ['toJSON', Date.prototype.toJSON],
+  ['toISOString', Date.prototype.toISOString],
+  ['valueOf', Date.prototype.valueOf],
+  [Symbol.toPrimitive, Date.prototype[Symbol.toPrimitive]],
+]);
+const trustedDateGetTime = Date.prototype.getTime;
+
 const isCanonicalDateDefault = (value: Date): boolean =>
   Object.getPrototypeOf(value) === Date.prototype &&
-  Number.isFinite(Date.prototype.getTime.call(value)) &&
-  ['toJSON', 'toISOString', 'valueOf'].every(
-    (property) => !Object.getOwnPropertyDescriptor(value, property),
-  ) &&
-  !Object.getOwnPropertyDescriptor(value, Symbol.toPrimitive);
+  Number.isFinite(trustedDateGetTime.call(value)) &&
+  [...trustedDatePrototypeMethods].every(
+    ([property, method]) =>
+      Object.getOwnPropertyDescriptor(Date.prototype, property)?.value === method &&
+      !Object.getOwnPropertyDescriptor(value, property),
+  );
 
 const normalizeStrictDefaultValue = (
   value: unknown,
@@ -815,10 +827,15 @@ const selectParser = (
                 producesBigIntOutput(candidate._def) &&
                 (candidateIndex < index || fallibleNumber),
             );
-            return applyUnsafeBigIntBounds(
+            const bounded = applyUnsafeBigIntBounds(
               boundedBranch,
               competingBigInts.map((candidate) => candidate._def),
             );
+            const fractionalTransform = options.some(
+              (candidate, candidateIndex) =>
+                candidateIndex < index && throwsOnFractionalBigIntInput(candidate._def, bounded),
+            );
+            return fractionalTransform ? ({ ...bounded, type: 'integer' } as JsonSchema7Type) : bounded;
           })
           .filter(
             (branch): branch is JsonSchema7Type =>
@@ -831,6 +848,13 @@ const selectParser = (
       return parseUnionDef(def, refs);
     }
     case ZodFirstPartyTypeKind.ZodIntersection: {
+      if (refs.openaiStrictMode) {
+        const left = knownParsedOutputType(def.left._def);
+        const right = knownParsedOutputType(def.right._def);
+        if (left !== undefined && right !== undefined && left !== right) {
+          throw new TypeError(`ZodIntersection arms have incompatible parsed outputs: ${left} and ${right}`);
+        }
+      }
       const intersectionRefs: PreprocessedRefs = refs.openaiStrictMode
         ? { ...refs, [constrainedReferenceContext]: true as const }
         : refs;

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -57,9 +57,10 @@ import { parseReadonlyDef } from './parsers/readonly';
 import {
   acceptsEveryJSONNumber,
   acceptsJSONNumber,
-  acceptsUnsafeJSONInteger,
+  applyNestedNumericOverlaps,
+  applyUnsafeBigIntBounds,
   convertsJSONPipelineInput,
-  capturesUnsafeBigIntInput,
+  findNestedNumericOverlaps,
   producesBigIntAtPath,
   producesBigIntOutput,
 } from './schema-capabilities';
@@ -526,8 +527,24 @@ const selectParser = (
         (option) =>
           option._def.typeName === ZodFirstPartyTypeKind.ZodLiteral && typeof option._def.value === 'bigint',
       );
+      const nestedOverlaps = refs.openaiStrictMode
+        ? options.map((consumer, consumerIndex) =>
+            options.flatMap((producer, producerIndex) =>
+              producerIndex === consumerIndex
+                ? []
+                : findNestedNumericOverlaps(producer._def, consumer._def).filter(
+                    (overlap) =>
+                      overlap.path.length > 0 &&
+                      (producerIndex < consumerIndex || !acceptsEveryJSONNumber(overlap.consumer)),
+                  ),
+            ),
+          )
+        : [];
 
-      if (refs.openaiStrictMode && (bigintIndex !== -1 || hasBigIntLiteral)) {
+      if (
+        refs.openaiStrictMode &&
+        (bigintIndex !== -1 || hasBigIntLiteral || nestedOverlaps.some((overlaps) => overlaps.length > 0))
+      ) {
         const branches = options
           .map((option, index) => {
             const fallibleNumber = !acceptsEveryJSONNumber(option._def);
@@ -536,17 +553,22 @@ const selectParser = (
               !producesBigIntOutput(option._def) &&
               acceptsJSONNumber(option._def) &&
               (index > bigintIndex || fallibleNumber);
+            const branchOverlaps = nestedOverlaps[index] ?? [];
             const branch = parseDef(
               option._def,
               {
                 ...refs,
                 currentPath: [...refs.currentPath, 'anyOf', String(index)],
               },
-              boundNumber,
+              boundNumber || branchOverlaps.length > 0,
             );
 
-            if (!boundNumber || branch === undefined) {
+            if (branch === undefined) {
               return branch;
+            }
+            const boundedBranch = applyNestedNumericOverlaps(branch, branchOverlaps);
+            if (!boundNumber) {
+              return boundedBranch;
             }
 
             const competingBigInts = options.filter(
@@ -555,42 +577,10 @@ const selectParser = (
                 producesBigIntOutput(candidate._def) &&
                 (candidateIndex < index || fallibleNumber),
             );
-            const minimum =
-              competingBigInts.some((candidate) => capturesUnsafeBigIntInput(candidate._def, 'minimum')) &&
-              (acceptsUnsafeJSONInteger(branch, 'minimum') || (!('type' in branch) && !('$ref' in branch)));
-            const maximum =
-              competingBigInts.some((candidate) => capturesUnsafeBigIntInput(candidate._def, 'maximum')) &&
-              (acceptsUnsafeJSONInteger(branch, 'maximum') || (!('type' in branch) && !('$ref' in branch)));
-            if (!minimum && !maximum) {
-              return branch;
-            }
-
-            if ('$ref' in branch) {
-              return {
-                allOf: [
-                  branch,
-                  {
-                    ...(minimum ? { minimum: Number.MIN_SAFE_INTEGER } : undefined),
-                    ...(maximum ? { maximum: Number.MAX_SAFE_INTEGER } : undefined),
-                  } as JsonSchema7Type,
-                ],
-              };
-            }
-
-            const record = branch as unknown as Record<string, unknown>;
-            if (minimum) {
-              record['minimum'] = Math.max(
-                typeof record['minimum'] === 'number' ? record['minimum'] : Number.MIN_SAFE_INTEGER,
-                Number.MIN_SAFE_INTEGER,
-              );
-            }
-            if (maximum) {
-              record['maximum'] = Math.min(
-                typeof record['maximum'] === 'number' ? record['maximum'] : Number.MAX_SAFE_INTEGER,
-                Number.MAX_SAFE_INTEGER,
-              );
-            }
-            return branch;
+            return applyUnsafeBigIntBounds(
+              boundedBranch,
+              competingBigInts.map((candidate) => candidate._def),
+            );
           })
           .filter(
             (branch): branch is JsonSchema7Type =>

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -798,13 +798,18 @@ const selectParser = (
             options.flatMap((producer, producerIndex) =>
               producerIndex === consumerIndex
                 ? []
-                : findNestedNumericOverlaps(producer._def, consumer._def).filter(
-                    (overlap) =>
-                      overlap.path.length > 0 &&
-                      (producerIndex < consumerIndex ||
-                        !acceptsEveryJSONNumber(overlap.consumer) ||
-                        hasOpaqueJSONValidation(consumer._def)),
-                  ),
+                : findNestedNumericOverlaps(producer._def, consumer._def)
+                    .filter(
+                      (overlap) =>
+                        overlap.path.length > 0 &&
+                        (producerIndex < consumerIndex ||
+                          !acceptsEveryJSONNumber(overlap.consumer) ||
+                          hasOpaqueJSONValidation(consumer._def)),
+                    )
+                    .map((overlap) => ({
+                      ...overlap,
+                      producerPrecedesConsumer: producerIndex < consumerIndex,
+                    })),
             ),
           )
         : [];
@@ -985,19 +990,37 @@ const selectParser = (
         acceptsJSONNumber(def.schema._def);
       const expectedOutput = (refs as PreprocessedRefs)[expectedPipelineOutput];
       const transform = def.effect?.transform as unknown;
+      const exactBigIntTransform = refs.openaiStrictMode === true && transform === BigInt;
       const boundNumericTransform =
         numericTransform &&
-        (transform === BigInt || (expectedOutput && producesBigIntOutput(expectedOutput)));
-      const schema = parseEffectsDef(def, refs, forceResolution || boundNumericTransform === true);
+        (exactBigIntTransform || (expectedOutput && producesBigIntOutput(expectedOutput)));
+      const schema = parseEffectsDef(
+        def,
+        refs,
+        forceResolution || boundNumericTransform === true || exactBigIntTransform,
+      );
+
+      if (exactBigIntTransform && schema !== undefined) {
+        if ('type' in schema && schema.type === 'string') {
+          const pattern = '^[+-]?[0-9]+$';
+          if ('pattern' in schema && schema.pattern !== undefined && schema.pattern !== pattern) {
+            throw new Error(
+              `ZodEffects BigInt transform at \`${refs.currentPath.join('/')}\` cannot combine an existing string constraint with the required integer-string pattern in strict Structured Outputs.`,
+            );
+          }
+          return { ...schema, pattern } as JsonSchema7Type;
+        }
+        if (!('type' in schema) || !isNumericSchemaType(schema.type)) {
+          throw new Error(
+            `ZodEffects BigInt transform at \`${refs.currentPath.join('/')}\` requires a directly representable numeric JSON input in strict Structured Outputs.`,
+          );
+        }
+      }
+
       if (!boundNumericTransform || schema === undefined) {
         return schema;
       }
 
-      if (transform === BigInt && (!('type' in schema) || !isNumericSchemaType(schema.type))) {
-        throw new Error(
-          `ZodEffects BigInt transform at \`${refs.currentPath.join('/')}\` requires a directly representable numeric JSON input in strict Structured Outputs.`,
-        );
-      }
       const bounded = applySafeIntegerBounds(schema);
       if (transform === BigInt && 'type' in bounded && bounded.type === 'number') {
         bounded.type = 'integer';

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -58,9 +58,11 @@ import {
   acceptsEveryJSONNumber,
   acceptsJSONNumber,
   applyNestedNumericOverlaps,
+  applySafeIntegerBounds,
   applyUnsafeBigIntBounds,
   convertsJSONPipelineInput,
   findNestedNumericOverlaps,
+  hasOpaqueJSONValidation,
   producesBigIntAtPath,
   producesBigIntOutput,
 } from './schema-capabilities';
@@ -104,8 +106,9 @@ export type JsonSchema7TypeUnion =
 export type JsonSchema7Type = JsonSchema7TypeUnion & JsonSchema7Meta;
 
 const jsonInputPreprocessor = Symbol('openaiJsonInputPreprocessor');
+const constrainedReferenceContext = Symbol('openaiConstrainedReferenceContext');
 
-type PreprocessedRefs = Refs & { [jsonInputPreprocessor]?: true };
+type PreprocessedRefs = Refs & { [jsonInputPreprocessor]?: true; [constrainedReferenceContext]?: true };
 
 const hasJSONInputPreprocessor = (refs: Refs): boolean =>
   (refs as PreprocessedRefs)[jsonInputPreprocessor] === true;
@@ -207,10 +210,13 @@ export function parseDef(
   }
 
   // Native leaves and their already-materialized shared ancestors must remain
-  // inside the conversion context. In-progress recursive definitions still use
-  // references so recursive schemas terminate normally.
+  // inside the conversion context. Constrained union branches similarly need
+  // materialized copies instead of unsupported allOf ref overlays.
+  const materializeConstrainedReference =
+    refs.openaiStrictMode === true && (refs as PreprocessedRefs)[constrainedReferenceContext] === true;
   const inlinePreprocessedType =
-    isPreprocessed && (needsPreprocessing || (seenItem !== undefined && seenItem.jsonSchema !== undefined));
+    (isPreprocessed || materializeConstrainedReference) &&
+    (needsPreprocessing || (seenItem !== undefined && seenItem.jsonSchema !== undefined));
 
   if (seenItem && !forceResolution && !inlinePreprocessedType) {
     const seenSchema = get$ref(seenItem, refs);
@@ -379,15 +385,20 @@ const normalizeStrictDefaultValue = (
   keyword = 'default',
   seen = new WeakMap<object, unknown>(),
   path: readonly (string | number)[] = [],
+  rootValue: unknown = value,
 ): unknown => {
   if (typeof value === 'bigint') {
-    if (!producesBigIntAtPath(definition, path)) {
+    if (!producesBigIntAtPath(definition, path, rootValue)) {
       throwUnrepresentableStrictZodType(ZodFirstPartyTypeKind.ZodBigInt, refs);
     }
     return normalizeStrictBigIntValue(value, keyword, refs);
   }
   if (!value || typeof value !== 'object') {
     return value;
+  }
+  if (value instanceof Set || value instanceof Map) {
+    const typeName = value instanceof Set ? ZodFirstPartyTypeKind.ZodSet : ZodFirstPartyTypeKind.ZodMap;
+    throwUnrepresentableStrictZodType(typeName, refs);
   }
 
   const previous = seen.get(value);
@@ -408,6 +419,7 @@ const normalizeStrictDefaultValue = (
         `${keyword}[${index}]`,
         seen,
         [...path, index],
+        rootValue,
       );
       normalized.push(normalizedItem);
       changed ||= normalizedItem !== item;
@@ -429,10 +441,15 @@ const normalizeStrictDefaultValue = (
   seen.set(value, normalized);
   let changed = false;
   for (const [key, item] of Object.entries(value)) {
-    const normalizedItem = normalizeStrictDefaultValue(item, definition, refs, `${keyword}.${key}`, seen, [
-      ...path,
-      key,
-    ]);
+    const normalizedItem = normalizeStrictDefaultValue(
+      item,
+      definition,
+      refs,
+      `${keyword}.${key}`,
+      seen,
+      [...path, key],
+      rootValue,
+    );
     Object.defineProperty(normalized, key, {
       value: normalizedItem,
       configurable: true,
@@ -447,6 +464,40 @@ const normalizeStrictDefaultValue = (
     return value;
   }
   return normalized;
+};
+
+const isNumericSchemaType = (type: unknown) => type === 'number' || type === 'integer';
+
+const mergeStrictScalarSchemas = (
+  left: JsonSchema7Type,
+  right: JsonSchema7Type,
+): JsonSchema7Type | undefined => {
+  const first = left as Record<string, unknown>;
+  const second = right as Record<string, unknown>;
+  if (
+    '$ref' in first ||
+    '$ref' in second ||
+    (first['type'] !== second['type'] &&
+      !(isNumericSchemaType(first['type']) && isNumericSchemaType(second['type'])))
+  ) {
+    return undefined;
+  }
+
+  const merged: Record<string, unknown> = { ...first };
+  for (const [keyword, value] of Object.entries(second)) {
+    if (value === undefined || merged[keyword] === undefined || Object.is(merged[keyword], value)) {
+      merged[keyword] = value;
+    } else if (keyword === 'minimum' || keyword === 'exclusiveMinimum' || keyword === 'minLength') {
+      merged[keyword] = Math.max(merged[keyword] as number, value as number);
+    } else if (keyword === 'maximum' || keyword === 'exclusiveMaximum' || keyword === 'maxLength') {
+      merged[keyword] = Math.min(merged[keyword] as number, value as number);
+    } else if (keyword === 'type' && isNumericSchemaType(merged[keyword]) && isNumericSchemaType(value)) {
+      merged[keyword] = 'integer';
+    } else {
+      return undefined;
+    }
+  }
+  return merged as JsonSchema7Type;
 };
 
 const selectParser = (
@@ -535,7 +586,9 @@ const selectParser = (
                 : findNestedNumericOverlaps(producer._def, consumer._def).filter(
                     (overlap) =>
                       overlap.path.length > 0 &&
-                      (producerIndex < consumerIndex || !acceptsEveryJSONNumber(overlap.consumer)),
+                      (producerIndex < consumerIndex ||
+                        !acceptsEveryJSONNumber(overlap.consumer) ||
+                        hasOpaqueJSONValidation(consumer._def)),
                   ),
             ),
           )
@@ -559,6 +612,9 @@ const selectParser = (
               {
                 ...refs,
                 currentPath: [...refs.currentPath, 'anyOf', String(index)],
+                ...(boundNumber || branchOverlaps.length > 0
+                  ? { [constrainedReferenceContext]: true as const }
+                  : undefined),
               },
               boundNumber || branchOverlaps.length > 0,
             );
@@ -593,7 +649,26 @@ const selectParser = (
       return parseUnionDef(def, refs);
     }
     case ZodFirstPartyTypeKind.ZodIntersection: {
-      return parseIntersectionDef(def, refs);
+      const intersectionRefs: PreprocessedRefs = refs.openaiStrictMode
+        ? { ...refs, [constrainedReferenceContext]: true as const }
+        : refs;
+      const schema = parseIntersectionDef(def, intersectionRefs);
+      if (!refs.openaiStrictMode || !schema || !('allOf' in schema)) {
+        return schema;
+      }
+
+      const [first, ...remaining] = (schema as JsonSchema7AllOfType).allOf;
+      if (!first) {
+        return schema;
+      }
+      let merged: JsonSchema7Type | undefined = first;
+      for (const next of remaining) {
+        if (!merged) {
+          break;
+        }
+        merged = mergeStrictScalarSchemas(merged, next);
+      }
+      return merged ?? schema;
     }
     case ZodFirstPartyTypeKind.ZodTuple: {
       return parseTupleDef(def, refs);
@@ -667,7 +742,12 @@ const selectParser = (
         return parseEffectsDef(def, preprocessedRefs, forceResolution);
       }
 
-      return parseEffectsDef(def, refs, forceResolution);
+      const boundNumericTransform =
+        refs.openaiStrictMode === true &&
+        def.effect?.type === 'transform' &&
+        acceptsJSONNumber(def.schema._def);
+      const schema = parseEffectsDef(def, refs, forceResolution || boundNumericTransform);
+      return boundNumericTransform && schema !== undefined ? applySafeIntegerBounds(schema) : schema;
     }
     case ZodFirstPartyTypeKind.ZodAny: {
       return parseAnyDef();
@@ -700,13 +780,18 @@ const selectParser = (
       return parseCatchDef(def, refs, forceResolution);
     }
     case ZodFirstPartyTypeKind.ZodPipeline: {
-      if (refs.openaiStrictMode && convertsJSONPipelineInput(def.in._def, def.out._def)) {
-        const outputRefs: PreprocessedRefs = {
-          ...refs,
-          [jsonInputPreprocessor]: true,
-        };
-
-        return parsePipelineDef(def, refs, forceResolution, outputRefs);
+      if (refs.openaiStrictMode) {
+        const outputRefs: PreprocessedRefs = convertsJSONPipelineInput(def.in._def, def.out._def)
+          ? { ...refs, [jsonInputPreprocessor]: true as const }
+          : refs;
+        const output = parseDef(def.out._def, {
+          ...outputRefs,
+          currentPath: [...refs.currentPath, 'output'],
+        });
+        const input = parsePipelineDef(def, refs, forceResolution, outputRefs);
+        return input && output && outputRefs === refs
+          ? (mergeStrictScalarSchemas(input, output) ?? input)
+          : input;
       }
 
       return parsePipelineDef(def, refs, forceResolution);

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -1104,6 +1104,9 @@ const selectParser = (
           }
           return { ...schema, pattern } as JsonSchema7Type;
         }
+        if ('type' in schema && schema.type === 'boolean') {
+          return schema;
+        }
         if (!('type' in schema) || !isNumericSchemaType(schema.type)) {
           throw new Error(
             `ZodEffects BigInt transform at \`${refs.currentPath.join('/')}\` requires a directly representable numeric JSON input in strict Structured Outputs.`,

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -65,6 +65,7 @@ import {
   hasOpaqueJSONValidation,
   producesBigIntAtPath,
   producesBigIntOutput,
+  requiresAsynchronousJSONInput,
 } from './schema-capabilities';
 import { ignoreOverride } from './Options';
 import { zodDef } from './util';
@@ -606,12 +607,20 @@ const selectParser = (
     }
     case ZodFirstPartyTypeKind.ZodUnion:
     case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
-      const options = (def.options instanceof Map ? [...def.options.values()] : def.options) as {
+      const originalOptions = (def.options instanceof Map ? [...def.options.values()] : def.options) as {
         _def: ZodTypeDef & {
           typeName: ZodFirstPartyTypeKind;
           value?: unknown;
         };
       }[];
+      const options = refs.openaiStrictMode
+        ? originalOptions.filter((option) => !requiresAsynchronousJSONInput(option._def))
+        : originalOptions;
+      const omittedAsynchronousOptions = options.length !== originalOptions.length;
+      if (refs.openaiStrictMode && options.length === 0) {
+        throwUnrepresentableStrictZodType(ZodFirstPartyTypeKind.ZodPromise, refs);
+      }
+
       const bigintIndex = options.findIndex((option) => producesBigIntOutput(option._def));
       const hasBigIntLiteral = options.some(
         (option) =>
@@ -635,7 +644,10 @@ const selectParser = (
 
       if (
         refs.openaiStrictMode &&
-        (bigintIndex !== -1 || hasBigIntLiteral || nestedOverlaps.some((overlaps) => overlaps.length > 0))
+        (omittedAsynchronousOptions ||
+          bigintIndex !== -1 ||
+          hasBigIntLiteral ||
+          nestedOverlaps.some((overlaps) => overlaps.length > 0))
       ) {
         const branches = options
           .map((option, index) => {
@@ -765,7 +777,7 @@ const selectParser = (
       return parseDef(def.getter()._def, refs, forceResolution);
     }
     case ZodFirstPartyTypeKind.ZodPromise: {
-      if (refs.openaiStrictMode && !refs.currentPath.includes('anyOf')) {
+      if (refs.openaiStrictMode) {
         throwUnrepresentableStrictZodType(ZodFirstPartyTypeKind.ZodPromise, refs);
       }
       return parsePromiseDef(def, refs, forceResolution);
@@ -806,7 +818,15 @@ const selectParser = (
         );
       }
       const schema = parseEffectsDef(def, refs, forceResolution || boundNumericTransform === true);
-      return boundNumericTransform && schema !== undefined ? applySafeIntegerBounds(schema) : schema;
+      if (!boundNumericTransform || schema === undefined) {
+        return schema;
+      }
+
+      const bounded = applySafeIntegerBounds(schema);
+      if (transform === BigInt && 'type' in bounded && bounded.type === 'number') {
+        bounded.type = 'integer';
+      }
+      return bounded;
     }
     case ZodFirstPartyTypeKind.ZodAny: {
       return parseAnyDef();
@@ -853,7 +873,14 @@ const selectParser = (
         }
         const inputRefs: PreprocessedRefs =
           outputRefs === refs ? refs : { ...refs, [expectedPipelineOutput]: def.out._def };
-        const input = parsePipelineDef(def, inputRefs, forceResolution, outputRefs);
+        let input = parsePipelineDef(def, inputRefs, forceResolution, outputRefs);
+        if (input && '$ref' in input) {
+          const materializedInputRefs: PreprocessedRefs = {
+            ...inputRefs,
+            [constrainedReferenceContext]: true,
+          };
+          input = parseDef(def.in._def, materializedInputRefs, true);
+        }
         if (!input || !output) {
           return input;
         }

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -440,7 +440,12 @@ const normalizeStrictDefaultValue = (
 
   const prototype: unknown = Object.getPrototypeOf(value);
   if (prototype !== Object.prototype && prototype !== null) {
-    return value;
+    if (value instanceof Date) {
+      return value;
+    }
+    throw new TypeError(
+      `Zod field at \`${refs.currentPath.join('/')}\` cannot safely represent the \`${keyword}\` custom-prototype value in JSON Structured Outputs.`,
+    );
   }
 
   const normalized = Object.create(prototype) as Record<string, unknown>;
@@ -529,6 +534,12 @@ const mergeStrictSchemas = (left: JsonSchema7Type, right: JsonSchema7Type): Json
         return undefined;
       }
       merged[keyword] = nested;
+    } else if (keyword === 'enum' && Array.isArray(merged[keyword]) && Array.isArray(value)) {
+      const intersection = (merged[keyword] as unknown[]).filter((candidate) => value.includes(candidate));
+      if (intersection.length === 0) {
+        return undefined;
+      }
+      merged[keyword] = intersection;
     } else if (keyword === 'required' && Array.isArray(merged[keyword]) && Array.isArray(value)) {
       merged[keyword] = [...new Set([...(merged[keyword] as string[]), ...(value as string[])])];
     } else if (keyword === 'type' && isNumericSchemaType(merged[keyword]) && isNumericSchemaType(value)) {
@@ -537,6 +548,10 @@ const mergeStrictSchemas = (left: JsonSchema7Type, right: JsonSchema7Type): Json
       return undefined;
     }
   }
+  if (Array.isArray(merged['enum']) && hasOwn(merged, 'const') && !merged['enum'].includes(merged['const'])) {
+    return undefined;
+  }
+
   return merged as JsonSchema7Type;
 };
 
@@ -603,6 +618,17 @@ const selectParser = (
       return parseNullDef(refs);
     }
     case ZodFirstPartyTypeKind.ZodArray: {
+      if (refs.openaiStrictMode && requiresAsynchronousJSONInput(def.type._def)) {
+        const nonempty = (def.minLength?.value ?? 0) > 0 || (def.exactLength?.value ?? 0) > 0;
+        if (nonempty) {
+          throwUnrepresentableStrictZodType(ZodFirstPartyTypeKind.ZodPromise, refs);
+        }
+        return {
+          type: 'array',
+          items: {},
+          maxItems: 0,
+        };
+      }
       return parseArrayDef(def, refs);
     }
     case ZodFirstPartyTypeKind.ZodUnion:
@@ -749,6 +775,9 @@ const selectParser = (
       return parseNativeEnumDef(def);
     }
     case ZodFirstPartyTypeKind.ZodNullable: {
+      if (refs.openaiStrictMode && requiresAsynchronousJSONInput(def.innerType._def)) {
+        return { type: 'null' };
+      }
       if (refs.openaiStrictMode && def.innerType._def.typeName === ZodFirstPartyTypeKind.ZodBigInt) {
         const inner = parseDef(
           def.innerType._def,

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -64,6 +64,7 @@ import {
   findIncompatibleParsedOutputs,
   findNestedNumericOverlaps,
   hasConstrainedPipelineOutput,
+  hasDeclaredSchemaPropertyAtPath,
   hasOpaqueJSONValidation,
   hasOpaquePipelineTransform,
   producesBigIntAtPath,
@@ -580,6 +581,15 @@ const normalizeStrictDefaultValue = (
         return value;
       }
       return normalized;
+    }
+
+    const hiddenSchemaProperty = descriptors.find(
+      ([key, descriptor]) => !descriptor.enumerable && hasDeclaredSchemaPropertyAtPath(definition, path, key),
+    );
+    if (hiddenSchemaProperty) {
+      throw new TypeError(
+        `Zod field at \`${refs.currentPath.join('/')}\` cannot safely represent the non-enumerable \`${keyword}.${hiddenSchemaProperty[0]}\` schema property in JSON Structured Outputs.`,
+      );
     }
 
     const prototype: unknown = prototypes[0] ?? null;

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -57,14 +57,18 @@ import { parseReadonlyDef } from './parsers/readonly';
 import {
   acceptsEveryJSONNumber,
   acceptsJSONNumber,
+  acceptsJSONString,
+  applyBigIntStringFallbackBounds,
   applyNestedNumericOverlaps,
   applySafeIntegerBounds,
   applyUnsafeBigIntBounds,
+  bigIntStringPattern,
   convertsJSONPipelineInput,
   findIncompatibleParsedOutputs,
   findNestedNumericOverlaps,
   hasConstrainedPipelineOutput,
   hasDeclaredSchemaPropertyAtPath,
+  hasExactBigIntStringInput,
   hasOpaqueJSONValidation,
   hasOpaquePipelineTransform,
   producesBigIntAtPath,
@@ -825,6 +829,9 @@ const selectParser = (
       }
 
       const bigintIndex = options.findIndex((option) => producesBigIntOutput(option._def));
+      const numericBigintIndex = options.findIndex(
+        (option) => producesBigIntOutput(option._def) && acceptsJSONNumber(option._def),
+      );
       const hasBigIntLiteral = options.some(
         (option) =>
           option._def.typeName === ZodFirstPartyTypeKind.ZodLiteral && typeof option._def.value === 'bigint',
@@ -844,9 +851,11 @@ const selectParser = (
                     .filter(
                       (overlap) =>
                         overlap.path.length > 0 &&
-                        (producerIndex < consumerIndex ||
-                          !acceptsEveryJSONNumber(overlap.consumer) ||
-                          hasOpaqueJSONValidation(consumer._def)),
+                        (overlap.kind === 'string'
+                          ? producerIndex < consumerIndex
+                          : producerIndex < consumerIndex ||
+                            !acceptsEveryJSONNumber(overlap.consumer) ||
+                            hasOpaqueJSONValidation(consumer._def)),
                     )
                     .map((overlap) => ({
                       ...overlap,
@@ -868,27 +877,41 @@ const selectParser = (
           .map((option, index) => {
             const fallibleNumber = !acceptsEveryJSONNumber(option._def);
             const boundNumber =
-              bigintIndex !== -1 &&
+              numericBigintIndex !== -1 &&
               !producesBigIntOutput(option._def) &&
               acceptsJSONNumber(option._def) &&
-              (index > bigintIndex || fallibleNumber);
+              (index > numericBigintIndex || fallibleNumber);
+            const precedingStringBigInts = options.filter(
+              (candidate, candidateIndex) =>
+                candidateIndex < index && hasExactBigIntStringInput(candidate._def),
+            );
+            const boundString =
+              !producesBigIntOutput(option._def) &&
+              acceptsJSONString(option._def) &&
+              precedingStringBigInts.length > 0;
             const branchOverlaps = nestedOverlaps[index] ?? [];
             const branch = parseDef(
               option._def,
               {
                 ...refs,
                 currentPath: [...refs.currentPath, 'anyOf', String(index)],
-                ...(boundNumber || branchOverlaps.length > 0
+                ...(boundNumber || boundString || branchOverlaps.length > 0
                   ? { [constrainedReferenceContext]: true as const }
                   : undefined),
               },
-              boundNumber || branchOverlaps.length > 0,
+              boundNumber || boundString || branchOverlaps.length > 0,
             );
 
             if (branch === undefined) {
               return branch;
             }
-            const boundedBranch = applyNestedNumericOverlaps(branch, branchOverlaps);
+            const nestedBranch = applyNestedNumericOverlaps(branch, branchOverlaps);
+            const boundedBranch = boundString
+              ? applyBigIntStringFallbackBounds(
+                  nestedBranch,
+                  precedingStringBigInts.map((candidate) => candidate._def),
+                )
+              : nestedBranch;
             if (!boundNumber) {
               return boundedBranch;
             }
@@ -897,6 +920,7 @@ const selectParser = (
               (candidate, candidateIndex) =>
                 candidateIndex !== index &&
                 producesBigIntOutput(candidate._def) &&
+                acceptsJSONNumber(candidate._def) &&
                 (candidateIndex < index || fallibleNumber),
             );
             const bounded = applyUnsafeBigIntBounds(
@@ -1050,7 +1074,7 @@ const selectParser = (
 
       if (exactBigIntTransform && schema !== undefined) {
         if ('type' in schema && schema.type === 'string') {
-          const pattern = '^[+-]?[0-9]+$';
+          const pattern = bigIntStringPattern;
           if ('pattern' in schema && schema.pattern !== undefined && schema.pattern !== pattern) {
             throw new Error(
               `ZodEffects BigInt transform at \`${refs.currentPath.join('/')}\` cannot combine an existing string constraint with the required integer-string pattern in strict Structured Outputs.`,

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -72,6 +72,7 @@ import {
   hasExactBigIntStringInput,
   hasOpaqueJSONValidation,
   hasOpaquePipelineTransform,
+  hasUnconstrainedPipelineOutput,
   knownParsedOutputType,
   producesBigIntAtPath,
   producesDateAtPath,
@@ -1397,6 +1398,15 @@ const selectParser = (
     }
     case ZodFirstPartyTypeKind.ZodLiteral: {
       assertFiniteStrictSchemaValue(def.value, 'const', refs);
+      if (
+        refs.openaiStrictMode &&
+        def.value !== null &&
+        !['string', 'number', 'boolean', 'bigint'].includes(typeof def.value)
+      ) {
+        throw new TypeError(
+          `ZodLiteral at \`${refs.currentPath.join('/')}\` has a non-JSON literal value that cannot be represented in strict Structured Outputs.`,
+        );
+      }
       const schema = parseLiteralDef(def, refs);
       if (refs.openaiStrictMode && typeof def.value === 'bigint') {
         const record = schema as unknown as Record<string, unknown>;
@@ -1592,6 +1602,10 @@ const selectParser = (
               `ZodPipeline output constraints at \`${refs.currentPath.join('/')}\` cannot be safely projected across an opaque transform in strict Structured Outputs.`,
             );
           }
+          return input;
+        }
+
+        if (hasUnconstrainedPipelineOutput(def.out._def)) {
           return input;
         }
 

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -378,6 +378,14 @@ const throwUnrepresentableStrictZodType = (typeName: ZodFirstPartyTypeKind, refs
   );
 };
 
+const assertFiniteStrictSchemaValue = (value: unknown, keyword: string, refs: Refs): void => {
+  if (refs.openaiStrictMode && typeof value === 'number' && !Number.isFinite(value)) {
+    throw new TypeError(
+      `Zod field at \`${refs.currentPath.join('/')}\` cannot represent the non-finite \`${keyword}\` value in JSON Structured Outputs.`,
+    );
+  }
+};
+
 const normalizeStrictBigIntValue = (value: bigint, keyword: string, refs: Refs): number => {
   if (keyword === 'multipleOf' && value <= 0n) {
     throw new RangeError(
@@ -821,6 +829,12 @@ const selectParser = (
         (option) =>
           option._def.typeName === ZodFirstPartyTypeKind.ZodLiteral && typeof option._def.value === 'bigint',
       );
+      const hasNonFiniteLiteral = options.some(
+        (option) =>
+          option._def.typeName === ZodFirstPartyTypeKind.ZodLiteral &&
+          typeof option._def.value === 'number' &&
+          !Number.isFinite(option._def.value),
+      );
       const nestedOverlaps = refs.openaiStrictMode
         ? options.map((consumer, consumerIndex) =>
             options.flatMap((producer, producerIndex) =>
@@ -847,6 +861,7 @@ const selectParser = (
         (omittedAsynchronousOptions ||
           bigintIndex !== -1 ||
           hasBigIntLiteral ||
+          hasNonFiniteLiteral ||
           nestedOverlaps.some((overlaps) => overlaps.length > 0))
       ) {
         const branches = options
@@ -941,6 +956,7 @@ const selectParser = (
       return parseRecordDef(def, refs);
     }
     case ZodFirstPartyTypeKind.ZodLiteral: {
+      assertFiniteStrictSchemaValue(def.value, 'const', refs);
       const schema = parseLiteralDef(def, refs);
       if (refs.openaiStrictMode && typeof def.value === 'bigint') {
         const record = schema as unknown as Record<string, unknown>;
@@ -959,7 +975,11 @@ const selectParser = (
       return parseEnumDef(def);
     }
     case ZodFirstPartyTypeKind.ZodNativeEnum: {
-      return parseNativeEnumDef(def);
+      const schema = parseNativeEnumDef(def);
+      for (const value of schema.enum) {
+        assertFiniteStrictSchemaValue(value, 'enum', refs);
+      }
+      return schema;
     }
     case ZodFirstPartyTypeKind.ZodNullable: {
       if (refs.openaiStrictMode && requiresAsynchronousJSONInput(def.innerType._def)) {

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -376,6 +376,11 @@ const throwUnrepresentableStrictZodType = (typeName: ZodFirstPartyTypeKind, refs
 };
 
 const normalizeStrictBigIntValue = (value: bigint, keyword: string, refs: Refs): number => {
+  if (keyword === 'multipleOf' && value <= 0n) {
+    throw new RangeError(
+      `Zod field at \`${refs.currentPath.join('/')}\` uses \`ZodBigInt\` and requires a strictly positive \`multipleOf\` value for JSON Structured Outputs.`,
+    );
+  }
   const normalized = Number(value);
 
   if (!Number.isSafeInteger(normalized)) {
@@ -387,10 +392,28 @@ const normalizeStrictBigIntValue = (value: bigint, keyword: string, refs: Refs):
   return normalized;
 };
 
+const strictDefaultPrototypeChain = (value: object, keyword: string, refs: Refs): object[] => {
+  const prototypes: object[] = [];
+  const visited = new WeakSet<object>([value]);
+  let prototype: object | null = Object.getPrototypeOf(value) as object | null;
+  while (prototype) {
+    if (visited.has(prototype) || prototypes.length >= 128) {
+      throw new TypeError(
+        `Zod field at \`${refs.currentPath.join('/')}\` cannot safely represent the cyclic or excessive \`${keyword}\` prototype chain in JSON Structured Outputs.`,
+      );
+    }
+    visited.add(prototype);
+    prototypes.push(prototype);
+    prototype = Object.getPrototypeOf(prototype) as object | null;
+  }
+  return prototypes;
+};
+
 const strictDefaultDescriptors = (
   value: object,
   keyword: string,
   refs: Refs,
+  prototypes: readonly object[],
 ): [string, PropertyDescriptor][] => {
   const descriptors = Object.entries(Object.getOwnPropertyDescriptors(value));
   for (const [key, descriptor] of descriptors) {
@@ -406,15 +429,13 @@ const strictDefaultDescriptors = (
     }
   }
 
-  let prototype: object | null = Object.getPrototypeOf(value) as object | null;
-  while (prototype) {
+  for (const prototype of prototypes) {
     const serializer = Object.getOwnPropertyDescriptor(prototype, 'toJSON');
     if (serializer && (serializer.get || serializer.set || typeof serializer.value === 'function')) {
       throw new TypeError(
         `Zod field at \`${refs.currentPath.join('/')}\` cannot safely represent an inherited \`${keyword}.toJSON\` serializer in JSON Structured Outputs.`,
       );
     }
-    prototype = Object.getPrototypeOf(prototype) as object | null;
   }
   return descriptors;
 };
@@ -456,6 +477,7 @@ const normalizeStrictDefaultValue = (
   if (!value || typeof value !== 'object') {
     return value;
   }
+  const prototypes = strictDefaultPrototypeChain(value, keyword, refs);
   if (value instanceof Set || value instanceof Map) {
     const typeName = value instanceof Set ? ZodFirstPartyTypeKind.ZodSet : ZodFirstPartyTypeKind.ZodMap;
     throwUnrepresentableStrictZodType(typeName, refs);
@@ -468,6 +490,16 @@ const normalizeStrictDefaultValue = (
   }
   const previous = seen.get(value);
   if (previous !== undefined) {
+    normalizeStrictDefaultValue(
+      value,
+      definition,
+      refs,
+      keyword,
+      new WeakMap<object, unknown>(),
+      path,
+      rootValue,
+      active,
+    );
     return previous;
   }
 
@@ -485,7 +517,7 @@ const normalizeStrictDefaultValue = (
       return value;
     }
 
-    const descriptors = strictDefaultDescriptors(value, keyword, refs);
+    const descriptors = strictDefaultDescriptors(value, keyword, refs, prototypes);
     if (Array.isArray(value)) {
       const normalized: unknown[] = [];
       seen.set(value, normalized);
@@ -513,7 +545,7 @@ const normalizeStrictDefaultValue = (
       return normalized;
     }
 
-    const prototype: unknown = Object.getPrototypeOf(value);
+    const prototype: unknown = prototypes[0] ?? null;
     const plainPrototype = prototype === null ? null : Object.prototype;
     const normalized = Object.create(plainPrototype) as Record<string, unknown>;
     seen.set(value, normalized);

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -77,6 +77,7 @@ import {
   producesDateAtPath,
   producesBigIntOutput,
   requiresAsynchronousJSONInput,
+  requiresNativeBigIntPipelineOutput,
 } from './schema-capabilities';
 import { ignoreOverride } from './Options';
 import { zodDef } from './util';
@@ -1075,8 +1076,8 @@ const selectParser = (
           const compatibleExpectedOutput =
             mismatch.path.length === 0 &&
             expectedKind !== undefined &&
-            (mismatch.left === 'opaque' || mismatch.left === expectedKind) &&
-            (mismatch.right === 'opaque' || mismatch.right === expectedKind);
+            mismatch.left === 'opaque' &&
+            mismatch.right === 'opaque';
           if (!compatibleExpectedOutput) {
             throw new TypeError(
               `ZodIntersection arms have incompatible parsed outputs: ${mismatch.left} and ${mismatch.right}`,
@@ -1292,6 +1293,14 @@ const selectParser = (
         }
 
         if (hasOpaquePipelineTransform(def.in._def)) {
+          if (
+            requiresNativeBigIntPipelineOutput(def.out._def) &&
+            knownParsedOutputType(def.in._def) !== ZodFirstPartyTypeKind.ZodBigInt
+          ) {
+            throw new TypeError(
+              `ZodPipeline opaque transform at \`${refs.currentPath.join('/')}\` cannot establish a compatible native ZodBigInt output in strict Structured Outputs.`,
+            );
+          }
           if (hasConstrainedPipelineOutput(def.out._def)) {
             throw new Error(
               `ZodPipeline output constraints at \`${refs.currentPath.join('/')}\` cannot be safely projected across an opaque transform in strict Structured Outputs.`,

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -125,7 +125,49 @@ const requiresJSONInputPreprocessor = (def: ZodTypeDef): boolean => {
   }
 };
 
-const acceptsJSONNumber = (def: any): boolean => {
+const producesBigIntOutput = (def: any, seen = new Set<ZodTypeDef>()): boolean => {
+  if (seen.has(def)) {
+    return false;
+  }
+  seen.add(def);
+
+  switch (def.typeName as ZodFirstPartyTypeKind) {
+    case ZodFirstPartyTypeKind.ZodBigInt: {
+      return true;
+    }
+    case ZodFirstPartyTypeKind.ZodNullable:
+    case ZodFirstPartyTypeKind.ZodOptional:
+    case ZodFirstPartyTypeKind.ZodDefault:
+    case ZodFirstPartyTypeKind.ZodCatch:
+    case ZodFirstPartyTypeKind.ZodReadonly: {
+      return producesBigIntOutput(def.innerType._def, seen);
+    }
+    case ZodFirstPartyTypeKind.ZodBranded: {
+      return producesBigIntOutput(def.type._def, seen);
+    }
+    case ZodFirstPartyTypeKind.ZodEffects: {
+      return producesBigIntOutput(def.schema._def, seen);
+    }
+    case ZodFirstPartyTypeKind.ZodPipeline: {
+      return producesBigIntOutput(def.out._def, seen);
+    }
+    case ZodFirstPartyTypeKind.ZodUnion:
+    case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
+      const options = def.options instanceof Map ? [...def.options.values()] : def.options;
+      return options.some((option: { _def: ZodTypeDef }) => producesBigIntOutput(option._def, seen));
+    }
+    default: {
+      return false;
+    }
+  }
+};
+
+const acceptsJSONNumber = (def: any, seen = new Set<ZodTypeDef>()): boolean => {
+  if (seen.has(def)) {
+    return false;
+  }
+  seen.add(def);
+
   switch (def.typeName as ZodFirstPartyTypeKind) {
     case ZodFirstPartyTypeKind.ZodNumber:
     case ZodFirstPartyTypeKind.ZodAny:
@@ -140,16 +182,21 @@ const acceptsJSONNumber = (def: any): boolean => {
     case ZodFirstPartyTypeKind.ZodDefault:
     case ZodFirstPartyTypeKind.ZodCatch:
     case ZodFirstPartyTypeKind.ZodReadonly: {
-      return acceptsJSONNumber(def.innerType._def);
+      return acceptsJSONNumber(def.innerType._def, seen);
     }
     case ZodFirstPartyTypeKind.ZodBranded: {
-      return acceptsJSONNumber(def.type._def);
+      return acceptsJSONNumber(def.type._def, seen);
     }
     case ZodFirstPartyTypeKind.ZodEffects: {
-      return def.effect.type === 'preprocess' || acceptsJSONNumber(def.schema._def);
+      return def.effect.type === 'preprocess' || acceptsJSONNumber(def.schema._def, seen);
     }
     case ZodFirstPartyTypeKind.ZodPipeline: {
-      return acceptsJSONNumber(def.in._def);
+      return acceptsJSONNumber(def.in._def, seen);
+    }
+    case ZodFirstPartyTypeKind.ZodUnion:
+    case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
+      const options = def.options instanceof Map ? [...def.options.values()] : def.options;
+      return options.some((option: { _def: ZodTypeDef }) => acceptsJSONNumber(option._def, seen));
     }
     default: {
       return def.coerce === true;
@@ -172,6 +219,21 @@ const convertsJSONPipelineInput = (def: any): boolean => {
 
   const inner = def.innerType?._def ?? def.type?._def;
   return inner ? convertsJSONPipelineInput(inner) : def.coerce === true;
+};
+
+const hasJSONIntegerBranch = (schema: unknown): boolean => {
+  if (!schema || typeof schema !== 'object') {
+    return false;
+  }
+
+  const record = schema as Record<string, unknown>;
+  const { type } = record;
+  if (type === 'integer' || (Array.isArray(type) && type.includes('integer'))) {
+    return true;
+  }
+
+  const branches = record['anyOf'] ?? record['allOf'];
+  return Array.isArray(branches) && branches.some((branch) => hasJSONIntegerBranch(branch));
 };
 
 export function parseDef(
@@ -368,6 +430,68 @@ const normalizeStrictBigIntValue = (value: bigint, keyword: string, refs: Refs):
   return normalized;
 };
 
+const normalizeStrictDefaultValue = (
+  value: unknown,
+  refs: Refs,
+  keyword = 'default',
+  seen = new WeakMap<object, unknown>(),
+): unknown => {
+  if (typeof value === 'bigint') {
+    return normalizeStrictBigIntValue(value, keyword, refs);
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  const previous = seen.get(value);
+  if (previous !== undefined) {
+    return previous;
+  }
+
+  if (Array.isArray(value)) {
+    const normalized: unknown[] = [];
+    seen.set(value, normalized);
+    let changed = false;
+
+    for (const [index, item] of value.entries()) {
+      const normalizedItem = normalizeStrictDefaultValue(item, refs, `${keyword}[${index}]`, seen);
+      normalized.push(normalizedItem);
+      changed ||= normalizedItem !== item;
+    }
+
+    if (!changed) {
+      seen.set(value, value);
+      return value;
+    }
+    return normalized;
+  }
+
+  const prototype: unknown = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    return value;
+  }
+
+  const normalized = Object.create(prototype) as Record<string, unknown>;
+  seen.set(value, normalized);
+  let changed = false;
+  for (const [key, item] of Object.entries(value)) {
+    const normalizedItem = normalizeStrictDefaultValue(item, refs, `${keyword}.${key}`, seen);
+    Object.defineProperty(normalized, key, {
+      value: normalizedItem,
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    });
+    changed ||= normalizedItem !== item;
+  }
+
+  if (!changed) {
+    seen.set(value, value);
+    return value;
+  }
+  return normalized;
+};
+
 const selectParser = (
   def: any,
   typeName: ZodFirstPartyTypeKind,
@@ -396,6 +520,24 @@ const selectParser = (
 
         record['minimum'] ??= Number.MIN_SAFE_INTEGER;
         record['maximum'] ??= Number.MAX_SAFE_INTEGER;
+
+        let lowerBound = BigInt(record['minimum'] as number);
+        let upperBound = BigInt(record['maximum'] as number);
+        const { exclusiveMinimum, exclusiveMaximum } = record;
+        if (typeof exclusiveMinimum === 'number') {
+          const exclusiveLowerBound = BigInt(exclusiveMinimum) + 1n;
+          lowerBound = exclusiveLowerBound > lowerBound ? exclusiveLowerBound : lowerBound;
+        }
+        if (typeof exclusiveMaximum === 'number') {
+          const exclusiveUpperBound = BigInt(exclusiveMaximum) - 1n;
+          upperBound = exclusiveUpperBound < upperBound ? exclusiveUpperBound : upperBound;
+        }
+
+        if (lowerBound > upperBound) {
+          throw new RangeError(
+            `Zod field at \`${refs.currentPath.join('/')}\` uses \`ZodBigInt\` but has no safe JSON integer values that satisfy its bounds.`,
+          );
+        }
       }
 
       return schema;
@@ -423,25 +565,16 @@ const selectParser = (
           value?: unknown;
         };
       }[];
-      const bigintIndex = options.findIndex(
-        (option) => option._def.typeName === ZodFirstPartyTypeKind.ZodBigInt,
-      );
+      const bigintIndex = options.findIndex((option) => producesBigIntOutput(option._def));
       const hasBigIntLiteral = options.some(
         (option) =>
           option._def.typeName === ZodFirstPartyTypeKind.ZodLiteral && typeof option._def.value === 'bigint',
       );
 
       if (refs.openaiStrictMode && (bigintIndex !== -1 || hasBigIntLiteral)) {
-        const numberWinsBeforeBigInt =
-          bigintIndex !== -1 &&
-          options.slice(0, bigintIndex).some((option) => acceptsJSONNumber(option._def));
         const branches = options
           .map((option, index) => {
-            const boundNumber =
-              bigintIndex !== -1 &&
-              index > bigintIndex &&
-              !numberWinsBeforeBigInt &&
-              acceptsJSONNumber(option._def);
+            const boundNumber = bigintIndex !== -1 && index > bigintIndex && acceptsJSONNumber(option._def);
             const branch = parseDef(
               option._def as ZodTypeDef,
               {
@@ -573,12 +706,12 @@ const selectParser = (
     }
     case ZodFirstPartyTypeKind.ZodDefault: {
       const schema = parseDefaultDef(def, refs, forceResolution);
-      if (refs.openaiStrictMode && typeof schema.default === 'bigint') {
-        if (!('type' in schema) || schema.type !== 'integer') {
+      if (refs.openaiStrictMode) {
+        if (typeof schema.default === 'bigint' && !hasJSONIntegerBranch(schema)) {
           throwUnrepresentableStrictZodType(ZodFirstPartyTypeKind.ZodBigInt, refs);
         }
 
-        schema.default = normalizeStrictBigIntValue(schema.default, 'default', refs);
+        schema.default = normalizeStrictDefaultValue(schema.default, refs);
       }
 
       return schema;

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -125,6 +125,55 @@ const requiresJSONInputPreprocessor = (def: ZodTypeDef): boolean => {
   }
 };
 
+const acceptsJSONNumber = (def: any): boolean => {
+  switch (def.typeName as ZodFirstPartyTypeKind) {
+    case ZodFirstPartyTypeKind.ZodNumber:
+    case ZodFirstPartyTypeKind.ZodAny:
+    case ZodFirstPartyTypeKind.ZodUnknown: {
+      return true;
+    }
+    case ZodFirstPartyTypeKind.ZodLiteral: {
+      return typeof def.value === 'number';
+    }
+    case ZodFirstPartyTypeKind.ZodNullable:
+    case ZodFirstPartyTypeKind.ZodOptional:
+    case ZodFirstPartyTypeKind.ZodDefault:
+    case ZodFirstPartyTypeKind.ZodCatch:
+    case ZodFirstPartyTypeKind.ZodReadonly: {
+      return acceptsJSONNumber(def.innerType._def);
+    }
+    case ZodFirstPartyTypeKind.ZodBranded: {
+      return acceptsJSONNumber(def.type._def);
+    }
+    case ZodFirstPartyTypeKind.ZodEffects: {
+      return def.effect.type === 'preprocess' || acceptsJSONNumber(def.schema._def);
+    }
+    case ZodFirstPartyTypeKind.ZodPipeline: {
+      return acceptsJSONNumber(def.in._def);
+    }
+    default: {
+      return def.coerce === true;
+    }
+  }
+};
+
+const convertsJSONPipelineInput = (def: any): boolean => {
+  if (def.typeName === ZodFirstPartyTypeKind.ZodEffects) {
+    return (
+      def.effect.type === 'transform' ||
+      def.effect.type === 'preprocess' ||
+      convertsJSONPipelineInput(def.schema._def)
+    );
+  }
+
+  if (def.typeName === ZodFirstPartyTypeKind.ZodPipeline) {
+    return convertsJSONPipelineInput(def.in._def) || convertsJSONPipelineInput(def.out._def);
+  }
+
+  const inner = def.innerType?._def ?? def.type?._def;
+  return inner ? convertsJSONPipelineInput(inner) : def.coerce === true;
+};
+
 export function parseDef(
   def: ZodTypeDef,
   refs: Refs,
@@ -156,9 +205,11 @@ export function parseDef(
     throwUnrepresentableStrictZodType((def as { typeName: ZodFirstPartyTypeKind }).typeName, diagnosticRefs);
   }
 
-  // A native schema reused by different preprocessors must not be extracted as
-  // a bare definition, because its input-conversion context would be lost.
-  const inlinePreprocessedType = needsPreprocessing && isPreprocessed;
+  // Native leaves and their already-materialized shared ancestors must remain
+  // inside the conversion context. In-progress recursive definitions still use
+  // references so recursive schemas terminate normally.
+  const inlinePreprocessedType =
+    isPreprocessed && (needsPreprocessing || (seenItem !== undefined && seenItem.jsonSchema !== undefined));
 
   if (seenItem && !forceResolution && !inlinePreprocessedType) {
     const seenSchema = get$ref(seenItem, refs);
@@ -381,32 +432,56 @@ const selectParser = (
       );
 
       if (refs.openaiStrictMode && (bigintIndex !== -1 || hasBigIntLiteral)) {
+        const numberWinsBeforeBigInt =
+          bigintIndex !== -1 &&
+          options.slice(0, bigintIndex).some((option) => acceptsJSONNumber(option._def));
         const branches = options
-          .map((option, index) =>
-            parseDef(option._def as ZodTypeDef, {
-              ...refs,
-              currentPath: [...refs.currentPath, 'anyOf', String(index)],
-            }),
-          )
+          .map((option, index) => {
+            const boundNumber =
+              bigintIndex !== -1 &&
+              index > bigintIndex &&
+              !numberWinsBeforeBigInt &&
+              acceptsJSONNumber(option._def);
+            const branch = parseDef(
+              option._def as ZodTypeDef,
+              {
+                ...refs,
+                currentPath: [...refs.currentPath, 'anyOf', String(index)],
+              },
+              boundNumber,
+            );
+
+            if (!boundNumber || branch === undefined) {
+              return branch;
+            }
+
+            if ('$ref' in branch) {
+              return {
+                allOf: [
+                  branch,
+                  {
+                    minimum: Number.MIN_SAFE_INTEGER,
+                    maximum: Number.MAX_SAFE_INTEGER,
+                  } as JsonSchema7Type,
+                ],
+              };
+            }
+
+            const record = branch as unknown as Record<string, unknown>;
+            record['minimum'] = Math.max(
+              typeof record['minimum'] === 'number' ? record['minimum'] : Number.MIN_SAFE_INTEGER,
+              Number.MIN_SAFE_INTEGER,
+            );
+            record['maximum'] = Math.min(
+              typeof record['maximum'] === 'number' ? record['maximum'] : Number.MAX_SAFE_INTEGER,
+              Number.MAX_SAFE_INTEGER,
+            );
+            return branch;
+          })
           .filter(
             (branch): branch is JsonSchema7Type =>
               branch !== undefined && (!refs.strictUnions || Object.keys(branch).length > 0),
           );
-        const numberWinsBeforeBigInt =
-          bigintIndex !== -1 &&
-          options
-            .slice(0, bigintIndex)
-            .some((option) => option._def.typeName === ZodFirstPartyTypeKind.ZodNumber);
-
-        if (bigintIndex !== -1 && !numberWinsBeforeBigInt) {
-          for (const branch of branches) {
-            if ('type' in branch && branch.type === 'number') {
-              const record = branch as unknown as Record<string, unknown>;
-              record['minimum'] ??= Number.MIN_SAFE_INTEGER;
-              record['maximum'] ??= Number.MAX_SAFE_INTEGER;
-            }
-          }
-        }
 
         return branches.length > 0 ? { anyOf: branches } : undefined;
       }
@@ -518,6 +593,15 @@ const selectParser = (
       return parseCatchDef(def, refs, forceResolution);
     }
     case ZodFirstPartyTypeKind.ZodPipeline: {
+      if (refs.openaiStrictMode && convertsJSONPipelineInput(def.in._def)) {
+        const outputRefs: PreprocessedRefs = {
+          ...refs,
+          [jsonInputPreprocessor]: true,
+        };
+
+        return parsePipelineDef(def, refs, forceResolution, outputRefs);
+      }
+
       return parsePipelineDef(def, refs, forceResolution);
     }
     case ZodFirstPartyTypeKind.ZodFunction:

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -502,6 +502,44 @@ const nativeCollectionDefaultType = (
   return undefined;
 };
 
+const trustedInternalSlotObjectMethods = [
+  { type: 'RegExp', method: Object.getOwnPropertyDescriptor(RegExp.prototype, 'source')?.get },
+  { type: 'ArrayBuffer', method: Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, 'byteLength')?.get },
+  {
+    type: 'SharedArrayBuffer',
+    method:
+      typeof SharedArrayBuffer === 'undefined'
+        ? undefined
+        : Object.getOwnPropertyDescriptor(SharedArrayBuffer.prototype, 'byteLength')?.get,
+  },
+  { type: 'DataView', method: Object.getOwnPropertyDescriptor(DataView.prototype, 'byteLength')?.get },
+  { type: 'WeakMap', method: WeakMap.prototype.has },
+  { type: 'WeakSet', method: WeakSet.prototype.has },
+] as const;
+const trustedArrayBufferIsView = ArrayBuffer.isView;
+const trustedInternalSlotObjectPrototypes = new Map<object, string>([
+  [Object.getOwnPropertyDescriptor(Promise, 'prototype')?.value as object, 'Promise'],
+  [Error.prototype, 'Error'],
+]);
+
+const unsupportedInternalSlotDefaultType = (value: object): string | undefined => {
+  if (trustedArrayBufferIsView(value)) {
+    return 'ArrayBuffer view';
+  }
+  for (const { type, method } of trustedInternalSlotObjectMethods) {
+    if (typeof method !== 'function') {
+      continue;
+    }
+    try {
+      Reflect.apply(method, value, []);
+      return type;
+    } catch {
+      // Captured intrinsic methods reject receivers without their corresponding native slot.
+    }
+  }
+  return undefined;
+};
+
 const trustedDatePrototypeMethods = new Map<PropertyKey, unknown>([
   ['getTime', Date.prototype.getTime],
   ['toJSON', Date.prototype.toJSON],
@@ -510,6 +548,16 @@ const trustedDatePrototypeMethods = new Map<PropertyKey, unknown>([
   [Symbol.toPrimitive, Date.prototype[Symbol.toPrimitive]],
 ]);
 const trustedDateGetTime = Date.prototype.getTime;
+
+const hasNativeDateInternalSlot = (value: object): value is Date => {
+  try {
+    Reflect.apply(trustedDateGetTime, value, []);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 const trustedBoxedPrimitiveMethods = [
   BigInt.prototype.valueOf,
   Symbol.prototype.valueOf,
@@ -580,7 +628,20 @@ const normalizeStrictDefaultValue = (
   if (nativeCollection !== undefined) {
     throwUnrepresentableStrictZodType(nativeCollection, refs);
   }
+  const nativeObject = unsupportedInternalSlotDefaultType(value);
+  if (nativeObject !== undefined) {
+    throw new TypeError(
+      `Zod field at \`${refs.currentPath.join('/')}\` cannot safely represent the \`${keyword}\` ${nativeObject} object with hidden internal slots in JSON Structured Outputs.`,
+    );
+  }
   const prototypes = strictDefaultPrototypeChain(value, keyword, refs);
+  const nativePrototype = prototypes.find((prototype) => trustedInternalSlotObjectPrototypes.has(prototype));
+  if (nativePrototype !== undefined) {
+    const nativeType = trustedInternalSlotObjectPrototypes.get(nativePrototype);
+    throw new TypeError(
+      `Zod field at \`${refs.currentPath.join('/')}\` cannot safely represent the \`${keyword}\` ${nativeType} object with hidden internal slots in JSON Structured Outputs.`,
+    );
+  }
 
   if (active.has(value)) {
     throw new TypeError(
@@ -604,7 +665,7 @@ const normalizeStrictDefaultValue = (
 
   active.add(value);
   try {
-    if (value instanceof Date) {
+    if (hasNativeDateInternalSlot(value)) {
       if (!isCanonicalDateDefault(value)) {
         throw new TypeError(
           `Zod field at \`${refs.currentPath.join('/')}\` cannot safely represent the invalid or customized \`${keyword}\` Date in JSON Structured Outputs.`,
@@ -882,6 +943,17 @@ const mergeStrictSchemas = (left: JsonSchema7Type, right: JsonSchema7Type): Json
   return merged as JsonSchema7Type;
 };
 
+const hasDisjointStrictSchemaTypes = (first: JsonSchema7Type, second: JsonSchema7Type): boolean => {
+  const left = (first as Record<string, unknown>)['type'];
+  const right = (second as Record<string, unknown>)['type'];
+  return (
+    typeof left === 'string' &&
+    typeof right === 'string' &&
+    left !== right &&
+    !(isNumericSchemaType(left) && isNumericSchemaType(right))
+  );
+};
+
 const selectParser = (
   def: any,
   typeName: ZodFirstPartyTypeKind,
@@ -1126,18 +1198,9 @@ const selectParser = (
       if (refs.openaiStrictMode) {
         const mismatch = findIncompatibleParsedOutputs(def.left._def, def.right._def);
         if (mismatch) {
-          const expectedOutput = (refs as PreprocessedRefs)[expectedPipelineOutput];
-          const expectedKind = expectedOutput ? knownParsedOutputType(expectedOutput) : undefined;
-          const compatibleExpectedOutput =
-            mismatch.path.length === 0 &&
-            expectedKind !== undefined &&
-            mismatch.left === 'opaque' &&
-            mismatch.right === 'opaque';
-          if (!compatibleExpectedOutput) {
-            throw new TypeError(
-              `ZodIntersection arms have incompatible parsed outputs: ${mismatch.left} and ${mismatch.right}`,
-            );
-          }
+          throw new TypeError(
+            `ZodIntersection arms have incompatible parsed outputs: ${mismatch.left} and ${mismatch.right}`,
+          );
         }
       }
       const intersectionRefs: PreprocessedRefs = refs.openaiStrictMode
@@ -1373,11 +1436,24 @@ const selectParser = (
         }
         const alternatives = (output as Record<string, unknown>)['anyOf'];
         if (Array.isArray(alternatives)) {
-          const projected = alternatives.map((alternative) =>
-            mergeStrictSchemas(input, alternative as JsonSchema7Type),
-          );
-          if (projected.every((alternative) => alternative !== undefined)) {
-            return { anyOf: projected } as JsonSchema7Type;
+          const projected: JsonSchema7Type[] = [];
+          let discarded = false;
+          let unprojectable = false;
+          for (const alternative of alternatives) {
+            const candidate = alternative as JsonSchema7Type;
+            const combinedAlternative = mergeStrictSchemas(input, candidate);
+            if (combinedAlternative) {
+              projected.push(combinedAlternative);
+            } else if (hasDisjointStrictSchemaTypes(input, candidate)) {
+              discarded = true;
+            } else {
+              unprojectable = true;
+              break;
+            }
+          }
+          const [first] = projected;
+          if (!unprojectable && first !== undefined) {
+            return discarded && projected.length === 1 ? first : ({ anyOf: projected } as JsonSchema7Type);
           }
           throw new Error(
             `ZodPipeline output constraints at \`${refs.currentPath.join('/')}\` cannot be represented in strict Structured Outputs.`,

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -247,6 +247,24 @@ const getRelativePath = (pathA: string[], pathB: string[]) => {
   return [(pathA.length - i).toString(), ...pathB.slice(i)].join('/');
 };
 
+const throwUnrepresentableStrictZodType = (typeName: ZodFirstPartyTypeKind, refs: Refs): never => {
+  throw new Error(
+    `Zod field at \`${refs.currentPath.join('/')}\` uses \`${typeName}\`, which cannot be represented in JSON Structured Outputs. Use a JSON-compatible schema or a supported coercion.`,
+  );
+};
+
+const normalizeStrictBigIntValue = (value: bigint, keyword: string, refs: Refs): number => {
+  const normalized = Number(value);
+
+  if (!Number.isSafeInteger(normalized)) {
+    throw new TypeError(
+      `Zod field at \`${refs.currentPath.join('/')}\` uses \`ZodBigInt\` and cannot represent the \`${keyword}\` value as a safe JSON integer.`,
+    );
+  }
+
+  return normalized;
+};
+
 const selectParser = (
   def: any,
   typeName: ZodFirstPartyTypeKind,
@@ -264,12 +282,33 @@ const selectParser = (
       return parseObjectDef(def, refs);
     }
     case ZodFirstPartyTypeKind.ZodBigInt: {
-      return parseBigintDef(def, refs);
+      if (refs.openaiStrictMode && !def.coerce) {
+        throwUnrepresentableStrictZodType(typeName, refs);
+      }
+
+      const schema = parseBigintDef(def, refs);
+      if (refs.openaiStrictMode) {
+        for (const [keyword, value] of Object.entries(schema)) {
+          if (typeof value === 'bigint') {
+            (schema as unknown as Record<string, unknown>)[keyword] = normalizeStrictBigIntValue(
+              value,
+              keyword,
+              refs,
+            );
+          }
+        }
+      }
+
+      return schema;
     }
     case ZodFirstPartyTypeKind.ZodBoolean: {
       return parseBooleanDef();
     }
     case ZodFirstPartyTypeKind.ZodDate: {
+      if (refs.openaiStrictMode && !def.coerce) {
+        throwUnrepresentableStrictZodType(typeName, refs);
+      }
+
       return parseDateDef(def, refs);
     }
     case ZodFirstPartyTypeKind.ZodUndefined: {
@@ -310,9 +349,17 @@ const selectParser = (
       return parseOptionalDef(def, refs, forceResolution);
     }
     case ZodFirstPartyTypeKind.ZodMap: {
+      if (refs.openaiStrictMode) {
+        throwUnrepresentableStrictZodType(typeName, refs);
+      }
+
       return parseMapDef(def, refs);
     }
     case ZodFirstPartyTypeKind.ZodSet: {
+      if (refs.openaiStrictMode) {
+        throwUnrepresentableStrictZodType(typeName, refs);
+      }
+
       return parseSetDef(def, refs);
     }
     case ZodFirstPartyTypeKind.ZodLazy: {
@@ -335,7 +382,16 @@ const selectParser = (
       return parseUnknownDef();
     }
     case ZodFirstPartyTypeKind.ZodDefault: {
-      return parseDefaultDef(def, refs, forceResolution);
+      const schema = parseDefaultDef(def, refs, forceResolution);
+      if (refs.openaiStrictMode && typeof schema.default === 'bigint') {
+        if (!('type' in schema) || schema.type !== 'integer') {
+          throwUnrepresentableStrictZodType(ZodFirstPartyTypeKind.ZodBigInt, refs);
+        }
+
+        schema.default = normalizeStrictBigIntValue(schema.default, 'default', refs);
+      }
+
+      return schema;
     }
     case ZodFirstPartyTypeKind.ZodBranded: {
       return parseBrandedDef(def, refs, forceResolution);

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -99,6 +99,36 @@ type PreprocessedRefs = Refs & { [jsonInputPreprocessor]?: true };
 
 const hasJSONInputPreprocessor = (refs: Refs): boolean =>
   (refs as PreprocessedRefs)[jsonInputPreprocessor] === true;
+const registeredDefinitionInputContexts = new WeakMap<Seen, 'preprocessed' | 'unprocessed' | 'mixed'>();
+
+const recordDefinitionInputContext = (def: ZodTypeDef, seen: Seen, refs: Refs, preprocessed: boolean) => {
+  const definitionName = seen.path[refs.basePath.length + 1];
+  const definition = definitionName === undefined ? undefined : refs.definitions[definitionName];
+  if (
+    seen.path.length !== refs.basePath.length + 2 ||
+    seen.path[refs.basePath.length] !== refs.definitionPath ||
+    definitionName === undefined ||
+    definition === undefined ||
+    !hasOwn(refs.definitions, definitionName) ||
+    zodDef(definition) !== def
+  ) {
+    return;
+  }
+
+  const context = preprocessed ? 'preprocessed' : 'unprocessed';
+  const previous = registeredDefinitionInputContexts.get(seen);
+  registeredDefinitionInputContexts.set(seen, previous && previous !== context ? 'mixed' : context);
+};
+
+export const getDefinitionInputRefs = (def: ZodTypeDef, refs: Refs): Refs => {
+  const seen = refs.seen.get(def);
+  if (!seen || registeredDefinitionInputContexts.get(seen) !== 'preprocessed') {
+    return refs;
+  }
+
+  const preprocessedRefs: PreprocessedRefs = { ...refs, [jsonInputPreprocessor]: true };
+  return preprocessedRefs;
+};
 
 const requiresJSONInputPreprocessor = (def: ZodTypeDef): boolean => {
   const schema = def as ZodTypeDef & {
@@ -204,21 +234,28 @@ const acceptsJSONNumber = (def: any, seen = new Set<ZodTypeDef>()): boolean => {
   }
 };
 
-const convertsJSONPipelineInput = (def: any): boolean => {
+const convertsJSONPipelineInput = (def: any, output: any): boolean => {
   if (def.typeName === ZodFirstPartyTypeKind.ZodEffects) {
     return (
       def.effect.type === 'transform' ||
       def.effect.type === 'preprocess' ||
-      convertsJSONPipelineInput(def.schema._def)
+      convertsJSONPipelineInput(def.schema._def, output)
     );
   }
 
   if (def.typeName === ZodFirstPartyTypeKind.ZodPipeline) {
-    return convertsJSONPipelineInput(def.in._def) || convertsJSONPipelineInput(def.out._def);
+    return convertsJSONPipelineInput(def.in._def, output) || convertsJSONPipelineInput(def.out._def, output);
   }
 
   const inner = def.innerType?._def ?? def.type?._def;
-  return inner ? convertsJSONPipelineInput(inner) : def.coerce === true;
+  if (inner) {
+    return convertsJSONPipelineInput(inner, output);
+  }
+
+  const outputInner = output.innerType?._def ?? output.type?._def;
+  return outputInner
+    ? convertsJSONPipelineInput(def, outputInner)
+    : def.coerce === true && def.typeName === output.typeName;
 };
 
 const hasJSONIntegerBranch = (schema: unknown): boolean => {
@@ -253,6 +290,9 @@ export function parseDef(
 
   const needsPreprocessing = refs.openaiStrictMode === true && requiresJSONInputPreprocessor(def);
   const isPreprocessed = hasJSONInputPreprocessor(refs);
+  if (refs.openaiStrictMode && seenItem && !forceResolution) {
+    recordDefinitionInputContext(def, seenItem, refs, isPreprocessed);
+  }
   if (needsPreprocessing && !isPreprocessed) {
     const registeredDefinitionPath =
       seenItem?.jsonSchema === undefined &&
@@ -726,7 +766,7 @@ const selectParser = (
       return parseCatchDef(def, refs, forceResolution);
     }
     case ZodFirstPartyTypeKind.ZodPipeline: {
-      if (refs.openaiStrictMode && convertsJSONPipelineInput(def.in._def)) {
+      if (refs.openaiStrictMode && convertsJSONPipelineInput(def.in._def, def.out._def)) {
         const outputRefs: PreprocessedRefs = {
           ...refs,
           [jsonInputPreprocessor]: true,

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -61,11 +61,11 @@ import {
   applySafeIntegerBounds,
   applyUnsafeBigIntBounds,
   convertsJSONPipelineInput,
+  findIncompatibleParsedOutputs,
   findNestedNumericOverlaps,
   hasConstrainedPipelineOutput,
   hasOpaqueJSONValidation,
   hasOpaquePipelineTransform,
-  knownParsedOutputType,
   producesBigIntAtPath,
   producesDateAtPath,
   producesBigIntOutput,
@@ -450,6 +450,13 @@ const trustedDatePrototypeMethods = new Map<PropertyKey, unknown>([
   [Symbol.toPrimitive, Date.prototype[Symbol.toPrimitive]],
 ]);
 const trustedDateGetTime = Date.prototype.getTime;
+const trustedBoxedPrimitiveMethods = [
+  BigInt.prototype.valueOf,
+  Symbol.prototype.valueOf,
+  Number.prototype.valueOf,
+  String.prototype.valueOf,
+  Boolean.prototype.valueOf,
+];
 
 const isCanonicalDateDefault = (value: Date): boolean =>
   Object.getPrototypeOf(value) === Date.prototype &&
@@ -529,14 +536,31 @@ const normalizeStrictDefaultValue = (
       return value;
     }
 
+    const boxedPrimitive = trustedBoxedPrimitiveMethods.some((valueOf) => {
+      try {
+        Reflect.apply(valueOf, value, []);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    if (boxedPrimitive) {
+      throw new TypeError('Zod default cannot safely represent a boxed primitive in JSON Structured Outputs');
+    }
+
     const descriptors = strictDefaultDescriptors(value, keyword, refs, prototypes);
     if (Array.isArray(value)) {
       const normalized: unknown[] = [];
       seen.set(value, normalized);
       let changed = false;
+      const ownDescriptors = new Map(descriptors);
 
       for (let index = 0; index < value.length; index += 1) {
-        const item: unknown = value[index];
+        const descriptor = ownDescriptors.get(String(index));
+        if (!descriptor) {
+          throw new TypeError('Zod default cannot safely represent an inherited or sparse array index');
+        }
+        const item: unknown = descriptor.value;
         const normalizedItem = normalizeStrictDefaultValue(
           item,
           definition,
@@ -849,10 +873,11 @@ const selectParser = (
     }
     case ZodFirstPartyTypeKind.ZodIntersection: {
       if (refs.openaiStrictMode) {
-        const left = knownParsedOutputType(def.left._def);
-        const right = knownParsedOutputType(def.right._def);
-        if (left !== undefined && right !== undefined && left !== right) {
-          throw new TypeError(`ZodIntersection arms have incompatible parsed outputs: ${left} and ${right}`);
+        const mismatch = findIncompatibleParsedOutputs(def.left._def, def.right._def);
+        if (mismatch) {
+          throw new TypeError(
+            `ZodIntersection arms have incompatible parsed outputs: ${mismatch.left} and ${mismatch.right}`,
+          );
         }
       }
       const intersectionRefs: PreprocessedRefs = refs.openaiStrictMode

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -72,6 +72,7 @@ import {
   hasExactBigIntStringInput,
   hasOpaqueJSONValidation,
   hasOpaquePipelineTransform,
+  knownParsedOutputType,
   producesBigIntAtPath,
   producesDateAtPath,
   producesBigIntOutput,
@@ -658,6 +659,99 @@ const normalizeStrictDefaultValue = (
   }
 };
 
+type DecimalMultiple = { numerator: bigint; places: number };
+
+const decimalMultiple = (value: unknown): DecimalMultiple | undefined => {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  const text = value.toString();
+  if (!/^\d+(?:\.\d+)?$/u.test(text)) {
+    return undefined;
+  }
+  const [whole, fraction = ''] = text.split('.');
+  return { numerator: BigInt(whole + fraction), places: fraction.length };
+};
+
+const greatestCommonDivisor = (first: bigint, second: bigint): bigint => {
+  let left = first;
+  let right = second;
+  while (right !== 0n) {
+    const remainder = left % right;
+    left = right;
+    right = remainder;
+  }
+  return left;
+};
+
+const mergeStrictNumericMultiples = (first: unknown, second: unknown): number | undefined => {
+  const left = decimalMultiple(first);
+  const right = decimalMultiple(second);
+  if (!left || !right) {
+    return undefined;
+  }
+
+  const places = Math.max(left.places, right.places);
+  const firstNumerator = left.numerator * 10n ** BigInt(places - left.places);
+  const secondNumerator = right.numerator * 10n ** BigInt(places - right.places);
+  const multiple =
+    (firstNumerator / greatestCommonDivisor(firstNumerator, secondNumerator)) * secondNumerator;
+  if (multiple > BigInt(Number.MAX_SAFE_INTEGER)) {
+    return undefined;
+  }
+
+  const combined = Number(`${multiple.toString()}e-${places}`);
+  const normalized = decimalMultiple(combined);
+  if (!normalized) {
+    return undefined;
+  }
+  const verificationPlaces = Math.max(places, normalized.places);
+  const expected = multiple * 10n ** BigInt(verificationPlaces - places);
+  const actual = normalized.numerator * 10n ** BigInt(verificationPlaces - normalized.places);
+  return expected === actual ? combined : undefined;
+};
+
+type StrictBigIntCheck = { kind: string; value?: bigint; inclusive?: boolean };
+
+const strictBigIntBoundKeywords = {
+  min: { inclusive: 'minimum', exclusive: 'exclusiveMinimum' },
+  max: { inclusive: 'maximum', exclusive: 'exclusiveMaximum' },
+} as const;
+
+const retainStrictBigIntChecks = (
+  record: Record<string, unknown>,
+  checks: readonly StrictBigIntCheck[],
+): void => {
+  for (const check of checks) {
+    if (typeof check.value !== 'bigint') {
+      continue;
+    }
+    if (check.kind === 'multipleOf') {
+      const current = record['multipleOf'];
+      if (check.value <= 0n) {
+        record['multipleOf'] = check.value;
+      } else if (typeof current !== 'bigint') {
+        record['multipleOf'] = check.value;
+      } else if (current > 0n) {
+        record['multipleOf'] = (current / greatestCommonDivisor(current, check.value)) * check.value;
+      }
+      continue;
+    }
+    if (check.kind !== 'min' && check.kind !== 'max') {
+      continue;
+    }
+    const keywords = strictBigIntBoundKeywords[check.kind];
+    const keyword = check.inclusive === false ? keywords.exclusive : keywords.inclusive;
+    const current = record[keyword];
+    if (
+      typeof current !== 'bigint' ||
+      (check.kind === 'min' ? check.value > current : check.value < current)
+    ) {
+      record[keyword] = check.value;
+    }
+  }
+};
+
 const isNumericSchemaType = (type: unknown) => type === 'number' || type === 'integer';
 
 const mergeStrictSchemas = (left: JsonSchema7Type, right: JsonSchema7Type): JsonSchema7Type | undefined => {
@@ -690,6 +784,12 @@ const mergeStrictSchemas = (left: JsonSchema7Type, right: JsonSchema7Type): Json
       keyword === 'maxItems'
     ) {
       merged[keyword] = Math.min(merged[keyword] as number, value as number);
+    } else if (keyword === 'multipleOf') {
+      const multiple = mergeStrictNumericMultiples(merged[keyword], value);
+      if (multiple === undefined) {
+        return undefined;
+      }
+      merged[keyword] = multiple;
     } else if (keyword === 'properties' && value && typeof value === 'object') {
       const original = merged[keyword] as Record<string, JsonSchema7Type>;
       const properties = value as Record<string, JsonSchema7Type>;
@@ -779,6 +879,7 @@ const selectParser = (
       const schema = parseBigintDef(def, refs);
       if (refs.openaiStrictMode) {
         const record = schema as unknown as Record<string, unknown>;
+        retainStrictBigIntChecks(record, def.checks ?? []);
         for (const [keyword, value] of Object.entries(schema)) {
           if (typeof value === 'bigint') {
             record[keyword] = normalizeStrictBigIntValue(value, keyword, refs);
@@ -969,9 +1070,18 @@ const selectParser = (
       if (refs.openaiStrictMode) {
         const mismatch = findIncompatibleParsedOutputs(def.left._def, def.right._def);
         if (mismatch) {
-          throw new TypeError(
-            `ZodIntersection arms have incompatible parsed outputs: ${mismatch.left} and ${mismatch.right}`,
-          );
+          const expectedOutput = (refs as PreprocessedRefs)[expectedPipelineOutput];
+          const expectedKind = expectedOutput ? knownParsedOutputType(expectedOutput) : undefined;
+          const compatibleExpectedOutput =
+            mismatch.path.length === 0 &&
+            expectedKind !== undefined &&
+            (mismatch.left === 'opaque' || mismatch.left === expectedKind) &&
+            (mismatch.right === 'opaque' || mismatch.right === expectedKind);
+          if (!compatibleExpectedOutput) {
+            throw new TypeError(
+              `ZodIntersection arms have incompatible parsed outputs: ${mismatch.left} and ${mismatch.right}`,
+            );
+          }
         }
       }
       const intersectionRefs: PreprocessedRefs = refs.openaiStrictMode

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -468,6 +468,26 @@ const isCanonicalDateDefault = (value: Date): boolean =>
       !Object.getOwnPropertyDescriptor(value, property),
   );
 
+const invisibleDeclaredDefaultProperty = (
+  descriptors: readonly [string, PropertyDescriptor][],
+  prototypes: readonly object[],
+  definition: ZodTypeDef,
+  path: readonly (string | number)[],
+): { key: string; visibility: 'non-enumerable' | 'inherited' } | undefined => {
+  const hidden = descriptors.find(
+    ([key, descriptor]) => !descriptor.enumerable && hasDeclaredSchemaPropertyAtPath(definition, path, key),
+  );
+  if (hidden) {
+    return { key: hidden[0], visibility: 'non-enumerable' };
+  }
+
+  const ownProperties = new Set(descriptors.map(([key]) => key));
+  const inherited = prototypes
+    .flatMap((prototype) => Object.getOwnPropertyNames(prototype))
+    .find((key) => !ownProperties.has(key) && hasDeclaredSchemaPropertyAtPath(definition, path, key));
+  return inherited === undefined ? undefined : { key: inherited, visibility: 'inherited' };
+};
+
 const normalizeStrictDefaultValue = (
   value: unknown,
   definition: ZodTypeDef,
@@ -583,12 +603,10 @@ const normalizeStrictDefaultValue = (
       return normalized;
     }
 
-    const hiddenSchemaProperty = descriptors.find(
-      ([key, descriptor]) => !descriptor.enumerable && hasDeclaredSchemaPropertyAtPath(definition, path, key),
-    );
+    const hiddenSchemaProperty = invisibleDeclaredDefaultProperty(descriptors, prototypes, definition, path);
     if (hiddenSchemaProperty) {
       throw new TypeError(
-        `Zod field at \`${refs.currentPath.join('/')}\` cannot safely represent the non-enumerable \`${keyword}.${hiddenSchemaProperty[0]}\` schema property in JSON Structured Outputs.`,
+        `Zod field at \`${refs.currentPath.join('/')}\` cannot safely represent the ${hiddenSchemaProperty.visibility} \`${keyword}.${hiddenSchemaProperty.key}\` schema property in JSON Structured Outputs.`,
       );
     }
 

--- a/src/_vendor/zod-to-json-schema/parseDef.ts
+++ b/src/_vendor/zod-to-json-schema/parseDef.ts
@@ -384,6 +384,32 @@ const throwUnrepresentableStrictZodType = (typeName: ZodFirstPartyTypeKind, refs
   );
 };
 
+type StrictDateCheck = { kind: 'min' | 'max'; value: number };
+
+const dateSchemaPreservesBounds = (
+  schema: JsonSchema7DateType,
+  checks: readonly StrictDateCheck[],
+): boolean => {
+  if ('anyOf' in schema) {
+    return (
+      schema.anyOf.length > 0 &&
+      schema.anyOf.every((candidate) => dateSchemaPreservesBounds(candidate, checks))
+    );
+  }
+  if (schema.type !== 'integer') {
+    return false;
+  }
+  return checks.every((check) => {
+    const bound = check.kind === 'min' ? schema.minimum : schema.maximum;
+    return (
+      typeof bound === 'number' &&
+      Number.isFinite(bound) &&
+      Number.isFinite(check.value) &&
+      (check.kind === 'min' ? bound >= check.value : bound <= check.value)
+    );
+  });
+};
+
 const assertFiniteStrictSchemaValue = (value: unknown, keyword: string, refs: Refs): void => {
   if (refs.openaiStrictMode && typeof value === 'number' && !Number.isFinite(value)) {
     throw new TypeError(
@@ -455,6 +481,25 @@ const strictDefaultDescriptors = (
     }
   }
   return descriptors;
+};
+
+const trustedNativeCollectionMethods = [
+  { type: ZodFirstPartyTypeKind.ZodSet, has: Set.prototype.has },
+  { type: ZodFirstPartyTypeKind.ZodMap, has: Map.prototype.has },
+] as const;
+
+const nativeCollectionDefaultType = (
+  value: object,
+): ZodFirstPartyTypeKind.ZodSet | ZodFirstPartyTypeKind.ZodMap | undefined => {
+  for (const { type, has } of trustedNativeCollectionMethods) {
+    try {
+      Reflect.apply(has, value, [undefined]);
+      return type;
+    } catch {
+      // Native methods reject receivers without their corresponding internal collection slot.
+    }
+  }
+  return undefined;
 };
 
 const trustedDatePrototypeMethods = new Map<PropertyKey, unknown>([
@@ -531,11 +576,11 @@ const normalizeStrictDefaultValue = (
   if (!value || typeof value !== 'object') {
     return value;
   }
-  const prototypes = strictDefaultPrototypeChain(value, keyword, refs);
-  if (value instanceof Set || value instanceof Map) {
-    const typeName = value instanceof Set ? ZodFirstPartyTypeKind.ZodSet : ZodFirstPartyTypeKind.ZodMap;
-    throwUnrepresentableStrictZodType(typeName, refs);
+  const nativeCollection = nativeCollectionDefaultType(value);
+  if (nativeCollection !== undefined) {
+    throwUnrepresentableStrictZodType(nativeCollection, refs);
   }
+  const prototypes = strictDefaultPrototypeChain(value, keyword, refs);
 
   if (active.has(value)) {
     throw new TypeError(
@@ -915,7 +960,17 @@ const selectParser = (
       return parseBooleanDef();
     }
     case ZodFirstPartyTypeKind.ZodDate: {
-      return parseDateDef(def, refs);
+      const schema = parseDateDef(def, refs);
+      if (
+        refs.openaiStrictMode &&
+        def.checks.length > 0 &&
+        !dateSchemaPreservesBounds(schema, def.checks as StrictDateCheck[])
+      ) {
+        throw new TypeError(
+          `Zod field at \`${refs.currentPath.join('/')}\` uses \`ZodDate\` bounds that cannot be represented by its configured JSON Structured Outputs date strategy.`,
+        );
+      }
+      return schema;
     }
     case ZodFirstPartyTypeKind.ZodUndefined: {
       return parseUndefinedDef();

--- a/src/_vendor/zod-to-json-schema/parsers/optional.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/optional.ts
@@ -9,8 +9,11 @@ export const parseOptionalDef = (
   forceResolution: boolean,
 ): JsonSchema7Type | undefined => {
   if (
-    refs.propertyPath &&
-    refs.currentPath.slice(0, refs.propertyPath.length).toString() === refs.propertyPath.toString()
+    (refs.openaiStrictMode &&
+      (refs.currentPath.length > refs.basePath.length + 2 ||
+        refs.currentPath[refs.basePath.length + 1] !== refs.name)) ||
+    (refs.propertyPath &&
+      refs.currentPath.slice(0, refs.propertyPath.length).toString() === refs.propertyPath.toString())
   ) {
     return parseDef(def.innerType._def, { ...refs, currentPath: refs.currentPath }, forceResolution);
   }

--- a/src/_vendor/zod-to-json-schema/parsers/pipeline.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/pipeline.ts
@@ -8,11 +8,12 @@ export const parsePipelineDef = (
   def: ZodPipelineDef<any, any>,
   refs: Refs,
   forceResolution: boolean,
+  outputRefs: Refs = refs,
 ): JsonSchema7AllOfType | JsonSchema7Type | undefined => {
   if (refs.pipeStrategy === 'input') {
     return parseDef(def.in._def, refs, forceResolution);
   } else if (refs.pipeStrategy === 'output') {
-    return parseDef(def.out._def, refs, forceResolution);
+    return parseDef(def.out._def, outputRefs, forceResolution);
   }
 
   const a = parseDef(def.in._def, {
@@ -20,7 +21,7 @@ export const parsePipelineDef = (
     currentPath: [...refs.currentPath, 'allOf', '0'],
   });
   const b = parseDef(def.out._def, {
-    ...refs,
+    ...outputRefs,
     currentPath: [...refs.currentPath, 'allOf', a ? '1' : '0'],
   });
 

--- a/src/_vendor/zod-to-json-schema/parsers/set.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/set.ts
@@ -15,7 +15,7 @@ export type JsonSchema7SetType = {
 };
 
 export function parseSetDef(def: ZodSetDef, refs: Refs): JsonSchema7SetType {
-  if (refs.openaiStrictMode && (def.minSize?.value ?? 0) > 0) {
+  if (refs.openaiStrictMode && (def.minSize?.value ?? 0) > 1) {
     throw new Error(
       `Zod field at \`${refs.currentPath.join('/')}\` uses \`ZodSet\` size constraints, which cannot be represented without the unsupported \`uniqueItems\` keyword.`,
     );

--- a/src/_vendor/zod-to-json-schema/parsers/set.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/set.ts
@@ -7,7 +7,7 @@ import type { Refs } from '../Refs';
 
 export type JsonSchema7SetType = {
   type: 'array';
-  uniqueItems: true;
+  uniqueItems?: true;
   items?: JsonSchema7Type | undefined;
   minItems?: number;
   maxItems?: number;
@@ -22,7 +22,7 @@ export function parseSetDef(def: ZodSetDef, refs: Refs): JsonSchema7SetType {
 
   const schema: JsonSchema7SetType = {
     type: 'array',
-    uniqueItems: true,
+    ...(refs.openaiStrictMode ? undefined : { uniqueItems: true as const }),
     items,
   };
 

--- a/src/_vendor/zod-to-json-schema/parsers/set.ts
+++ b/src/_vendor/zod-to-json-schema/parsers/set.ts
@@ -15,6 +15,12 @@ export type JsonSchema7SetType = {
 };
 
 export function parseSetDef(def: ZodSetDef, refs: Refs): JsonSchema7SetType {
+  if (refs.openaiStrictMode && (def.minSize?.value ?? 0) > 0) {
+    throw new Error(
+      `Zod field at \`${refs.currentPath.join('/')}\` uses \`ZodSet\` size constraints, which cannot be represented without the unsupported \`uniqueItems\` keyword.`,
+    );
+  }
+
   const items = parseDef(def.valueType._def, {
     ...refs,
     currentPath: [...refs.currentPath, 'items'],

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -596,12 +596,39 @@ const serializedNativeDefault = (value: unknown): unknown => {
   return value;
 };
 
+const matchesPrimitiveDefaultInput = (definition: InspectableDefinition, value: unknown): boolean => {
+  if (definition.coerce) {
+    return true;
+  }
+  const serialized = serializedNativeDefault(value);
+  switch (definition.typeName) {
+    case ZodFirstPartyTypeKind.ZodString: {
+      return typeof serialized === 'string';
+    }
+    case ZodFirstPartyTypeKind.ZodNumber: {
+      return typeof serialized === 'number';
+    }
+    case ZodFirstPartyTypeKind.ZodBoolean: {
+      return typeof serialized === 'boolean';
+    }
+    case ZodFirstPartyTypeKind.ZodNull: {
+      return serialized === null;
+    }
+    case ZodFirstPartyTypeKind.ZodArray: {
+      return Array.isArray(serialized);
+    }
+    default: {
+      return true;
+    }
+  }
+};
+
 const matchesDefaultDiscriminators = (
   definition: ZodTypeDef,
   value: unknown,
   active = new Set<ZodTypeDef>(),
 ): boolean => {
-  if (active.has(definition) || !value || typeof value !== 'object' || Array.isArray(value)) {
+  if (active.has(definition)) {
     return true;
   }
   active.add(definition);
@@ -624,10 +651,13 @@ const matchesDefaultDiscriminators = (
         return matchesDefaultDiscriminators(def.getter()._def, value, active);
       }
       case ZodFirstPartyTypeKind.ZodObject: {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+          return false;
+        }
         break;
       }
       default: {
-        return true;
+        return matchesPrimitiveDefaultInput(def, value);
       }
     }
     const record = value as Record<string, unknown>;
@@ -681,11 +711,16 @@ const producesSelectedNativeUnion = (
       if (
         candidate.typeName === ZodFirstPartyTypeKind.ZodNumber &&
         typeof scalar === 'number' &&
-        candidate.checks?.some((check) =>
-          check.kind === 'min'
-            ? scalar < Number(check.value)
-            : check.kind === 'max' && scalar > Number(check.value),
-        )
+        candidate.checks?.some((check) => {
+          const boundary = Number(check.value);
+          if (check.kind === 'min') {
+            return scalar < boundary || (check.inclusive === false && scalar === boundary);
+          }
+          if (check.kind === 'max') {
+            return scalar > boundary || (check.inclusive === false && scalar === boundary);
+          }
+          return false;
+        })
       ) {
         continue;
       }

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -25,6 +25,8 @@ type InspectableDefinition = ZodTypeDef & {
   items: SchemaType[];
   rest?: SchemaType;
   valueType: SchemaType;
+  minLength?: { value: number };
+  exactLength?: { value: number };
 };
 type Traversal =
   | 'input'
@@ -106,6 +108,26 @@ const childDefinitions = (def: InspectableDefinition, traversal: Traversal): Tra
   }
 };
 
+const asynchronousContainerChildren = (
+  def: InspectableDefinition,
+  traversal: Traversal,
+): TraversalChildren | null | undefined => {
+  if (traversal !== 'async-input') {
+    return undefined;
+  }
+  if (def.typeName === ZodFirstPartyTypeKind.ZodNullable) {
+    return null;
+  }
+  if (def.typeName === ZodFirstPartyTypeKind.ZodObject) {
+    return { values: Object.values(def.shape()), every: false };
+  }
+  if (def.typeName === ZodFirstPartyTypeKind.ZodArray) {
+    const nonempty = (def.minLength?.value ?? 0) > 0 || (def.exactLength?.value ?? 0) > 0;
+    return nonempty ? { values: [def.type], every: false } : null;
+  }
+  return undefined;
+};
+
 const visitDefinition = (
   definition: ZodTypeDef,
   inspect: Inspector,
@@ -124,7 +146,8 @@ const visitDefinition = (
       return result;
     }
 
-    const children = childDefinitions(def, traversal);
+    const containerChildren = asynchronousContainerChildren(def, traversal);
+    const children = containerChildren === undefined ? childDefinitions(def, traversal) : containerChildren;
     if (!children) {
       return false;
     }
@@ -564,6 +587,108 @@ type PairedChild = {
   segment: NumericPathSegment;
 };
 
+const jsonPrimitiveKinds = new Map<ZodFirstPartyTypeKind, string>([
+  [ZodFirstPartyTypeKind.ZodString, 'string'],
+  [ZodFirstPartyTypeKind.ZodNumber, 'number'],
+  [ZodFirstPartyTypeKind.ZodBoolean, 'boolean'],
+  [ZodFirstPartyTypeKind.ZodNull, 'null'],
+  [ZodFirstPartyTypeKind.ZodObject, 'object'],
+  [ZodFirstPartyTypeKind.ZodArray, 'array'],
+]);
+
+const leafJSONInputTypes = (def: InspectableDefinition): Set<string> | null | undefined => {
+  const primitive = jsonPrimitiveKinds.get(def.typeName);
+  if (primitive !== undefined) {
+    return def.coerce ? null : new Set([primitive]);
+  }
+  if (def.typeName === ZodFirstPartyTypeKind.ZodLiteral) {
+    const { value } = def;
+    if (value === null) {
+      return new Set(['null']);
+    }
+    const primitiveType = typeof value;
+    return ['string', 'number', 'boolean'].includes(primitiveType) ? new Set([primitiveType]) : null;
+  }
+  if (
+    def.typeName === ZodFirstPartyTypeKind.ZodEnum ||
+    def.typeName === ZodFirstPartyTypeKind.ZodNativeEnum
+  ) {
+    return new Set(Object.values(def.values).map((value) => typeof value));
+  }
+  return undefined;
+};
+
+const transparentJSONInput = (def: InspectableDefinition): ZodTypeDef | undefined => {
+  switch (def.typeName) {
+    case ZodFirstPartyTypeKind.ZodOptional:
+    case ZodFirstPartyTypeKind.ZodDefault:
+    case ZodFirstPartyTypeKind.ZodReadonly: {
+      return def.innerType._def;
+    }
+    case ZodFirstPartyTypeKind.ZodBranded: {
+      return def.type._def;
+    }
+    case ZodFirstPartyTypeKind.ZodEffects: {
+      return def.effect.type === 'preprocess' ? undefined : def.schema._def;
+    }
+    case ZodFirstPartyTypeKind.ZodLazy: {
+      return def.getter()._def;
+    }
+    case ZodFirstPartyTypeKind.ZodPipeline: {
+      return def.in._def;
+    }
+    default: {
+      return undefined;
+    }
+  }
+};
+
+const jsonInputTypes = (definition: ZodTypeDef, active = new Set<ZodTypeDef>()): Set<string> | undefined => {
+  if (active.has(definition)) {
+    return undefined;
+  }
+  active.add(definition);
+  try {
+    const def = definition as InspectableDefinition;
+    const leaf = leafJSONInputTypes(def);
+    if (leaf !== undefined) {
+      return leaf ?? undefined;
+    }
+    const transparent = transparentJSONInput(def);
+    if (transparent !== undefined) {
+      return jsonInputTypes(transparent, active);
+    }
+
+    switch (def.typeName) {
+      case ZodFirstPartyTypeKind.ZodNullable: {
+        const inner = jsonInputTypes(def.innerType._def, active);
+        return inner && new Set([...inner, 'null']);
+      }
+      case ZodFirstPartyTypeKind.ZodUnion:
+      case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
+        const options = def.options instanceof Map ? [...def.options.values()] : def.options;
+        const types = options.map((option) => jsonInputTypes(option._def, active));
+        return types.some((option) => option === undefined)
+          ? undefined
+          : new Set(types.flatMap((option) => [...(option ?? [])]));
+      }
+      case ZodFirstPartyTypeKind.ZodIntersection: {
+        const left = jsonInputTypes(def.left._def, active);
+        const right = jsonInputTypes(def.right._def, active);
+        if (!left || !right) {
+          return left ?? right;
+        }
+        return new Set([...left].filter((type) => right.has(type)));
+      }
+      default: {
+        return undefined;
+      }
+    }
+  } finally {
+    active.delete(definition);
+  }
+};
+
 const haveDisjointDiscriminators = (
   producer: ZodTypeDef,
   consumer: ZodTypeDef,
@@ -583,6 +708,12 @@ const haveDisjointDiscriminators = (
     if (leftValues && rightValues) {
       return leftValues.every((value) => !rightValues.includes(value));
     }
+    const leftTypes = jsonInputTypes(left);
+    const rightTypes = jsonInputTypes(right);
+    if (leftTypes && rightTypes && [...leftTypes].every((type) => !rightTypes.has(type))) {
+      return true;
+    }
+
     if (
       left.typeName !== ZodFirstPartyTypeKind.ZodObject ||
       right.typeName !== ZodFirstPartyTypeKind.ZodObject

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -240,6 +240,8 @@ const definiteParsedOutputKinds = new Set<ZodFirstPartyTypeKind>([
   ZodFirstPartyTypeKind.ZodNull,
   ZodFirstPartyTypeKind.ZodObject,
   ZodFirstPartyTypeKind.ZodArray,
+  ZodFirstPartyTypeKind.ZodSet,
+  ZodFirstPartyTypeKind.ZodMap,
 ]);
 
 export const knownParsedOutputType = (
@@ -358,9 +360,26 @@ const hasOpaqueParsedOutput = (definition: ZodTypeDef): boolean =>
     'output',
   );
 
+type OpaqueParsedOutput = 'opaque' | 'preprocessed';
+
+const classifyOpaqueParsedOutput = (definition: ZodTypeDef): OpaqueParsedOutput | undefined => {
+  const preprocessed = visitDefinition(
+    definition,
+    (def) =>
+      def.typeName === ZodFirstPartyTypeKind.ZodEffects && def.effect.type === 'preprocess'
+        ? true
+        : undefined,
+    'output',
+  );
+  if (preprocessed) {
+    return 'preprocessed';
+  }
+  return hasOpaqueParsedOutput(definition) ? 'opaque' : undefined;
+};
+
 type ParsedOutputMismatch = {
-  left: ZodFirstPartyTypeKind | 'opaque';
-  right: ZodFirstPartyTypeKind | 'opaque';
+  left: ZodFirstPartyTypeKind | OpaqueParsedOutput;
+  right: ZodFirstPartyTypeKind | OpaqueParsedOutput;
   path: readonly string[];
 };
 
@@ -440,10 +459,38 @@ const findOpaqueParsedOutputMismatch = (
   rightKind: ZodFirstPartyTypeKind | undefined,
   path: readonly string[],
 ): ParsedOutputMismatch | undefined => {
-  const leftOpaque = leftKind === undefined && hasOpaqueParsedOutput(left);
-  const rightOpaque = rightKind === undefined && hasOpaqueParsedOutput(right);
+  const leftOpaque = classifyOpaqueParsedOutput(left);
+  const rightOpaque = classifyOpaqueParsedOutput(right);
   return leftOpaque || rightOpaque
-    ? { left: leftKind ?? 'opaque', right: rightKind ?? 'opaque', path }
+    ? {
+        left: leftOpaque ?? leftKind ?? 'opaque',
+        right: rightOpaque ?? rightKind ?? 'opaque',
+        path,
+      }
+    : undefined;
+};
+
+const unmergeableParsedOutputKinds = new Set<ZodFirstPartyTypeKind>([
+  ZodFirstPartyTypeKind.ZodSet,
+  ZodFirstPartyTypeKind.ZodMap,
+]);
+
+const findDirectParsedOutputMismatch = (
+  left: ZodTypeDef,
+  right: ZodTypeDef,
+  leftKind: ZodFirstPartyTypeKind | undefined,
+  rightKind: ZodFirstPartyTypeKind | undefined,
+  path: readonly string[],
+): ParsedOutputMismatch | undefined => {
+  if (leftKind !== undefined && rightKind !== undefined && leftKind !== rightKind) {
+    return { left: leftKind, right: rightKind, path };
+  }
+  const opaqueMismatch = findOpaqueParsedOutputMismatch(left, right, leftKind, rightKind, path);
+  if (opaqueMismatch) {
+    return opaqueMismatch;
+  }
+  return leftKind !== undefined && rightKind !== undefined && unmergeableParsedOutputKinds.has(leftKind)
+    ? { left: leftKind, right: rightKind, path }
     : undefined;
 };
 
@@ -463,11 +510,12 @@ export const findIncompatibleParsedOutputs = (
   try {
     const leftKind = knownParsedOutputType(left);
     const rightKind = knownParsedOutputType(right);
-    if (leftKind === undefined || rightKind === undefined) {
-      return findOpaqueParsedOutputMismatch(left, right, leftKind, rightKind, path);
+    const directMismatch = findDirectParsedOutputMismatch(left, right, leftKind, rightKind, path);
+    if (directMismatch) {
+      return directMismatch;
     }
-    if (leftKind !== rightKind) {
-      return { left: leftKind, right: rightKind, path };
+    if (leftKind === undefined || rightKind === undefined) {
+      return undefined;
     }
     if (leftKind !== ZodFirstPartyTypeKind.ZodObject && leftKind !== ZodFirstPartyTypeKind.ZodArray) {
       return undefined;

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -26,14 +26,28 @@ type InspectableDefinition = ZodTypeDef & {
   rest?: SchemaType;
   valueType: SchemaType;
 };
-type Traversal = 'input' | 'output' | 'unsafe-output' | 'conversion' | 'default' | 'unconditional-number';
+type Traversal =
+  | 'input'
+  | 'output'
+  | 'compatible-output'
+  | 'unsafe-output'
+  | 'conversion'
+  | 'async-input'
+  | 'default'
+  | 'unconditional-number';
 type Inspector = (definition: InspectableDefinition) => boolean | null | undefined;
 
 type TraversalChildren = { values: SchemaType[]; every: boolean };
-const asynchronousOutputTraversals = new Set<Traversal>(['output', 'unsafe-output', 'default']);
+const asynchronousOutputTraversals = new Set<Traversal>([
+  'output',
+  'compatible-output',
+  'unsafe-output',
+  'default',
+]);
 const universalIntersectionTraversals = new Set<Traversal>([
   'input',
   'conversion',
+  'compatible-output',
   'unsafe-output',
   'unconditional-number',
 ]);
@@ -42,7 +56,7 @@ const pipelineChildren = (def: InspectableDefinition, traversal: Traversal): Sch
   if (traversal === 'input') {
     return [def.in];
   }
-  if (traversal === 'conversion' || traversal === 'unconditional-number') {
+  if (traversal === 'conversion' || traversal === 'async-input' || traversal === 'unconditional-number') {
     return [def.in, def.out];
   }
   return [def.out];
@@ -78,7 +92,7 @@ const childDefinitions = (def: InspectableDefinition, traversal: Traversal): Tra
     case ZodFirstPartyTypeKind.ZodUnion:
     case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
       const values = def.options instanceof Map ? [...def.options.values()] : def.options;
-      return { values, every: traversal === 'conversion' };
+      return { values, every: traversal === 'conversion' || traversal === 'async-input' };
     }
     case ZodFirstPartyTypeKind.ZodIntersection: {
       return {
@@ -121,6 +135,13 @@ const visitDefinition = (
     active.delete(definition);
   }
 };
+
+export const requiresAsynchronousJSONInput = (definition: ZodTypeDef): boolean =>
+  visitDefinition(
+    definition,
+    (def) => (def.typeName === ZodFirstPartyTypeKind.ZodPromise ? true : undefined),
+    'async-input',
+  );
 
 export const producesBigIntOutput = (definition: ZodTypeDef): boolean =>
   visitDefinition(
@@ -343,7 +364,7 @@ export const convertsJSONPipelineInput = (definition: ZodTypeDef, output: ZodTyp
       return visitDefinition(
         output,
         (candidate) => (candidate.typeName === def.typeName ? true : undefined),
-        'output',
+        'compatible-output',
       );
     },
     'conversion',
@@ -428,8 +449,28 @@ const matchesDefaultDiscriminators = (
   active.add(definition);
   try {
     const def = definition as InspectableDefinition;
-    if (def.typeName !== ZodFirstPartyTypeKind.ZodObject) {
-      return true;
+    switch (def.typeName) {
+      case ZodFirstPartyTypeKind.ZodBranded: {
+        return matchesDefaultDiscriminators(def.type._def, value, active);
+      }
+      case ZodFirstPartyTypeKind.ZodReadonly:
+      case ZodFirstPartyTypeKind.ZodDefault: {
+        return matchesDefaultDiscriminators(def.innerType._def, value, active);
+      }
+      case ZodFirstPartyTypeKind.ZodEffects: {
+        return def.effect.type === 'refinement'
+          ? matchesDefaultDiscriminators(def.schema._def, value, active)
+          : true;
+      }
+      case ZodFirstPartyTypeKind.ZodLazy: {
+        return matchesDefaultDiscriminators(def.getter()._def, value, active);
+      }
+      case ZodFirstPartyTypeKind.ZodObject: {
+        break;
+      }
+      default: {
+        return true;
+      }
     }
     const record = value as Record<string, unknown>;
     return Object.entries(def.shape()).every(([key, child]) => {

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -125,6 +125,9 @@ const asynchronousContainerChildren = (
   if (def.typeName === ZodFirstPartyTypeKind.ZodObject) {
     return { values: Object.values(def.shape()), every: false };
   }
+  if (def.typeName === ZodFirstPartyTypeKind.ZodTuple) {
+    return { values: def.items, every: false };
+  }
   if (def.typeName === ZodFirstPartyTypeKind.ZodArray) {
     const nonempty = (def.minLength?.value ?? 0) > 0 || (def.exactLength?.value ?? 0) > 0;
     return nonempty ? { values: [def.type], every: false } : null;
@@ -234,6 +237,92 @@ export const knownParsedOutputType = (
       : undefined;
   } finally {
     active.delete(definition);
+  }
+};
+
+type ParsedOutputMismatch = {
+  left: ZodFirstPartyTypeKind;
+  right: ZodFirstPartyTypeKind;
+  path: readonly string[];
+};
+
+const parsedOutputContainer = (
+  definition: ZodTypeDef,
+  kind: ZodFirstPartyTypeKind,
+  active = new Set<ZodTypeDef>(),
+): InspectableDefinition | undefined => {
+  if (active.has(definition)) {
+    return undefined;
+  }
+  active.add(definition);
+  try {
+    const def = definition as InspectableDefinition;
+    if (def.typeName === kind) {
+      return def;
+    }
+    const children = childDefinitions(def, 'output');
+    const child = children?.values[0];
+    return children?.values.length === 1 && child !== undefined
+      ? parsedOutputContainer(child._def, kind, active)
+      : undefined;
+  } finally {
+    active.delete(definition);
+  }
+};
+
+export const findIncompatibleParsedOutputs = (
+  left: ZodTypeDef,
+  right: ZodTypeDef,
+  path: readonly string[] = [],
+  active = new Map<ZodTypeDef, Set<ZodTypeDef>>(),
+): ParsedOutputMismatch | undefined => {
+  const existing = active.get(left);
+  if (existing?.has(right)) {
+    return undefined;
+  }
+  const current = existing ?? new Set<ZodTypeDef>();
+  active.set(left, current);
+  current.add(right);
+  try {
+    const leftKind = knownParsedOutputType(left);
+    const rightKind = knownParsedOutputType(right);
+    if (leftKind === undefined || rightKind === undefined) {
+      return undefined;
+    }
+    if (leftKind !== rightKind) {
+      return { left: leftKind, right: rightKind, path };
+    }
+    if (leftKind !== ZodFirstPartyTypeKind.ZodObject && leftKind !== ZodFirstPartyTypeKind.ZodArray) {
+      return undefined;
+    }
+    const first = parsedOutputContainer(left, leftKind);
+    const second = parsedOutputContainer(right, rightKind);
+    if (!first || !second) {
+      return undefined;
+    }
+    if (leftKind === ZodFirstPartyTypeKind.ZodArray) {
+      return findIncompatibleParsedOutputs(first.type._def, second.type._def, [...path, '[]'], active);
+    }
+    const firstShape = first.shape();
+    const secondShape = second.shape();
+    for (const [key, child] of Object.entries(firstShape)) {
+      if (!hasOwn(secondShape, key)) {
+        continue;
+      }
+      const sibling = secondShape[key];
+      if (sibling) {
+        const mismatch = findIncompatibleParsedOutputs(child._def, sibling._def, [...path, key], active);
+        if (mismatch) {
+          return mismatch;
+        }
+      }
+    }
+    return undefined;
+  } finally {
+    current.delete(right);
+    if (current.size === 0) {
+      active.delete(left);
+    }
   }
 };
 

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -26,10 +26,17 @@ type InspectableDefinition = ZodTypeDef & {
   rest?: SchemaType;
   valueType: SchemaType;
 };
-type Traversal = 'input' | 'output' | 'conversion' | 'default' | 'unconditional-number';
+type Traversal = 'input' | 'output' | 'unsafe-output' | 'conversion' | 'default' | 'unconditional-number';
 type Inspector = (definition: InspectableDefinition) => boolean | null | undefined;
 
 type TraversalChildren = { values: SchemaType[]; every: boolean };
+const asynchronousOutputTraversals = new Set<Traversal>(['output', 'unsafe-output', 'default']);
+const universalIntersectionTraversals = new Set<Traversal>([
+  'input',
+  'conversion',
+  'unsafe-output',
+  'unconditional-number',
+]);
 
 const pipelineChildren = (def: InspectableDefinition, traversal: Traversal): SchemaType[] => {
   if (traversal === 'input') {
@@ -50,9 +57,11 @@ const childDefinitions = (def: InspectableDefinition, traversal: Traversal): Tra
     case ZodFirstPartyTypeKind.ZodReadonly: {
       return { values: [def.innerType], every: false };
     }
-    case ZodFirstPartyTypeKind.ZodBranded:
-    case ZodFirstPartyTypeKind.ZodPromise: {
+    case ZodFirstPartyTypeKind.ZodBranded: {
       return { values: [def.type], every: false };
+    }
+    case ZodFirstPartyTypeKind.ZodPromise: {
+      return asynchronousOutputTraversals.has(traversal) ? null : { values: [def.type], every: false };
     }
     case ZodFirstPartyTypeKind.ZodEffects: {
       return { values: [def.schema], every: false };
@@ -69,12 +78,12 @@ const childDefinitions = (def: InspectableDefinition, traversal: Traversal): Tra
     case ZodFirstPartyTypeKind.ZodUnion:
     case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
       const values = def.options instanceof Map ? [...def.options.values()] : def.options;
-      return { values, every: traversal === 'conversion' || traversal === 'default' };
+      return { values, every: traversal === 'conversion' };
     }
     case ZodFirstPartyTypeKind.ZodIntersection: {
       return {
         values: [def.left, def.right],
-        every: traversal === 'input' || traversal === 'unconditional-number',
+        every: universalIntersectionTraversals.has(traversal),
       };
     }
     default: {
@@ -222,6 +231,35 @@ const classifyJSONNumberAcceptance = (
 export const acceptsEveryJSONNumber = (definition: ZodTypeDef): boolean =>
   classifyJSONNumberAcceptance(definition) !== 'opaque';
 
+const validationChildren = (def: InspectableDefinition): SchemaType[] => {
+  if (def.typeName === ZodFirstPartyTypeKind.ZodObject) {
+    return Object.values(def.shape());
+  }
+  if (def.typeName === ZodFirstPartyTypeKind.ZodArray) {
+    return [def.type];
+  }
+  return childDefinitions(def, 'input')?.values ?? [];
+};
+
+export const hasOpaqueJSONValidation = (definition: ZodTypeDef, active = new Set<ZodTypeDef>()): boolean => {
+  if (active.has(definition)) {
+    return true;
+  }
+  active.add(definition);
+  try {
+    const def = definition as InspectableDefinition;
+    if (
+      def.typeName === ZodFirstPartyTypeKind.ZodEffects ||
+      def.typeName === ZodFirstPartyTypeKind.ZodPromise
+    ) {
+      return true;
+    }
+    return validationChildren(def).some((child) => hasOpaqueJSONValidation(child._def, active));
+  } finally {
+    active.delete(definition);
+  }
+};
+
 type UnsafeIntegerSide = 'minimum' | 'maximum';
 
 export const capturesUnsafeBigIntInput = (definition: ZodTypeDef, side: UnsafeIntegerSide): boolean =>
@@ -241,7 +279,7 @@ export const capturesUnsafeBigIntInput = (definition: ZodTypeDef, side: UnsafeIn
           (side === 'minimum' ? check.value >= safeLimit : check.value <= safeLimit),
       );
     },
-    'output',
+    'unsafe-output',
   );
 
 export const acceptsUnsafeJSONInteger = (schema: unknown, side: UnsafeIntegerSide): boolean => {
@@ -311,13 +349,129 @@ export const convertsJSONPipelineInput = (definition: ZodTypeDef, output: ZodTyp
     'conversion',
   );
 
+const acceptsJSONNumberAtPath = (definition: ZodTypeDef, path: readonly (string | number)[]): boolean =>
+  visitDefinition(
+    definition,
+    (def) => {
+      if (path.length === 0) {
+        return acceptsJSONNumber(def);
+      }
+      if (
+        def.typeName === ZodFirstPartyTypeKind.ZodAny ||
+        def.typeName === ZodFirstPartyTypeKind.ZodUnknown
+      ) {
+        return true;
+      }
+      const [key, ...remaining] = path;
+      let child: SchemaType | undefined;
+      if (def.typeName === ZodFirstPartyTypeKind.ZodObject && typeof key === 'string') {
+        const shape = def.shape();
+        child = hasOwn(shape, key) ? shape[key] : def.catchall;
+      } else if (def.typeName === ZodFirstPartyTypeKind.ZodArray && typeof key === 'number') {
+        child = def.type;
+      } else {
+        return;
+      }
+      return child !== undefined && acceptsJSONNumberAtPath(child._def, remaining);
+    },
+    'input',
+  );
+
+const discriminatorValues = (
+  definition: ZodTypeDef,
+  active = new Set<ZodTypeDef>(),
+): readonly unknown[] | undefined => {
+  if (active.has(definition)) {
+    return undefined;
+  }
+  active.add(definition);
+  try {
+    const def = definition as InspectableDefinition;
+    switch (def.typeName) {
+      case ZodFirstPartyTypeKind.ZodLiteral: {
+        return [def.value];
+      }
+      case ZodFirstPartyTypeKind.ZodEnum:
+      case ZodFirstPartyTypeKind.ZodNativeEnum: {
+        return Object.values(def.values);
+      }
+      case ZodFirstPartyTypeKind.ZodEffects: {
+        return def.effect.type === 'refinement' ? discriminatorValues(def.schema._def, active) : undefined;
+      }
+      case ZodFirstPartyTypeKind.ZodBranded: {
+        return discriminatorValues(def.type._def, active);
+      }
+      case ZodFirstPartyTypeKind.ZodReadonly:
+      case ZodFirstPartyTypeKind.ZodDefault: {
+        return discriminatorValues(def.innerType._def, active);
+      }
+      case ZodFirstPartyTypeKind.ZodLazy: {
+        return discriminatorValues(def.getter()._def, active);
+      }
+      default: {
+        return undefined;
+      }
+    }
+  } finally {
+    active.delete(definition);
+  }
+};
+
+const matchesDefaultDiscriminators = (
+  definition: ZodTypeDef,
+  value: unknown,
+  active = new Set<ZodTypeDef>(),
+): boolean => {
+  if (active.has(definition) || !value || typeof value !== 'object' || Array.isArray(value)) {
+    return true;
+  }
+  active.add(definition);
+  try {
+    const def = definition as InspectableDefinition;
+    if (def.typeName !== ZodFirstPartyTypeKind.ZodObject) {
+      return true;
+    }
+    const record = value as Record<string, unknown>;
+    return Object.entries(def.shape()).every(([key, child]) => {
+      if (!hasOwn(record, key)) {
+        return true;
+      }
+      const literals = discriminatorValues(child._def);
+      return literals
+        ? literals.includes(record[key])
+        : matchesDefaultDiscriminators(child._def, record[key], active);
+    });
+  } finally {
+    active.delete(definition);
+  }
+};
+
 export const producesBigIntAtPath = (
   definition: ZodTypeDef,
   path: readonly (string | number)[] = [],
+  value?: unknown,
 ): boolean =>
   visitDefinition(
     definition,
     (def) => {
+      if (
+        def.typeName === ZodFirstPartyTypeKind.ZodUnion ||
+        def.typeName === ZodFirstPartyTypeKind.ZodDiscriminatedUnion
+      ) {
+        const options = def.options instanceof Map ? [...def.options.values()] : def.options;
+        for (const option of options) {
+          if (!matchesDefaultDiscriminators(option._def, value)) {
+            continue;
+          }
+          if (producesBigIntAtPath(option._def, path, value)) {
+            return true;
+          }
+          if (acceptsJSONNumberAtPath(option._def, path)) {
+            return false;
+          }
+        }
+        return false;
+      }
       if (path.length === 0) {
         if (def.typeName === ZodFirstPartyTypeKind.ZodBigInt) {
           return true;
@@ -326,6 +480,9 @@ export const producesBigIntAtPath = (
       }
 
       const [key, ...remaining] = path;
+      if (key === undefined) {
+        return false;
+      }
       let child: SchemaType | undefined;
       switch (def.typeName) {
         case ZodFirstPartyTypeKind.ZodObject: {
@@ -340,30 +497,19 @@ export const producesBigIntAtPath = (
           child = typeof key === 'number' ? (def.type as SchemaType) : undefined;
           break;
         }
-        case ZodFirstPartyTypeKind.ZodTuple: {
-          child =
-            typeof key === 'number' ? ((def.items[key] ?? def.rest) as SchemaType | undefined) : undefined;
-          break;
-        }
-        case ZodFirstPartyTypeKind.ZodRecord: {
-          child = typeof key === 'string' ? (def.valueType as SchemaType) : undefined;
-          break;
-        }
         default: {
           return;
         }
       }
 
-      return child !== undefined && producesBigIntAtPath(child._def, remaining);
+      const nestedValue =
+        value && typeof value === 'object' ? (value as Record<string | number, unknown>)[key] : undefined;
+      return child !== undefined && producesBigIntAtPath(child._def, remaining, nestedValue);
     },
     'default',
   );
 
-type NumericPathSegment =
-  | { kind: 'property'; key: string }
-  | { kind: 'array' }
-  | { kind: 'tuple'; index: number }
-  | { kind: 'record' };
+type NumericPathSegment = { kind: 'property'; key: string } | { kind: 'array' };
 
 export type NestedNumericOverlap = {
   path: readonly NumericPathSegment[];
@@ -377,21 +523,46 @@ type PairedChild = {
   segment: NumericPathSegment;
 };
 
+const haveDisjointDiscriminators = (
+  producer: ZodTypeDef,
+  consumer: ZodTypeDef,
+  active = new Map<ZodTypeDef, Set<ZodTypeDef>>(),
+): boolean => {
+  if (active.get(producer)?.has(consumer)) {
+    return false;
+  }
+  const consumers = active.get(producer) ?? new Set<ZodTypeDef>();
+  active.set(producer, consumers);
+  consumers.add(consumer);
+  try {
+    const left = producer as InspectableDefinition;
+    const right = consumer as InspectableDefinition;
+    const leftValues = discriminatorValues(left);
+    const rightValues = discriminatorValues(right);
+    if (leftValues && rightValues) {
+      return leftValues.every((value) => !rightValues.includes(value));
+    }
+    if (
+      left.typeName !== ZodFirstPartyTypeKind.ZodObject ||
+      right.typeName !== ZodFirstPartyTypeKind.ZodObject
+    ) {
+      return false;
+    }
+    const leftShape = left.shape();
+    return Object.entries(right.shape()).some(([key, value]) => {
+      const candidate = hasOwn(leftShape, key) ? leftShape[key] : undefined;
+      return candidate !== undefined && haveDisjointDiscriminators(candidate._def, value._def, active);
+    });
+  } finally {
+    consumers.delete(consumer);
+  }
+};
+
 const objectChildren = (producer: InspectableDefinition, consumer: InspectableDefinition): PairedChild[] => {
   const producerShape = producer.shape();
   const consumerShape = consumer.shape();
   const sharedKeys = Object.keys(consumerShape).filter((key) => hasOwn(producerShape, key));
-  if (
-    sharedKeys.some((key) => {
-      const left = producerShape[key]?._def as InspectableDefinition | undefined;
-      const right = consumerShape[key]?._def as InspectableDefinition | undefined;
-      return (
-        left?.typeName === ZodFirstPartyTypeKind.ZodLiteral &&
-        right?.typeName === ZodFirstPartyTypeKind.ZodLiteral &&
-        left.value !== right.value
-      );
-    })
-  ) {
+  if (haveDisjointDiscriminators(producer, consumer)) {
     return [];
   }
 
@@ -400,17 +571,6 @@ const objectChildren = (producer: InspectableDefinition, consumer: InspectableDe
     const right = consumerShape[key];
     return left && right ? [{ producer: left, consumer: right, segment: { kind: 'property', key } }] : [];
   });
-};
-
-const tupleChildren = (producer: InspectableDefinition, consumer: InspectableDefinition): PairedChild[] => {
-  const values: PairedChild[] = consumer.items.flatMap((item, index) => {
-    const left = producer.items[index] ?? producer.rest;
-    return left ? [{ producer: left, consumer: item, segment: { kind: 'tuple' as const, index } }] : [];
-  });
-  if (producer.rest && consumer.rest) {
-    values.push({ producer: producer.rest, consumer: consumer.rest, segment: { kind: 'array' } });
-  }
-  return values;
 };
 
 const pairedContainerChildren = (
@@ -428,18 +588,6 @@ const pairedContainerChildren = (
     consumer.typeName === ZodFirstPartyTypeKind.ZodArray
   ) {
     return [{ producer: producer.type, consumer: consumer.type, segment: { kind: 'array' } }];
-  }
-  if (
-    producer.typeName === ZodFirstPartyTypeKind.ZodTuple &&
-    consumer.typeName === ZodFirstPartyTypeKind.ZodTuple
-  ) {
-    return tupleChildren(producer, consumer);
-  }
-  if (
-    producer.typeName === ZodFirstPartyTypeKind.ZodRecord &&
-    consumer.typeName === ZodFirstPartyTypeKind.ZodRecord
-  ) {
-    return [{ producer: producer.valueType, consumer: consumer.valueType, segment: { kind: 'record' } }];
   }
   return [];
 };
@@ -506,30 +654,15 @@ export const findNestedNumericOverlaps = (
   return overlaps;
 };
 
-export const applyUnsafeBigIntBounds = (
-  schema: JsonSchema7Type,
-  producers: readonly ZodTypeDef[],
-): JsonSchema7Type => {
-  const minimum =
-    producers.some((candidate) => capturesUnsafeBigIntInput(candidate, 'minimum')) &&
-    (acceptsUnsafeJSONInteger(schema, 'minimum') || (!('type' in schema) && !('$ref' in schema)));
-  const maximum =
-    producers.some((candidate) => capturesUnsafeBigIntInput(candidate, 'maximum')) &&
-    (acceptsUnsafeJSONInteger(schema, 'maximum') || (!('type' in schema) && !('$ref' in schema)));
+const applyIntegerBounds = (schema: JsonSchema7Type, minimum: boolean, maximum: boolean): JsonSchema7Type => {
   if (!minimum && !maximum) {
     return schema;
   }
 
   if ('$ref' in schema) {
-    return {
-      allOf: [
-        schema,
-        {
-          ...(minimum ? { minimum: Number.MIN_SAFE_INTEGER } : undefined),
-          ...(maximum ? { maximum: Number.MAX_SAFE_INTEGER } : undefined),
-        } as JsonSchema7Type,
-      ],
-    };
+    throw new Error(
+      'A constrained JSON Schema reference must be materialized before applying integer bounds.',
+    );
   }
 
   const record = schema as Record<string, unknown>;
@@ -548,45 +681,24 @@ export const applyUnsafeBigIntBounds = (
   return schema;
 };
 
-const wrapNestedConstraint = (schema: JsonSchema7Type, segment: NumericPathSegment): JsonSchema7Type => {
-  switch (segment.kind) {
-    case 'property': {
-      return { type: 'object', properties: { [segment.key]: schema } } as JsonSchema7Type;
-    }
-    case 'array': {
-      return { type: 'array', items: schema } as JsonSchema7Type;
-    }
-    case 'tuple': {
-      const items: JsonSchema7Type[] = Array.from({ length: segment.index }, () => ({}) as JsonSchema7Type);
-      items.push(schema);
-      return { type: 'array', items } as JsonSchema7Type;
-    }
-    case 'record': {
-      return { type: 'object', additionalProperties: schema } as JsonSchema7Type;
-    }
-    default: {
-      return schema;
-    }
-  }
-};
+export const applyUnsafeBigIntBounds = (
+  schema: JsonSchema7Type,
+  producers: readonly ZodTypeDef[],
+): JsonSchema7Type =>
+  applyIntegerBounds(
+    schema,
+    producers.some((candidate) => capturesUnsafeBigIntInput(candidate, 'minimum')) &&
+      (acceptsUnsafeJSONInteger(schema, 'minimum') || (!('type' in schema) && !('$ref' in schema))),
+    producers.some((candidate) => capturesUnsafeBigIntInput(candidate, 'maximum')) &&
+      (acceptsUnsafeJSONInteger(schema, 'maximum') || (!('type' in schema) && !('$ref' in schema))),
+  );
 
-const nestedConstraint = (
-  path: readonly NumericPathSegment[],
-  producer: ZodTypeDef,
-): JsonSchema7Type | null => {
-  let constrained = applyUnsafeBigIntBounds({} as JsonSchema7Type, [producer]);
-  if (!('minimum' in constrained) && !('maximum' in constrained)) {
-    return null;
-  }
-
-  for (let index = path.length - 1; index >= 0; index -= 1) {
-    const segment = path[index];
-    if (segment) {
-      constrained = wrapNestedConstraint(constrained, segment);
-    }
-  }
-  return constrained;
-};
+export const applySafeIntegerBounds = (schema: JsonSchema7Type): JsonSchema7Type =>
+  applyIntegerBounds(
+    schema,
+    acceptsUnsafeJSONInteger(schema, 'minimum'),
+    acceptsUnsafeJSONInteger(schema, 'maximum'),
+  );
 
 const boundNestedNumericPath = (
   schema: JsonSchema7Type,
@@ -603,8 +715,9 @@ const boundNestedNumericPath = (
   }
   const record = schema as Record<string, unknown>;
   if ('$ref' in record) {
-    const constraint = nestedConstraint(path, producer);
-    return constraint ? ({ allOf: [schema, constraint] } as JsonSchema7Type) : schema;
+    throw new Error(
+      'A constrained nested JSON Schema reference must be materialized before applying bounds.',
+    );
   }
   if (segment.kind === 'property') {
     const properties = record['properties'] as Record<string, JsonSchema7Type> | undefined;
@@ -615,17 +728,9 @@ const boundNestedNumericPath = (
     return schema;
   }
 
-  const key = segment.kind === 'record' ? 'additionalProperties' : 'items';
-  const child = record[key] as JsonSchema7Type | JsonSchema7Type[] | undefined;
-  if (Array.isArray(child)) {
-    if (segment.kind === 'tuple') {
-      const item = child[segment.index];
-      if (item) {
-        child[segment.index] = boundNestedNumericPath(item, remaining, producer);
-      }
-    }
-  } else if (child && typeof child === 'object') {
-    record[key] = boundNestedNumericPath(child, remaining, producer);
+  const child = record['items'] as JsonSchema7Type | undefined;
+  if (child && typeof child === 'object' && !Array.isArray(child)) {
+    record['items'] = boundNestedNumericPath(child, remaining, producer);
   }
   return schema;
 };

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -264,7 +264,6 @@ export const knownParsedOutputType = (
     }
     if (
       def.typeName === ZodFirstPartyTypeKind.ZodNullable ||
-      def.typeName === ZodFirstPartyTypeKind.ZodOptional ||
       def.typeName === ZodFirstPartyTypeKind.ZodCatch ||
       def.typeName === ZodFirstPartyTypeKind.ZodUnion ||
       def.typeName === ZodFirstPartyTypeKind.ZodDiscriminatedUnion ||
@@ -413,6 +412,21 @@ export const findIncompatibleParsedOutputs = (
   }
 };
 
+type FractionalInputBoundary = { value: number; inclusive: boolean };
+
+const tightenFractionalInputBoundary = (
+  current: FractionalInputBoundary,
+  value: number,
+  inclusive: boolean,
+  side: 'minimum' | 'maximum',
+): FractionalInputBoundary => {
+  const tighter = side === 'minimum' ? value > current.value : value < current.value;
+  if (tighter) {
+    return { value, inclusive };
+  }
+  return value === current.value && !inclusive ? { value, inclusive: false } : current;
+};
+
 const acceptsOverlappingFractionalInput = (
   definition: InspectableDefinition,
   schema: JsonSchema7Type,
@@ -430,22 +444,34 @@ const acceptsOverlappingFractionalInput = (
   ) {
     return false;
   }
-  let minimum = typeof input['minimum'] === 'number' ? input['minimum'] : -Infinity;
-  let maximum = typeof input['maximum'] === 'number' ? input['maximum'] : Infinity;
+  let minimum: FractionalInputBoundary = {
+    value: typeof input['minimum'] === 'number' ? input['minimum'] : -Infinity,
+    inclusive: true,
+  };
+  let maximum: FractionalInputBoundary = {
+    value: typeof input['maximum'] === 'number' ? input['maximum'] : Infinity,
+    inclusive: true,
+  };
   if (typeof input['exclusiveMinimum'] === 'number') {
-    minimum = Math.max(minimum, input['exclusiveMinimum']);
+    minimum = tightenFractionalInputBoundary(minimum, input['exclusiveMinimum'], false, 'minimum');
   }
   if (typeof input['exclusiveMaximum'] === 'number') {
-    maximum = Math.min(maximum, input['exclusiveMaximum']);
+    maximum = tightenFractionalInputBoundary(maximum, input['exclusiveMaximum'], false, 'maximum');
   }
   for (const check of definition.checks ?? []) {
     if (check.kind === 'min' && typeof check.value === 'number') {
-      minimum = Math.max(minimum, check.value);
+      minimum = tightenFractionalInputBoundary(minimum, check.value, check.inclusive !== false, 'minimum');
     } else if (check.kind === 'max' && typeof check.value === 'number') {
-      maximum = Math.min(maximum, check.value);
+      maximum = tightenFractionalInputBoundary(maximum, check.value, check.inclusive !== false, 'maximum');
     }
   }
-  return minimum < maximum || (minimum === maximum && !Number.isInteger(minimum));
+  return (
+    minimum.value < maximum.value ||
+    (minimum.value === maximum.value &&
+      minimum.inclusive &&
+      maximum.inclusive &&
+      !Number.isInteger(minimum.value))
+  );
 };
 
 export const throwsOnFractionalBigIntInput = (definition: ZodTypeDef, schema: JsonSchema7Type): boolean =>

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -214,6 +214,9 @@ export const knownParsedOutputType = (
     if (isExactBigIntTransform(def)) {
       return ZodFirstPartyTypeKind.ZodBigInt;
     }
+    if (def.typeName === ZodFirstPartyTypeKind.ZodTuple) {
+      return ZodFirstPartyTypeKind.ZodArray;
+    }
     if (definiteParsedOutputKinds.has(def.typeName)) {
       return def.typeName;
     }
@@ -257,7 +260,10 @@ const parsedOutputContainer = (
   active.add(definition);
   try {
     const def = definition as InspectableDefinition;
-    if (def.typeName === kind) {
+    if (
+      def.typeName === kind ||
+      (kind === ZodFirstPartyTypeKind.ZodArray && def.typeName === ZodFirstPartyTypeKind.ZodTuple)
+    ) {
       return def;
     }
     const children = childDefinitions(def, 'output');
@@ -268,6 +274,48 @@ const parsedOutputContainer = (
   } finally {
     active.delete(definition);
   }
+};
+
+const parsedArrayOutputItem = (definition: InspectableDefinition, index?: number): SchemaType | undefined => {
+  if (definition.typeName !== ZodFirstPartyTypeKind.ZodTuple) {
+    return definition.type;
+  }
+  return index === undefined ? definition.rest : (definition.items[index] ?? definition.rest);
+};
+
+const findIncompatibleArrayOutputs = (
+  first: InspectableDefinition,
+  second: InspectableDefinition,
+  path: readonly string[],
+  active: Map<ZodTypeDef, Set<ZodTypeDef>>,
+  recurse: (
+    left: ZodTypeDef,
+    right: ZodTypeDef,
+    path: readonly string[],
+    active: Map<ZodTypeDef, Set<ZodTypeDef>>,
+  ) => ParsedOutputMismatch | undefined,
+): ParsedOutputMismatch | undefined => {
+  const firstLength = first.typeName === ZodFirstPartyTypeKind.ZodTuple ? first.items.length : 0;
+  const secondLength = second.typeName === ZodFirstPartyTypeKind.ZodTuple ? second.items.length : 0;
+  const length = Math.max(firstLength, secondLength);
+  for (let index = 0; index < length; index += 1) {
+    const firstItem = parsedArrayOutputItem(first, index);
+    const secondItem = parsedArrayOutputItem(second, index);
+    if (!firstItem || !secondItem) {
+      continue;
+    }
+
+    const mismatch = recurse(firstItem._def, secondItem._def, [...path, String(index)], active);
+    if (mismatch) {
+      return mismatch;
+    }
+  }
+
+  const firstRest = parsedArrayOutputItem(first);
+  const secondRest = parsedArrayOutputItem(second);
+  return firstRest && secondRest
+    ? recurse(firstRest._def, secondRest._def, [...path, '[]'], active)
+    : undefined;
 };
 
 export const findIncompatibleParsedOutputs = (
@@ -301,7 +349,7 @@ export const findIncompatibleParsedOutputs = (
       return undefined;
     }
     if (leftKind === ZodFirstPartyTypeKind.ZodArray) {
-      return findIncompatibleParsedOutputs(first.type._def, second.type._def, [...path, '[]'], active);
+      return findIncompatibleArrayOutputs(first, second, path, active, findIncompatibleParsedOutputs);
     }
     const firstShape = first.shape();
     const secondShape = second.shape();
@@ -996,6 +1044,7 @@ export type NestedNumericOverlap = {
   path: readonly NumericPathSegment[];
   producer: ZodTypeDef;
   consumer: ZodTypeDef;
+  producerPrecedesConsumer?: boolean;
 };
 
 type PairedChild = {
@@ -1341,10 +1390,13 @@ export const applySafeIntegerBounds = (schema: JsonSchema7Type): JsonSchema7Type
 const boundNestedNumericPath = (
   schema: JsonSchema7Type,
   path: readonly NumericPathSegment[],
-  producer: ZodTypeDef,
+  overlap: NestedNumericOverlap,
 ): JsonSchema7Type => {
   if (path.length === 0) {
-    return applyUnsafeBigIntBounds(schema, [producer]);
+    const bounded = applyUnsafeBigIntBounds(schema, [overlap.producer]);
+    return overlap.producerPrecedesConsumer && throwsOnFractionalBigIntInput(overlap.producer, bounded)
+      ? ({ ...bounded, type: 'integer' } as JsonSchema7Type)
+      : bounded;
   }
 
   const [segment, ...remaining] = path;
@@ -1362,7 +1414,7 @@ const boundNestedNumericPath = (
     if (Array.isArray(alternatives)) {
       record[keyword] = alternatives.map((alternative) =>
         alternative && typeof alternative === 'object'
-          ? boundNestedNumericPath(alternative as JsonSchema7Type, path, producer)
+          ? boundNestedNumericPath(alternative as JsonSchema7Type, path, overlap)
           : alternative,
       );
       return schema;
@@ -1372,14 +1424,14 @@ const boundNestedNumericPath = (
     const properties = record['properties'] as Record<string, JsonSchema7Type> | undefined;
     const property = properties?.[segment.key];
     if (properties && property) {
-      properties[segment.key] = boundNestedNumericPath(property, remaining, producer);
+      properties[segment.key] = boundNestedNumericPath(property, remaining, overlap);
     }
     return schema;
   }
 
   const child = record['items'] as JsonSchema7Type | undefined;
   if (child && typeof child === 'object' && !Array.isArray(child)) {
-    record['items'] = boundNestedNumericPath(child, remaining, producer);
+    record['items'] = boundNestedNumericPath(child, remaining, overlap);
   }
   return schema;
 };
@@ -1390,7 +1442,7 @@ export const applyNestedNumericOverlaps = (
 ): JsonSchema7Type => {
   let bounded = schema;
   for (const overlap of overlaps) {
-    bounded = boundNestedNumericPath(bounded, overlap.path, overlap.producer);
+    bounded = boundNestedNumericPath(bounded, overlap.path, overlap);
   }
   return bounded;
 };

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -17,9 +17,11 @@ type InspectableDefinition = ZodTypeDef & {
   right: SchemaType;
   value: unknown;
   values: Record<string, unknown>;
-  effect: { type: string };
+  effect: { type: string; transform?: unknown };
   coerce?: boolean;
-  checks?: { kind: string; value?: bigint }[];
+  checks?: { kind: string; value?: bigint | number; inclusive?: boolean }[];
+  minSize?: { value: number };
+  maxSize?: { value: number };
   shape: () => Record<string, SchemaType>;
   catchall: SchemaType;
   items: SchemaType[];
@@ -69,9 +71,11 @@ const childDefinitions = (def: InspectableDefinition, traversal: Traversal): Tra
     case ZodFirstPartyTypeKind.ZodNullable:
     case ZodFirstPartyTypeKind.ZodOptional:
     case ZodFirstPartyTypeKind.ZodDefault:
-    case ZodFirstPartyTypeKind.ZodCatch:
     case ZodFirstPartyTypeKind.ZodReadonly: {
       return { values: [def.innerType], every: false };
+    }
+    case ZodFirstPartyTypeKind.ZodCatch: {
+      return traversal === 'async-input' ? null : { values: [def.innerType], every: false };
     }
     case ZodFirstPartyTypeKind.ZodBranded: {
       return { values: [def.type], every: false };
@@ -166,11 +170,16 @@ export const requiresAsynchronousJSONInput = (definition: ZodTypeDef): boolean =
     'async-input',
   );
 
+const isExactBigIntTransform = (definition: InspectableDefinition): boolean =>
+  definition.typeName === ZodFirstPartyTypeKind.ZodEffects &&
+  definition.effect.type === 'transform' &&
+  definition.effect.transform === BigInt;
+
 export const producesBigIntOutput = (definition: ZodTypeDef): boolean =>
   visitDefinition(
     definition,
     (def) => {
-      if (def.typeName === ZodFirstPartyTypeKind.ZodBigInt) {
+      if (def.typeName === ZodFirstPartyTypeKind.ZodBigInt || isExactBigIntTransform(def)) {
         return true;
       }
       return def.typeName === ZodFirstPartyTypeKind.ZodLiteral ? typeof def.value === 'bigint' : undefined;
@@ -311,17 +320,86 @@ export const hasOpaqueJSONValidation = (definition: ZodTypeDef, active = new Set
   }
 };
 
+export const hasOpaquePipelineTransform = (
+  definition: ZodTypeDef,
+  active = new Set<ZodTypeDef>(),
+): boolean => {
+  if (active.has(definition)) {
+    return true;
+  }
+  active.add(definition);
+  try {
+    const def = definition as InspectableDefinition;
+    if (
+      def.typeName === ZodFirstPartyTypeKind.ZodCatch ||
+      (def.typeName === ZodFirstPartyTypeKind.ZodEffects &&
+        (def.effect.type === 'preprocess' ||
+          (def.effect.type === 'transform' && !isExactBigIntTransform(def))))
+    ) {
+      return true;
+    }
+    const children =
+      def.typeName === ZodFirstPartyTypeKind.ZodPipeline ? [def.in, def.out] : validationChildren(def);
+    return children.some((child) => hasOpaquePipelineTransform(child._def, active));
+  } finally {
+    active.delete(definition);
+  }
+};
+
+export const hasConstrainedPipelineOutput = (
+  definition: ZodTypeDef,
+  active = new Set<ZodTypeDef>(),
+): boolean => {
+  if (active.has(definition)) {
+    return true;
+  }
+  active.add(definition);
+  try {
+    const def = definition as InspectableDefinition;
+    if (
+      (def.checks?.length ?? 0) > 0 ||
+      (def.minSize !== undefined && def.minSize !== null) ||
+      (def.maxSize !== undefined && def.maxSize !== null) ||
+      [
+        ZodFirstPartyTypeKind.ZodLiteral,
+        ZodFirstPartyTypeKind.ZodEnum,
+        ZodFirstPartyTypeKind.ZodNativeEnum,
+        ZodFirstPartyTypeKind.ZodObject,
+        ZodFirstPartyTypeKind.ZodArray,
+        ZodFirstPartyTypeKind.ZodEffects,
+      ].includes(def.typeName)
+    ) {
+      return true;
+    }
+    return (childDefinitions(def, 'output')?.values ?? []).some((child) =>
+      hasConstrainedPipelineOutput(child._def, active),
+    );
+  } finally {
+    active.delete(definition);
+  }
+};
+
 type UnsafeIntegerSide = 'minimum' | 'maximum';
 
 export const capturesUnsafeBigIntInput = (definition: ZodTypeDef, side: UnsafeIntegerSide): boolean =>
   visitDefinition(
     definition,
     (def) => {
+      const boundary = side === 'minimum' ? 'min' : 'max';
+      if (isExactBigIntTransform(def)) {
+        const input = def.schema._def as InspectableDefinition;
+        const safeLimit = side === 'minimum' ? Number.MIN_SAFE_INTEGER : Number.MAX_SAFE_INTEGER;
+        return !input.checks?.some(
+          (check) =>
+            check.kind === boundary &&
+            typeof check.value === 'number' &&
+            (side === 'minimum' ? check.value >= safeLimit : check.value <= safeLimit),
+        );
+      }
       if (def.typeName !== ZodFirstPartyTypeKind.ZodBigInt) {
         return;
       }
 
-      const boundary = side === 'minimum' ? 'min' : 'max';
       const safeLimit = BigInt(side === 'minimum' ? Number.MIN_SAFE_INTEGER : Number.MAX_SAFE_INTEGER);
       return !(def.checks as { kind: string; value?: bigint }[] | undefined)?.some(
         (check) =>
@@ -508,6 +586,16 @@ const discriminatorValues = (
   }
 };
 
+const serializedNativeDefault = (value: unknown): unknown => {
+  if (typeof value === 'bigint') {
+    return Number(value);
+  }
+  if (value instanceof Date) {
+    return Date.prototype.toISOString.call(value);
+  }
+  return value;
+};
+
 const matchesDefaultDiscriminators = (
   definition: ZodTypeDef,
   value: unknown,
@@ -548,8 +636,9 @@ const matchesDefaultDiscriminators = (
         return true;
       }
       const literals = discriminatorValues(child._def);
+      const serialized = serializedNativeDefault(record[key]);
       return literals
-        ? literals.includes(record[key])
+        ? literals.some((candidate) => Object.is(candidate, serialized))
         : matchesDefaultDiscriminators(child._def, record[key], active);
     });
   } finally {
@@ -582,6 +671,25 @@ const producesSelectedNativeUnion = (
       nativeType === ZodFirstPartyTypeKind.ZodBigInt
         ? acceptsJSONNumberAtPath(option._def, path)
         : acceptsJSONStringAtPath(option._def, path);
+    if (intercepts && path.length === 0) {
+      const scalar = serializedNativeDefault(value);
+      const literals = discriminatorValues(option._def);
+      if (literals && !literals.some((candidate) => Object.is(candidate, scalar))) {
+        continue;
+      }
+      const candidate = option._def as InspectableDefinition;
+      if (
+        candidate.typeName === ZodFirstPartyTypeKind.ZodNumber &&
+        typeof scalar === 'number' &&
+        candidate.checks?.some((check) =>
+          check.kind === 'min'
+            ? scalar < Number(check.value)
+            : check.kind === 'max' && scalar > Number(check.value),
+        )
+      ) {
+        continue;
+      }
+    }
     if (intercepts) {
       return false;
     }

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -960,19 +960,23 @@ const collectNestedNumericOverlaps = (
   consumer: ZodTypeDef,
   path: readonly NumericPathSegment[],
   overlaps: NestedNumericOverlap[],
-  active: Map<ZodTypeDef, Set<ZodTypeDef>>,
-  traversal: { recursive: boolean; lazyTargets: WeakMap<ZodTypeDef, SchemaType> },
+  active: Map<ZodTypeDef, Map<ZodTypeDef, readonly NumericPathSegment[]>>,
+  traversal: {
+    recursivePaths: (readonly NumericPathSegment[])[];
+    lazyTargets: WeakMap<ZodTypeDef, SchemaType>;
+  },
 ): void => {
   let activeConsumers = active.get(producer);
-  if (activeConsumers?.has(consumer)) {
-    traversal.recursive = true;
+  const recursivePath = activeConsumers?.get(consumer);
+  if (recursivePath) {
+    traversal.recursivePaths.push(recursivePath);
     return;
   }
   if (!activeConsumers) {
-    activeConsumers = new Set();
+    activeConsumers = new Map();
     active.set(producer, activeConsumers);
   }
-  activeConsumers.add(consumer);
+  activeConsumers.set(consumer, path);
 
   try {
     if (producesBigIntOutput(producer) && acceptsJSONNumber(consumer)) {
@@ -1032,14 +1036,26 @@ export const findNestedNumericOverlaps = (
   consumer: ZodTypeDef,
 ): NestedNumericOverlap[] => {
   const overlaps: NestedNumericOverlap[] = [];
-  const traversal = { recursive: false, lazyTargets: new WeakMap<ZodTypeDef, SchemaType>() };
+  const traversal = {
+    recursivePaths: [] as (readonly NumericPathSegment[])[],
+    lazyTargets: new WeakMap<ZodTypeDef, SchemaType>(),
+  };
   collectNestedNumericOverlaps(producer, consumer, [], overlaps, new Map(), traversal);
   if (
-    traversal.recursive &&
     overlaps.some(
       (overlap) =>
-        capturesUnsafeBigIntInput(overlap.producer, 'minimum') ||
-        capturesUnsafeBigIntInput(overlap.producer, 'maximum'),
+        (capturesUnsafeBigIntInput(overlap.producer, 'minimum') ||
+          capturesUnsafeBigIntInput(overlap.producer, 'maximum')) &&
+        traversal.recursivePaths.some((recursivePath) =>
+          recursivePath.every((segment, index) => {
+            const candidate = overlap.path[index];
+            return (
+              candidate?.kind === segment.kind &&
+              (segment.kind !== 'property' ||
+                (candidate.kind === 'property' && candidate.key === segment.key))
+            );
+          }),
+        ),
     )
   ) {
     throw new Error(

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -166,10 +166,35 @@ const visitDefinition = (
   }
 };
 
+const hasPotentialJSONInputConversion = (definition: ZodTypeDef): boolean =>
+  visitDefinition(
+    definition,
+    (def) =>
+      def.typeName === ZodFirstPartyTypeKind.ZodEffects &&
+      (def.effect.type === 'preprocess' || def.effect.type === 'transform')
+        ? true
+        : undefined,
+    'input',
+  );
+
 export const requiresAsynchronousJSONInput = (definition: ZodTypeDef): boolean =>
   visitDefinition(
     definition,
-    (def) => (def.typeName === ZodFirstPartyTypeKind.ZodPromise ? true : undefined),
+    (def) => {
+      if (def.typeName === ZodFirstPartyTypeKind.ZodPromise) {
+        return true;
+      }
+      if (def.typeName === ZodFirstPartyTypeKind.ZodEffects && def.effect.type === 'preprocess') {
+        return false;
+      }
+      if (
+        def.typeName === ZodFirstPartyTypeKind.ZodPipeline &&
+        hasPotentialJSONInputConversion(def.in._def)
+      ) {
+        return false;
+      }
+      return null;
+    },
     'async-input',
   );
 
@@ -1024,6 +1049,34 @@ const producesNativeAtPath = (
       return child !== undefined && producesNativeAtPath(child._def, remaining, nestedValue, nativeType);
     },
     'default',
+  );
+
+export const hasDeclaredSchemaPropertyAtPath = (
+  definition: ZodTypeDef,
+  path: readonly (string | number)[],
+  property: string,
+): boolean =>
+  visitDefinition(
+    definition,
+    (def) => {
+      if (path.length === 0) {
+        return def.typeName === ZodFirstPartyTypeKind.ZodObject ? hasOwn(def.shape(), property) : undefined;
+      }
+
+      const [segment, ...remaining] = path;
+      let child: SchemaType | undefined;
+      if (def.typeName === ZodFirstPartyTypeKind.ZodObject && typeof segment === 'string') {
+        const shape = def.shape();
+        child = hasOwn(shape, segment) ? shape[segment] : def.catchall;
+      } else if (def.typeName === ZodFirstPartyTypeKind.ZodArray && typeof segment === 'number') {
+        child = def.type;
+      } else {
+        return;
+      }
+
+      return child !== undefined && hasDeclaredSchemaPropertyAtPath(child._def, remaining, property);
+    },
+    'input',
   );
 
 export const producesBigIntAtPath = (

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -270,7 +270,6 @@ export const knownParsedOutputType = (
     }
     if (
       def.typeName === ZodFirstPartyTypeKind.ZodNullable ||
-      def.typeName === ZodFirstPartyTypeKind.ZodCatch ||
       def.typeName === ZodFirstPartyTypeKind.ZodUnion ||
       def.typeName === ZodFirstPartyTypeKind.ZodDiscriminatedUnion ||
       def.typeName === ZodFirstPartyTypeKind.ZodIntersection

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -513,6 +513,7 @@ const findOpaqueParsedOutputMismatch = (
 const transparentNullableParsedOutputWrappers = new Set<ZodFirstPartyTypeKind>([
   ZodFirstPartyTypeKind.ZodOptional,
   ZodFirstPartyTypeKind.ZodDefault,
+  ZodFirstPartyTypeKind.ZodCatch,
   ZodFirstPartyTypeKind.ZodReadonly,
   ZodFirstPartyTypeKind.ZodBranded,
   ZodFirstPartyTypeKind.ZodLazy,
@@ -531,6 +532,9 @@ const nonNullParsedOutputAlternative = (
     const def = definition as InspectableDefinition;
     if (def.typeName === ZodFirstPartyTypeKind.ZodNullable) {
       return def.innerType._def;
+    }
+    if (def.typeName === ZodFirstPartyTypeKind.ZodCatch && hasOpaqueJSONValidation(def.innerType._def)) {
+      return undefined;
     }
     if (
       def.typeName === ZodFirstPartyTypeKind.ZodUnion ||
@@ -577,6 +581,151 @@ const findDirectParsedOutputMismatch = (
     : undefined;
 };
 
+const definiteIntersectionInputTypes = new Map<ZodFirstPartyTypeKind, string>([
+  [ZodFirstPartyTypeKind.ZodNumber, 'number'],
+  [ZodFirstPartyTypeKind.ZodString, 'string'],
+  [ZodFirstPartyTypeKind.ZodBoolean, 'boolean'],
+  [ZodFirstPartyTypeKind.ZodNull, 'null'],
+  [ZodFirstPartyTypeKind.ZodObject, 'object'],
+  [ZodFirstPartyTypeKind.ZodArray, 'array'],
+  [ZodFirstPartyTypeKind.ZodTuple, 'array'],
+]);
+
+const definiteIntersectionInputType = (
+  definition: ZodTypeDef,
+  active = new Set<ZodTypeDef>(),
+): string | undefined => {
+  if (active.has(definition)) {
+    return undefined;
+  }
+  active.add(definition);
+  try {
+    const def = definition as InspectableDefinition;
+    if (def.coerce === true) {
+      return undefined;
+    }
+    const known = definiteIntersectionInputTypes.get(def.typeName);
+    if (known !== undefined) {
+      return known;
+    }
+    if (def.typeName === ZodFirstPartyTypeKind.ZodLiteral) {
+      return def.value === null ? 'null' : typeof def.value;
+    }
+    if (def.typeName === ZodFirstPartyTypeKind.ZodEnum) {
+      return 'string';
+    }
+    if (def.typeName === ZodFirstPartyTypeKind.ZodEffects && def.effect.type === 'preprocess') {
+      return undefined;
+    }
+    const children = childDefinitions(def, 'input');
+    const child = children?.values[0];
+    return children?.values.length === 1 && child !== undefined
+      ? definiteIntersectionInputType(child._def, active)
+      : undefined;
+  } finally {
+    active.delete(definition);
+  }
+};
+
+const intersectionLiteralValue = (definition: ZodTypeDef): unknown =>
+  (definition as InspectableDefinition).typeName === ZodFirstPartyTypeKind.ZodLiteral
+    ? (definition as InspectableDefinition).value
+    : undefined;
+
+const haveDisjointIntersectionInputs = (left: ZodTypeDef, right: ZodTypeDef): boolean => {
+  const first = definiteIntersectionInputType(left);
+  const second = definiteIntersectionInputType(right);
+  if (first !== undefined && second !== undefined && first !== second) {
+    return true;
+  }
+  const leftLiteral = intersectionLiteralValue(left);
+  const rightLiteral = intersectionLiteralValue(right);
+  if (leftLiteral !== undefined && rightLiteral !== undefined && !Object.is(leftLiteral, rightLiteral)) {
+    return true;
+  }
+
+  const leftObject = parsedOutputContainer(left, ZodFirstPartyTypeKind.ZodObject);
+  const rightObject = parsedOutputContainer(right, ZodFirstPartyTypeKind.ZodObject);
+  if (!leftObject || !rightObject) {
+    return false;
+  }
+  const firstShape = leftObject.shape();
+  const secondShape = rightObject.shape();
+  return Object.entries(firstShape).some(([key, child]) => {
+    const sibling = hasOwn(secondShape, key) ? secondShape[key] : undefined;
+    if (!sibling) {
+      return false;
+    }
+    const firstValue = intersectionLiteralValue(child._def);
+    const secondValue = intersectionLiteralValue(sibling._def);
+    return firstValue !== undefined && secondValue !== undefined && !Object.is(firstValue, secondValue);
+  });
+};
+
+const compoundParsedOutputAlternatives = (
+  definition: ZodTypeDef,
+  active = new Set<ZodTypeDef>(),
+): readonly ZodTypeDef[] | undefined => {
+  if (active.has(definition)) {
+    return undefined;
+  }
+  active.add(definition);
+  try {
+    const def = definition as InspectableDefinition;
+    if (
+      def.typeName === ZodFirstPartyTypeKind.ZodUnion ||
+      def.typeName === ZodFirstPartyTypeKind.ZodDiscriminatedUnion
+    ) {
+      const options = def.options instanceof Map ? [...def.options.values()] : def.options;
+      return options.map((option) => option._def);
+    }
+    if (!transparentNullableParsedOutputWrappers.has(def.typeName)) {
+      return undefined;
+    }
+    if (def.typeName === ZodFirstPartyTypeKind.ZodCatch && hasOpaqueJSONValidation(def.innerType._def)) {
+      return undefined;
+    }
+    const children = childDefinitions(def, 'output');
+    const child = children?.values[0];
+    return children?.values.length === 1 && child !== undefined
+      ? compoundParsedOutputAlternatives(child._def, active)
+      : undefined;
+  } finally {
+    active.delete(definition);
+  }
+};
+
+const findUnionParsedOutputMismatch = (
+  left: ZodTypeDef,
+  right: ZodTypeDef,
+  path: readonly string[],
+  active: Map<ZodTypeDef, Set<ZodTypeDef>>,
+  recurse: (
+    left: ZodTypeDef,
+    right: ZodTypeDef,
+    path: readonly string[],
+    active: Map<ZodTypeDef, Set<ZodTypeDef>>,
+  ) => ParsedOutputMismatch | undefined,
+): ParsedOutputMismatch | undefined => {
+  const leftAlternatives = compoundParsedOutputAlternatives(left);
+  const rightAlternatives = compoundParsedOutputAlternatives(right);
+  if (!leftAlternatives && !rightAlternatives) {
+    return undefined;
+  }
+  for (const first of leftAlternatives ?? [left]) {
+    for (const second of rightAlternatives ?? [right]) {
+      if (haveDisjointIntersectionInputs(first, second)) {
+        continue;
+      }
+      const mismatch = recurse(first, second, path, active);
+      if (mismatch) {
+        return mismatch;
+      }
+    }
+  }
+  return undefined;
+};
+
 const findNonNullParsedOutputMismatch = (
   left: ZodTypeDef,
   right: ZodTypeDef,
@@ -601,6 +750,21 @@ const findNonNullParsedOutputMismatch = (
     : undefined;
 };
 
+const findCompoundParsedOutputMismatch = (
+  left: ZodTypeDef,
+  right: ZodTypeDef,
+  path: readonly string[],
+  active: Map<ZodTypeDef, Set<ZodTypeDef>>,
+  recurse: (
+    left: ZodTypeDef,
+    right: ZodTypeDef,
+    path: readonly string[],
+    active: Map<ZodTypeDef, Set<ZodTypeDef>>,
+  ) => ParsedOutputMismatch | undefined,
+): ParsedOutputMismatch | undefined =>
+  findNonNullParsedOutputMismatch(left, right, path, active, recurse) ??
+  findUnionParsedOutputMismatch(left, right, path, active, recurse);
+
 export const findIncompatibleParsedOutputs = (
   left: ZodTypeDef,
   right: ZodTypeDef,
@@ -619,7 +783,7 @@ export const findIncompatibleParsedOutputs = (
     const rightKind = knownParsedOutputType(right);
     const directMismatch =
       findDirectParsedOutputMismatch(left, right, leftKind, rightKind, path) ??
-      findNonNullParsedOutputMismatch(left, right, path, active, findIncompatibleParsedOutputs);
+      findCompoundParsedOutputMismatch(left, right, path, active, findIncompatibleParsedOutputs);
     if (directMismatch) {
       return directMismatch;
     }
@@ -1043,7 +1207,7 @@ export const hasOpaquePipelineTransform = (
   try {
     const def = definition as InspectableDefinition;
     if (
-      def.typeName === ZodFirstPartyTypeKind.ZodCatch ||
+      (def.typeName === ZodFirstPartyTypeKind.ZodCatch && hasOpaqueJSONValidation(def.innerType._def)) ||
       (def.typeName === ZodFirstPartyTypeKind.ZodString &&
         def.checks?.some((check) => valueChangingStringChecks.has(check.kind)) === true) ||
       (def.typeName === ZodFirstPartyTypeKind.ZodEffects &&

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -178,6 +178,13 @@ export const producesBigIntOutput = (definition: ZodTypeDef): boolean =>
     'output',
   );
 
+const nativeEnumValues = (definition: InspectableDefinition): readonly (string | number)[] => {
+  const values = definition.values as Record<string, string | number>;
+  return Object.entries(values)
+    .filter(([, value]) => typeof values[value] !== 'number')
+    .map(([, value]) => value);
+};
+
 export const acceptsJSONNumber = (definition: ZodTypeDef): boolean =>
   visitDefinition(
     definition,
@@ -192,7 +199,7 @@ export const acceptsJSONNumber = (definition: ZodTypeDef): boolean =>
           return typeof def.value === 'number';
         }
         case ZodFirstPartyTypeKind.ZodNativeEnum: {
-          return Object.values(def.values).some((value) => typeof value === 'number');
+          return nativeEnumValues(def).some((value) => typeof value === 'number');
         }
         case ZodFirstPartyTypeKind.ZodEffects: {
           return def.effect.type === 'preprocess' ? true : undefined;
@@ -421,6 +428,44 @@ const acceptsJSONNumberAtPath = (definition: ZodTypeDef, path: readonly (string 
     'input',
   );
 
+const acceptsJSONStringAtPath = (definition: ZodTypeDef, path: readonly (string | number)[]): boolean =>
+  visitDefinition(
+    definition,
+    (def) => {
+      if (path.length === 0) {
+        if (
+          def.typeName === ZodFirstPartyTypeKind.ZodString ||
+          def.typeName === ZodFirstPartyTypeKind.ZodAny ||
+          def.typeName === ZodFirstPartyTypeKind.ZodUnknown
+        ) {
+          return true;
+        }
+        if (def.typeName === ZodFirstPartyTypeKind.ZodLiteral) {
+          return typeof def.value === 'string';
+        }
+        if (def.typeName === ZodFirstPartyTypeKind.ZodNativeEnum) {
+          return nativeEnumValues(def).some((value) => typeof value === 'string');
+        }
+        if (def.typeName === ZodFirstPartyTypeKind.ZodEnum) {
+          return true;
+        }
+        return def.coerce === true ? true : undefined;
+      }
+      const [key, ...remaining] = path;
+      let child: SchemaType | undefined;
+      if (def.typeName === ZodFirstPartyTypeKind.ZodObject && typeof key === 'string') {
+        const shape = def.shape();
+        child = hasOwn(shape, key) ? shape[key] : def.catchall;
+      } else if (def.typeName === ZodFirstPartyTypeKind.ZodArray && typeof key === 'number') {
+        child = def.type;
+      } else {
+        return;
+      }
+      return child !== undefined && acceptsJSONStringAtPath(child._def, remaining);
+    },
+    'input',
+  );
+
 const discriminatorValues = (
   definition: ZodTypeDef,
   active = new Set<ZodTypeDef>(),
@@ -435,9 +480,11 @@ const discriminatorValues = (
       case ZodFirstPartyTypeKind.ZodLiteral: {
         return [def.value];
       }
-      case ZodFirstPartyTypeKind.ZodEnum:
-      case ZodFirstPartyTypeKind.ZodNativeEnum: {
+      case ZodFirstPartyTypeKind.ZodEnum: {
         return Object.values(def.values);
+      }
+      case ZodFirstPartyTypeKind.ZodNativeEnum: {
+        return nativeEnumValues(def);
       }
       case ZodFirstPartyTypeKind.ZodEffects: {
         return def.effect.type === 'refinement' ? discriminatorValues(def.schema._def, active) : undefined;
@@ -510,10 +557,43 @@ const matchesDefaultDiscriminators = (
   }
 };
 
-export const producesBigIntAtPath = (
+type NativeDefaultType = ZodFirstPartyTypeKind.ZodBigInt | ZodFirstPartyTypeKind.ZodDate;
+
+const producesSelectedNativeUnion = (
+  options: readonly SchemaType[],
+  path: readonly (string | number)[],
+  value: unknown,
+  nativeType: NativeDefaultType,
+  producesNative: (
+    definition: ZodTypeDef,
+    path: readonly (string | number)[],
+    value: unknown,
+    nativeType: NativeDefaultType,
+  ) => boolean,
+): boolean => {
+  for (const option of options) {
+    if (!matchesDefaultDiscriminators(option._def, value)) {
+      continue;
+    }
+    if (producesNative(option._def, path, value, nativeType)) {
+      return true;
+    }
+    const intercepts =
+      nativeType === ZodFirstPartyTypeKind.ZodBigInt
+        ? acceptsJSONNumberAtPath(option._def, path)
+        : acceptsJSONStringAtPath(option._def, path);
+    if (intercepts) {
+      return false;
+    }
+  }
+  return false;
+};
+
+const producesNativeAtPath = (
   definition: ZodTypeDef,
-  path: readonly (string | number)[] = [],
-  value?: unknown,
+  path: readonly (string | number)[],
+  value: unknown,
+  nativeType: NativeDefaultType,
 ): boolean =>
   visitDefinition(
     definition,
@@ -523,24 +603,15 @@ export const producesBigIntAtPath = (
         def.typeName === ZodFirstPartyTypeKind.ZodDiscriminatedUnion
       ) {
         const options = def.options instanceof Map ? [...def.options.values()] : def.options;
-        for (const option of options) {
-          if (!matchesDefaultDiscriminators(option._def, value)) {
-            continue;
-          }
-          if (producesBigIntAtPath(option._def, path, value)) {
-            return true;
-          }
-          if (acceptsJSONNumberAtPath(option._def, path)) {
-            return false;
-          }
-        }
-        return false;
+        return producesSelectedNativeUnion(options, path, value, nativeType, producesNativeAtPath);
       }
       if (path.length === 0) {
-        if (def.typeName === ZodFirstPartyTypeKind.ZodBigInt) {
+        if (def.typeName === nativeType) {
           return true;
         }
-        return def.typeName === ZodFirstPartyTypeKind.ZodLiteral ? typeof def.value === 'bigint' : undefined;
+        return def.typeName === ZodFirstPartyTypeKind.ZodLiteral
+          ? nativeType === ZodFirstPartyTypeKind.ZodBigInt && typeof def.value === 'bigint'
+          : undefined;
       }
 
       const [key, ...remaining] = path;
@@ -568,10 +639,22 @@ export const producesBigIntAtPath = (
 
       const nestedValue =
         value && typeof value === 'object' ? (value as Record<string | number, unknown>)[key] : undefined;
-      return child !== undefined && producesBigIntAtPath(child._def, remaining, nestedValue);
+      return child !== undefined && producesNativeAtPath(child._def, remaining, nestedValue, nativeType);
     },
     'default',
   );
+
+export const producesBigIntAtPath = (
+  definition: ZodTypeDef,
+  path: readonly (string | number)[] = [],
+  value?: unknown,
+): boolean => producesNativeAtPath(definition, path, value, ZodFirstPartyTypeKind.ZodBigInt);
+
+export const producesDateAtPath = (
+  definition: ZodTypeDef,
+  path: readonly (string | number)[] = [],
+  value?: unknown,
+): boolean => producesNativeAtPath(definition, path, value, ZodFirstPartyTypeKind.ZodDate);
 
 type NumericPathSegment = { kind: 'property'; key: string } | { kind: 'array' };
 
@@ -609,11 +692,11 @@ const leafJSONInputTypes = (def: InspectableDefinition): Set<string> | null | un
     const primitiveType = typeof value;
     return ['string', 'number', 'boolean'].includes(primitiveType) ? new Set([primitiveType]) : null;
   }
-  if (
-    def.typeName === ZodFirstPartyTypeKind.ZodEnum ||
-    def.typeName === ZodFirstPartyTypeKind.ZodNativeEnum
-  ) {
+  if (def.typeName === ZodFirstPartyTypeKind.ZodEnum) {
     return new Set(Object.values(def.values).map((value) => typeof value));
+  }
+  if (def.typeName === ZodFirstPartyTypeKind.ZodNativeEnum) {
+    return new Set(nativeEnumValues(def).map((value) => typeof value));
   }
   return undefined;
 };
@@ -923,6 +1006,17 @@ const boundNestedNumericPath = (
     throw new Error(
       'A constrained nested JSON Schema reference must be materialized before applying bounds.',
     );
+  }
+  for (const keyword of ['anyOf', 'oneOf']) {
+    const alternatives = record[keyword];
+    if (Array.isArray(alternatives)) {
+      record[keyword] = alternatives.map((alternative) =>
+        alternative && typeof alternative === 'object'
+          ? boundNestedNumericPath(alternative as JsonSchema7Type, path, producer)
+          : alternative,
+      );
+      return schema;
+    }
   }
   if (segment.kind === 'property') {
     const properties = record['properties'] as Record<string, JsonSchema7Type> | undefined;

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -482,6 +482,9 @@ const acceptsOverlappingBigIntStringInput = (
       minimum = Math.max(minimum, check.value);
     } else if (check.kind === 'max' && typeof check.value === 'number') {
       maximum = Math.min(maximum, check.value);
+    } else if (check.kind === 'length' && typeof check.value === 'number') {
+      minimum = Math.max(minimum, check.value);
+      maximum = Math.min(maximum, check.value);
     }
   }
   const fallbackMinimum = typeof input['minLength'] === 'number' ? input['minLength'] : 0;
@@ -534,6 +537,34 @@ export const applyBigIntStringFallbackBounds = (
         ),
       } as JsonSchema7Type;
     }
+  }
+  const isReachableStringValue = (value: string): boolean => {
+    if (new RegExp(bigIntStringPattern, 'u').test(value)) {
+      return true;
+    }
+    const concrete = {
+      type: 'string',
+      minLength: value.length,
+      maxLength: value.length,
+    } as JsonSchema7Type;
+    return !producers.some((producer) => throwsOnInvalidBigIntStringInput(producer, concrete));
+  };
+  if (typeof record['const'] === 'string') {
+    if (!isReachableStringValue(record['const'])) {
+      throw new Error('A BigInt union fallback has no synchronously reachable string values.');
+    }
+    return schema;
+  }
+  if (Array.isArray(record['enum'])) {
+    const reachable = record['enum'].filter(
+      (value) => typeof value !== 'string' || isReachableStringValue(value),
+    );
+    if (reachable.length === 0) {
+      throw new Error('A BigInt union fallback has no synchronously reachable string values.');
+    }
+    return reachable.length === record['enum'].length
+      ? schema
+      : ({ ...schema, enum: reachable } as JsonSchema7Type);
   }
   if (!producers.some((producer) => throwsOnInvalidBigIntStringInput(producer, schema))) {
     return schema;
@@ -766,20 +797,40 @@ export const hasConstrainedPipelineOutput = (
 
 type UnsafeIntegerSide = 'minimum' | 'maximum';
 
+const capturesUnsafeNumericInput = (definition: ZodTypeDef, side: UnsafeIntegerSide): boolean =>
+  visitDefinition(
+    definition,
+    (input) => {
+      if (
+        input.typeName === ZodFirstPartyTypeKind.ZodAny ||
+        input.typeName === ZodFirstPartyTypeKind.ZodUnknown ||
+        (input.typeName === ZodFirstPartyTypeKind.ZodEffects && input.effect.type !== 'refinement') ||
+        (input.coerce === true && input.typeName !== ZodFirstPartyTypeKind.ZodNumber)
+      ) {
+        return true;
+      }
+      if (input.typeName !== ZodFirstPartyTypeKind.ZodNumber) {
+        return;
+      }
+      const boundary = side === 'minimum' ? 'min' : 'max';
+      const safeLimit = side === 'minimum' ? Number.MIN_SAFE_INTEGER : Number.MAX_SAFE_INTEGER;
+      return !input.checks?.some(
+        (check) =>
+          check.kind === boundary &&
+          typeof check.value === 'number' &&
+          (side === 'minimum' ? check.value >= safeLimit : check.value <= safeLimit),
+      );
+    },
+    'input',
+  );
+
 export const capturesUnsafeBigIntInput = (definition: ZodTypeDef, side: UnsafeIntegerSide): boolean =>
   visitDefinition(
     definition,
     (def) => {
       const boundary = side === 'minimum' ? 'min' : 'max';
       if (isExactBigIntTransform(def)) {
-        const input = def.schema._def as InspectableDefinition;
-        const safeLimit = side === 'minimum' ? Number.MIN_SAFE_INTEGER : Number.MAX_SAFE_INTEGER;
-        return !input.checks?.some(
-          (check) =>
-            check.kind === boundary &&
-            typeof check.value === 'number' &&
-            (side === 'minimum' ? check.value >= safeLimit : check.value <= safeLimit),
-        );
+        return capturesUnsafeNumericInput(def.schema._def, side);
       }
       if (def.typeName !== ZodFirstPartyTypeKind.ZodBigInt) {
         return;

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -1,5 +1,6 @@
 import type { ZodTypeDef } from 'zod/v3';
 import { ZodFirstPartyTypeKind } from 'zod/v3';
+import type { JsonSchema7Type } from './parseDef';
 import { hasOwn } from '../../internal/utils/values';
 
 type SchemaType = { _def: ZodTypeDef };
@@ -357,3 +358,285 @@ export const producesBigIntAtPath = (
     },
     'default',
   );
+
+type NumericPathSegment =
+  | { kind: 'property'; key: string }
+  | { kind: 'array' }
+  | { kind: 'tuple'; index: number }
+  | { kind: 'record' };
+
+export type NestedNumericOverlap = {
+  path: readonly NumericPathSegment[];
+  producer: ZodTypeDef;
+  consumer: ZodTypeDef;
+};
+
+type PairedChild = {
+  producer: SchemaType;
+  consumer: SchemaType;
+  segment: NumericPathSegment;
+};
+
+const objectChildren = (producer: InspectableDefinition, consumer: InspectableDefinition): PairedChild[] => {
+  const producerShape = producer.shape();
+  const consumerShape = consumer.shape();
+  const sharedKeys = Object.keys(consumerShape).filter((key) => hasOwn(producerShape, key));
+  if (
+    sharedKeys.some((key) => {
+      const left = producerShape[key]?._def as InspectableDefinition | undefined;
+      const right = consumerShape[key]?._def as InspectableDefinition | undefined;
+      return (
+        left?.typeName === ZodFirstPartyTypeKind.ZodLiteral &&
+        right?.typeName === ZodFirstPartyTypeKind.ZodLiteral &&
+        left.value !== right.value
+      );
+    })
+  ) {
+    return [];
+  }
+
+  return sharedKeys.flatMap((key) => {
+    const left = producerShape[key];
+    const right = consumerShape[key];
+    return left && right ? [{ producer: left, consumer: right, segment: { kind: 'property', key } }] : [];
+  });
+};
+
+const tupleChildren = (producer: InspectableDefinition, consumer: InspectableDefinition): PairedChild[] => {
+  const values: PairedChild[] = consumer.items.flatMap((item, index) => {
+    const left = producer.items[index] ?? producer.rest;
+    return left ? [{ producer: left, consumer: item, segment: { kind: 'tuple' as const, index } }] : [];
+  });
+  if (producer.rest && consumer.rest) {
+    values.push({ producer: producer.rest, consumer: consumer.rest, segment: { kind: 'array' } });
+  }
+  return values;
+};
+
+const pairedContainerChildren = (
+  producer: InspectableDefinition,
+  consumer: InspectableDefinition,
+): PairedChild[] => {
+  if (
+    producer.typeName === ZodFirstPartyTypeKind.ZodObject &&
+    consumer.typeName === ZodFirstPartyTypeKind.ZodObject
+  ) {
+    return objectChildren(producer, consumer);
+  }
+  if (
+    producer.typeName === ZodFirstPartyTypeKind.ZodArray &&
+    consumer.typeName === ZodFirstPartyTypeKind.ZodArray
+  ) {
+    return [{ producer: producer.type, consumer: consumer.type, segment: { kind: 'array' } }];
+  }
+  if (
+    producer.typeName === ZodFirstPartyTypeKind.ZodTuple &&
+    consumer.typeName === ZodFirstPartyTypeKind.ZodTuple
+  ) {
+    return tupleChildren(producer, consumer);
+  }
+  if (
+    producer.typeName === ZodFirstPartyTypeKind.ZodRecord &&
+    consumer.typeName === ZodFirstPartyTypeKind.ZodRecord
+  ) {
+    return [{ producer: producer.valueType, consumer: consumer.valueType, segment: { kind: 'record' } }];
+  }
+  return [];
+};
+
+const collectNestedNumericOverlaps = (
+  producer: ZodTypeDef,
+  consumer: ZodTypeDef,
+  path: readonly NumericPathSegment[],
+  overlaps: NestedNumericOverlap[],
+  active: Map<ZodTypeDef, Set<ZodTypeDef>>,
+): void => {
+  let activeConsumers = active.get(producer);
+  if (activeConsumers?.has(consumer)) {
+    return;
+  }
+  if (!activeConsumers) {
+    activeConsumers = new Set();
+    active.set(producer, activeConsumers);
+  }
+  activeConsumers.add(consumer);
+
+  try {
+    if (producesBigIntOutput(producer) && acceptsJSONNumber(consumer)) {
+      overlaps.push({ path, producer, consumer });
+      return;
+    }
+
+    const left = producer as InspectableDefinition;
+    const right = consumer as InspectableDefinition;
+    const containers = pairedContainerChildren(left, right);
+    if (containers.length > 0) {
+      for (const child of containers) {
+        collectNestedNumericOverlaps(
+          child.producer._def,
+          child.consumer._def,
+          [...path, child.segment],
+          overlaps,
+          active,
+        );
+      }
+      return;
+    }
+
+    for (const child of childDefinitions(left, 'output')?.values ?? []) {
+      collectNestedNumericOverlaps(child._def, consumer, path, overlaps, active);
+    }
+    for (const child of childDefinitions(right, 'input')?.values ?? []) {
+      collectNestedNumericOverlaps(producer, child._def, path, overlaps, active);
+    }
+  } finally {
+    activeConsumers.delete(consumer);
+    if (activeConsumers.size === 0) {
+      active.delete(producer);
+    }
+  }
+};
+
+export const findNestedNumericOverlaps = (
+  producer: ZodTypeDef,
+  consumer: ZodTypeDef,
+): NestedNumericOverlap[] => {
+  const overlaps: NestedNumericOverlap[] = [];
+  collectNestedNumericOverlaps(producer, consumer, [], overlaps, new Map());
+  return overlaps;
+};
+
+export const applyUnsafeBigIntBounds = (
+  schema: JsonSchema7Type,
+  producers: readonly ZodTypeDef[],
+): JsonSchema7Type => {
+  const minimum =
+    producers.some((candidate) => capturesUnsafeBigIntInput(candidate, 'minimum')) &&
+    (acceptsUnsafeJSONInteger(schema, 'minimum') || (!('type' in schema) && !('$ref' in schema)));
+  const maximum =
+    producers.some((candidate) => capturesUnsafeBigIntInput(candidate, 'maximum')) &&
+    (acceptsUnsafeJSONInteger(schema, 'maximum') || (!('type' in schema) && !('$ref' in schema)));
+  if (!minimum && !maximum) {
+    return schema;
+  }
+
+  if ('$ref' in schema) {
+    return {
+      allOf: [
+        schema,
+        {
+          ...(minimum ? { minimum: Number.MIN_SAFE_INTEGER } : undefined),
+          ...(maximum ? { maximum: Number.MAX_SAFE_INTEGER } : undefined),
+        } as JsonSchema7Type,
+      ],
+    };
+  }
+
+  const record = schema as Record<string, unknown>;
+  if (minimum) {
+    record['minimum'] = Math.max(
+      typeof record['minimum'] === 'number' ? record['minimum'] : Number.MIN_SAFE_INTEGER,
+      Number.MIN_SAFE_INTEGER,
+    );
+  }
+  if (maximum) {
+    record['maximum'] = Math.min(
+      typeof record['maximum'] === 'number' ? record['maximum'] : Number.MAX_SAFE_INTEGER,
+      Number.MAX_SAFE_INTEGER,
+    );
+  }
+  return schema;
+};
+
+const wrapNestedConstraint = (schema: JsonSchema7Type, segment: NumericPathSegment): JsonSchema7Type => {
+  switch (segment.kind) {
+    case 'property': {
+      return { type: 'object', properties: { [segment.key]: schema } } as JsonSchema7Type;
+    }
+    case 'array': {
+      return { type: 'array', items: schema } as JsonSchema7Type;
+    }
+    case 'tuple': {
+      const items: JsonSchema7Type[] = Array.from({ length: segment.index }, () => ({}) as JsonSchema7Type);
+      items.push(schema);
+      return { type: 'array', items } as JsonSchema7Type;
+    }
+    case 'record': {
+      return { type: 'object', additionalProperties: schema } as JsonSchema7Type;
+    }
+    default: {
+      return schema;
+    }
+  }
+};
+
+const nestedConstraint = (
+  path: readonly NumericPathSegment[],
+  producer: ZodTypeDef,
+): JsonSchema7Type | null => {
+  let constrained = applyUnsafeBigIntBounds({} as JsonSchema7Type, [producer]);
+  if (!('minimum' in constrained) && !('maximum' in constrained)) {
+    return null;
+  }
+
+  for (let index = path.length - 1; index >= 0; index -= 1) {
+    const segment = path[index];
+    if (segment) {
+      constrained = wrapNestedConstraint(constrained, segment);
+    }
+  }
+  return constrained;
+};
+
+const boundNestedNumericPath = (
+  schema: JsonSchema7Type,
+  path: readonly NumericPathSegment[],
+  producer: ZodTypeDef,
+): JsonSchema7Type => {
+  if (path.length === 0) {
+    return applyUnsafeBigIntBounds(schema, [producer]);
+  }
+
+  const [segment, ...remaining] = path;
+  if (!segment) {
+    return schema;
+  }
+  const record = schema as Record<string, unknown>;
+  if ('$ref' in record) {
+    const constraint = nestedConstraint(path, producer);
+    return constraint ? ({ allOf: [schema, constraint] } as JsonSchema7Type) : schema;
+  }
+  if (segment.kind === 'property') {
+    const properties = record['properties'] as Record<string, JsonSchema7Type> | undefined;
+    const property = properties?.[segment.key];
+    if (properties && property) {
+      properties[segment.key] = boundNestedNumericPath(property, remaining, producer);
+    }
+    return schema;
+  }
+
+  const key = segment.kind === 'record' ? 'additionalProperties' : 'items';
+  const child = record[key] as JsonSchema7Type | JsonSchema7Type[] | undefined;
+  if (Array.isArray(child)) {
+    if (segment.kind === 'tuple') {
+      const item = child[segment.index];
+      if (item) {
+        child[segment.index] = boundNestedNumericPath(item, remaining, producer);
+      }
+    }
+  } else if (child && typeof child === 'object') {
+    record[key] = boundNestedNumericPath(child, remaining, producer);
+  }
+  return schema;
+};
+
+export const applyNestedNumericOverlaps = (
+  schema: JsonSchema7Type,
+  overlaps: readonly NestedNumericOverlap[],
+): JsonSchema7Type => {
+  let bounded = schema;
+  for (const overlap of overlaps) {
+    bounded = boundNestedNumericPath(bounded, overlap.path, overlap.producer);
+  }
+  return bounded;
+};

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -598,9 +598,11 @@ const collectNestedNumericOverlaps = (
   path: readonly NumericPathSegment[],
   overlaps: NestedNumericOverlap[],
   active: Map<ZodTypeDef, Set<ZodTypeDef>>,
+  traversal: { recursive: boolean; lazyTargets: WeakMap<ZodTypeDef, SchemaType> },
 ): void => {
   let activeConsumers = active.get(producer);
   if (activeConsumers?.has(consumer)) {
+    traversal.recursive = true;
     return;
   }
   if (!activeConsumers) {
@@ -617,6 +619,22 @@ const collectNestedNumericOverlaps = (
 
     const left = producer as InspectableDefinition;
     const right = consumer as InspectableDefinition;
+    if (left.typeName === ZodFirstPartyTypeKind.ZodLazy || right.typeName === ZodFirstPartyTypeKind.ZodLazy) {
+      const unwrap = (definition: InspectableDefinition): ZodTypeDef => {
+        if (definition.typeName !== ZodFirstPartyTypeKind.ZodLazy) {
+          return definition;
+        }
+        let target = traversal.lazyTargets.get(definition);
+        if (!target) {
+          target = definition.getter();
+          traversal.lazyTargets.set(definition, target);
+        }
+        return target._def;
+      };
+      collectNestedNumericOverlaps(unwrap(left), unwrap(right), path, overlaps, active, traversal);
+      return;
+    }
+
     const containers = pairedContainerChildren(left, right);
     if (containers.length > 0) {
       for (const child of containers) {
@@ -626,16 +644,17 @@ const collectNestedNumericOverlaps = (
           [...path, child.segment],
           overlaps,
           active,
+          traversal,
         );
       }
       return;
     }
 
     for (const child of childDefinitions(left, 'output')?.values ?? []) {
-      collectNestedNumericOverlaps(child._def, consumer, path, overlaps, active);
+      collectNestedNumericOverlaps(child._def, consumer, path, overlaps, active, traversal);
     }
     for (const child of childDefinitions(right, 'input')?.values ?? []) {
-      collectNestedNumericOverlaps(producer, child._def, path, overlaps, active);
+      collectNestedNumericOverlaps(producer, child._def, path, overlaps, active, traversal);
     }
   } finally {
     activeConsumers.delete(consumer);
@@ -650,7 +669,21 @@ export const findNestedNumericOverlaps = (
   consumer: ZodTypeDef,
 ): NestedNumericOverlap[] => {
   const overlaps: NestedNumericOverlap[] = [];
-  collectNestedNumericOverlaps(producer, consumer, [], overlaps, new Map());
+  const traversal = { recursive: false, lazyTargets: new WeakMap<ZodTypeDef, SchemaType>() };
+  collectNestedNumericOverlaps(producer, consumer, [], overlaps, new Map(), traversal);
+  if (
+    traversal.recursive &&
+    overlaps.some(
+      (overlap) =>
+        capturesUnsafeBigIntInput(overlap.producer, 'minimum') ||
+        capturesUnsafeBigIntInput(overlap.producer, 'maximum'),
+    )
+  ) {
+    throw new Error(
+      'Recursive BigInt and number union alternatives cannot safely preserve integer precision in strict Structured Outputs.',
+    );
+  }
+
   return overlaps;
 };
 

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -1,0 +1,307 @@
+import type { ZodTypeDef } from 'zod/v3';
+import { ZodFirstPartyTypeKind } from 'zod/v3';
+import { hasOwn } from '../../internal/utils/values';
+
+type SchemaType = { _def: ZodTypeDef };
+type InspectableDefinition = ZodTypeDef & {
+  typeName: ZodFirstPartyTypeKind;
+  innerType: SchemaType;
+  type: SchemaType;
+  schema: SchemaType;
+  getter: () => SchemaType;
+  in: SchemaType;
+  out: SchemaType;
+  options: SchemaType[] | Map<unknown, SchemaType>;
+  left: SchemaType;
+  right: SchemaType;
+  value: unknown;
+  values: Record<string, unknown>;
+  effect: { type: string };
+  coerce?: boolean;
+  checks?: { kind: string; value?: bigint }[];
+  shape: () => Record<string, SchemaType>;
+  catchall: SchemaType;
+  items: SchemaType[];
+  rest?: SchemaType;
+  valueType: SchemaType;
+};
+type Traversal = 'input' | 'output' | 'conversion' | 'default' | 'unconditional-number';
+type Inspector = (definition: InspectableDefinition) => boolean | null | undefined;
+
+type TraversalChildren = { values: SchemaType[]; every: boolean };
+
+const pipelineChildren = (def: InspectableDefinition, traversal: Traversal): SchemaType[] => {
+  if (traversal === 'input' || traversal === 'unconditional-number') {
+    return [def.in];
+  }
+  if (traversal === 'conversion') {
+    return [def.in, def.out];
+  }
+  return [def.out];
+};
+
+const childDefinitions = (def: InspectableDefinition, traversal: Traversal): TraversalChildren | null => {
+  switch (def.typeName) {
+    case ZodFirstPartyTypeKind.ZodNullable:
+    case ZodFirstPartyTypeKind.ZodOptional:
+    case ZodFirstPartyTypeKind.ZodDefault:
+    case ZodFirstPartyTypeKind.ZodCatch:
+    case ZodFirstPartyTypeKind.ZodReadonly: {
+      return { values: [def.innerType], every: false };
+    }
+    case ZodFirstPartyTypeKind.ZodBranded:
+    case ZodFirstPartyTypeKind.ZodPromise: {
+      return { values: [def.type], every: false };
+    }
+    case ZodFirstPartyTypeKind.ZodEffects: {
+      return { values: [def.schema], every: false };
+    }
+    case ZodFirstPartyTypeKind.ZodLazy: {
+      return { values: [def.getter()], every: false };
+    }
+    case ZodFirstPartyTypeKind.ZodPipeline: {
+      return { values: pipelineChildren(def, traversal), every: false };
+    }
+    case ZodFirstPartyTypeKind.ZodUnion:
+    case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
+      const values = def.options instanceof Map ? [...def.options.values()] : def.options;
+      return { values, every: traversal === 'conversion' || traversal === 'default' };
+    }
+    case ZodFirstPartyTypeKind.ZodIntersection: {
+      return {
+        values: [def.left, def.right],
+        every: traversal === 'input' || traversal === 'unconditional-number',
+      };
+    }
+    default: {
+      return null;
+    }
+  }
+};
+
+const visitDefinition = (
+  definition: ZodTypeDef,
+  inspect: Inspector,
+  traversal: Traversal,
+  active = new Set<ZodTypeDef>(),
+): boolean => {
+  if (active.has(definition)) {
+    return false;
+  }
+  active.add(definition);
+
+  try {
+    const def = definition as InspectableDefinition;
+    const result = inspect(def);
+    if (result !== undefined && result !== null) {
+      return result;
+    }
+
+    const children = childDefinitions(def, traversal);
+    if (!children) {
+      return false;
+    }
+    return children.every
+      ? children.values.every((child) => visitDefinition(child._def, inspect, traversal, active))
+      : children.values.some((child) => visitDefinition(child._def, inspect, traversal, active));
+  } finally {
+    active.delete(definition);
+  }
+};
+
+export const producesBigIntOutput = (definition: ZodTypeDef): boolean =>
+  visitDefinition(
+    definition,
+    (def) => {
+      if (def.typeName === ZodFirstPartyTypeKind.ZodBigInt) {
+        return true;
+      }
+      return def.typeName === ZodFirstPartyTypeKind.ZodLiteral ? typeof def.value === 'bigint' : undefined;
+    },
+    'output',
+  );
+
+export const acceptsJSONNumber = (definition: ZodTypeDef): boolean =>
+  visitDefinition(
+    definition,
+    (def) => {
+      switch (def.typeName) {
+        case ZodFirstPartyTypeKind.ZodNumber:
+        case ZodFirstPartyTypeKind.ZodAny:
+        case ZodFirstPartyTypeKind.ZodUnknown: {
+          return true;
+        }
+        case ZodFirstPartyTypeKind.ZodLiteral: {
+          return typeof def.value === 'number';
+        }
+        case ZodFirstPartyTypeKind.ZodNativeEnum: {
+          return Object.values(def.values).some((value) => typeof value === 'number');
+        }
+        case ZodFirstPartyTypeKind.ZodEffects: {
+          return def.effect.type === 'preprocess' ? true : undefined;
+        }
+        default: {
+          return def.coerce === true ? true : undefined;
+        }
+      }
+    },
+    'input',
+  );
+
+export const acceptsEveryJSONNumber = (definition: ZodTypeDef): boolean =>
+  visitDefinition(
+    definition,
+    (def) => {
+      switch (def.typeName) {
+        case ZodFirstPartyTypeKind.ZodNumber:
+        case ZodFirstPartyTypeKind.ZodAny:
+        case ZodFirstPartyTypeKind.ZodUnknown: {
+          return true;
+        }
+        case ZodFirstPartyTypeKind.ZodEffects: {
+          return false;
+        }
+        default: {
+          return null;
+        }
+      }
+    },
+    'unconditional-number',
+  );
+
+type UnsafeIntegerSide = 'minimum' | 'maximum';
+
+export const capturesUnsafeBigIntInput = (definition: ZodTypeDef, side: UnsafeIntegerSide): boolean =>
+  visitDefinition(
+    definition,
+    (def) => {
+      if (def.typeName !== ZodFirstPartyTypeKind.ZodBigInt) {
+        return;
+      }
+
+      const boundary = side === 'minimum' ? 'min' : 'max';
+      const safeLimit = BigInt(side === 'minimum' ? Number.MIN_SAFE_INTEGER : Number.MAX_SAFE_INTEGER);
+      return !(def.checks as { kind: string; value?: bigint }[] | undefined)?.some(
+        (check) =>
+          check.kind === boundary &&
+          typeof check.value === 'bigint' &&
+          (side === 'minimum' ? check.value >= safeLimit : check.value <= safeLimit),
+      );
+    },
+    'output',
+  );
+
+export const acceptsUnsafeJSONInteger = (schema: unknown, side: UnsafeIntegerSide): boolean => {
+  if (!schema || typeof schema !== 'object') {
+    return true;
+  }
+
+  const record = schema as Record<string, unknown>;
+  const { type } = record;
+  if (
+    (typeof type === 'string' && type !== 'number' && type !== 'integer') ||
+    (Array.isArray(type) && !type.includes('number') && !type.includes('integer'))
+  ) {
+    return false;
+  }
+
+  let minimum = typeof record['minimum'] === 'number' ? Math.ceil(record['minimum']) : -Infinity;
+  let maximum = typeof record['maximum'] === 'number' ? Math.floor(record['maximum']) : Infinity;
+  if (typeof record['exclusiveMinimum'] === 'number') {
+    minimum = Math.max(minimum, Math.floor(record['exclusiveMinimum']) + 1);
+  }
+  if (typeof record['exclusiveMaximum'] === 'number') {
+    maximum = Math.min(maximum, Math.ceil(record['exclusiveMaximum']) - 1);
+  }
+  if (typeof record['const'] === 'number') {
+    minimum = Math.max(minimum, record['const']);
+    maximum = Math.min(maximum, record['const']);
+  }
+
+  if (side === 'minimum') {
+    maximum = Math.min(maximum, Number.MIN_SAFE_INTEGER - 1);
+  } else {
+    minimum = Math.max(minimum, Number.MAX_SAFE_INTEGER + 1);
+  }
+  if (minimum > maximum) {
+    return false;
+  }
+
+  const { anyOf, allOf } = record;
+  if (Array.isArray(anyOf) && !anyOf.some((branch) => acceptsUnsafeJSONInteger(branch, side))) {
+    return false;
+  }
+  if (Array.isArray(allOf) && !allOf.every((branch) => acceptsUnsafeJSONInteger(branch, side))) {
+    return false;
+  }
+
+  return true;
+};
+
+export const convertsJSONPipelineInput = (definition: ZodTypeDef, output: ZodTypeDef): boolean =>
+  visitDefinition(
+    definition,
+    (def) => {
+      if (def.typeName === ZodFirstPartyTypeKind.ZodEffects) {
+        return def.effect.type === 'transform' || def.effect.type === 'preprocess' ? true : undefined;
+      }
+      if (def.coerce !== true) {
+        return;
+      }
+
+      return visitDefinition(
+        output,
+        (candidate) => (candidate.typeName === def.typeName ? true : undefined),
+        'output',
+      );
+    },
+    'conversion',
+  );
+
+export const producesBigIntAtPath = (
+  definition: ZodTypeDef,
+  path: readonly (string | number)[] = [],
+): boolean =>
+  visitDefinition(
+    definition,
+    (def) => {
+      if (path.length === 0) {
+        if (def.typeName === ZodFirstPartyTypeKind.ZodBigInt) {
+          return true;
+        }
+        return def.typeName === ZodFirstPartyTypeKind.ZodLiteral ? typeof def.value === 'bigint' : undefined;
+      }
+
+      const [key, ...remaining] = path;
+      let child: SchemaType | undefined;
+      switch (def.typeName) {
+        case ZodFirstPartyTypeKind.ZodObject: {
+          if (typeof key !== 'string') {
+            return false;
+          }
+          const shape = def.shape() as Record<string, SchemaType>;
+          child = hasOwn(shape, key) ? shape[key] : def.catchall;
+          break;
+        }
+        case ZodFirstPartyTypeKind.ZodArray: {
+          child = typeof key === 'number' ? (def.type as SchemaType) : undefined;
+          break;
+        }
+        case ZodFirstPartyTypeKind.ZodTuple: {
+          child =
+            typeof key === 'number' ? ((def.items[key] ?? def.rest) as SchemaType | undefined) : undefined;
+          break;
+        }
+        case ZodFirstPartyTypeKind.ZodRecord: {
+          child = typeof key === 'string' ? (def.valueType as SchemaType) : undefined;
+          break;
+        }
+        default: {
+          return;
+        }
+      }
+
+      return child !== undefined && producesBigIntAtPath(child._def, remaining);
+    },
+    'default',
+  );

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -349,6 +349,35 @@ export const requiresNativeBigIntPipelineOutput = (
   }
 };
 
+const validationChildren = (def: InspectableDefinition): SchemaType[] => {
+  if (def.typeName === ZodFirstPartyTypeKind.ZodObject) {
+    return Object.values(def.shape());
+  }
+  if (def.typeName === ZodFirstPartyTypeKind.ZodArray) {
+    return [def.type];
+  }
+  return childDefinitions(def, 'input')?.values ?? [];
+};
+
+export const hasOpaqueJSONValidation = (definition: ZodTypeDef, active = new Set<ZodTypeDef>()): boolean => {
+  if (active.has(definition)) {
+    return true;
+  }
+  active.add(definition);
+  try {
+    const def = definition as InspectableDefinition;
+    if (
+      def.typeName === ZodFirstPartyTypeKind.ZodEffects ||
+      def.typeName === ZodFirstPartyTypeKind.ZodPromise
+    ) {
+      return true;
+    }
+    return validationChildren(def).some((child) => hasOpaqueJSONValidation(child._def, active));
+  } finally {
+    active.delete(definition);
+  }
+};
+
 const hasOpaqueParsedOutput = (definition: ZodTypeDef): boolean =>
   visitDefinition(
     definition,
@@ -359,9 +388,21 @@ const hasOpaqueParsedOutput = (definition: ZodTypeDef): boolean =>
     'output',
   );
 
-type OpaqueParsedOutput = 'opaque' | 'preprocessed';
+type OpaqueParsedOutput = 'opaque' | 'preprocessed' | 'caught';
 
 const classifyOpaqueParsedOutput = (definition: ZodTypeDef): OpaqueParsedOutput | undefined => {
+  const caught = visitDefinition(
+    definition,
+    (def) =>
+      def.typeName === ZodFirstPartyTypeKind.ZodCatch
+        ? hasOpaqueJSONValidation(def.innerType._def)
+        : undefined,
+    'output',
+  );
+  if (caught) {
+    return 'caught';
+  }
+
   const preprocessed = visitDefinition(
     definition,
     (def) =>
@@ -469,6 +510,49 @@ const findOpaqueParsedOutputMismatch = (
     : undefined;
 };
 
+const transparentNullableParsedOutputWrappers = new Set<ZodFirstPartyTypeKind>([
+  ZodFirstPartyTypeKind.ZodOptional,
+  ZodFirstPartyTypeKind.ZodDefault,
+  ZodFirstPartyTypeKind.ZodReadonly,
+  ZodFirstPartyTypeKind.ZodBranded,
+  ZodFirstPartyTypeKind.ZodLazy,
+  ZodFirstPartyTypeKind.ZodPipeline,
+]);
+
+const nonNullParsedOutputAlternative = (
+  definition: ZodTypeDef,
+  active = new Set<ZodTypeDef>(),
+): ZodTypeDef | undefined => {
+  if (active.has(definition)) {
+    return undefined;
+  }
+  active.add(definition);
+  try {
+    const def = definition as InspectableDefinition;
+    if (def.typeName === ZodFirstPartyTypeKind.ZodNullable) {
+      return def.innerType._def;
+    }
+    if (
+      def.typeName === ZodFirstPartyTypeKind.ZodUnion ||
+      def.typeName === ZodFirstPartyTypeKind.ZodDiscriminatedUnion
+    ) {
+      const options = def.options instanceof Map ? [...def.options.values()] : def.options;
+      const nonNull = options.filter((option) => !isNullishParsedOutput(option._def));
+      return nonNull.length === 1 && nonNull.length < options.length ? nonNull[0]?._def : undefined;
+    }
+    if (!transparentNullableParsedOutputWrappers.has(def.typeName)) {
+      return undefined;
+    }
+    const children = childDefinitions(def, 'output');
+    const child = children?.values[0];
+    return children?.values.length === 1 && child !== undefined
+      ? nonNullParsedOutputAlternative(child._def, active)
+      : undefined;
+  } finally {
+    active.delete(definition);
+  }
+};
+
 const unmergeableParsedOutputKinds = new Set<ZodFirstPartyTypeKind>([
   ZodFirstPartyTypeKind.ZodSet,
   ZodFirstPartyTypeKind.ZodMap,
@@ -493,6 +577,30 @@ const findDirectParsedOutputMismatch = (
     : undefined;
 };
 
+const findNonNullParsedOutputMismatch = (
+  left: ZodTypeDef,
+  right: ZodTypeDef,
+  path: readonly string[],
+  active: Map<ZodTypeDef, Set<ZodTypeDef>>,
+  recurse: (
+    left: ZodTypeDef,
+    right: ZodTypeDef,
+    path: readonly string[],
+    active: Map<ZodTypeDef, Set<ZodTypeDef>>,
+  ) => ParsedOutputMismatch | undefined,
+): ParsedOutputMismatch | undefined => {
+  const nonNullLeft = nonNullParsedOutputAlternative(left);
+  const nonNullRight = nonNullParsedOutputAlternative(right);
+  if (!nonNullLeft && !nonNullRight) {
+    return undefined;
+  }
+  const first = nonNullLeft ?? left;
+  const second = nonNullRight ?? right;
+  return !isNullishParsedOutput(first) && !isNullishParsedOutput(second)
+    ? recurse(first, second, path, active)
+    : undefined;
+};
+
 export const findIncompatibleParsedOutputs = (
   left: ZodTypeDef,
   right: ZodTypeDef,
@@ -509,10 +617,13 @@ export const findIncompatibleParsedOutputs = (
   try {
     const leftKind = knownParsedOutputType(left);
     const rightKind = knownParsedOutputType(right);
-    const directMismatch = findDirectParsedOutputMismatch(left, right, leftKind, rightKind, path);
+    const directMismatch =
+      findDirectParsedOutputMismatch(left, right, leftKind, rightKind, path) ??
+      findNonNullParsedOutputMismatch(left, right, path, active, findIncompatibleParsedOutputs);
     if (directMismatch) {
       return directMismatch;
     }
+
     if (leftKind === undefined || rightKind === undefined) {
       return undefined;
     }
@@ -919,34 +1030,7 @@ const classifyJSONNumberAcceptance = (
 export const acceptsEveryJSONNumber = (definition: ZodTypeDef): boolean =>
   classifyJSONNumberAcceptance(definition) !== 'opaque';
 
-const validationChildren = (def: InspectableDefinition): SchemaType[] => {
-  if (def.typeName === ZodFirstPartyTypeKind.ZodObject) {
-    return Object.values(def.shape());
-  }
-  if (def.typeName === ZodFirstPartyTypeKind.ZodArray) {
-    return [def.type];
-  }
-  return childDefinitions(def, 'input')?.values ?? [];
-};
-
-export const hasOpaqueJSONValidation = (definition: ZodTypeDef, active = new Set<ZodTypeDef>()): boolean => {
-  if (active.has(definition)) {
-    return true;
-  }
-  active.add(definition);
-  try {
-    const def = definition as InspectableDefinition;
-    if (
-      def.typeName === ZodFirstPartyTypeKind.ZodEffects ||
-      def.typeName === ZodFirstPartyTypeKind.ZodPromise
-    ) {
-      return true;
-    }
-    return validationChildren(def).some((child) => hasOpaqueJSONValidation(child._def, active));
-  } finally {
-    active.delete(definition);
-  }
-};
+const valueChangingStringChecks = new Set(['trim', 'toLowerCase', 'toUpperCase']);
 
 export const hasOpaquePipelineTransform = (
   definition: ZodTypeDef,
@@ -960,6 +1044,8 @@ export const hasOpaquePipelineTransform = (
     const def = definition as InspectableDefinition;
     if (
       def.typeName === ZodFirstPartyTypeKind.ZodCatch ||
+      (def.typeName === ZodFirstPartyTypeKind.ZodString &&
+        def.checks?.some((check) => valueChangingStringChecks.has(check.kind)) === true) ||
       (def.typeName === ZodFirstPartyTypeKind.ZodEffects &&
         (def.effect.type === 'preprocess' ||
           (def.effect.type === 'transform' && !isExactBigIntTransform(def))))

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -217,6 +217,13 @@ export const producesBigIntOutput = (definition: ZodTypeDef): boolean =>
     'output',
   );
 
+const literalParsedOutputKinds = new Map<string, ZodFirstPartyTypeKind>([
+  ['bigint', ZodFirstPartyTypeKind.ZodBigInt],
+  ['number', ZodFirstPartyTypeKind.ZodNumber],
+  ['string', ZodFirstPartyTypeKind.ZodString],
+  ['boolean', ZodFirstPartyTypeKind.ZodBoolean],
+]);
+
 const definiteParsedOutputKinds = new Set<ZodFirstPartyTypeKind>([
   ZodFirstPartyTypeKind.ZodBigInt,
   ZodFirstPartyTypeKind.ZodNumber,
@@ -240,6 +247,11 @@ export const knownParsedOutputType = (
     const def = definition as InspectableDefinition;
     if (isExactBigIntTransform(def)) {
       return ZodFirstPartyTypeKind.ZodBigInt;
+    }
+    if (def.typeName === ZodFirstPartyTypeKind.ZodLiteral) {
+      return def.value === null
+        ? ZodFirstPartyTypeKind.ZodNull
+        : literalParsedOutputKinds.get(typeof def.value);
     }
     if (def.typeName === ZodFirstPartyTypeKind.ZodTuple) {
       return ZodFirstPartyTypeKind.ZodArray;
@@ -452,6 +464,42 @@ export const throwsOnFractionalBigIntInput = (definition: ZodTypeDef, schema: Js
         : undefined,
     'output',
   );
+
+export const applyFractionalBigIntFallbackBounds = (
+  schema: JsonSchema7Type,
+  producers: readonly ZodTypeDef[],
+): JsonSchema7Type => {
+  if (producers.length === 0) {
+    return schema;
+  }
+
+  const record = schema as Record<string, unknown>;
+  for (const keyword of ['anyOf', 'oneOf']) {
+    const alternatives = record[keyword];
+    if (Array.isArray(alternatives)) {
+      return {
+        ...record,
+        [keyword]: alternatives.map((alternative) =>
+          alternative && typeof alternative === 'object'
+            ? applyFractionalBigIntFallbackBounds(alternative as JsonSchema7Type, producers)
+            : alternative,
+        ),
+      } as JsonSchema7Type;
+    }
+  }
+
+  const types = record['type'];
+  if (Array.isArray(types) && types.includes('number')) {
+    const numeric = { ...record, type: 'number' } as JsonSchema7Type;
+    return producers.some((producer) => throwsOnFractionalBigIntInput(producer, numeric))
+      ? ({ ...record, type: types.map((type) => (type === 'number' ? 'integer' : type)) } as JsonSchema7Type)
+      : schema;
+  }
+
+  return producers.some((producer) => throwsOnFractionalBigIntInput(producer, schema))
+    ? ({ ...schema, type: 'integer' } as JsonSchema7Type)
+    : schema;
+};
 
 export const hasExactBigIntStringInput = (definition: ZodTypeDef): boolean =>
   visitDefinition(
@@ -1155,6 +1203,9 @@ const producesSelectedNativeUnion = (
           if (check.kind === 'max') {
             return scalar > boundary || (check.inclusive === false && scalar === boundary);
           }
+          if (check.kind === 'multipleOf') {
+            return !Number.isInteger(scalar / boundary);
+          }
           return false;
         })
       ) {
@@ -1628,8 +1679,8 @@ const boundNestedNumericPath = (
       return applyBigIntStringFallbackBounds(schema, [overlap.producer]);
     }
     const bounded = applyUnsafeBigIntBounds(schema, [overlap.producer]);
-    return overlap.producerPrecedesConsumer && throwsOnFractionalBigIntInput(overlap.producer, bounded)
-      ? ({ ...bounded, type: 'integer' } as JsonSchema7Type)
+    return overlap.producerPrecedesConsumer
+      ? applyFractionalBigIntFallbackBounds(bounded, [overlap.producer])
       : bounded;
   }
 

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -31,10 +31,10 @@ type Inspector = (definition: InspectableDefinition) => boolean | null | undefin
 type TraversalChildren = { values: SchemaType[]; every: boolean };
 
 const pipelineChildren = (def: InspectableDefinition, traversal: Traversal): SchemaType[] => {
-  if (traversal === 'input' || traversal === 'unconditional-number') {
+  if (traversal === 'input') {
     return [def.in];
   }
-  if (traversal === 'conversion') {
+  if (traversal === 'conversion' || traversal === 'unconditional-number') {
     return [def.in, def.out];
   }
   return [def.out];
@@ -60,7 +60,10 @@ const childDefinitions = (def: InspectableDefinition, traversal: Traversal): Tra
       return { values: [def.getter()], every: false };
     }
     case ZodFirstPartyTypeKind.ZodPipeline: {
-      return { values: pipelineChildren(def, traversal), every: false };
+      return {
+        values: pipelineChildren(def, traversal),
+        every: traversal === 'unconditional-number',
+      };
     }
     case ZodFirstPartyTypeKind.ZodUnion:
     case ZodFirstPartyTypeKind.ZodDiscriminatedUnion: {
@@ -148,26 +151,75 @@ export const acceptsJSONNumber = (definition: ZodTypeDef): boolean =>
     'input',
   );
 
-export const acceptsEveryJSONNumber = (definition: ZodTypeDef): boolean =>
-  visitDefinition(
-    definition,
-    (def) => {
-      switch (def.typeName) {
-        case ZodFirstPartyTypeKind.ZodNumber:
-        case ZodFirstPartyTypeKind.ZodAny:
-        case ZodFirstPartyTypeKind.ZodUnknown: {
-          return true;
-        }
-        case ZodFirstPartyTypeKind.ZodEffects: {
-          return false;
-        }
-        default: {
-          return null;
-        }
+type JSONNumberAcceptance = 'total' | 'represented' | 'opaque';
+
+const classifyJSONNumberChecks = (checks: InspectableDefinition['checks'] = []): JSONNumberAcceptance => {
+  if (checks.some((check) => !['int', 'min', 'max', 'multipleOf', 'finite'].includes(check.kind))) {
+    return 'opaque';
+  }
+
+  return checks.some((check) => check.kind !== 'finite') ? 'represented' : 'total';
+};
+
+const classifyJSONNumberAcceptance = (
+  definition: ZodTypeDef,
+  active = new Set<ZodTypeDef>(),
+): JSONNumberAcceptance => {
+  if (active.has(definition)) {
+    return 'opaque';
+  }
+  active.add(definition);
+
+  try {
+    const def = definition as InspectableDefinition;
+    switch (def.typeName) {
+      case ZodFirstPartyTypeKind.ZodNumber: {
+        return classifyJSONNumberChecks(def.checks);
       }
-    },
-    'unconditional-number',
-  );
+      case ZodFirstPartyTypeKind.ZodAny:
+      case ZodFirstPartyTypeKind.ZodUnknown: {
+        return 'total';
+      }
+      case ZodFirstPartyTypeKind.ZodLiteral:
+      case ZodFirstPartyTypeKind.ZodNativeEnum: {
+        return 'represented';
+      }
+      case ZodFirstPartyTypeKind.ZodEffects:
+      case ZodFirstPartyTypeKind.ZodPromise: {
+        return 'opaque';
+      }
+      default: {
+        const children = childDefinitions(def, 'unconditional-number');
+        if (!children) {
+          return acceptsJSONNumber(def) ? 'opaque' : 'represented';
+        }
+
+        const union =
+          def.typeName === ZodFirstPartyTypeKind.ZodUnion ||
+          def.typeName === ZodFirstPartyTypeKind.ZodDiscriminatedUnion;
+        const values = union
+          ? children.values.filter((child) => acceptsJSONNumber(child._def))
+          : children.values;
+        const capabilities = values.map((child) => classifyJSONNumberAcceptance(child._def, active));
+        if (children.every) {
+          if (capabilities.includes('opaque')) {
+            return 'opaque';
+          }
+          return capabilities.every((capability) => capability === 'total') ? 'total' : 'represented';
+        }
+        if (capabilities.includes('total')) {
+          return 'total';
+        }
+        return capabilities.includes('opaque') ? 'opaque' : 'represented';
+      }
+    }
+  } finally {
+    active.delete(definition);
+  }
+};
+
+export const acceptsEveryJSONNumber = (definition: ZodTypeDef): boolean =>
+  classifyJSONNumberAcceptance(definition) !== 'opaque';
 
 type UnsafeIntegerSide = 'minimum' | 'maximum';
 

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -187,6 +187,108 @@ export const producesBigIntOutput = (definition: ZodTypeDef): boolean =>
     'output',
   );
 
+const definiteParsedOutputKinds = new Set<ZodFirstPartyTypeKind>([
+  ZodFirstPartyTypeKind.ZodBigInt,
+  ZodFirstPartyTypeKind.ZodNumber,
+  ZodFirstPartyTypeKind.ZodString,
+  ZodFirstPartyTypeKind.ZodBoolean,
+  ZodFirstPartyTypeKind.ZodDate,
+  ZodFirstPartyTypeKind.ZodNull,
+  ZodFirstPartyTypeKind.ZodObject,
+  ZodFirstPartyTypeKind.ZodArray,
+]);
+
+export const knownParsedOutputType = (
+  definition: ZodTypeDef,
+  active = new Set<ZodTypeDef>(),
+): ZodFirstPartyTypeKind | undefined => {
+  if (active.has(definition)) {
+    return undefined;
+  }
+  active.add(definition);
+  try {
+    const def = definition as InspectableDefinition;
+    if (isExactBigIntTransform(def)) {
+      return ZodFirstPartyTypeKind.ZodBigInt;
+    }
+    if (definiteParsedOutputKinds.has(def.typeName)) {
+      return def.typeName;
+    }
+    if (def.typeName === ZodFirstPartyTypeKind.ZodEffects && def.effect.type === 'transform') {
+      return undefined;
+    }
+    if (
+      def.typeName === ZodFirstPartyTypeKind.ZodNullable ||
+      def.typeName === ZodFirstPartyTypeKind.ZodOptional ||
+      def.typeName === ZodFirstPartyTypeKind.ZodCatch ||
+      def.typeName === ZodFirstPartyTypeKind.ZodUnion ||
+      def.typeName === ZodFirstPartyTypeKind.ZodDiscriminatedUnion ||
+      def.typeName === ZodFirstPartyTypeKind.ZodIntersection
+    ) {
+      return undefined;
+    }
+    const children = childDefinitions(def, 'output');
+    const child = children?.values[0];
+    return children?.values.length === 1 && child !== undefined
+      ? knownParsedOutputType(child._def, active)
+      : undefined;
+  } finally {
+    active.delete(definition);
+  }
+};
+
+const acceptsOverlappingFractionalInput = (
+  definition: InspectableDefinition,
+  schema: JsonSchema7Type,
+): boolean => {
+  const input = schema as Record<string, unknown>;
+  if (input['type'] !== 'number') {
+    return false;
+  }
+  if (
+    definition.checks?.some(
+      (check) =>
+        check.kind === 'int' ||
+        (check.kind === 'multipleOf' && typeof check.value === 'number' && Number.isInteger(check.value)),
+    )
+  ) {
+    return false;
+  }
+  let minimum = typeof input['minimum'] === 'number' ? input['minimum'] : -Infinity;
+  let maximum = typeof input['maximum'] === 'number' ? input['maximum'] : Infinity;
+  if (typeof input['exclusiveMinimum'] === 'number') {
+    minimum = Math.max(minimum, input['exclusiveMinimum']);
+  }
+  if (typeof input['exclusiveMaximum'] === 'number') {
+    maximum = Math.min(maximum, input['exclusiveMaximum']);
+  }
+  for (const check of definition.checks ?? []) {
+    if (check.kind === 'min' && typeof check.value === 'number') {
+      minimum = Math.max(minimum, check.value);
+    } else if (check.kind === 'max' && typeof check.value === 'number') {
+      maximum = Math.min(maximum, check.value);
+    }
+  }
+  return minimum < maximum || (minimum === maximum && !Number.isInteger(minimum));
+};
+
+export const throwsOnFractionalBigIntInput = (definition: ZodTypeDef, schema: JsonSchema7Type): boolean =>
+  visitDefinition(
+    definition,
+    (def) =>
+      isExactBigIntTransform(def)
+        ? visitDefinition(
+            def.schema._def,
+            (input) =>
+              input.typeName === ZodFirstPartyTypeKind.ZodNumber
+                ? acceptsOverlappingFractionalInput(input, schema)
+                : undefined,
+            'input',
+          )
+        : undefined,
+    'output',
+  );
+
 const nativeEnumValues = (definition: InspectableDefinition): readonly (string | number)[] => {
   const values = definition.values as Record<string, string | number>;
   return Object.entries(values)

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -285,6 +285,69 @@ export const knownParsedOutputType = (
   }
 };
 
+const isNullishParsedOutput = (definition: ZodTypeDef): boolean => {
+  const def = definition as InspectableDefinition;
+  return (
+    knownParsedOutputType(definition) === ZodFirstPartyTypeKind.ZodNull ||
+    def.typeName === ZodFirstPartyTypeKind.ZodUndefined
+  );
+};
+
+const unionRequiresNativeBigIntOutput = (
+  definition: InspectableDefinition,
+  active: Set<ZodTypeDef>,
+  inspect: (definition: ZodTypeDef, active: Set<ZodTypeDef>) => boolean,
+): boolean => {
+  const options = definition.options instanceof Map ? [...definition.options.values()] : definition.options;
+  const required = options.map((option) => inspect(option._def, active));
+  return (
+    required.includes(true) &&
+    options.every((option, index) => required[index] || isNullishParsedOutput(option._def))
+  );
+};
+
+export const requiresNativeBigIntPipelineOutput = (
+  definition: ZodTypeDef,
+  active = new Set<ZodTypeDef>(),
+): boolean => {
+  if (active.has(definition)) {
+    return false;
+  }
+  active.add(definition);
+  try {
+    const def = definition as InspectableDefinition;
+    if (def.typeName === ZodFirstPartyTypeKind.ZodBigInt) {
+      return def.coerce !== true;
+    }
+    if (def.typeName === ZodFirstPartyTypeKind.ZodLiteral) {
+      return typeof def.value === 'bigint';
+    }
+    if (
+      def.typeName === ZodFirstPartyTypeKind.ZodCatch ||
+      (def.typeName === ZodFirstPartyTypeKind.ZodEffects && def.effect.type === 'preprocess')
+    ) {
+      return false;
+    }
+    if (
+      def.typeName === ZodFirstPartyTypeKind.ZodUnion ||
+      def.typeName === ZodFirstPartyTypeKind.ZodDiscriminatedUnion
+    ) {
+      return unionRequiresNativeBigIntOutput(def, active, requiresNativeBigIntPipelineOutput);
+    }
+    if (def.typeName === ZodFirstPartyTypeKind.ZodIntersection) {
+      return [def.left, def.right].some((child) => requiresNativeBigIntPipelineOutput(child._def, active));
+    }
+    const children =
+      def.typeName === ZodFirstPartyTypeKind.ZodPipeline ? [def.in] : childDefinitions(def, 'output')?.values;
+    const child = children?.[0];
+    return children?.length === 1 && child !== undefined
+      ? requiresNativeBigIntPipelineOutput(child._def, active)
+      : false;
+  } finally {
+    active.delete(definition);
+  }
+};
+
 const hasOpaqueParsedOutput = (definition: ZodTypeDef): boolean =>
   visitDefinition(
     definition,

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -217,6 +217,13 @@ export const producesBigIntOutput = (definition: ZodTypeDef): boolean =>
     'output',
   );
 
+const knownTransformOutputKinds = new Map<unknown, ZodFirstPartyTypeKind>([
+  [BigInt, ZodFirstPartyTypeKind.ZodBigInt],
+  [Number, ZodFirstPartyTypeKind.ZodNumber],
+  [String, ZodFirstPartyTypeKind.ZodString],
+  [Boolean, ZodFirstPartyTypeKind.ZodBoolean],
+]);
+
 const literalParsedOutputKinds = new Map<string, ZodFirstPartyTypeKind>([
   ['bigint', ZodFirstPartyTypeKind.ZodBigInt],
   ['number', ZodFirstPartyTypeKind.ZodNumber],
@@ -245,8 +252,8 @@ export const knownParsedOutputType = (
   active.add(definition);
   try {
     const def = definition as InspectableDefinition;
-    if (isExactBigIntTransform(def)) {
-      return ZodFirstPartyTypeKind.ZodBigInt;
+    if (def.typeName === ZodFirstPartyTypeKind.ZodEffects && def.effect.type === 'transform') {
+      return knownTransformOutputKinds.get(def.effect.transform);
     }
     if (def.typeName === ZodFirstPartyTypeKind.ZodLiteral) {
       return def.value === null
@@ -258,9 +265,6 @@ export const knownParsedOutputType = (
     }
     if (definiteParsedOutputKinds.has(def.typeName)) {
       return def.typeName;
-    }
-    if (def.typeName === ZodFirstPartyTypeKind.ZodEffects && def.effect.type === 'transform') {
-      return undefined;
     }
     if (
       def.typeName === ZodFirstPartyTypeKind.ZodNullable ||
@@ -281,9 +285,19 @@ export const knownParsedOutputType = (
   }
 };
 
+const hasOpaqueParsedOutput = (definition: ZodTypeDef): boolean =>
+  visitDefinition(
+    definition,
+    (def) =>
+      def.typeName === ZodFirstPartyTypeKind.ZodEffects && def.effect.type === 'transform'
+        ? !knownTransformOutputKinds.has(def.effect.transform)
+        : undefined,
+    'output',
+  );
+
 type ParsedOutputMismatch = {
-  left: ZodFirstPartyTypeKind;
-  right: ZodFirstPartyTypeKind;
+  left: ZodFirstPartyTypeKind | 'opaque';
+  right: ZodFirstPartyTypeKind | 'opaque';
   path: readonly string[];
 };
 
@@ -356,6 +370,20 @@ const findIncompatibleArrayOutputs = (
     : undefined;
 };
 
+const findOpaqueParsedOutputMismatch = (
+  left: ZodTypeDef,
+  right: ZodTypeDef,
+  leftKind: ZodFirstPartyTypeKind | undefined,
+  rightKind: ZodFirstPartyTypeKind | undefined,
+  path: readonly string[],
+): ParsedOutputMismatch | undefined => {
+  const leftOpaque = leftKind === undefined && hasOpaqueParsedOutput(left);
+  const rightOpaque = rightKind === undefined && hasOpaqueParsedOutput(right);
+  return leftOpaque || rightOpaque
+    ? { left: leftKind ?? 'opaque', right: rightKind ?? 'opaque', path }
+    : undefined;
+};
+
 export const findIncompatibleParsedOutputs = (
   left: ZodTypeDef,
   right: ZodTypeDef,
@@ -373,7 +401,7 @@ export const findIncompatibleParsedOutputs = (
     const leftKind = knownParsedOutputType(left);
     const rightKind = knownParsedOutputType(right);
     if (leftKind === undefined || rightKind === undefined) {
-      return undefined;
+      return findOpaqueParsedOutputMismatch(left, right, leftKind, rightKind, path);
     }
     if (leftKind !== rightKind) {
       return { left: leftKind, right: rightKind, path };

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -203,6 +203,8 @@ const isExactBigIntTransform = (definition: InspectableDefinition): boolean =>
   definition.effect.type === 'transform' &&
   definition.effect.transform === BigInt;
 
+export const bigIntStringPattern = '^[+-]?[0-9]+$';
+
 export const producesBigIntOutput = (definition: ZodTypeDef): boolean =>
   visitDefinition(
     definition,
@@ -451,6 +453,97 @@ export const throwsOnFractionalBigIntInput = (definition: ZodTypeDef, schema: Js
     'output',
   );
 
+export const hasExactBigIntStringInput = (definition: ZodTypeDef): boolean =>
+  visitDefinition(
+    definition,
+    (def) =>
+      isExactBigIntTransform(def)
+        ? visitDefinition(
+            def.schema._def,
+            (input) => (input.typeName === ZodFirstPartyTypeKind.ZodString ? true : undefined),
+            'input',
+          )
+        : undefined,
+    'output',
+  );
+
+const acceptsOverlappingBigIntStringInput = (
+  definition: InspectableDefinition,
+  schema: JsonSchema7Type,
+): boolean => {
+  const input = schema as Record<string, unknown>;
+  if (input['type'] !== 'string') {
+    return false;
+  }
+  let minimum = 0;
+  let maximum = Infinity;
+  for (const check of definition.checks ?? []) {
+    if (check.kind === 'min' && typeof check.value === 'number') {
+      minimum = Math.max(minimum, check.value);
+    } else if (check.kind === 'max' && typeof check.value === 'number') {
+      maximum = Math.min(maximum, check.value);
+    }
+  }
+  const fallbackMinimum = typeof input['minLength'] === 'number' ? input['minLength'] : 0;
+  const fallbackMaximum = typeof input['maxLength'] === 'number' ? input['maxLength'] : Infinity;
+  if (fallbackMaximum < minimum || fallbackMinimum > maximum) {
+    return false;
+  }
+  if (fallbackMinimum < minimum || fallbackMaximum > maximum) {
+    throw new Error(
+      'ZodUnion BigInt string transforms cannot safely preserve partially overlapping string fallbacks in strict Structured Outputs.',
+    );
+  }
+  return true;
+};
+
+const throwsOnInvalidBigIntStringInput = (definition: ZodTypeDef, schema: JsonSchema7Type): boolean =>
+  visitDefinition(
+    definition,
+    (def) =>
+      isExactBigIntTransform(def)
+        ? visitDefinition(
+            def.schema._def,
+            (input) =>
+              input.typeName === ZodFirstPartyTypeKind.ZodString
+                ? acceptsOverlappingBigIntStringInput(input, schema)
+                : undefined,
+            'input',
+          )
+        : undefined,
+    'output',
+  );
+
+export const applyBigIntStringFallbackBounds = (
+  schema: JsonSchema7Type,
+  producers: readonly ZodTypeDef[],
+): JsonSchema7Type => {
+  if ('$ref' in schema) {
+    throw new Error('A constrained BigInt string fallback reference must be materialized.');
+  }
+  const record = schema as Record<string, unknown>;
+  for (const keyword of ['anyOf', 'oneOf']) {
+    const alternatives = record[keyword];
+    if (Array.isArray(alternatives)) {
+      return {
+        ...record,
+        [keyword]: alternatives.map((alternative) =>
+          alternative && typeof alternative === 'object'
+            ? applyBigIntStringFallbackBounds(alternative as JsonSchema7Type, producers)
+            : alternative,
+        ),
+      } as JsonSchema7Type;
+    }
+  }
+  if (!producers.some((producer) => throwsOnInvalidBigIntStringInput(producer, schema))) {
+    return schema;
+  }
+  if (record['pattern'] !== undefined && record['pattern'] !== bigIntStringPattern) {
+    throw new Error('A BigInt string fallback cannot combine incompatible lexical constraints.');
+  }
+  return { ...schema, pattern: bigIntStringPattern } as JsonSchema7Type;
+};
+
 const nativeEnumValues = (definition: InspectableDefinition): readonly (string | number)[] => {
   const values = definition.values as Record<string, string | number>;
   return Object.entries(values)
@@ -473,6 +566,34 @@ export const acceptsJSONNumber = (definition: ZodTypeDef): boolean =>
         }
         case ZodFirstPartyTypeKind.ZodNativeEnum: {
           return nativeEnumValues(def).some((value) => typeof value === 'number');
+        }
+        case ZodFirstPartyTypeKind.ZodEffects: {
+          return def.effect.type === 'preprocess' ? true : undefined;
+        }
+        default: {
+          return def.coerce === true ? true : undefined;
+        }
+      }
+    },
+    'input',
+  );
+
+export const acceptsJSONString = (definition: ZodTypeDef): boolean =>
+  visitDefinition(
+    definition,
+    (def) => {
+      switch (def.typeName) {
+        case ZodFirstPartyTypeKind.ZodString:
+        case ZodFirstPartyTypeKind.ZodAny:
+        case ZodFirstPartyTypeKind.ZodUnknown:
+        case ZodFirstPartyTypeKind.ZodEnum: {
+          return true;
+        }
+        case ZodFirstPartyTypeKind.ZodLiteral: {
+          return typeof def.value === 'string';
+        }
+        case ZodFirstPartyTypeKind.ZodNativeEnum: {
+          return nativeEnumValues(def).some((value) => typeof value === 'string');
         }
         case ZodFirstPartyTypeKind.ZodEffects: {
           return def.effect.type === 'preprocess' ? true : undefined;
@@ -1098,6 +1219,7 @@ export type NestedNumericOverlap = {
   producer: ZodTypeDef;
   consumer: ZodTypeDef;
   producerPrecedesConsumer?: boolean;
+  kind?: 'string';
 };
 
 type PairedChild = {
@@ -1307,8 +1429,12 @@ const collectNestedNumericOverlaps = (
   activeConsumers.set(consumer, path);
 
   try {
-    if (producesBigIntOutput(producer) && acceptsJSONNumber(consumer)) {
+    if (producesBigIntOutput(producer) && acceptsJSONNumber(producer) && acceptsJSONNumber(consumer)) {
       overlaps.push({ path, producer, consumer });
+      return;
+    }
+    if (hasExactBigIntStringInput(producer) && acceptsJSONString(consumer)) {
+      overlaps.push({ path, producer, consumer, kind: 'string' });
       return;
     }
 
@@ -1372,6 +1498,7 @@ export const findNestedNumericOverlaps = (
   if (
     overlaps.some(
       (overlap) =>
+        overlap.kind !== 'string' &&
         (capturesUnsafeBigIntInput(overlap.producer, 'minimum') ||
           capturesUnsafeBigIntInput(overlap.producer, 'maximum')) &&
         traversal.recursivePaths.some((recursivePath) =>
@@ -1446,6 +1573,9 @@ const boundNestedNumericPath = (
   overlap: NestedNumericOverlap,
 ): JsonSchema7Type => {
   if (path.length === 0) {
+    if (overlap.kind === 'string') {
+      return applyBigIntStringFallbackBounds(schema, [overlap.producer]);
+    }
     const bounded = applyUnsafeBigIntBounds(schema, [overlap.producer]);
     return overlap.producerPrecedesConsumer && throwsOnFractionalBigIntInput(overlap.producer, bounded)
       ? ({ ...bounded, type: 'integer' } as JsonSchema7Type)

--- a/src/_vendor/zod-to-json-schema/schema-capabilities.ts
+++ b/src/_vendor/zod-to-json-schema/schema-capabilities.ts
@@ -359,6 +359,12 @@ const validationChildren = (def: InspectableDefinition): SchemaType[] => {
   return childDefinitions(def, 'input')?.values ?? [];
 };
 
+const valueChangingStringChecks = new Set(['trim', 'toLowerCase', 'toUpperCase']);
+
+const hasValueChangingStringChecks = (definition: InspectableDefinition): boolean =>
+  definition.typeName === ZodFirstPartyTypeKind.ZodString &&
+  definition.checks?.some((check) => valueChangingStringChecks.has(check.kind)) === true;
+
 export const hasOpaqueJSONValidation = (definition: ZodTypeDef, active = new Set<ZodTypeDef>()): boolean => {
   if (active.has(definition)) {
     return true;
@@ -368,11 +374,52 @@ export const hasOpaqueJSONValidation = (definition: ZodTypeDef, active = new Set
     const def = definition as InspectableDefinition;
     if (
       def.typeName === ZodFirstPartyTypeKind.ZodEffects ||
-      def.typeName === ZodFirstPartyTypeKind.ZodPromise
+      def.typeName === ZodFirstPartyTypeKind.ZodPromise ||
+      hasValueChangingStringChecks(def)
     ) {
       return true;
     }
     return validationChildren(def).some((child) => hasOpaqueJSONValidation(child._def, active));
+  } finally {
+    active.delete(definition);
+  }
+};
+
+const unconstrainedPipelineOutputWrappers = new Set<ZodFirstPartyTypeKind>([
+  ZodFirstPartyTypeKind.ZodNullable,
+  ZodFirstPartyTypeKind.ZodOptional,
+  ZodFirstPartyTypeKind.ZodDefault,
+  ZodFirstPartyTypeKind.ZodReadonly,
+  ZodFirstPartyTypeKind.ZodCatch,
+  ZodFirstPartyTypeKind.ZodBranded,
+  ZodFirstPartyTypeKind.ZodLazy,
+]);
+
+export const hasUnconstrainedPipelineOutput = (
+  definition: ZodTypeDef,
+  active = new Set<ZodTypeDef>(),
+): boolean => {
+  if (active.has(definition)) {
+    return false;
+  }
+  active.add(definition);
+  try {
+    const def = definition as InspectableDefinition;
+    if (def.typeName === ZodFirstPartyTypeKind.ZodAny || def.typeName === ZodFirstPartyTypeKind.ZodUnknown) {
+      return true;
+    }
+    if (!unconstrainedPipelineOutputWrappers.has(def.typeName)) {
+      return false;
+    }
+    if (def.typeName === ZodFirstPartyTypeKind.ZodCatch && hasOpaqueJSONValidation(def.innerType._def)) {
+      return false;
+    }
+
+    const children = childDefinitions(def, 'output');
+    const child = children?.values[0];
+    return children?.values.length === 1 && child !== undefined
+      ? hasUnconstrainedPipelineOutput(child._def, active)
+      : false;
   } finally {
     active.delete(definition);
   }
@@ -388,7 +435,7 @@ const hasOpaqueParsedOutput = (definition: ZodTypeDef): boolean =>
     'output',
   );
 
-type OpaqueParsedOutput = 'opaque' | 'preprocessed' | 'caught';
+type OpaqueParsedOutput = 'opaque' | 'preprocessed' | 'caught' | 'string-transformed';
 
 const classifyOpaqueParsedOutput = (definition: ZodTypeDef): OpaqueParsedOutput | undefined => {
   const caught = visitDefinition(
@@ -414,7 +461,60 @@ const classifyOpaqueParsedOutput = (definition: ZodTypeDef): OpaqueParsedOutput 
   if (preprocessed) {
     return 'preprocessed';
   }
+  const transformedString = visitDefinition(
+    definition,
+    (def) => (hasValueChangingStringChecks(def) ? true : undefined),
+    'output',
+  );
+  if (transformedString) {
+    return 'string-transformed';
+  }
   return hasOpaqueParsedOutput(definition) ? 'opaque' : undefined;
+};
+
+const parsedStringTransformSignature = (
+  definition: ZodTypeDef,
+  active = new Set<ZodTypeDef>(),
+): readonly string[] | undefined => {
+  if (active.has(definition)) {
+    return undefined;
+  }
+  active.add(definition);
+  try {
+    const def = definition as InspectableDefinition;
+    if (def.typeName === ZodFirstPartyTypeKind.ZodString) {
+      const checks = def.checks
+        ?.filter((check) => valueChangingStringChecks.has(check.kind))
+        .map((check) => check.kind);
+      return checks && checks.length > 0 ? checks : undefined;
+    }
+    if (
+      (def.typeName === ZodFirstPartyTypeKind.ZodEffects && def.effect.type !== 'refinement') ||
+      (def.typeName === ZodFirstPartyTypeKind.ZodCatch && hasOpaqueJSONValidation(def.innerType._def)) ||
+      def.typeName === ZodFirstPartyTypeKind.ZodPipeline
+    ) {
+      return undefined;
+    }
+
+    const children = childDefinitions(def, 'output');
+    const child = children?.values[0];
+    return children?.values.length === 1 && child !== undefined
+      ? parsedStringTransformSignature(child._def, active)
+      : undefined;
+  } finally {
+    active.delete(definition);
+  }
+};
+
+const haveMatchingStringTransformSignatures = (left: ZodTypeDef, right: ZodTypeDef): boolean => {
+  const first = parsedStringTransformSignature(left);
+  const second = parsedStringTransformSignature(right);
+  return (
+    first !== undefined &&
+    second !== undefined &&
+    first.length === second.length &&
+    first.every((kind, index) => kind === second[index])
+  );
 };
 
 type ParsedOutputMismatch = {
@@ -501,6 +601,13 @@ const findOpaqueParsedOutputMismatch = (
 ): ParsedOutputMismatch | undefined => {
   const leftOpaque = classifyOpaqueParsedOutput(left);
   const rightOpaque = classifyOpaqueParsedOutput(right);
+  if (
+    leftOpaque === 'string-transformed' &&
+    rightOpaque === 'string-transformed' &&
+    haveMatchingStringTransformSignatures(left, right)
+  ) {
+    return undefined;
+  }
   return leftOpaque || rightOpaque
     ? {
         left: leftOpaque ?? leftKind ?? 'opaque',
@@ -1194,8 +1301,6 @@ const classifyJSONNumberAcceptance = (
 export const acceptsEveryJSONNumber = (definition: ZodTypeDef): boolean =>
   classifyJSONNumberAcceptance(definition) !== 'opaque';
 
-const valueChangingStringChecks = new Set(['trim', 'toLowerCase', 'toUpperCase']);
-
 export const hasOpaquePipelineTransform = (
   definition: ZodTypeDef,
   active = new Set<ZodTypeDef>(),
@@ -1208,8 +1313,7 @@ export const hasOpaquePipelineTransform = (
     const def = definition as InspectableDefinition;
     if (
       (def.typeName === ZodFirstPartyTypeKind.ZodCatch && hasOpaqueJSONValidation(def.innerType._def)) ||
-      (def.typeName === ZodFirstPartyTypeKind.ZodString &&
-        def.checks?.some((check) => valueChangingStringChecks.has(check.kind)) === true) ||
+      hasValueChangingStringChecks(def) ||
       (def.typeName === ZodFirstPartyTypeKind.ZodEffects &&
         (def.effect.type === 'preprocess' ||
           (def.effect.type === 'transform' && !isExactBigIntTransform(def))))

--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -136,7 +136,16 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
         break;
       }
 
-      for (const [key, schema] of newDefinitions) {
+      while (newDefinitions.length > 0) {
+        const contextualIndex = newDefinitions.findIndex(
+          ([, schema]) => getDefinitionInputRefs(zodDef(schema), refs) !== refs,
+        );
+        const [nextDefinition] = newDefinitions.splice(contextualIndex === -1 ? 0 : contextualIndex, 1);
+        if (nextDefinition === undefined) {
+          break;
+        }
+        const [key, schema] = nextDefinition;
+
         definitions[key] =
           parseDef(
             zodDef(schema),

--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -1,7 +1,7 @@
 import type { ZodSchema } from 'zod/v3';
 import type { Options, Targets } from './Options';
 import type { JsonSchema7Type } from './parseDef';
-import { parseDef } from './parseDef';
+import { getDefinitionInputRefs, parseDef } from './parseDef';
 import { getRefs } from './Refs';
 import { zodDef, isEmptyObj } from './util';
 
@@ -140,7 +140,10 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
         definitions[key] =
           parseDef(
             zodDef(schema),
-            { ...refs, currentPath: [...refs.basePath, refs.definitionPath, key] },
+            getDefinitionInputRefs(zodDef(schema), {
+              ...refs,
+              currentPath: [...refs.basePath, refs.definitionPath, key],
+            }),
             true,
           ) ?? {};
         processedDefinitions.add(key);

--- a/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
+++ b/src/_vendor/zod-to-json-schema/zodToJsonSchema.ts
@@ -121,7 +121,7 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
     }
 
     const definitions: Record<string, any> = {};
-    const processedDefinitions = new Set();
+    const processedDefinitions = new Map<string, boolean>();
 
     // the call to `parseDef()` here might itself add more entries to `.definitions`
     // so we need to continually evaluate definitions until we've resolved all of them
@@ -129,9 +129,10 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
     // we have a generous iteration limit here to avoid blowing up the stack if there
     // are any bugs that would otherwise result in us iterating indefinitely
     for (let i = 0; i < 500; i++) {
-      const newDefinitions = Object.entries(refs.definitions).filter(
-        ([key]) => !processedDefinitions.has(key),
-      );
+      const newDefinitions = Object.entries(refs.definitions).filter(([key, definition]) => {
+        const preprocessed = getDefinitionInputRefs(zodDef(definition), refs) !== refs;
+        return !processedDefinitions.has(key) || processedDefinitions.get(key) !== preprocessed;
+      });
       if (newDefinitions.length === 0) {
         break;
       }
@@ -146,6 +147,7 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
         }
         const [key, schema] = nextDefinition;
 
+        const preprocessed = getDefinitionInputRefs(zodDef(schema), refs) !== refs;
         definitions[key] =
           parseDef(
             zodDef(schema),
@@ -155,7 +157,7 @@ const zodToJsonSchema = <Target extends Targets = 'jsonSchema7'>(
             }),
             true,
           ) ?? {};
-        processedDefinitions.add(key);
+        processedDefinitions.set(key, preprocessed);
       }
     }
 

--- a/src/helpers/zod.ts
+++ b/src/helpers/zod.ts
@@ -124,6 +124,38 @@ function getZodV3RootName(name: string, schemaDefinitions: ZodSchemaDefinitions 
   return rootName;
 }
 
+function restoreZodV3DefaultAnnotations(
+  original: unknown,
+  normalized: unknown,
+  visited = new Set<object>(),
+): void {
+  if (
+    !original ||
+    typeof original !== 'object' ||
+    !normalized ||
+    typeof normalized !== 'object' ||
+    visited.has(original)
+  ) {
+    return;
+  }
+  visited.add(original);
+  const source = original as Record<string, unknown>;
+  const target = normalized as Record<string, unknown>;
+  if (hasOwn(source, 'default')) {
+    target['default'] = source['default'];
+  }
+  forEachJSONSchemaChild(source, [], (child, path) => {
+    let corresponding: unknown = target;
+    for (const key of path) {
+      corresponding =
+        corresponding && typeof corresponding === 'object'
+          ? (corresponding as Record<string, unknown>)[key]
+          : undefined;
+    }
+    restoreZodV3DefaultAnnotations(child, corresponding, visited);
+  });
+}
+
 function zodV3ToJsonSchema(
   schema: z3.ZodType,
   options: { name: string; schemaDefinitions?: ZodSchemaDefinitions | undefined },
@@ -134,13 +166,17 @@ function zodV3ToJsonSchema(
     name: rootName,
     nameStrategy: 'duplicate-ref',
     $refStrategy: 'extract-to-root',
+    pipeStrategy: 'input',
     nullableStrategy: 'property',
     ...(options.schemaDefinitions
       ? { definitions: options.schemaDefinitions as unknown as Record<string, z3.ZodType> }
       : undefined),
   });
 
-  return escapeSchemaDefinitionRefs(jsonSchema, options.schemaDefinitions);
+  const escapedSchema = escapeSchemaDefinitionRefs(jsonSchema, options.schemaDefinitions);
+  const strictSchema = toStrictJsonSchema(escapedSchema as JSONSchema) as Record<string, unknown>;
+  restoreZodV3DefaultAnnotations(escapedSchema, strictSchema);
+  return strictSchema;
 }
 
 function zodV4ToJsonSchema(

--- a/tests/helpers/zod-ref-literals.test.ts
+++ b/tests/helpers/zod-ref-literals.test.ts
@@ -104,14 +104,15 @@ describe.each([
   });
 
   if (version === 'v3') {
-    it('does not recursively traverse cyclic or shared literal defaults', () => {
+    it('preserves shared literal defaults and rejects unserializable cyclic defaults', () => {
       const Account = z.object({ id: z.string() });
+      const shared = { $ref: '#/definitions/account/admin' };
       const cyclic: { $ref: string; self?: unknown } = { $ref: '#/definitions/account/admin' };
       cyclic.self = cyclic;
       const Root = z.object({
         account: Account,
-        first: z.any().default(cyclic),
-        second: z.any().default(cyclic),
+        first: z.any().default(shared),
+        second: z.any().default(shared),
       });
 
       const { schema } = zodResponseFormat(Root, 'account_response', {
@@ -123,9 +124,18 @@ describe.each([
 
       expect(properties['account']?.['$ref']).toBe('#/definitions/account~1admin');
       expect(firstDefault.$ref).toBe('#/definitions/account/admin');
-      expect(firstDefault.self).toBe(firstDefault);
       expect(secondDefault.$ref).toBe('#/definitions/account/admin');
-      expect(secondDefault.self).toBe(secondDefault);
+      expect(firstDefault).toBe(secondDefault);
+
+      expect(() =>
+        zodResponseFormat(
+          z.object({ account: Account, cyclic: z.any().default(cyclic) }),
+          'account_response',
+          {
+            schemaDefinitions: { 'account/admin': Account },
+          },
+        ),
+      ).toThrow('cyclic');
       expect(cyclic.self).toBe(cyclic);
     });
   }

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -1454,6 +1454,53 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     expect(() => create(z3.object({ value: schema() }))).toThrow('incompatible parsed outputs');
   });
 
+  it.each([
+    { name: 'readonly', input: () => z3.number().max(10).readonly() },
+    { name: 'default', input: () => z3.number().max(10).default(0) },
+    { name: 'branded', input: () => z3.number().max(10).brand<'bounded'>() },
+    { name: 'lazy', input: () => z3.lazy(() => z3.number().max(10)) },
+  ])(
+    'preserves disjoint numeric fallback after a $name wrapped BigInt transform input',
+    ({ name, input }) => {
+      const union = z3.union([input().transform(BigInt), z3.number().min(1e20)]);
+      const value = name === 'default' ? union.default(0) : union;
+      const result = create(z3.object({ value }));
+
+      expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1', {
+        type: 'number',
+        minimum: 1e20,
+      });
+      expect(result.$parseRaw('{"value":100000000000000000000}')).toEqual({ value: 1e20 });
+    },
+  );
+
+  it('preserves a negative disjoint fallback after a wrapped minimum-constrained BigInt input', () => {
+    const value = z3.union([z3.number().min(-10).readonly().transform(BigInt), z3.number().max(-1e20)]);
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1', {
+      type: 'number',
+      maximum: -1e20,
+    });
+    expect(result.$parseRaw('{"value":-100000000000000000000}')).toEqual({ value: -1e20 });
+  });
+
+  it('preserves nested disjoint fallback after a wrapped BigInt numeric input', () => {
+    const value = z3.union([
+      z3.object({ count: z3.number().max(10).readonly().transform(BigInt) }),
+      z3.object({ count: z3.number().min(1e20) }),
+    ]);
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1.properties.count', {
+      type: 'number',
+      minimum: 1e20,
+    });
+    expect(result.$parseRaw('{"value":{"count":100000000000000000000}}')).toEqual({
+      value: { count: 1e20 },
+    });
+  });
+
   it('preserves numeric intervals disjoint from an exact bounded BigInt transform', () => {
     const value = z3.union([z3.number().max(10).transform(BigInt), z3.number().min(1e20)]);
     const result = create(z3.object({ value }));
@@ -1517,6 +1564,51 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
       minLength: 3,
     });
     expect(result.$parseRaw('{"value":"not-a-bigint"}')).toEqual({ value: 'not-a-bigint' });
+  });
+
+  it.each([
+    { name: 'literal', fallback: () => z3.literal('abc') },
+    { name: 'enum', fallback: () => z3.enum(['abc', 'longer']) },
+    { name: 'readonly enum', fallback: () => z3.enum(['abc', 'longer']).readonly() },
+    {
+      name: 'native enum',
+      fallback: () => z3.nativeEnum({ Short: 'abc', Long: 'longer' } as const),
+    },
+  ])('preserves a concrete disjoint $name string fallback', ({ fallback }) => {
+    const value = z3.union([z3.string().max(2).transform(BigInt), fallback()]);
+    const result = create(z3.object({ value }));
+
+    expect(result.$parseRaw('{"value":"abc"}')).toEqual({ value: 'abc' });
+    expect(strictHelperSchema(result)).not.toHaveProperty('properties.value.anyOf.1.pattern');
+  });
+
+  it('filters only unsafe overlapping members from a mixed finite string fallback', () => {
+    const value = z3.union([z3.string().max(2).transform(BigInt), z3.enum(['7', 'x', 'abc'])]);
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1.enum', ['7', 'abc']);
+    expect(result.$parseRaw('{"value":"7"}')).toEqual({ value: 7n });
+    expect(result.$parseRaw('{"value":"abc"}')).toEqual({ value: 'abc' });
+    expect(() => result.$parseRaw('{"value":"x"}')).toThrow(SyntaxError);
+  });
+
+  it('preserves a nested literal fallback disjoint from a bounded BigInt string transform', () => {
+    const value = z3.union([
+      z3.object({ count: z3.string().max(2).transform(BigInt) }),
+      z3.object({ count: z3.literal('abc') }),
+    ]);
+    const result = create(z3.object({ value }));
+
+    expect(result.$parseRaw('{"value":{"count":"abc"}}')).toEqual({ value: { count: 'abc' } });
+    expect(strictHelperSchema(result)).not.toHaveProperty(
+      'properties.value.anyOf.1.properties.count.pattern',
+    );
+  });
+
+  it('rejects a finite fallback whose every concrete string triggers BigInt conversion failure', () => {
+    const value = z3.union([z3.string().max(2).transform(BigInt), z3.enum(['x', 'no'])]);
+
+    expect(() => create(z3.object({ value }))).toThrow('no synchronously reachable string values');
   });
 
   it('rejects partially overlapping string fallback that cannot be represented without data loss', () => {

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -217,6 +217,53 @@ describe('Zod v3 strict schema capability analysis', () => {
     expect(() => formatFor(schema().default(value))).toThrow(/non-enumerable.*count/u);
   });
 
+  it.each([
+    {
+      name: 'required string',
+      schema: () => z3.object({ count: z3.string() }) as z3.ZodTypeAny,
+      prototype: () => ({ count: 'inherited' }),
+    },
+    {
+      name: 'optional string',
+      schema: () => z3.object({ count: z3.string().optional().nullable() }) as z3.ZodTypeAny,
+      prototype: () => ({ count: 'inherited' }),
+    },
+    {
+      name: 'non-enumerable BigInt',
+      schema: () => z3.object({ count: z3.coerce.bigint() }) as z3.ZodTypeAny,
+      prototype: () => Object.defineProperty({}, 'count', { value: 4n, enumerable: false }),
+    },
+    {
+      name: 'multi-level property',
+      schema: () => z3.object({ count: z3.string() }) as z3.ZodTypeAny,
+      prototype: () => Object.create({ count: 'inherited' }) as object,
+    },
+  ])('rejects an inherited declared $name default property', ({ schema, prototype }) => {
+    const value = Object.create(prototype()) as object;
+
+    expect(() => formatFor(schema().default(value))).toThrow(/inherited.*count/u);
+  });
+
+  it('rejects inherited nested schema getters without invoking them', () => {
+    const getter = vi.fn(() => 4n);
+    const prototype = Object.defineProperty({}, 'count', { get: getter });
+    const inherited = Object.create(prototype) as { count: bigint };
+    const value = z3
+      .object({ detail: z3.object({ count: z3.coerce.bigint() }) })
+      .default({ detail: inherited });
+
+    expect(() => formatFor(value)).toThrow(/inherited.*count/u);
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  it('preserves own schema values that shadow benign inherited metadata', () => {
+    const value = Object.assign(Object.create({ count: 'inherited', metadata: 4n }), { count: 'own' });
+    const format = formatFor(z3.object({ count: z3.string() }).default(value));
+
+    expect(format.$parseRaw('{}')).toEqual({ value: { count: 'own' } });
+    expect(() => JSON.stringify(format)).not.toThrow();
+  });
+
   it('rejects nested hidden schema properties without invoking their getters', () => {
     const getter = vi.fn(() => 4n);
     const hidden = Object.defineProperty({}, 'count', { get: getter, enumerable: false });

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -1,7 +1,33 @@
-import { zodResponseFormat } from 'openai/helpers/zod';
+import { zodFunction, zodResponseFormat, zodResponsesFunction, zodTextFormat } from 'openai/helpers/zod';
 import { z as z3 } from 'zod/v3';
 
 const formatFor = (value: z3.ZodTypeAny) => zodResponseFormat(z3.object({ value }), 'strict');
+
+const strictHelpers = [
+  { name: 'zodResponseFormat', create: (schema: z3.ZodTypeAny) => zodResponseFormat(schema, 'strict') },
+  { name: 'zodTextFormat', create: (schema: z3.ZodTypeAny) => zodTextFormat(schema, 'strict') },
+  {
+    name: 'zodFunction',
+    create: (schema: z3.ZodTypeAny) => zodFunction({ name: 'strict', parameters: schema }),
+  },
+  {
+    name: 'zodResponsesFunction',
+    create: (schema: z3.ZodTypeAny) => zodResponsesFunction({ name: 'strict', parameters: schema }),
+  },
+];
+
+const strictHelperSchema = (helper: ReturnType<(typeof strictHelpers)[number]['create']>) => {
+  if ('json_schema' in helper) {
+    return helper.json_schema.schema;
+  }
+  if ('schema' in helper) {
+    return helper.schema;
+  }
+  if ('function' in helper) {
+    return helper.function.parameters;
+  }
+  return helper.parameters;
+};
 
 interface RecursiveDateNode {
   when: Date;
@@ -229,5 +255,202 @@ describe('Zod v3 strict schema capability analysis', () => {
         'strict',
       ),
     ).toThrow('ZodDate');
+  });
+});
+
+describe.each(strictHelpers)('$name strict numeric input capability analysis', ({ create }) => {
+  it.each([
+    {
+      name: 'output refinement',
+      schema: () => z3.number().pipe(z3.number().refine((value) => Math.abs(value) < 10)),
+    },
+    {
+      name: 'output super refinement',
+      schema: () =>
+        z3.number().pipe(
+          z3.number().superRefine((value, context) => {
+            if (Math.abs(value) >= 10) {
+              context.addIssue({ code: z3.ZodIssueCode.custom, message: 'outside range' });
+            }
+          }),
+        ),
+    },
+    {
+      name: 'output preprocessor',
+      schema: () =>
+        z3
+          .number()
+          .pipe(
+            z3.preprocess(
+              (value) => (typeof value === 'number' && Math.abs(value) >= 10 ? 'rejected' : value),
+              z3.number(),
+            ),
+          ),
+    },
+    {
+      name: 'output transform',
+      schema: () =>
+        z3.number().pipe(
+          z3.number().transform((value, context) => {
+            if (Math.abs(value) >= 10) {
+              context.addIssue({ code: z3.ZodIssueCode.custom, message: 'outside range' });
+              return z3.NEVER;
+            }
+            return value;
+          }),
+        ),
+    },
+    {
+      name: 'nested output pipeline',
+      schema: () => z3.number().pipe(z3.number().pipe(z3.number().refine((value) => Math.abs(value) < 10))),
+    },
+    {
+      name: 'lazy output pipeline',
+      schema: () => z3.lazy(() => z3.number().pipe(z3.number().refine((value) => Math.abs(value) < 10))),
+    },
+    {
+      name: 'intersection output pipeline',
+      schema: () =>
+        z3.intersection(z3.number().pipe(z3.number().refine((value) => Math.abs(value) < 10)), z3.number()),
+    },
+  ])('bounds fallible $name branches before BigInt coercion', ({ schema }) => {
+    const result = create(z3.object({ value: z3.union([schema(), z3.coerce.bigint()]) }));
+    const generated = strictHelperSchema(result) as {
+      properties: { value: { anyOf: Record<string, unknown>[] } };
+    };
+
+    expect(generated.properties.value.anyOf[0]).toMatchObject({
+      minimum: Number.MIN_SAFE_INTEGER,
+      maximum: Number.MAX_SAFE_INTEGER,
+    });
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7 });
+    expect(result.$parseRaw('{"value":9007199254740993}')).toEqual({ value: 9_007_199_254_740_992n });
+    expect(result.$parseRaw('{"value":-9007199254740993}')).toEqual({ value: -9_007_199_254_740_992n });
+  });
+
+  it.each([
+    {
+      name: 'positive refinement',
+      number: () => z3.number().max(9),
+      fallback: () => z3.number().refine((value) => Math.abs(value) < 10),
+      raw: '9007199254740993',
+      rounded: 9_007_199_254_740_992n,
+    },
+    {
+      name: 'negative refinement',
+      number: () => z3.number().min(-9),
+      fallback: () => z3.number().refine((value) => Math.abs(value) < 10),
+      raw: '-9007199254740993',
+      rounded: -9_007_199_254_740_992n,
+    },
+    {
+      name: 'positive Promise',
+      number: () => z3.number().max(9),
+      fallback: () => z3.promise(z3.number()),
+      raw: '9007199254740993',
+      rounded: 9_007_199_254_740_992n,
+    },
+  ])(
+    'bounds nested constrained numeric unions with $name fallthrough',
+    ({ number, fallback, raw, rounded }) => {
+      const result = create(
+        z3.object({ value: z3.union([z3.union([number(), fallback()]), z3.coerce.bigint()]) }),
+      );
+      const generated = strictHelperSchema(result) as {
+        properties: { value: { anyOf: Record<string, unknown>[] } };
+      };
+
+      expect(generated.properties.value.anyOf[0]).toMatchObject({
+        minimum: Number.MIN_SAFE_INTEGER,
+        maximum: Number.MAX_SAFE_INTEGER,
+      });
+      expect(result.$parseRaw(`{"value":${raw}}`)).toEqual({ value: rounded });
+    },
+  );
+
+  it.each([
+    { name: 'direct', schema: () => z3.promise(z3.number()) },
+    { name: 'lazy', schema: () => z3.lazy(() => z3.promise(z3.number())) },
+    {
+      name: 'intersection',
+      schema: () => z3.intersection(z3.promise(z3.number()), z3.number()),
+    },
+    {
+      name: 'pipeline output',
+      schema: () => z3.number().pipe(z3.promise(z3.number())),
+    },
+  ])('bounds $name Promise numeric branches that synchronously fall through', ({ schema }) => {
+    const result = create(z3.object({ value: z3.union([schema(), z3.coerce.bigint()]) }));
+    const generated = strictHelperSchema(result) as {
+      properties: { value: { anyOf: Record<string, unknown>[] } };
+    };
+
+    expect(generated.properties.value.anyOf[0]).toMatchObject({
+      minimum: Number.MIN_SAFE_INTEGER,
+      maximum: Number.MAX_SAFE_INTEGER,
+    });
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
+    expect(result.$parseRaw('{"value":9007199254740993}')).toEqual({ value: 9_007_199_254_740_992n });
+    expect(result.$parseRaw('{"value":-9007199254740993}')).toEqual({ value: -9_007_199_254_740_992n });
+  });
+
+  it.each([
+    { name: 'plain', schema: () => z3.number(), expected: { type: 'number' } },
+    { name: 'coerced', schema: () => z3.coerce.number(), expected: { type: 'number' } },
+    { name: 'finite', schema: () => z3.number().finite(), expected: { type: 'number' } },
+    { name: 'integer', schema: () => z3.number().int(), expected: { type: 'integer' } },
+    {
+      name: 'maximum',
+      schema: () => z3.number().max(9),
+      expected: { type: 'number', maximum: 9 },
+    },
+    {
+      name: 'minimum',
+      schema: () => z3.number().min(-9),
+      expected: { type: 'number', minimum: -9 },
+    },
+    {
+      name: 'multiple',
+      schema: () => z3.number().multipleOf(2),
+      expected: { type: 'number', multipleOf: 2 },
+    },
+  ])('preserves represented $name numeric branches before BigInt coercion', ({ schema, expected }) => {
+    const result = create(z3.object({ value: z3.union([schema(), z3.coerce.bigint()]) }));
+    const generated = strictHelperSchema(result) as {
+      properties: { value: { anyOf: Record<string, unknown>[] } };
+    };
+
+    expect(generated.properties.value.anyOf[0]).toEqual(expected);
+  });
+
+  it('preserves nested total numeric branches ahead of opaque alternatives', () => {
+    const result = create(
+      z3.object({
+        value: z3.union([
+          z3.union([z3.number(), z3.number().refine((value) => Math.abs(value) < 10)]),
+          z3.coerce.bigint(),
+        ]),
+      }),
+    );
+    const generated = strictHelperSchema(result) as {
+      properties: { value: { anyOf: Record<string, unknown>[] } };
+    };
+
+    expect(generated.properties.value.anyOf[0]).not.toHaveProperty('minimum');
+    expect(generated.properties.value.anyOf[0]).not.toHaveProperty('maximum');
+    expect(result.$parseRaw('{"value":9007199254740993}')).toEqual({ value: 9_007_199_254_740_992 });
+  });
+
+  it('preserves represented restrictions in pipeline outputs', () => {
+    const result = create(
+      z3.object({ value: z3.union([z3.number().pipe(z3.number().max(9)), z3.coerce.bigint()]) }),
+    );
+    const generated = strictHelperSchema(result) as {
+      properties: { value: { anyOf: Record<string, unknown>[] } };
+    };
+
+    expect(generated.properties.value.anyOf[0]).toEqual({
+      allOf: [{ type: 'number' }, { type: 'number', maximum: 9 }],
+    });
   });
 });

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -428,11 +428,13 @@ describe('Zod v3 strict schema capability analysis', () => {
       parameters: z3.object({
         literal: z3.literal(Infinity),
         native: z3.nativeEnum({ NonFinite: -Infinity, Finite: 7 } as const),
+        bound: z3.number().max(Infinity),
       }),
     });
 
     expect(realtime.parameters).toHaveProperty('properties.literal.const', Infinity);
     expect(realtime.parameters).toHaveProperty('properties.native.enum', [-Infinity, 7]);
+    expect(realtime.parameters).toHaveProperty('properties.bound.maximum', Infinity);
   });
 
   it.each([Infinity, -Infinity, Number.NaN])('rejects a non-finite numeric default %s', (value) => {
@@ -565,6 +567,18 @@ describe('Zod v3 strict schema capability analysis', () => {
       normalized: 4,
     },
     {
+      name: 'disjoint numeric multiple',
+      schema: () => z3.union([z3.number().multipleOf(2), z3.coerce.bigint()]).default(3n),
+      output: 3n,
+      normalized: 3,
+    },
+    {
+      name: 'disjoint fractional multiple',
+      schema: () => z3.union([z3.number().multipleOf(0.4), z3.coerce.bigint()]).default(3n),
+      output: 3n,
+      normalized: 3,
+    },
+    {
       name: 'nested object union',
       schema: () =>
         z3.union([z3.object({ count: z3.coerce.bigint() }), z3.object({ count: z3.string() })]).default({
@@ -650,6 +664,14 @@ describe('Zod v3 strict schema capability analysis', () => {
     {
       name: 'inclusive numeric maximum equality',
       schema: () => z3.union([z3.number().max(4), z3.coerce.bigint()]).default(4n),
+    },
+    {
+      name: 'matching numeric multiple',
+      schema: () => z3.union([z3.number().multipleOf(2), z3.coerce.bigint()]).default(4n),
+    },
+    {
+      name: 'matching fractional multiple',
+      schema: () => z3.union([z3.number().multipleOf(0.5), z3.coerce.bigint()]).default(3n),
     },
     {
       name: 'matching literal',
@@ -914,6 +936,24 @@ describe('Zod v3 strict schema capability analysis', () => {
   ])('rejects a preprocessed Set with an unrepresentable $name cardinality constraint', ({ schema }) => {
     const value = z3.preprocess((input) => new Set(input as string[]), schema());
     expect(() => formatFor(value)).toThrow(/ZodSet.*uniqueItems/u);
+  });
+
+  it.each([
+    { name: 'minimum of one', schema: () => z3.set(z3.string()).min(1), expected: { minItems: 1 } },
+    {
+      name: 'exact size of one',
+      schema: () => z3.set(z3.string()).size(1),
+      expected: { minItems: 1, maxItems: 1 },
+    },
+  ])('preserves a preprocessed Set with a representable $name constraint', ({ schema, expected }) => {
+    const value = z3.preprocess((input) => new Set(input as string[]), schema());
+    const format = formatFor(value);
+
+    expect(format.json_schema.schema).toHaveProperty(
+      'properties.value',
+      expect.objectContaining({ type: 'array', items: { type: 'string' }, ...expected }),
+    );
+    expect(format.$parseRaw('{"value":["x"]}')).toEqual({ value: new Set(['x']) });
   });
 
   it.each([
@@ -1229,6 +1269,33 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     }
   });
 
+  it.each([
+    { name: 'inclusive maximum', schema: () => z3.number().max(Infinity) },
+    { name: 'exclusive maximum', schema: () => z3.number().lt(Infinity) },
+    { name: 'inclusive minimum', schema: () => z3.number().min(-Infinity) },
+    { name: 'exclusive minimum', schema: () => z3.number().gt(-Infinity) },
+  ])('omits a vacuous infinite $name constraint', ({ schema }) => {
+    const result = create(z3.object({ value: schema() }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value', { type: 'number' });
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7 });
+    expect(JSON.stringify(strictHelperSchema(result))).not.toContain('null');
+  });
+
+  it.each([
+    { name: 'impossible inclusive minimum', schema: () => z3.number().min(Infinity) },
+    { name: 'impossible inclusive maximum', schema: () => z3.number().max(-Infinity) },
+    { name: 'impossible exclusive minimum', schema: () => z3.number().gt(Infinity) },
+    { name: 'impossible exclusive maximum', schema: () => z3.number().lt(-Infinity) },
+    { name: 'NaN minimum', schema: () => z3.number().min(Number.NaN) },
+    { name: 'NaN maximum', schema: () => z3.number().max(Number.NaN) },
+    { name: 'infinite multiple', schema: () => z3.number().multipleOf(Infinity) },
+    { name: 'negative infinite multiple', schema: () => z3.number().multipleOf(-Infinity) },
+    { name: 'NaN multiple', schema: () => z3.number().multipleOf(Number.NaN) },
+  ])('rejects an unrepresentable non-finite $name constraint', ({ schema }) => {
+    expect(() => create(z3.object({ value: schema() }))).toThrow('non-finite');
+  });
+
   it('preserves finite literals, compact literal unions, and native enum values', () => {
     const finite = create(
       z3.object({
@@ -1381,6 +1448,54 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     expect(result.$parseRaw('{"value":1.5}')).toEqual({ value: 1.5 });
   });
 
+  it('narrows nullable numeric fallback properties without removing null', () => {
+    const value = z3.union([z3.number().transform(BigInt), z3.number().nullable()]);
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1.type', 'integer');
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1.nullable', true);
+    expect(result.$parseRaw('{"value":null}')).toEqual({ value: null });
+    expect(() => result.$parseRaw('{"value":1.5}')).toThrow(RangeError);
+  });
+
+  it('narrows only the numeric alternative of a checked nullable fractional fallback', () => {
+    const value = z3.union([z3.number().transform(BigInt), z3.number().min(0).nullable()]);
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1.anyOf.0.type', 'integer');
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1.anyOf.1', { type: 'null' });
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
+    expect(result.$parseRaw('{"value":null}')).toEqual({ value: null });
+    expect(() => result.$parseRaw('{"value":1.5}')).toThrow(RangeError);
+  });
+
+  it('narrows checked nullable numeric fallbacks nested inside object properties', () => {
+    const value = z3.union([
+      z3.object({ count: z3.number().transform(BigInt) }),
+      z3.object({ count: z3.number().min(0).nullable() }),
+    ]);
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty(
+      'properties.value.anyOf.1.properties.count.anyOf.0.type',
+      'integer',
+    );
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1.properties.count.anyOf.1', {
+      type: 'null',
+    });
+    expect(result.$parseRaw('{"value":{"count":null}}')).toEqual({ value: { count: null } });
+    expect(() => result.$parseRaw('{"value":{"count":1.5}}')).toThrow(RangeError);
+  });
+
+  it('preserves nullable fractional fallback after an integer-constrained BigInt transform', () => {
+    const value = z3.union([z3.number().int().transform(BigInt), z3.number().min(0).nullable()]);
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1.anyOf.0.type', 'number');
+    expect(result.$parseRaw('{"value":1.5}')).toEqual({ value: 1.5 });
+    expect(result.$parseRaw('{"value":null}')).toEqual({ value: null });
+  });
+
   it('preserves fractional numbers accepted before a later exact BigInt transform', () => {
     const value = z3.union([z3.number(), z3.number().transform(BigInt)]);
     const result = create(z3.object({ value }));
@@ -1412,6 +1527,30 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     {
       name: 'wrapped exact BigInt transform',
       schema: () => z3.intersection(z3.number().transform(BigInt).readonly(), z3.number()),
+    },
+    {
+      name: 'preprocessed BigInt and number literals',
+      schema: () =>
+        z3.intersection(
+          z3.preprocess((value) => BigInt(value as number), z3.literal(1n)),
+          z3.literal(1),
+        ),
+    },
+    {
+      name: 'number and preprocessed BigInt literals',
+      schema: () =>
+        z3.intersection(
+          z3.literal(1),
+          z3.preprocess((value) => BigInt(value as number), z3.literal(1n)),
+        ),
+    },
+    {
+      name: 'nested BigInt and number literal properties',
+      schema: () =>
+        z3.intersection(
+          z3.object({ value: z3.preprocess((input) => BigInt(input as number), z3.literal(1n)) }),
+          z3.object({ value: z3.literal(1) }),
+        ),
     },
     {
       name: 'nested object BigInt and number',

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -1878,6 +1878,100 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     expect(convert).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      name: 'preprocessed Set before an array',
+      schema: () =>
+        z3.intersection(
+          z3.preprocess((value) => new Set(value as string[]), z3.set(z3.string())),
+          z3.array(z3.string()),
+        ),
+    },
+    {
+      name: 'array before a preprocessed Set',
+      schema: () =>
+        z3.intersection(
+          z3.array(z3.string()),
+          z3.preprocess((value) => new Set(value as string[]), z3.set(z3.string())),
+        ),
+    },
+    {
+      name: 'readonly lazy Set before an array',
+      schema: () =>
+        z3.intersection(
+          z3.lazy(() => z3.preprocess((value) => new Set(value as string[]), z3.set(z3.string())).readonly()),
+          z3.array(z3.string()),
+        ),
+    },
+    {
+      name: 'nested Set object property',
+      schema: () =>
+        z3.intersection(
+          z3.object({ values: z3.preprocess((value) => new Set(value as string[]), z3.set(z3.string())) }),
+          z3.object({ values: z3.array(z3.string()) }),
+        ),
+    },
+    {
+      name: 'preprocessed Map before an array',
+      schema: () =>
+        z3.intersection(
+          z3.preprocess((value) => new Map(value as [string, number][]), z3.map(z3.string(), z3.number())),
+          z3.array(z3.tuple([z3.string(), z3.number()])),
+        ),
+    },
+  ])('rejects incompatible $name intersection output containers', ({ schema }) => {
+    expect(() => create(z3.object({ value: schema() }))).toThrow('incompatible parsed outputs');
+  });
+
+  it.each([
+    {
+      name: 'direct BigInt preprocessors',
+      schema: (first: () => bigint, second: () => bigint) =>
+        z3.intersection(z3.preprocess(first, z3.bigint()), z3.preprocess(second, z3.bigint())),
+    },
+    {
+      name: 'readonly lazy BigInt preprocessors',
+      schema: (first: () => bigint, second: () => bigint) =>
+        z3.intersection(
+          z3.lazy(() => z3.preprocess(first, z3.bigint()).readonly()),
+          z3.preprocess(second, z3.bigint()),
+        ),
+    },
+    {
+      name: 'nested BigInt object preprocessors',
+      schema: (first: () => bigint, second: () => bigint) =>
+        z3.intersection(
+          z3.object({ count: z3.preprocess(first, z3.bigint()) }),
+          z3.object({ count: z3.preprocess(second, z3.bigint()) }),
+        ),
+    },
+    {
+      name: 'nested BigInt array preprocessors',
+      schema: (first: () => bigint, second: () => bigint) =>
+        z3.intersection(
+          z3.array(z3.preprocess(first, z3.bigint())),
+          z3.array(z3.preprocess(second, z3.bigint())),
+        ),
+    },
+    {
+      name: 'BigInt preprocessors before a downstream pipeline',
+      schema: (first: () => bigint, second: () => bigint) =>
+        z3
+          .intersection(z3.preprocess(first, z3.bigint()), z3.preprocess(second, z3.bigint()))
+          .pipe(z3.bigint()),
+    },
+    {
+      name: 'preprocessed and coerced BigInt outputs',
+      schema: (first: () => bigint) => z3.intersection(z3.preprocess(first, z3.bigint()), z3.coerce.bigint()),
+    },
+  ])('rejects opaque $name intersection values without invoking user callbacks', ({ schema }) => {
+    const first = vi.fn(() => 1n);
+    const second = vi.fn(() => 2n);
+    expect(() => create(z3.object({ value: schema(first, second) }))).toThrow('incompatible parsed outputs');
+    expect(first).not.toHaveBeenCalled();
+    expect(second).not.toHaveBeenCalled();
+  });
+
   it('preserves intersections with compatible optional numeric outputs', () => {
     const result = create(z3.object({ value: z3.intersection(z3.number().optional(), z3.number()) }));
 
@@ -2470,6 +2564,20 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     expect(() => create(z3.object({ value }))).toThrow('ZodPipeline output constraints');
   });
 
+  it('keeps notation-sensitive scientific multiples fail-closed under the installed Zod runtime', () => {
+    const input = z3.number().multipleOf(1e-7);
+    const output = z3.number().multipleOf(2e-7);
+    const pipeline = input.pipe(output);
+
+    for (const value of [0, 2e-7, 4e-7]) {
+      expect(input.safeParse(value).success).toBe(false);
+      expect(output.safeParse(value).success).toBe(false);
+      expect(pipeline.safeParse(value).success).toBe(false);
+    }
+    expect(pipeline.safeParse(0.0000012).success).toBe(true);
+    expect(() => create(z3.object({ value: pipeline }))).toThrow('ZodPipeline output constraints');
+  });
+
   it.each([
     {
       name: 'object property minimum',
@@ -2706,6 +2814,31 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
   ])('preserves a provably compatible $name pipeline output', ({ schema, expected }) => {
     const result = create(z3.object({ value: schema() }));
     expect(result.$parseRaw('{"value":7}')).toEqual({ value: expected });
+  });
+
+  it.each([
+    { name: 'function', output: () => z3.function(), type: 'ZodFunction' },
+    { name: 'void', output: () => z3.void(), type: 'ZodVoid' },
+    { name: 'symbol', output: () => z3.symbol(), type: 'ZodSymbol' },
+    { name: 'readonly function', output: () => z3.function().readonly(), type: 'ZodReadonly' },
+    { name: 'lazy symbol', output: () => z3.lazy(() => z3.symbol()), type: 'ZodLazy' },
+    { name: 'optional void', output: () => z3.void().optional(), type: 'ZodOptional' },
+    { name: 'nullable function', output: () => z3.function().nullable(), type: 'ZodNullable' },
+    {
+      name: 'only unsupported union alternatives',
+      output: () => z3.union([z3.function(), z3.symbol()]),
+      type: 'ZodUnion',
+    },
+  ])('rejects an unrepresentable downstream $name pipeline output', ({ output, type }) => {
+    expect(() => create(z3.object({ value: z3.number().pipe(output()) }))).toThrow(type);
+  });
+
+  it('preserves a representable numeric alternative beside an unsupported pipeline output', () => {
+    const value = z3.number().pipe(z3.union([z3.function(), z3.number()]));
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.0.type', 'number');
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7 });
   });
 
   it.each([

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -181,6 +181,21 @@ describe('Zod v3 strict schema capability analysis', () => {
     expect(format.$parseRaw('{}')).toEqual({ values: [4n], detail: { count: 5n } });
   });
 
+  it('normalizes array defaults without invoking an overridden entries method', () => {
+    const value = [4n];
+    const entries = vi.fn(function* ignoredEntries() {
+      yield* [];
+    });
+    Object.defineProperty(value, 'entries', { value: entries });
+
+    const format = formatFor(z3.array(z3.coerce.bigint()).default(value));
+
+    expect(format.json_schema.schema).toHaveProperty('properties.value.default', [4]);
+    expect(format.$parseRaw('{}')).toEqual({ value: [4n] });
+    expect(() => JSON.stringify(format)).not.toThrow();
+    expect(entries).not.toHaveBeenCalled();
+  });
+
   it.each([
     {
       name: 'direct',
@@ -407,6 +422,18 @@ describe('Zod v3 strict schema capability analysis', () => {
       normalized: 4,
     },
     {
+      name: 'exclusive numeric minimum equality',
+      schema: () => z3.union([z3.number().gt(4), z3.coerce.bigint()]).default(4n),
+      output: 4n,
+      normalized: 4,
+    },
+    {
+      name: 'exclusive numeric maximum equality',
+      schema: () => z3.union([z3.number().lt(4), z3.coerce.bigint()]).default(4n),
+      output: 4n,
+      normalized: 4,
+    },
+    {
       name: 'nested object union',
       schema: () =>
         z3.union([z3.object({ count: z3.coerce.bigint() }), z3.object({ count: z3.string() })]).default({
@@ -426,6 +453,33 @@ describe('Zod v3 strict schema capability analysis', () => {
           .default({ kind: 'bigint', count: 4n }),
       output: { kind: 'bigint', count: 4n },
       normalized: { kind: 'bigint', count: 4 },
+    },
+    {
+      name: 'primitive-type-discriminated object union',
+      schema: () =>
+        z3
+          .union([
+            z3.object({ kind: z3.number(), count: z3.number() }),
+            z3.object({ kind: z3.string(), count: z3.coerce.bigint() }),
+          ])
+          .default({ kind: 'bigint', count: 4n }),
+      output: { kind: 'bigint', count: 4n },
+      normalized: { kind: 'bigint', count: 4 },
+    },
+    {
+      name: 'nested wrapped primitive-type discriminator',
+      schema: () =>
+        z3
+          .union([
+            z3.object({ kind: z3.object({ type: z3.boolean().readonly() }), count: z3.number() }),
+            z3.object({
+              kind: z3.object({ type: z3.string().brand<'bigint-kind'>() }),
+              count: z3.coerce.bigint(),
+            }),
+          ])
+          .default({ kind: { type: 'bigint' }, count: 4n }),
+      output: { kind: { type: 'bigint' }, count: 4n },
+      normalized: { kind: { type: 'bigint' }, count: 4 },
     },
   ])(
     'normalizes a safe BigInt default through a compatible $name branch',
@@ -459,6 +513,14 @@ describe('Zod v3 strict schema capability analysis', () => {
     { name: 'number', schema: () => z3.union([z3.number(), z3.coerce.bigint()]).default(4n) },
     { name: 'any', schema: () => z3.union([z3.any(), z3.coerce.bigint()]).default(4n) },
     {
+      name: 'inclusive numeric minimum equality',
+      schema: () => z3.union([z3.number().min(4), z3.coerce.bigint()]).default(4n),
+    },
+    {
+      name: 'inclusive numeric maximum equality',
+      schema: () => z3.union([z3.number().max(4), z3.coerce.bigint()]).default(4n),
+    },
+    {
       name: 'matching literal',
       schema: () => z3.union([z3.literal(4), z3.coerce.bigint()]).default(4n),
     },
@@ -472,6 +534,16 @@ describe('Zod v3 strict schema capability analysis', () => {
         z3
           .union([z3.object({ count: z3.number() }), z3.object({ count: z3.coerce.bigint() })])
           .default({ count: 4n }),
+    },
+    {
+      name: 'coercing primitive discriminator',
+      schema: () =>
+        z3
+          .union([
+            z3.object({ kind: z3.coerce.number(), count: z3.number() }),
+            z3.object({ kind: z3.string(), count: z3.coerce.bigint() }),
+          ])
+          .default({ kind: '4', count: 4n }),
     },
   ])('rejects BigInt defaults intercepted by an earlier $name union option', ({ schema }) => {
     expect(() => formatFor(schema())).toThrow('ZodBigInt');

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -197,6 +197,58 @@ describe('Zod v3 strict schema capability analysis', () => {
   });
 
   it.each([
+    { name: 'string', first: () => z3.string() },
+    { name: 'any value', first: () => z3.any() },
+    { name: 'wrapped string', first: () => z3.string().readonly() },
+  ])('rejects a Date default intercepted by an earlier $name union option', ({ first }) => {
+    const value = z3.union([first(), z3.coerce.date()]).default(new Date('2026-08-17T00:00:00.000Z'));
+    expect(() => formatFor(value)).toThrow('ZodDate');
+  });
+
+  it('preserves Date defaults selected by direct, ordered, and discriminated native branches', () => {
+    const date = new Date('2026-08-17T00:00:00.000Z');
+    const format = zodResponseFormat(
+      z3.object({
+        direct: z3.coerce.date().default(date),
+        ordered: z3.union([z3.coerce.date(), z3.string()]).default(date),
+        tagged: z3
+          .union([
+            z3.object({ kind: z3.literal('string'), when: z3.string() }),
+            z3.object({ kind: z3.literal('date'), when: z3.coerce.date() }),
+          ])
+          .default({ kind: 'date', when: date }),
+      }),
+      'strict',
+    );
+    expect(format.$parseRaw('{}')).toEqual({
+      direct: date,
+      ordered: date,
+      tagged: { kind: 'date', when: date },
+    });
+    expect(() => JSON.stringify(format)).not.toThrow();
+  });
+
+  it.each([Infinity, -Infinity, Number.NaN])('rejects a non-finite numeric default %s', (value) => {
+    expect(() => formatFor(z3.number().default(value))).toThrow('non-finite');
+    expect(() => formatFor(z3.any().default({ nested: [value] }))).toThrow('non-finite');
+  });
+
+  it('rejects cyclic defaults while preserving completed shared default values', () => {
+    const cyclic: { nested?: unknown } = {};
+    cyclic.nested = cyclic;
+    expect(() => formatFor(z3.any().default(cyclic))).toThrow('cyclic');
+
+    const array: unknown[] = [];
+    array.push(array);
+    expect(() => formatFor(z3.any().default(array))).toThrow('cyclic');
+
+    const shared = { count: 4 };
+    const format = formatFor(z3.any().default({ first: shared, second: shared }));
+    expect(format.$parseRaw('{}')).toEqual({ value: { first: shared, second: shared } });
+    expect(() => JSON.stringify(format)).not.toThrow();
+  });
+
+  it.each([
     { name: 'tuple', schema: () => z3.tuple([z3.number()]), message: 'tuple-form' },
     { name: 'record', schema: () => z3.record(z3.number()), message: 'additionalProperties: false' },
     {
@@ -581,6 +633,22 @@ describe('Zod v3 strict schema capability analysis', () => {
       output: { values: [{ count: 7n }] },
       path: ['properties', 'values', 'items', 'properties', 'count'],
     },
+    {
+      name: 'nullable nested object',
+      producer: () => z3.object({ nested: z3.object({ count: z3.coerce.bigint() }).nullable() }),
+      consumer: () => z3.object({ nested: z3.object({ count: z3.number() }).nullable() }),
+      input: { nested: { count: 7 } },
+      output: { nested: { count: 7n } },
+      path: ['properties', 'nested', 'anyOf', 0, 'properties', 'count'],
+    },
+    {
+      name: 'nullable nested array',
+      producer: () => z3.object({ values: z3.array(z3.object({ count: z3.coerce.bigint() })).nullable() }),
+      consumer: () => z3.object({ values: z3.array(z3.object({ count: z3.number() })).nullable() }),
+      input: { values: [{ count: 7 }] },
+      output: { values: [{ count: 7n }] },
+      path: ['properties', 'values', 'anyOf', 0, 'items', 'properties', 'count'],
+    },
   ])(
     'bounds unsafe overlap at matching $name in union alternatives',
     ({ producer, consumer, input, output, path }) => {
@@ -654,6 +722,13 @@ describe('Zod v3 strict schema capability analysis', () => {
       bigint: () => z3.object({ kind: z3.object({ type: z3.number() }), count: z3.coerce.bigint() }),
       number: () => z3.object({ kind: z3.object({ type: z3.string() }), count: z3.number().min(1e20) }),
       input: { kind: { type: 'number' }, count: 1e20 },
+    },
+    {
+      name: 'numeric native enum reverse mapping',
+      bigint: () =>
+        z3.object({ kind: z3.nativeEnum({ 0: 'numeric', numeric: 0 } as const), count: z3.coerce.bigint() }),
+      number: () => z3.object({ kind: z3.literal('numeric'), count: z3.number().min(1e20) }),
+      input: { kind: 'numeric', count: 1e20 },
     },
   ])(
     'preserves unsafe-range number branches separated by a $name discriminator',
@@ -779,6 +854,11 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
       maximum: Number.MAX_SAFE_INTEGER,
     });
     expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
+  });
+
+  it('rejects compound inputs that the built-in BigInt transform cannot safely represent', () => {
+    const value = z3.union([z3.number(), z3.string()]).transform(BigInt);
+    expect(() => create(z3.object({ value }))).toThrow('directly representable numeric JSON input');
   });
 
   it.each([
@@ -1168,6 +1248,26 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
       expect(strictHelperSchema(result)).toHaveProperty(`properties.value.${keyword}`, expected);
     },
   );
+
+  it('projects every constrained BigInt pipeline output alternative onto numeric input', () => {
+    const value = z3
+      .number()
+      .transform(BigInt)
+      .pipe(z3.union([z3.bigint().max(10n), z3.bigint().min(100n)]));
+    const result = create(z3.object({ value }));
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf', [
+      expect.objectContaining({ type: 'integer', maximum: 10 }),
+      expect.objectContaining({ type: 'integer', minimum: 100 }),
+    ]);
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
+    expect(result.$parseRaw('{"value":101}')).toEqual({ value: 101n });
+    expect(() => result.$parseRaw('{"value":50}')).toThrow();
+  });
+
+  it('rejects compound pipeline outputs that cannot be projected without losing constraints', () => {
+    const value = z3.number().transform(BigInt).pipe(z3.bigint().max(10n).nullable());
+    expect(() => create(z3.object({ value }))).toThrow('ZodPipeline output constraints');
+  });
 
   it('rejects converting output constraints that cannot be projected onto their input', () => {
     const value = z3.string().transform(BigInt).pipe(z3.bigint().max(9n));

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -1826,6 +1826,58 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     expect(() => create(z3.object({ value: schema() }))).toThrow('incompatible parsed outputs');
   });
 
+  it.each([
+    {
+      name: 'opaque arm before a numeric arm',
+      schema: (convert: (value: number) => bigint) =>
+        z3.intersection(z3.number().transform(convert), z3.number()).pipe(z3.number()),
+    },
+    {
+      name: 'opaque arm before a classified numeric transform',
+      schema: (convert: (value: number) => bigint) =>
+        z3.intersection(z3.number().transform(convert), z3.number().transform(Number)).pipe(z3.number()),
+    },
+    {
+      name: 'classified numeric transform before an opaque arm',
+      schema: (convert: (value: number) => bigint) =>
+        z3.intersection(z3.number().transform(Number), z3.number().transform(convert)).pipe(z3.number()),
+    },
+    {
+      name: 'opaque arm before a coercing numeric arm',
+      schema: (convert: (value: number) => bigint) =>
+        z3.intersection(z3.number().transform(convert), z3.coerce.number()).pipe(z3.number()),
+    },
+    {
+      name: 'numeric arm before an opaque arm',
+      schema: (convert: (value: number) => bigint) =>
+        z3.intersection(z3.number(), z3.number().transform(convert)).pipe(z3.number()),
+    },
+    {
+      name: 'readonly lazy opaque arm',
+      schema: (convert: (value: number) => bigint) =>
+        z3
+          .intersection(
+            z3.lazy(() => z3.number().transform(convert).readonly()),
+            z3.number(),
+          )
+          .pipe(z3.number()),
+    },
+    {
+      name: 'nested object opaque arm',
+      schema: (convert: (value: number) => bigint) =>
+        z3
+          .intersection(
+            z3.object({ count: z3.number().transform(convert) }),
+            z3.object({ count: z3.number() }),
+          )
+          .pipe(z3.object({ count: z3.number() })),
+    },
+  ])('rejects an $name intersection before downstream pipeline validation', ({ schema }) => {
+    const convert = vi.fn((value: number) => BigInt(value.toString()));
+    expect(() => create(z3.object({ value: schema(convert) }))).toThrow('incompatible parsed outputs');
+    expect(convert).not.toHaveBeenCalled();
+  });
+
   it('preserves intersections with compatible optional numeric outputs', () => {
     const result = create(z3.object({ value: z3.intersection(z3.number().optional(), z3.number()) }));
 
@@ -2544,6 +2596,116 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
     expect(result.$parseRaw('{"value":101}')).toEqual({ value: 101n });
     expect(() => result.$parseRaw('{"value":50}')).toThrow();
+  });
+
+  it.each([
+    {
+      name: 'numeric identity transform',
+      schema: (convert: (value: number) => number) => z3.number().transform(convert).pipe(z3.bigint()),
+    },
+    {
+      name: 'readonly input transform',
+      schema: (convert: (value: number) => number) =>
+        z3.number().transform(convert).readonly().pipe(z3.bigint()),
+    },
+    {
+      name: 'lazy input transform',
+      schema: (convert: (value: number) => number) =>
+        z3.lazy(() => z3.number().transform(convert)).pipe(z3.bigint()),
+    },
+    {
+      name: 'readonly native output',
+      schema: (convert: (value: number) => number) =>
+        z3.number().transform(convert).pipe(z3.bigint().readonly()),
+    },
+    {
+      name: 'optional native output',
+      schema: (convert: (value: number) => number) =>
+        z3.number().transform(convert).pipe(z3.bigint().optional()),
+    },
+    {
+      name: 'nullable native output',
+      schema: (convert: (value: number) => number) =>
+        z3.number().transform(convert).pipe(z3.bigint().nullable()),
+    },
+    {
+      name: 'nullable native output union',
+      schema: (convert: (value: number) => number) =>
+        z3
+          .number()
+          .transform(convert)
+          .pipe(z3.union([z3.bigint(), z3.null()])),
+    },
+    {
+      name: 'nested object property',
+      schema: (convert: (value: number) => number) =>
+        z3.object({ count: z3.number().transform(convert).pipe(z3.bigint()) }),
+    },
+    {
+      name: 'nested array item',
+      schema: (convert: (value: number) => number) =>
+        z3.array(z3.number().transform(convert).pipe(z3.bigint())),
+    },
+  ])('rejects an unverifiable $name before native BigInt pipeline validation', ({ schema }) => {
+    const convert = vi.fn((value: number) => value);
+    expect(() => create(z3.object({ value: schema(convert) }))).toThrow('ZodBigInt');
+    expect(convert).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: 'exact built-in BigInt transform',
+      schema: () => z3.number().transform(BigInt).pipe(z3.bigint()),
+      expected: 7n,
+    },
+    {
+      name: 'independently validated opaque BigInt preprocessor',
+      schema: () =>
+        z3
+          .preprocess((value) => (typeof value === 'number' ? BigInt(value) : value), z3.bigint())
+          .pipe(z3.bigint()),
+      expected: 7n,
+    },
+    {
+      name: 'coercing downstream BigInt',
+      schema: () =>
+        z3
+          .number()
+          .transform((value) => value)
+          .pipe(z3.coerce.bigint()),
+      expected: 7n,
+    },
+    {
+      name: 'readonly coercing downstream BigInt',
+      schema: () =>
+        z3
+          .number()
+          .transform((value) => value)
+          .pipe(z3.coerce.bigint().readonly()),
+      expected: 7n,
+    },
+    {
+      name: 'mixed numeric and native BigInt output union',
+      schema: () =>
+        z3
+          .number()
+          .transform((value) => value)
+          .pipe(z3.union([z3.bigint(), z3.number()])),
+      expected: 7,
+    },
+    {
+      name: 'known built-in numeric transform',
+      schema: () => z3.number().transform(Number).pipe(z3.number()),
+      expected: 7,
+    },
+    {
+      name: 'known built-in string transform',
+      schema: () => z3.number().transform(String).pipe(z3.string()),
+      expected: '7',
+    },
+  ])('preserves a provably compatible $name pipeline output', ({ schema, expected }) => {
+    const result = create(z3.object({ value: schema() }));
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: expected });
   });
 
   it.each([

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -99,8 +99,14 @@ describe('Zod v3 strict schema capability analysis', () => {
       schema: () =>
         z3
           .intersection(
-            z3.string().transform((value) => new Date(value)),
-            z3.string().transform((value) => new Date(value)),
+            z3
+              .string()
+              .transform((value) => new Date(value))
+              .pipe(z3.date()),
+            z3
+              .string()
+              .transform((value) => new Date(value))
+              .pipe(z3.date()),
           )
           .pipe(z3.date()),
     },
@@ -1297,6 +1303,64 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
   });
 
   it.each([
+    { name: 'RegExp', value: () => /x/u as object },
+    { name: 'cross-realm RegExp', value: () => runInNewContext('/x/u') as object },
+    { name: 'null-prototype RegExp', value: () => Object.setPrototypeOf(/x/u, null) as object },
+    { name: 'WeakMap', value: () => new WeakMap<object, number>() as object },
+    { name: 'cross-realm WeakSet', value: () => runInNewContext('new WeakSet()') as object },
+    { name: 'Promise', value: () => Promise.resolve(1) as object },
+    { name: 'Error', value: () => new Error('hidden') as object },
+    { name: 'ArrayBuffer', value: () => new ArrayBuffer(4) as object },
+    { name: 'cross-realm ArrayBuffer', value: () => runInNewContext('new ArrayBuffer(4)') as object },
+    {
+      name: 'null-prototype ArrayBuffer',
+      value: () => Object.setPrototypeOf(new ArrayBuffer(4), null) as object,
+    },
+    { name: 'DataView', value: () => new DataView(new ArrayBuffer(4)) as object },
+    { name: 'typed array', value: () => new Uint8Array([1, 2]) as object },
+  ])('rejects a genuine $name default with hidden internal slots', ({ value }) => {
+    expect(() => create(z3.object({ value: z3.any().default(value()) }))).toThrow('internal slots');
+    expect(() => create(z3.object({ value: z3.unknown().default({ nested: value() }) }))).toThrow(
+      'internal slots',
+    );
+  });
+
+  it('detects RegExp default slots without invoking hostile accessors or tags', () => {
+    const getter = vi.fn(() => {
+      throw new Error('must never run');
+    });
+    const prototype = Object.defineProperty({}, Symbol.toStringTag, { get: getter });
+    const value = Object.setPrototypeOf(/x/u, prototype);
+    Object.defineProperty(value, 'toJSON', { enumerable: true, get: getter });
+
+    expect(() => create(z3.object({ value: z3.any().default(value) }))).toThrow('internal slots');
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  it('preserves a plain custom default prototype without invoking its toStringTag getter', () => {
+    const getter = vi.fn(() => 'RegExp');
+    const prototype = Object.defineProperty({}, Symbol.toStringTag, { get: getter });
+    const value = Object.assign(Object.create(prototype) as { label: string }, { label: 'safe' });
+    const result = create(z3.object({ value: z3.any().default(value) }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.default', { label: 'safe' });
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: 'null-prototype Date',
+      value: () => Object.setPrototypeOf(new Date('2026-01-01T00:00:00.000Z'), null) as object,
+    },
+    {
+      name: 'cross-realm Date',
+      value: () => runInNewContext("new Date('2026-01-01T00:00:00.000Z')") as object,
+    },
+  ])('rejects an unsupported $name default without trusting its prototype', ({ value }) => {
+    expect(() => create(z3.object({ value: z3.any().default(value()) }))).toThrow('invalid or customized');
+  });
+
+  it.each([
     { name: 'coerced minimum', schema: () => z3.coerce.date().min(new Date('2025-01-01T00:00:00.000Z')) },
     { name: 'coerced maximum', schema: () => z3.coerce.date().max(new Date('2025-12-31T00:00:00.000Z')) },
     {
@@ -1786,6 +1850,54 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
 
   it.each([
     {
+      name: 'nullable BigInt before nullable number',
+      schema: () => z3.intersection(z3.coerce.bigint().nullable(), z3.number().nullable()),
+    },
+    {
+      name: 'nullable number before nullable BigInt',
+      schema: () => z3.intersection(z3.number().nullable(), z3.coerce.bigint().nullable()),
+    },
+    {
+      name: 'readonly lazy nullable BigInt',
+      schema: () =>
+        z3.intersection(
+          z3.lazy(() => z3.coerce.bigint().nullable().readonly()),
+          z3.number().nullable(),
+        ),
+    },
+    {
+      name: 'nullable nested object properties',
+      schema: () =>
+        z3.intersection(
+          z3.object({ count: z3.coerce.bigint().nullable() }),
+          z3.object({ count: z3.number().nullable() }),
+        ),
+    },
+    {
+      name: 'nullable array items',
+      schema: () =>
+        z3.intersection(z3.array(z3.coerce.bigint().nullable()), z3.array(z3.number().nullable())),
+    },
+    {
+      name: 'explicit null unions',
+      schema: () =>
+        z3.intersection(z3.union([z3.null(), z3.coerce.bigint()]), z3.union([z3.null(), z3.number()])),
+    },
+  ])('rejects incompatible non-null $name intersection outputs', ({ schema }) => {
+    expect(() => create(z3.object({ value: schema() }))).toThrow('incompatible parsed outputs');
+  });
+
+  it('preserves compatible nullable numeric intersection outputs', () => {
+    const nullable = create(
+      z3.object({ value: z3.intersection(z3.number().nullable(), z3.number().nullable()) }),
+    );
+
+    expect(nullable.$parseRaw('{"value":7}')).toEqual({ value: 7 });
+    expect(nullable.$parseRaw('{"value":null}')).toEqual({ value: null });
+  });
+
+  it.each([
+    {
       name: 'coerced BigInt before number',
       schema: () => z3.intersection(z3.coerce.bigint(), z3.number()),
     },
@@ -1928,6 +2040,48 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
 
   it.each([
     {
+      name: 'two direct numeric transforms',
+      schema: (first: (value: number) => number, second: (value: number) => number) =>
+        z3.intersection(z3.number().transform(first), z3.number().transform(second)).pipe(z3.number()),
+    },
+    {
+      name: 'readonly lazy numeric transforms',
+      schema: (first: (value: number) => number, second: (value: number) => number) =>
+        z3
+          .intersection(
+            z3.lazy(() => z3.number().transform(first).readonly()),
+            z3.number().transform(second),
+          )
+          .pipe(z3.number()),
+    },
+    {
+      name: 'nullable downstream output',
+      schema: (first: (value: number) => number, second: (value: number) => number) =>
+        z3
+          .intersection(z3.number().transform(first), z3.number().transform(second))
+          .pipe(z3.number().nullable()),
+    },
+    {
+      name: 'nested object transforms',
+      schema: (first: (value: number) => number, second: (value: number) => number) =>
+        z3
+          .intersection(
+            z3.object({ count: z3.number().transform(first) }),
+            z3.object({ count: z3.number().transform(second) }),
+          )
+          .pipe(z3.object({ count: z3.number() })),
+    },
+  ])('rejects $name before a downstream pipeline can validate opaque values', ({ schema }) => {
+    const first = vi.fn(() => 1);
+    const second = vi.fn(() => 2);
+
+    expect(() => create(z3.object({ value: schema(first, second) }))).toThrow('incompatible parsed outputs');
+    expect(first).not.toHaveBeenCalled();
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
       name: 'opaque arm before a numeric arm',
       schema: (convert: (value: number) => bigint) =>
         z3.intersection(z3.number().transform(convert), z3.number()).pipe(z3.number()),
@@ -2028,6 +2182,68 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     const value = z3.intersection(z3.coerce.bigint().catch(fallback), z3.number());
 
     expect(() => create(z3.object({ value }))).toThrow('incompatible parsed outputs');
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: 'caught refinement before number',
+      schema: (refine: (value: number) => boolean) =>
+        z3.intersection(z3.number().refine(refine).catch(0), z3.number()),
+    },
+    {
+      name: 'number before a caught refinement',
+      schema: (refine: (value: number) => boolean) =>
+        z3.intersection(z3.number(), z3.number().refine(refine).catch(0)),
+    },
+    {
+      name: 'readonly lazy caught refinement',
+      schema: (refine: (value: number) => boolean) =>
+        z3.intersection(
+          z3.lazy(() => z3.number().refine(refine).catch(0).readonly()),
+          z3.number(),
+        ),
+    },
+    {
+      name: 'nested object caught refinement',
+      schema: (refine: (value: number) => boolean) =>
+        z3.intersection(
+          z3.object({ count: z3.number().refine(refine).catch(0) }),
+          z3.object({ count: z3.number() }),
+        ),
+    },
+    {
+      name: 'nested array caught refinement',
+      schema: (refine: (value: number) => boolean) =>
+        z3.intersection(z3.array(z3.number().refine(refine).catch(0)), z3.array(z3.number())),
+    },
+    {
+      name: 'caught object with a nested refinement',
+      schema: (refine: (value: number) => boolean) =>
+        z3.intersection(
+          z3.object({ count: z3.number().refine(refine) }).catch({ count: 0 }),
+          z3.object({ count: z3.number() }),
+        ),
+    },
+    {
+      name: 'caught array with a nested refinement',
+      schema: (refine: (value: number) => boolean) =>
+        z3.intersection(z3.array(z3.number().refine(refine)).catch([0]), z3.array(z3.number())),
+    },
+  ])('rejects an opaque $name intersection fallback without invoking refinements', ({ schema }) => {
+    const refine = vi.fn(() => false);
+
+    expect(() => create(z3.object({ value: schema(refine) }))).toThrow('incompatible parsed outputs');
+    expect(refine).not.toHaveBeenCalled();
+  });
+
+  it('inspects caught refinement outputs without invoking fallback callbacks', () => {
+    const refine = vi.fn(() => false);
+    const fallback = vi.fn(() => 0);
+    const value = z3.intersection(z3.number().refine(refine).catch(fallback), z3.number());
+
+    expect(() => create(z3.object({ value }))).toThrow('incompatible parsed outputs');
+    expect(refine).not.toHaveBeenCalled();
     expect(fallback).not.toHaveBeenCalled();
   });
 
@@ -2849,6 +3065,61 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     },
   );
 
+  it.each([
+    {
+      name: 'checked nullable number',
+      input: () => z3.number().min(0),
+      output: () => z3.number().min(0).nullable(),
+      valid: 7,
+      invalid: -1,
+      expected: { type: 'number', minimum: 0 },
+    },
+    {
+      name: 'readonly nullable number',
+      input: () => z3.number().min(0).readonly(),
+      output: () => z3.number().min(0).nullable().readonly(),
+      valid: 7,
+      invalid: -1,
+      expected: { type: 'number', minimum: 0 },
+    },
+    {
+      name: 'explicit null-first numeric union',
+      input: () => z3.number().min(0),
+      output: () => z3.union([z3.null(), z3.number().min(0)]),
+      valid: 7,
+      invalid: -1,
+      expected: { type: 'number', minimum: 0 },
+    },
+    {
+      name: 'incompatible string alternative',
+      input: () => z3.number().min(0),
+      output: () => z3.union([z3.string().min(1), z3.number().min(0)]),
+      valid: 7,
+      invalid: -1,
+      expected: { type: 'number', minimum: 0 },
+    },
+    {
+      name: 'checked nullable string',
+      input: () => z3.string().min(2),
+      output: () => z3.string().min(2).nullable(),
+      valid: 'safe',
+      invalid: 'x',
+      expected: { type: 'string', minLength: 2 },
+    },
+  ])(
+    'retains only reachable $name pipeline output alternatives',
+    ({ input, output, valid, invalid, expected }) => {
+      const result = create(z3.object({ value: input().pipe(output()) }));
+
+      expect(strictHelperSchema(result)).toHaveProperty(
+        'properties.value',
+        expect.objectContaining(expected),
+      );
+      expect(result.$parseRaw(JSON.stringify({ value: valid }))).toEqual({ value: valid });
+      expect(() => result.$parseRaw(JSON.stringify({ value: invalid }))).toThrow();
+    },
+  );
+
   it('projects every constrained BigInt pipeline output alternative onto numeric input', () => {
     const value = z3
       .number()
@@ -3001,6 +3272,54 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
 
   it.each([
     {
+      name: 'trim before a minimum',
+      schema: () => z3.string().trim().pipe(z3.string().min(2)),
+    },
+    {
+      name: 'lowercase before a literal',
+      schema: () => z3.string().toLowerCase().pipe(z3.literal('ABC')),
+    },
+    {
+      name: 'uppercase before an enum',
+      schema: () =>
+        z3
+          .string()
+          .toUpperCase()
+          .pipe(z3.enum(['abc'])),
+    },
+    {
+      name: 'readonly trim',
+      schema: () => z3.string().trim().readonly().pipe(z3.string().min(2)),
+    },
+    {
+      name: 'lazy lowercase',
+      schema: () => z3.lazy(() => z3.string().toLowerCase()).pipe(z3.string().regex(/^ABC$/u)),
+    },
+    {
+      name: 'nested object trim',
+      schema: () => z3.object({ text: z3.string().trim() }).pipe(z3.object({ text: z3.string().min(2) })),
+    },
+    {
+      name: 'nested array uppercase',
+      schema: () => z3.array(z3.string().toUpperCase()).pipe(z3.array(z3.string().regex(/^lower$/u))),
+    },
+  ])('rejects a value-changing $name before constrained pipeline output validation', ({ schema }) => {
+    expect(() => create(z3.object({ value: schema() }))).toThrow(
+      'cannot be safely projected across an opaque transform',
+    );
+  });
+
+  it.each([
+    { name: 'trim', input: () => z3.string().trim(), raw: ' a ', parsed: 'a' },
+    { name: 'lowercase', input: () => z3.string().toLowerCase(), raw: 'SAFE', parsed: 'safe' },
+    { name: 'uppercase', input: () => z3.string().toUpperCase(), raw: 'safe', parsed: 'SAFE' },
+  ])('preserves an unconstrained $name string pipeline output', ({ input, raw, parsed }) => {
+    const result = create(z3.object({ value: input().pipe(z3.string()) }));
+    expect(result.$parseRaw(JSON.stringify({ value: raw }))).toEqual({ value: parsed });
+  });
+
+  it.each([
+    {
       name: 'value-changing transform',
       input: () => z3.number().transform((value) => -value),
     },
@@ -3016,9 +3335,16 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     expect(unconstrained.$parseRaw('{"value":-1}')).toEqual({ value: 1 });
   });
 
-  it('rejects compound pipeline outputs that cannot be projected without losing constraints', () => {
+  it('projects a nullable native output through a known exact BigInt conversion', () => {
     const value = z3.number().transform(BigInt).pipe(z3.bigint().max(10n).nullable());
-    expect(() => create(z3.object({ value }))).toThrow('ZodPipeline output constraints');
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty(
+      'properties.value',
+      expect.objectContaining({ type: 'integer', maximum: 10 }),
+    );
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
+    expect(() => result.$parseRaw('{"value":11}')).toThrow();
   });
 
   it('rejects converting output constraints that cannot be projected onto their input', () => {

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import {
   zodFunction,
   zodRealtimeFunction,
@@ -184,6 +185,8 @@ describe('Zod v3 strict schema capability analysis', () => {
     {
       name: 'direct',
       schema: () => z3.object({ count: z3.coerce.bigint() }).default(new DefaultCounter()),
+      normalized: { count: 4 },
+      parsed: { count: 4n },
     },
     {
       name: 'nested',
@@ -191,9 +194,67 @@ describe('Zod v3 strict schema capability analysis', () => {
         z3.object({ detail: z3.object({ count: z3.coerce.bigint() }) }).default({
           detail: new DefaultCounter(),
         }),
+      normalized: { detail: { count: 4 } },
+      parsed: { detail: { count: 4n } },
     },
-  ])('rejects a $name custom-prototype default before JSON serialization', ({ schema }) => {
-    expect(() => formatFor(schema())).toThrow('custom-prototype');
+  ])(
+    'normalizes safe $name class-instance default data without invoking user code',
+    ({ schema, normalized, parsed }) => {
+      const format = formatFor(schema());
+      expect(format.json_schema.schema).toHaveProperty('properties.value.default', normalized);
+      expect(format.$parseRaw('{}')).toEqual({ value: parsed });
+      expect(() => JSON.stringify(format)).not.toThrow();
+    },
+  );
+
+  it.each([
+    {
+      name: 'plain serializer',
+      create: (hook: () => unknown) => ({ count: 4, toJSON: hook }),
+      message: 'toJSON',
+    },
+    {
+      name: 'inherited serializer',
+      create: (hook: () => unknown) => Object.assign(Object.create({ toJSON: hook }), { count: 4 }),
+      message: 'toJSON',
+    },
+    {
+      name: 'accessor',
+      create: (hook: () => unknown) => Object.defineProperty({}, 'count', { enumerable: true, get: hook }),
+      message: 'accessor',
+    },
+  ])('rejects a default $name hook without executing it', ({ create, message }) => {
+    const hook = vi.fn(() => {
+      throw new Error('must never run');
+    });
+    expect(() => formatFor(z3.any().default(create(hook)))).toThrow(message);
+    expect(hook).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: 'function', value: () => () => 4 },
+    { name: 'symbol', value: () => Symbol('default') },
+    { name: 'undefined', value: () => Object.getOwnPropertyDescriptor({}, 'missing') },
+  ])('rejects non-JSON $name values inside safe class data', ({ value }) => {
+    const instance = Object.assign(Object.create({ label: 'class' }), { count: value() });
+    expect(() => formatFor(z3.any().default(instance))).toThrow('non-JSON');
+  });
+
+  it.each([
+    { name: 'invalid timestamp', value: () => new Date(Number.NaN) },
+    {
+      name: 'subclass',
+      value: () => Object.setPrototypeOf(new Date('2026-08-17T00:00:00.000Z'), Object.create(Date.prototype)),
+    },
+    {
+      name: 'own serializer',
+      value: () =>
+        Object.defineProperty(new Date('2026-08-17T00:00:00.000Z'), 'toJSON', {
+          value: () => ({ value: 'unsafe' }),
+        }),
+    },
+  ])('rejects a noncanonical $name Date default', ({ value }) => {
+    expect(() => formatFor(z3.coerce.date().default(value()))).toThrow('invalid or customized');
   });
 
   it.each([
@@ -280,6 +341,24 @@ describe('Zod v3 strict schema capability analysis', () => {
       normalized: 4,
     },
     {
+      name: 'unmatched numeric literal',
+      schema: () => z3.union([z3.literal(5), z3.coerce.bigint()]).default(4n),
+      output: 4n,
+      normalized: 4,
+    },
+    {
+      name: 'unmatched native enum',
+      schema: () => z3.union([z3.nativeEnum({ Five: 5 } as const), z3.coerce.bigint()]).default(4n),
+      output: 4n,
+      normalized: 4,
+    },
+    {
+      name: 'disjoint numeric minimum',
+      schema: () => z3.union([z3.number().min(5), z3.coerce.bigint()]).default(4n),
+      output: 4n,
+      normalized: 4,
+    },
+    {
       name: 'nested object union',
       schema: () =>
         z3.union([z3.object({ count: z3.coerce.bigint() }), z3.object({ count: z3.string() })]).default({
@@ -331,6 +410,14 @@ describe('Zod v3 strict schema capability analysis', () => {
   it.each([
     { name: 'number', schema: () => z3.union([z3.number(), z3.coerce.bigint()]).default(4n) },
     { name: 'any', schema: () => z3.union([z3.any(), z3.coerce.bigint()]).default(4n) },
+    {
+      name: 'matching literal',
+      schema: () => z3.union([z3.literal(4), z3.coerce.bigint()]).default(4n),
+    },
+    {
+      name: 'matching native enum',
+      schema: () => z3.union([z3.nativeEnum({ Four: 4 } as const), z3.coerce.bigint()]).default(4n),
+    },
     {
       name: 'nested number',
       schema: () =>
@@ -618,6 +705,22 @@ describe('Zod v3 strict schema capability analysis', () => {
       path: ['properties', 'count'],
     },
     {
+      name: 'exact BigInt object transform',
+      producer: () => z3.object({ count: z3.number().transform(BigInt) }),
+      consumer: () => z3.object({ count: z3.number() }),
+      input: { count: 7 },
+      output: { count: 7n },
+      path: ['properties', 'count'],
+    },
+    {
+      name: 'exact BigInt array transform',
+      producer: () => z3.array(z3.number().transform(BigInt)),
+      consumer: () => z3.array(z3.number()),
+      input: [7],
+      output: [7n],
+      path: ['items'],
+    },
+    {
       name: 'array items',
       producer: () => z3.array(z3.coerce.bigint()),
       consumer: () => z3.array(z3.number()),
@@ -856,6 +959,29 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
   });
 
+  it.each([
+    { name: 'direct', producer: () => z3.number().transform(BigInt) },
+    { name: 'readonly', producer: () => z3.number().transform(BigInt).readonly() },
+    { name: 'lazy', producer: () => z3.lazy(() => z3.number().transform(BigInt)) },
+  ])('bounds later numbers after an exact $name BigInt transform producer', ({ producer }) => {
+    const result = create(z3.object({ value: z3.union([producer(), z3.number()]) }));
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1', {
+      type: 'number',
+      minimum: Number.MIN_SAFE_INTEGER,
+      maximum: Number.MAX_SAFE_INTEGER,
+    });
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
+  });
+
+  it('preserves numeric intervals disjoint from an exact bounded BigInt transform', () => {
+    const value = z3.union([z3.number().max(10).transform(BigInt), z3.number().min(1e20)]);
+    const result = create(z3.object({ value }));
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1', {
+      type: 'number',
+      minimum: 1e20,
+    });
+  });
+
   it('rejects compound inputs that the built-in BigInt transform cannot safely represent', () => {
     const value = z3.union([z3.number(), z3.string()]).transform(BigInt);
     expect(() => create(z3.object({ value }))).toThrow('directly representable numeric JSON input');
@@ -872,10 +998,22 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
   });
 
   it.each([
-    { name: 'BigInt', schema: () => z3.number().transform((value) => BigInt(Math.trunc(value))) },
-    { name: 'string', schema: () => z3.number().transform((value) => `number: ${value}`) },
-  ])('rejects opaque numeric $name transforms without an inspectable output type', ({ schema }) => {
-    expect(() => create(z3.object({ value: schema() }))).toThrow('no inspectable output type');
+    { name: 'BigInt', schema: () => z3.number().transform((value) => BigInt(Math.trunc(value))), output: 7n },
+    {
+      name: 'string',
+      schema: () => z3.number().transform((value) => `number: ${value}`),
+      output: 'number: 7',
+    },
+    { name: 'object', schema: () => z3.number().transform((value) => ({ value })), output: { value: 7 } },
+  ])('preserves standalone opaque numeric $name transform input compatibility', ({ schema, output }) => {
+    const result = create(z3.object({ value: schema() }));
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value', { type: 'number' });
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: output });
+  });
+
+  it('rejects a synchronously recoverable Promise catch rather than silently omitting its union branch', () => {
+    const fallback = z3.promise(z3.number()).catch(7 as unknown as Promise<number>);
+    expect(() => create(z3.object({ value: z3.union([fallback, z3.number()]) }))).toThrow('ZodPromise');
   });
 
   it.each([
@@ -1262,6 +1400,23 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
     expect(result.$parseRaw('{"value":101}')).toEqual({ value: 101n });
     expect(() => result.$parseRaw('{"value":50}')).toThrow();
+  });
+
+  it.each([
+    {
+      name: 'value-changing transform',
+      input: () => z3.number().transform((value) => -value),
+    },
+    {
+      name: 'value-changing preprocessor',
+      input: () => z3.preprocess((value) => (typeof value === 'number' ? -value : value), z3.number()),
+    },
+  ])('rejects constrained outputs after an opaque $name', ({ input }) => {
+    expect(() => create(z3.object({ value: input().pipe(z3.number().min(0)) }))).toThrow(
+      'cannot be safely projected across an opaque transform',
+    );
+    const unconstrained = create(z3.object({ value: input().pipe(z3.number()) }));
+    expect(unconstrained.$parseRaw('{"value":-1}')).toEqual({ value: 1 });
   });
 
   it('rejects compound pipeline outputs that cannot be projected without losing constraints', () => {

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -1344,6 +1344,38 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
   });
 
   it.each([
+    { name: 'direct', schema: () => z3.boolean().transform(BigInt) },
+    { name: 'readonly', schema: () => z3.boolean().transform(BigInt).readonly() },
+    { name: 'lazy', schema: () => z3.lazy(() => z3.boolean().transform(BigInt)) },
+  ])('preserves the exact boolean input of a $name BigInt transform', ({ schema }) => {
+    const result = create(z3.object({ value: schema() }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value', { type: 'boolean' });
+    expect(result.$parseRaw('{"value":true}')).toEqual({ value: 1n });
+    expect(result.$parseRaw('{"value":false}')).toEqual({ value: 0n });
+  });
+
+  it('preserves null beside a boolean BigInt transform', () => {
+    const result = create(z3.object({ value: z3.boolean().transform(BigInt).nullable() }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.0', { type: 'boolean' });
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1', { type: 'null' });
+    expect(result.$parseRaw('{"value":true}')).toEqual({ value: 1n });
+    expect(result.$parseRaw('{"value":false}')).toEqual({ value: 0n });
+    expect(result.$parseRaw('{"value":null}')).toEqual({ value: null });
+  });
+
+  it('preserves independent numeric alternatives beside a boolean BigInt transform', () => {
+    const value = z3.union([z3.boolean().transform(BigInt), z3.number()]);
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.0', { type: 'boolean' });
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1', { type: 'number' });
+    expect(result.$parseRaw('{"value":false}')).toEqual({ value: 0n });
+    expect(result.$parseRaw('{"value":1.5}')).toEqual({ value: 1.5 });
+  });
+
+  it.each([
     { name: 'direct', producer: () => z3.coerce.bigint() },
     { name: 'readonly', producer: () => z3.coerce.bigint().readonly() },
     { name: 'lazy', producer: () => z3.lazy(() => z3.coerce.bigint()) },
@@ -1517,6 +1549,66 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
 
   it.each([
     {
+      name: 'exclusive producer minimum',
+      producer: () => z3.number().gt(0.5).max(0.5),
+      fallback: () => z3.number(),
+      input: 1.5,
+    },
+    {
+      name: 'exclusive producer maximum',
+      producer: () => z3.number().min(0.5).lt(0.5),
+      fallback: () => z3.number(),
+      input: 1.5,
+    },
+    {
+      name: 'both exclusive producer endpoints',
+      producer: () => z3.number().gt(0.5).lt(0.5),
+      fallback: () => z3.number(),
+      input: 1.5,
+    },
+    {
+      name: 'exclusive producer and inclusive fallback endpoint',
+      producer: () => z3.number().gt(0.5),
+      fallback: () => z3.number().max(0.5),
+      input: 0.5,
+    },
+    {
+      name: 'inclusive producer and exclusive fallback endpoint',
+      producer: () => z3.number().max(0.5),
+      fallback: () => z3.number().gt(0.5),
+      input: 1.5,
+    },
+  ])('preserves fractional fallback across an empty $name overlap', ({ producer, fallback, input }) => {
+    const result = create(z3.object({ value: z3.union([producer().transform(BigInt), fallback()]) }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1.type', 'number');
+    expect(result.$parseRaw(JSON.stringify({ value: input }))).toEqual({ value: input });
+  });
+
+  it('preserves nested fractional fallback when exclusive producer bounds are empty', () => {
+    const value = z3.union([
+      z3.object({ count: z3.number().gt(0.5).max(0.5).transform(BigInt) }),
+      z3.object({ count: z3.number() }),
+    ]);
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty(
+      'properties.value.anyOf.1.properties.count.type',
+      'number',
+    );
+    expect(result.$parseRaw('{"value":{"count":1.5}}')).toEqual({ value: { count: 1.5 } });
+  });
+
+  it('keeps narrowing an inclusive fractional singleton that invokes BigInt', () => {
+    const value = z3.union([z3.number().min(0.5).max(0.5).transform(BigInt), z3.number()]);
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1.type', 'integer');
+    expect(() => result.$parseRaw('{"value":0.5}')).toThrow(RangeError);
+  });
+
+  it.each([
+    {
       name: 'coerced BigInt before number',
       schema: () => z3.intersection(z3.coerce.bigint(), z3.number()),
     },
@@ -1527,6 +1619,26 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     {
       name: 'wrapped exact BigInt transform',
       schema: () => z3.intersection(z3.number().transform(BigInt).readonly(), z3.number()),
+    },
+    {
+      name: 'optional coerced BigInt before number',
+      schema: () => z3.intersection(z3.coerce.bigint().optional(), z3.number()),
+    },
+    {
+      name: 'number before optional coerced BigInt',
+      schema: () => z3.intersection(z3.number(), z3.coerce.bigint().optional()),
+    },
+    {
+      name: 'readonly optional coerced BigInt',
+      schema: () => z3.intersection(z3.coerce.bigint().optional().readonly(), z3.number()),
+    },
+    {
+      name: 'optional preprocessed BigInt literal',
+      schema: () =>
+        z3.intersection(
+          z3.preprocess((value) => BigInt(value as number), z3.literal(1n)).optional(),
+          z3.literal(1),
+        ),
     },
     {
       name: 'preprocessed BigInt and number literals',
@@ -1591,6 +1703,13 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     },
   ])('rejects intersections with incompatible $name parsed outputs', ({ schema }) => {
     expect(() => create(z3.object({ value: schema() }))).toThrow('incompatible parsed outputs');
+  });
+
+  it('preserves intersections with compatible optional numeric outputs', () => {
+    const result = create(z3.object({ value: z3.intersection(z3.number().optional(), z3.number()) }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.type', 'number');
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7 });
   });
 
   it.each([

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -196,6 +196,18 @@ describe('Zod v3 strict schema capability analysis', () => {
     expect(entries).not.toHaveBeenCalled();
   });
 
+  it('rejects inherited indexed array accessors without invoking their getters', () => {
+    const getter = vi.fn(() => 4n);
+    const prototype = Object.create(Array.prototype) as object;
+    Object.defineProperty(prototype, '0', { get: getter });
+    const sparse: bigint[] = [];
+    sparse.length = 1;
+    const value = Object.setPrototypeOf(sparse, prototype) as bigint[];
+
+    expect(() => formatFor(z3.array(z3.coerce.bigint()).default(value))).toThrow('array index');
+    expect(getter).not.toHaveBeenCalled();
+  });
+
   it.each([
     {
       name: 'direct',
@@ -244,6 +256,17 @@ describe('Zod v3 strict schema capability analysis', () => {
     });
     expect(() => formatFor(z3.any().default(create(hook)))).toThrow(message);
     expect(hook).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: 'BigInt', value: () => Reflect.construct(Object, [4n]) as object },
+    { name: 'Symbol', value: () => Reflect.construct(Object, [Symbol('default')]) as object },
+    { name: 'Number', value: () => Reflect.construct(Object, [4]) as object },
+    { name: 'String', value: () => Reflect.construct(Object, ['default']) as object },
+    { name: 'Boolean', value: () => Reflect.construct(Object, [true]) as object },
+  ])('rejects a boxed $name primitive default before normalizing objects', ({ value }) => {
+    expect(() => formatFor(z3.any().default(value()))).toThrow('boxed primitive');
+    expect(() => formatFor(z3.any().default({ nested: value() }))).toThrow('boxed primitive');
   });
 
   it.each([
@@ -1178,6 +1201,27 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
       name: 'wrapped exact BigInt transform',
       schema: () => z3.intersection(z3.number().transform(BigInt).readonly(), z3.number()),
     },
+    {
+      name: 'nested object BigInt and number',
+      schema: () =>
+        z3.intersection(z3.object({ value: z3.coerce.bigint() }), z3.object({ value: z3.number() })),
+    },
+    {
+      name: 'nested array object BigInt and number',
+      schema: () =>
+        z3.intersection(
+          z3.array(z3.object({ value: z3.coerce.bigint() })),
+          z3.array(z3.object({ value: z3.number() })),
+        ),
+    },
+    {
+      name: 'wrapped nested object outputs',
+      schema: () =>
+        z3.intersection(
+          z3.object({ value: z3.coerce.bigint() }).readonly(),
+          z3.object({ value: z3.number() }),
+        ),
+    },
   ])('rejects intersections with incompatible $name parsed outputs', ({ schema }) => {
     expect(() => create(z3.object({ value: schema() }))).toThrow('incompatible parsed outputs');
   });
@@ -1245,6 +1289,18 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
       value: () => z3.union([z3.promise(z3.string()), z3.number()]),
       schema: { type: 'number' },
       raw: '{"value":7}',
+    },
+    {
+      name: 'required tuple Promise',
+      value: () => z3.union([z3.tuple([z3.promise(z3.number())]), z3.string()]),
+      schema: { type: 'string' },
+      raw: '{"value":"valid"}',
+    },
+    {
+      name: 'nested required tuple Promise',
+      value: () => z3.union([z3.tuple([z3.object({ value: z3.promise(z3.number()) })]), z3.string()]),
+      schema: { type: 'string' },
+      raw: '{"value":"valid"}',
     },
   ])('omits an uncovered $name union branch from its synchronous input schema', ({ value, schema, raw }) => {
     const result = create(z3.object({ value: value() }));

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -130,6 +130,28 @@ describe('Zod v3 strict schema capability analysis', () => {
   });
 
   it.each([
+    {
+      name: 'direct',
+      output: () => z3.intersection(z3.string(), z3.date()),
+    },
+    {
+      name: 'lazy',
+      output: () =>
+        z3.intersection(
+          z3.string(),
+          z3.lazy(() => z3.date()),
+        ),
+    },
+  ])('rejects incompatible $name arms in a coercing pipeline output intersection', ({ output }) => {
+    expect(() => formatFor(z3.coerce.string().pipe(output()))).toThrow('ZodDate');
+  });
+
+  it('preserves compatible intersections and existential unions in coercing pipeline outputs', () => {
+    expect(formatFor(z3.coerce.string().pipe(z3.intersection(z3.string(), z3.string())))).toBeDefined();
+    expect(formatFor(z3.coerce.string().pipe(z3.union([z3.string(), z3.date()])))).toBeDefined();
+  });
+
+  it.each([
     { name: 'any value', schema: () => z3.any().default({ count: 4n }) },
     { name: 'unknown value', schema: () => z3.unknown().default({ count: 4n }) },
     { name: 'any property', schema: () => z3.object({ count: z3.any() }).default({ count: 4n }) },
@@ -214,6 +236,25 @@ describe('Zod v3 strict schema capability analysis', () => {
       expect(format.$parseRaw('{}')).toEqual({ value: output });
     },
   );
+
+  it.each([
+    { name: 'branded', wrap: (schema: z3.ZodTypeAny) => schema.brand<'number-branch'>() },
+    { name: 'readonly', wrap: (schema: z3.ZodTypeAny) => schema.readonly() },
+    { name: 'refinement', wrap: (schema: z3.ZodTypeAny) => schema.refine(() => true) },
+    { name: 'defaulted', wrap: (schema: z3.ZodTypeAny) => schema.default({ kind: 'number', count: 0 }) },
+    { name: 'lazy', wrap: (schema: z3.ZodTypeAny) => z3.lazy(() => schema) },
+  ])('matches discriminators through a transparent $name union option', ({ wrap }) => {
+    const number = z3.object({ kind: z3.literal('number'), count: z3.number() });
+    const bigint = z3.object({ kind: z3.literal('bigint'), count: z3.coerce.bigint() });
+    const value = z3.union([wrap(number), bigint]).default({ kind: 'bigint', count: 4n });
+    const format = formatFor(value);
+
+    expect(format.json_schema.schema).toHaveProperty('properties.value.default', {
+      kind: 'bigint',
+      count: 4,
+    });
+    expect(format.$parseRaw('{}')).toEqual({ value: { kind: 'bigint', count: 4n } });
+  });
 
   it.each([
     { name: 'number', schema: () => z3.union([z3.number(), z3.coerce.bigint()]).default(4n) },
@@ -362,7 +403,7 @@ describe('Zod v3 strict schema capability analysis', () => {
     expect(format.json_schema.schema).toMatchObject({
       properties: {
         value: {
-          anyOf: [expect.anything(), { type: 'number' }],
+          anyOf: [{ type: 'number' }],
         },
       },
     });
@@ -666,6 +707,7 @@ describe('Zod v3 strict schema capability analysis', () => {
 describe.each(strictHelpers)('$name strict numeric input capability analysis', ({ create }) => {
   it.each([
     { name: 'direct BigInt', schema: () => z3.number().int().transform(BigInt) },
+    { name: 'unrestricted BigInt', schema: () => z3.number().transform(BigInt) },
     {
       name: 'wrapped BigInt',
       schema: () => z3.number().int().transform(BigInt).nullable(),
@@ -681,6 +723,7 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
       : property;
 
     expect(value).toMatchObject({
+      type: 'integer',
       minimum: Number.MIN_SAFE_INTEGER,
       maximum: Number.MAX_SAFE_INTEGER,
     });
@@ -710,6 +753,30 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     { name: 'pipeline output', schema: () => z3.string().pipe(z3.promise(z3.string())) },
   ])('rejects a synchronously unparseable $name Promise field', ({ schema }) => {
     expect(() => create(z3.object({ value: schema() }))).toThrow('ZodPromise');
+  });
+
+  it.each([
+    {
+      name: 'numeric Promise',
+      value: () => z3.union([z3.promise(z3.number()), z3.string()]),
+      schema: { type: 'string' },
+      raw: '{"value":"valid"}',
+    },
+    {
+      name: 'string Promise',
+      value: () => z3.union([z3.promise(z3.string()), z3.number()]),
+      schema: { type: 'number' },
+      raw: '{"value":7}',
+    },
+  ])('omits an uncovered $name union branch from its synchronous input schema', ({ value, schema, raw }) => {
+    const result = create(z3.object({ value: value() }));
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf', [schema]);
+    expect(() => result.$parseRaw(raw)).not.toThrow();
+  });
+
+  it('rejects a union whose options all require asynchronous Promise inputs', () => {
+    const value = z3.union([z3.promise(z3.string()), z3.lazy(() => z3.promise(z3.number()))]);
+    expect(() => create(z3.object({ value }))).toThrow('ZodPromise');
   });
 
   it.each([
@@ -918,6 +985,31 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
       expect(JSON.stringify(strictHelperSchema(result))).not.toContain('"allOf"');
     },
   );
+
+  it.each([
+    {
+      name: 'array',
+      schema: () => {
+        const shared = z3.array(z3.number().min(1));
+        return shared.pipe(shared);
+      },
+      path: 'properties.value.items.minimum',
+      expected: 1,
+    },
+    {
+      name: 'object',
+      schema: () => {
+        const shared = z3.object({ count: z3.number().max(9) });
+        return shared.pipe(shared);
+      },
+      path: 'properties.value.properties.count.maximum',
+      expected: 9,
+    },
+  ])('merges a shared $name pipeline input and output reference', ({ schema, path, expected }) => {
+    const result = create(z3.object({ value: schema() }));
+    expect(strictHelperSchema(result)).toHaveProperty(path, expected);
+    expect(JSON.stringify(strictHelperSchema(result))).not.toContain('"allOf"');
+  });
 
   it.each([
     {

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -422,6 +422,19 @@ describe('Zod v3 strict schema capability analysis', () => {
     expect(() => JSON.stringify(format)).not.toThrow();
   });
 
+  it('preserves non-finite literals and native enums in non-strict realtime schemas', () => {
+    const realtime = zodRealtimeFunction({
+      name: 'realtime',
+      parameters: z3.object({
+        literal: z3.literal(Infinity),
+        native: z3.nativeEnum({ NonFinite: -Infinity, Finite: 7 } as const),
+      }),
+    });
+
+    expect(realtime.parameters).toHaveProperty('properties.literal.const', Infinity);
+    expect(realtime.parameters).toHaveProperty('properties.native.enum', [-Infinity, 7]);
+  });
+
   it.each([Infinity, -Infinity, Number.NaN])('rejects a non-finite numeric default %s', (value) => {
     expect(() => formatFor(z3.number().default(value))).toThrow('non-finite');
     expect(() => formatFor(z3.any().default({ nested: [value] }))).toThrow('non-finite');
@@ -1190,6 +1203,48 @@ describe('Zod v3 strict schema capability analysis', () => {
 });
 
 describe.each(strictHelpers)('$name strict numeric input capability analysis', ({ create }) => {
+  it.each([
+    { name: 'literal', schema: (value: number) => z3.literal(value) },
+    { name: 'readonly literal', schema: (value: number) => z3.literal(value).readonly() },
+    { name: 'nullable literal', schema: (value: number) => z3.literal(value).nullable() },
+    {
+      name: 'compact literal union',
+      schema: (value: number) => z3.union([z3.literal(value), z3.literal(7)]),
+    },
+    {
+      name: 'mixed literal union',
+      schema: (value: number) => z3.union([z3.literal(value), z3.literal('finite')]),
+    },
+    {
+      name: 'native enum',
+      schema: (value: number) => z3.nativeEnum({ NonFinite: value, Finite: 7 } as const),
+    },
+    {
+      name: 'wrapped native enum',
+      schema: (value: number) => z3.nativeEnum({ NonFinite: value, Finite: 7 } as const).readonly(),
+    },
+  ])('rejects non-finite numeric values in a $name schema', ({ schema }) => {
+    for (const value of [Infinity, -Infinity, Number.NaN]) {
+      expect(() => create(z3.object({ value: schema(value) }))).toThrow('non-finite');
+    }
+  });
+
+  it('preserves finite literals, compact literal unions, and native enum values', () => {
+    const finite = create(
+      z3.object({
+        literal: z3.literal(7),
+        union: z3.union([z3.literal(7), z3.literal(9)]),
+        native: z3.nativeEnum({ Seven: 7, Nine: 9 } as const),
+      }),
+    );
+
+    expect(finite.$parseRaw('{"literal":7,"union":9,"native":7}')).toEqual({
+      literal: 7,
+      union: 9,
+      native: 7,
+    });
+  });
+
   it.each([0n, -2n])('rejects an invalid BigInt multiple %s before emitting JSON Schema', (multiple) => {
     expect(() => create(z3.object({ value: z3.coerce.bigint().multipleOf(multiple) }))).toThrow(
       'strictly positive',

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -624,6 +624,24 @@ describe('Zod v3 strict schema capability analysis', () => {
     );
   });
 
+  it('bounds a finite numeric overlap beside an unrelated recursive string subtree', () => {
+    const metadata: z3.ZodTypeAny = z3.lazy(() =>
+      z3.object({ label: z3.string(), next: metadata.nullable() }),
+    );
+    const producer = z3.object({ count: z3.coerce.bigint(), meta: metadata });
+    const consumer = z3.object({ count: z3.number(), meta: metadata });
+    const format = formatFor(z3.union([producer, consumer]));
+
+    expect(format.json_schema.schema).toHaveProperty('properties.value.anyOf.1.properties.count', {
+      type: 'number',
+      minimum: Number.MIN_SAFE_INTEGER,
+      maximum: Number.MAX_SAFE_INTEGER,
+    });
+    expect(
+      format.$parseRaw('{"value":{"count":7,"meta":{"label":"outer","next":{"label":"inner","next":null}}}}'),
+    ).toEqual({ value: { count: 7n, meta: { label: 'outer', next: { label: 'inner', next: null } } } });
+  });
+
   it('preserves independently recursive and discriminator-separated numeric alternatives', () => {
     const bigintNode: z3.ZodTypeAny = z3.lazy(() =>
       z3.object({ kind: z3.literal('bigint'), value: z3.coerce.bigint(), next: bigintNode.nullable() }),

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -209,6 +209,34 @@ describe('Zod v3 strict schema capability analysis', () => {
   });
 
   it.each([
+    { name: 'BigInt', hidden: 4n, schema: () => z3.object({ count: z3.coerce.bigint() }) as z3.ZodTypeAny },
+    { name: 'string', hidden: 'secret', schema: () => z3.object({ count: z3.string() }) as z3.ZodTypeAny },
+  ])('rejects a non-enumerable declared $name default property', ({ hidden, schema }) => {
+    const value = Object.defineProperty({}, 'count', { value: hidden, enumerable: false });
+
+    expect(() => formatFor(schema().default(value))).toThrow(/non-enumerable.*count/u);
+  });
+
+  it('rejects nested hidden schema properties without invoking their getters', () => {
+    const getter = vi.fn(() => 4n);
+    const hidden = Object.defineProperty({}, 'count', { get: getter, enumerable: false });
+    const value = z3
+      .object({ detail: z3.object({ count: z3.coerce.bigint() }) })
+      .default({ detail: hidden as { count: bigint } });
+
+    expect(() => formatFor(value)).toThrow('accessor');
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  it('preserves hidden metadata that is not a declared default schema property', () => {
+    const value = Object.defineProperty({ count: 7 }, 'metadata', { value: 4n, enumerable: false });
+    const format = formatFor(z3.object({ count: z3.number() }).default(value));
+
+    expect(format.$parseRaw('{}')).toEqual({ value: { count: 7 } });
+    expect(() => JSON.stringify(format)).not.toThrow();
+  });
+
+  it.each([
     {
       name: 'direct',
       schema: () => z3.object({ count: z3.coerce.bigint() }).default(new DefaultCounter()),
@@ -1347,6 +1375,33 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     const result = create(z3.object({ value: schema() }));
     expect(strictHelperSchema(result)).toHaveProperty('properties.value', { type: 'number' });
     expect(result.$parseRaw('{"value":7}')).toEqual({ value: output });
+  });
+
+  it.each([
+    {
+      name: 'preprocessor',
+      option: (convert: () => Promise<number>) => z3.preprocess(convert, z3.promise(z3.number())),
+    },
+    {
+      name: 'wrapped preprocessor',
+      option: (convert: () => Promise<number>) => z3.preprocess(convert, z3.promise(z3.number())).readonly(),
+    },
+    {
+      name: 'nested object preprocessor',
+      option: (convert: () => Promise<number>) =>
+        z3.object({ nested: z3.preprocess(convert, z3.promise(z3.number())) }),
+    },
+    {
+      name: 'pipeline transform',
+      option: (convert: () => Promise<number>) =>
+        z3.number().transform(convert).pipe(z3.promise(z3.number())),
+    },
+  ])('rejects a Promise union branch reachable through a $name', ({ option }) => {
+    const convert = vi.fn(() => Promise.resolve(1));
+    const value = z3.union([option(convert), z3.number()]);
+
+    expect(() => create(z3.object({ value }))).toThrow('ZodPromise');
+    expect(convert).not.toHaveBeenCalled();
   });
 
   it('rejects a synchronously recoverable Promise catch rather than silently omitting its union branch', () => {

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -51,6 +51,10 @@ const strictHelperSchema = (helper: ReturnType<(typeof strictHelpers)[number]['c
   return helper.parameters;
 };
 
+class DefaultCounter {
+  count = 4n;
+}
+
 interface RecursiveDateNode {
   when: Date;
   next: RecursiveDateNode | null;
@@ -174,6 +178,22 @@ describe('Zod v3 strict schema capability analysis', () => {
       properties: { values: { default: [4] }, detail: { default: { count: 5 } } },
     });
     expect(format.$parseRaw('{}')).toEqual({ values: [4n], detail: { count: 5n } });
+  });
+
+  it.each([
+    {
+      name: 'direct',
+      schema: () => z3.object({ count: z3.coerce.bigint() }).default(new DefaultCounter()),
+    },
+    {
+      name: 'nested',
+      schema: () =>
+        z3.object({ detail: z3.object({ count: z3.coerce.bigint() }) }).default({
+          detail: new DefaultCounter(),
+        }),
+    },
+  ])('rejects a $name custom-prototype default before JSON serialization', ({ schema }) => {
+    expect(() => formatFor(schema())).toThrow('custom-prototype');
   });
 
   it.each([
@@ -617,6 +637,24 @@ describe('Zod v3 strict schema capability analysis', () => {
       number: () => z3.object({ kind: z3.enum(['number']), count: z3.number().min(1e20) }),
       input: { kind: 'number', count: 1e20 },
     },
+    {
+      name: 'primitive number versus string',
+      bigint: () => z3.object({ kind: z3.number(), count: z3.coerce.bigint() }),
+      number: () => z3.object({ kind: z3.string(), count: z3.number().min(1e20) }),
+      input: { kind: 'number', count: 1e20 },
+    },
+    {
+      name: 'wrapped primitive boolean versus string',
+      bigint: () => z3.object({ kind: z3.boolean().readonly(), count: z3.coerce.bigint() }),
+      number: () => z3.object({ kind: z3.string().brand<'string-kind'>(), count: z3.number().min(1e20) }),
+      input: { kind: 'number', count: 1e20 },
+    },
+    {
+      name: 'nested primitive number versus string',
+      bigint: () => z3.object({ kind: z3.object({ type: z3.number() }), count: z3.coerce.bigint() }),
+      number: () => z3.object({ kind: z3.object({ type: z3.string() }), count: z3.number().min(1e20) }),
+      input: { kind: { type: 'number' }, count: 1e20 },
+    },
   ])(
     'preserves unsafe-range number branches separated by a $name discriminator',
     ({ bigint, number, input }) => {
@@ -628,6 +666,19 @@ describe('Zod v3 strict schema capability analysis', () => {
       expect(format.$parseRaw(JSON.stringify({ value: input }))).toEqual({ value: input });
     },
   );
+
+  it('keeps overlap bounds when a coercing discriminator accepts multiple JSON primitive types', () => {
+    const format = formatFor(
+      z3.union([
+        z3.object({ kind: z3.coerce.number(), count: z3.coerce.bigint() }),
+        z3.object({ kind: z3.string(), count: z3.number() }),
+      ]),
+    );
+    expect(format.json_schema.schema).toHaveProperty(
+      'properties.value.anyOf.1.properties.count.maximum',
+      Number.MAX_SAFE_INTEGER,
+    );
+  });
 
   it('preserves disjoint and one-sided nested numeric interception intervals', () => {
     const disjoint = formatFor(
@@ -772,6 +823,63 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     const result = create(z3.object({ value: value() }));
     expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf', [schema]);
     expect(() => result.$parseRaw(raw)).not.toThrow();
+  });
+
+  it.each([
+    {
+      name: 'object',
+      asynchronous: () => z3.object({ kind: z3.literal('async'), value: z3.promise(z3.number()) }),
+      synchronous: () => z3.object({ kind: z3.literal('sync'), value: z3.number() }),
+      value: { kind: 'sync', value: 7 },
+    },
+    {
+      name: 'nested object',
+      asynchronous: () =>
+        z3.object({
+          kind: z3.literal('async'),
+          detail: z3.object({ value: z3.promise(z3.number()) }),
+        }),
+      synchronous: () =>
+        z3.object({
+          kind: z3.literal('sync'),
+          detail: z3.object({ value: z3.number() }),
+        }),
+      value: { kind: 'sync', detail: { value: 7 } },
+    },
+    {
+      name: 'nonempty array',
+      asynchronous: () => z3.array(z3.promise(z3.number())).min(1),
+      synchronous: () => z3.array(z3.number()),
+      value: [7],
+    },
+  ])('omits a synchronously unreachable $name union container', ({ asynchronous, synchronous, value }) => {
+    const result = create(z3.object({ value: z3.union([asynchronous(), synchronous()]) }));
+    const branches = (
+      strictHelperSchema(result) as {
+        properties: { value: { anyOf: unknown[] } };
+      }
+    ).properties.value.anyOf;
+
+    expect(branches).toHaveLength(1);
+    expect(result.$parseRaw(JSON.stringify({ value }))).toEqual({ value });
+  });
+
+  it('preserves empty arrays and nulls that synchronously avoid Promise elements', () => {
+    const emptyArray = create(
+      z3.object({ value: z3.union([z3.array(z3.promise(z3.number())), z3.string()]) }),
+    );
+    const nullable = create(
+      z3.object({ value: z3.union([z3.promise(z3.number()).nullable(), z3.string()]) }),
+    );
+
+    expect(strictHelperSchema(emptyArray)).toHaveProperty('properties.value.anyOf.0', {
+      type: 'array',
+      items: {},
+      maxItems: 0,
+    });
+    expect(emptyArray.$parseRaw('{"value":[]}')).toEqual({ value: [] });
+    expect(nullable.$parseRaw('{"value":null}')).toEqual({ value: null });
+    expect(nullable.$parseRaw('{"value":"sync"}')).toEqual({ value: 'sync' });
   });
 
   it('rejects a union whose options all require asynchronous Promise inputs', () => {
@@ -1009,6 +1117,35 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     const result = create(z3.object({ value: schema() }));
     expect(strictHelperSchema(result)).toHaveProperty(path, expected);
     expect(JSON.stringify(strictHelperSchema(result))).not.toContain('"allOf"');
+  });
+
+  it.each([
+    { name: 'identical', input: ['a'] as const, output: ['a'] as const, expected: ['a'] },
+    {
+      name: 'reordered',
+      input: ['a', 'b'] as const,
+      output: ['b', 'a'] as const,
+      expected: ['a', 'b'],
+    },
+    {
+      name: 'overlapping',
+      input: ['a', 'b'] as const,
+      output: ['b', 'c'] as const,
+      expected: ['b'],
+    },
+  ])('intersects value-equivalent $name pipeline enum arrays', ({ input, output, expected }) => {
+    const result = create(z3.object({ value: z3.enum(input).pipe(z3.enum(output)) }));
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.enum', expected);
+    expect(() => result.$parseRaw(JSON.stringify({ value: expected[0] }))).not.toThrow();
+  });
+
+  it('rejects pipelines with disjoint enums or incompatible enum and literal constraints', () => {
+    expect(() => create(z3.object({ value: z3.enum(['a']).pipe(z3.enum(['b'])) }))).toThrow(
+      'ZodPipeline output constraints',
+    );
+    expect(() => create(z3.object({ value: z3.enum(['a']).pipe(z3.literal('b')) }))).toThrow(
+      'ZodPipeline output constraints',
+    );
   });
 
   it.each([

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -1,0 +1,233 @@
+import { zodResponseFormat } from 'openai/helpers/zod';
+import { z as z3 } from 'zod/v3';
+
+const formatFor = (value: z3.ZodTypeAny) => zodResponseFormat(z3.object({ value }), 'strict');
+
+interface RecursiveDateNode {
+  when: Date;
+  next: RecursiveDateNode | null;
+}
+
+const convertRegisteredDates = (value: unknown): unknown => {
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+  const input = value as { middle: { leaf: { when: string } } };
+  return { middle: { leaf: { when: new Date(input.middle.leaf.when) } } };
+};
+
+const convertRecursiveDates = (value: unknown): unknown => {
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+  const input = value as { when: string; next: unknown };
+  return { when: new Date(input.when), next: input.next === null ? null : convertRecursiveDates(input.next) };
+};
+
+describe('Zod v3 strict schema capability analysis', () => {
+  it.each([
+    {
+      name: 'union',
+      schema: () =>
+        z3
+          .union([
+            z3.string().transform((value) => new Date(value)),
+            z3.number().transform((value) => new Date(value)),
+          ])
+          .pipe(z3.date()),
+    },
+    {
+      name: 'lazy',
+      schema: () => z3.lazy(() => z3.string().transform((value) => new Date(value))).pipe(z3.date()),
+    },
+    {
+      name: 'intersection',
+      schema: () =>
+        z3
+          .intersection(
+            z3.string().transform((value) => new Date(value)),
+            z3.string().transform((value) => new Date(value)),
+          )
+          .pipe(z3.date()),
+    },
+  ])('recognizes native conversions inside $name pipeline inputs', ({ schema }) => {
+    expect(formatFor(schema()).$parseRaw('{"value":"2026-08-17T00:00:00.000Z"}')).toEqual({
+      value: new Date('2026-08-17T00:00:00.000Z'),
+    });
+  });
+
+  it('rejects compound pipelines when one union input does not convert', () => {
+    const value = z3.union([z3.string().transform((input) => new Date(input)), z3.number()]).pipe(z3.date());
+    expect(() => formatFor(value)).toThrow('ZodDate');
+  });
+
+  it.each([
+    { name: 'any value', schema: () => z3.any().default({ count: 4n }) },
+    { name: 'unknown value', schema: () => z3.unknown().default({ count: 4n }) },
+    { name: 'any property', schema: () => z3.object({ count: z3.any() }).default({ count: 4n }) },
+    { name: 'unknown array item', schema: () => z3.array(z3.unknown()).default([4n]) },
+    { name: 'any record value', schema: () => z3.record(z3.any()).default({ count: 4n }) },
+  ])('rejects nested BigInt defaults without a typed $name schema', ({ schema }) => {
+    expect(() => formatFor(schema())).toThrow('ZodBigInt');
+  });
+
+  it('preserves nested BigInt defaults in typed tuples and records', () => {
+    const format = zodResponseFormat(
+      z3.object({
+        tuple: z3.tuple([z3.coerce.bigint()]).default([4n]),
+        record: z3.record(z3.coerce.bigint()).default({ count: 5n }),
+      }),
+      'strict',
+    );
+
+    expect(format.json_schema.schema).toMatchObject({
+      properties: { tuple: { default: [4] }, record: { default: { count: 5 } } },
+    });
+    expect(format.$parseRaw('{}')).toEqual({ tuple: [4n], record: { count: 5n } });
+  });
+
+  it('bounds fallible numeric branches before BigInt coercion', () => {
+    const value = z3.union([z3.number().refine((input) => input < 100), z3.coerce.bigint()]);
+    const format = formatFor(value);
+
+    expect(format.json_schema.schema).toMatchObject({
+      properties: {
+        value: {
+          anyOf: [
+            { type: 'number', minimum: Number.MIN_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER },
+            { type: 'integer' },
+          ],
+        },
+      },
+    });
+    expect(format.$parseRaw('{"value":101}')).toEqual({ value: 101n });
+  });
+
+  it.each([
+    {
+      name: 'disjoint positive values',
+      bigint: () => z3.coerce.bigint().max(10n),
+      number: () => z3.number().min(1e20),
+      branch: { type: 'number', minimum: 1e20 },
+      input: 1e20,
+    },
+    {
+      name: 'only negative unsafe overlap',
+      bigint: () => z3.coerce.bigint().max(10n),
+      number: () => z3.number(),
+      branch: { type: 'number', minimum: Number.MIN_SAFE_INTEGER },
+      input: 1e20,
+    },
+    {
+      name: 'only positive unsafe overlap',
+      bigint: () => z3.coerce.bigint().min(-10n),
+      number: () => z3.number(),
+      branch: { type: 'number', maximum: Number.MAX_SAFE_INTEGER },
+      input: -1e20,
+    },
+    {
+      name: 'fully bounded BigInt values',
+      bigint: () => z3.coerce.bigint().min(-10n).max(10n),
+      number: () => z3.number(),
+      branch: { type: 'number' },
+      input: 1e20,
+    },
+  ])('preserves $name in later number alternatives', ({ bigint, number, branch, input }) => {
+    const format = formatFor(z3.union([bigint(), number()]));
+    const schema = format.json_schema.schema as {
+      properties: { value: { anyOf: Record<string, unknown>[] } };
+    };
+
+    expect(schema.properties.value.anyOf[1]).toEqual(branch);
+    expect(format.$parseRaw(JSON.stringify({ value: input }))).toEqual({ value: input });
+  });
+
+  it('bounds numbers after Promise-wrapped BigInt producers', async () => {
+    const value = z3.union([z3.promise(z3.coerce.bigint()), z3.number()]);
+    const format = formatFor(value);
+
+    expect(format.json_schema.schema).toMatchObject({
+      properties: {
+        value: {
+          anyOf: [
+            expect.anything(),
+            { type: 'number', minimum: Number.MIN_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER },
+          ],
+        },
+      },
+    });
+    await expect(value.parseAsync(7)).resolves.toBe(7n);
+  });
+
+  it.each([
+    { name: 'Date', schema: () => z3.date().catch(new Date(0)), input: 'fallback', output: new Date(0) },
+    { name: 'BigInt', schema: () => z3.bigint().catch(1n), input: 1, output: 1n },
+    {
+      name: 'Set',
+      schema: () => z3.set(z3.string()).catch(new Set(['fallback'])),
+      input: [],
+      output: new Set(['fallback']),
+    },
+    {
+      name: 'Map',
+      schema: () => z3.map(z3.string(), z3.number()).catch(new Map([['fallback', 1]])),
+      input: [],
+      output: new Map([['fallback', 1]]),
+    },
+  ])('treats typed $name catch fallbacks as native conversions', ({ schema, input, output }) => {
+    const format = formatFor(schema());
+    expect(format.$parseRaw(JSON.stringify({ value: input }))).toEqual({ value: output });
+    expect(() => JSON.stringify(format)).not.toThrow();
+  });
+
+  it('propagates preprocessing through reverse-ordered nested registered definitions', () => {
+    const leaf = z3.object({ when: z3.date() });
+    const middle = z3.object({ leaf });
+    const outer = z3.object({ middle });
+    const format = zodResponseFormat(
+      z3.object({ value: z3.preprocess(convertRegisteredDates, outer) }),
+      'strict',
+      {
+        schemaDefinitions: { Leaf: leaf, Middle: middle, Outer: outer },
+      },
+    );
+
+    expect(format.$parseRaw('{"value":{"middle":{"leaf":{"when":"2026-08-17T00:00:00.000Z"}}}}')).toEqual({
+      value: { middle: { leaf: { when: new Date('2026-08-17T00:00:00.000Z') } } },
+    });
+    expect(format.json_schema.schema).toHaveProperty('definitions.Leaf.properties.when.format', 'date-time');
+    expect(() =>
+      zodResponseFormat(
+        z3.object({ converted: z3.preprocess(convertRegisteredDates, outer), raw: leaf }),
+        'strict',
+        {
+          schemaDefinitions: { Leaf: leaf, Middle: middle, Outer: outer },
+        },
+      ),
+    ).toThrow('ZodDate');
+  });
+
+  it('preserves preprocessing context in extracted recursive lazy definitions', () => {
+    const node: z3.ZodType<RecursiveDateNode> = z3.lazy(() =>
+      z3.object({ when: z3.date(), next: node.nullable() }),
+    );
+    const format = formatFor(z3.preprocess(convertRecursiveDates, node));
+
+    expect(
+      format.$parseRaw(
+        '{"value":{"when":"2026-08-17T00:00:00.000Z","next":{"when":"2026-08-18T00:00:00.000Z","next":null}}}',
+      ),
+    ).toEqual({
+      value: {
+        when: new Date('2026-08-17T00:00:00.000Z'),
+        next: { when: new Date('2026-08-18T00:00:00.000Z'), next: null },
+      },
+    });
+    expect(() =>
+      zodResponseFormat(
+        z3.object({ converted: z3.preprocess(convertRecursiveDates, node), raw: node }),
+        'strict',
+      ),
+    ).toThrow('ZodDate');
+  });
+});

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -3,6 +3,22 @@ import { z as z3 } from 'zod/v3';
 
 const formatFor = (value: z3.ZodTypeAny) => zodResponseFormat(z3.object({ value }), 'strict');
 
+const nestedSchemaAt = (schema: unknown, path: readonly (string | number)[]): unknown => {
+  let current = schema;
+  for (const key of path) {
+    current = (current as Record<string, unknown>)[String(key)];
+  }
+  return current;
+};
+
+const convertLeafDate = (value: unknown): unknown => {
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+  const input = value as { when: string };
+  return { when: new Date(input.when) };
+};
+
 const strictHelpers = [
   { name: 'zodResponseFormat', create: (schema: z3.ZodTypeAny) => zodResponseFormat(schema, 'strict') },
   { name: 'zodTextFormat', create: (schema: z3.ZodTypeAny) => zodTextFormat(schema, 'strict') },
@@ -256,6 +272,152 @@ describe('Zod v3 strict schema capability analysis', () => {
       ),
     ).toThrow('ZodDate');
   });
+
+  it.each([
+    {
+      name: 'object properties',
+      producer: () => z3.object({ count: z3.coerce.bigint() }),
+      consumer: () => z3.object({ count: z3.number() }),
+      input: { count: 7 },
+      output: { count: 7n },
+      path: ['properties', 'count'],
+    },
+    {
+      name: 'array items',
+      producer: () => z3.array(z3.coerce.bigint()),
+      consumer: () => z3.array(z3.number()),
+      input: [7],
+      output: [7n],
+      path: ['items'],
+    },
+    {
+      name: 'tuple positions',
+      producer: () => z3.tuple([z3.coerce.bigint()]),
+      consumer: () => z3.tuple([z3.number()]),
+      input: [7],
+      output: [7n],
+      path: ['items', 0],
+    },
+    {
+      name: 'nested object-array paths',
+      producer: () => z3.object({ values: z3.array(z3.object({ count: z3.coerce.bigint() })) }),
+      consumer: () => z3.object({ values: z3.array(z3.object({ count: z3.number() })) }),
+      input: { values: [{ count: 7 }] },
+      output: { values: [{ count: 7n }] },
+      path: ['properties', 'values', 'items', 'properties', 'count'],
+    },
+    {
+      name: 'record values',
+      producer: () => z3.record(z3.coerce.bigint()),
+      consumer: () => z3.record(z3.number()),
+      input: { count: 7 },
+      output: { count: 7n },
+      path: ['additionalProperties'],
+    },
+  ])(
+    'bounds unsafe overlap at matching $name in union alternatives',
+    ({ producer, consumer, input, output, path }) => {
+      const format = formatFor(z3.union([producer(), consumer()]));
+      const schema = format.json_schema.schema as {
+        properties: { value: { anyOf: Record<string, unknown>[] } };
+      };
+
+      expect(nestedSchemaAt(schema.properties.value.anyOf[1], path)).toMatchObject({
+        minimum: Number.MIN_SAFE_INTEGER,
+        maximum: Number.MAX_SAFE_INTEGER,
+      });
+      expect(format.$parseRaw(JSON.stringify({ value: input }))).toEqual({ value: output });
+    },
+  );
+
+  it('preserves distinct object properties and disjoint literal branches', () => {
+    const differentPaths = formatFor(
+      z3.union([z3.object({ bigint: z3.coerce.bigint() }), z3.object({ number: z3.number() })]),
+    );
+    const tagged = formatFor(
+      z3.union([
+        z3.object({ kind: z3.literal('bigint'), count: z3.coerce.bigint() }),
+        z3.object({ kind: z3.literal('number'), count: z3.number() }),
+      ]),
+    );
+
+    expect(differentPaths.json_schema.schema).toHaveProperty('properties.value.anyOf.1.properties.number', {
+      type: 'number',
+    });
+    expect(tagged.json_schema.schema).toHaveProperty('properties.value.anyOf.1.properties.count', {
+      type: 'number',
+    });
+  });
+
+  it('preserves disjoint and one-sided nested numeric interception intervals', () => {
+    const disjoint = formatFor(
+      z3.union([
+        z3.object({ count: z3.coerce.bigint().max(10n) }),
+        z3.object({ count: z3.number().min(1e20) }),
+      ]),
+    );
+    const oneSided = formatFor(
+      z3.union([z3.object({ count: z3.coerce.bigint().max(10n) }), z3.object({ count: z3.number() })]),
+    );
+
+    expect(disjoint.json_schema.schema).toHaveProperty('properties.value.anyOf.1.properties.count', {
+      type: 'number',
+      minimum: 1e20,
+    });
+    expect(oneSided.json_schema.schema).toHaveProperty('properties.value.anyOf.1.properties.count', {
+      type: 'number',
+      minimum: Number.MIN_SAFE_INTEGER,
+    });
+  });
+
+  it('bounds shared nested numeric references without changing their other uses', () => {
+    const number = z3.number();
+    const container = z3.object({ count: z3.number() });
+    const format = zodResponseFormat(
+      z3.object({
+        outsideNumber: number,
+        outsideContainer: container,
+        direct: z3.union([z3.object({ count: z3.coerce.bigint() }), z3.object({ count: number })]),
+        nested: z3.union([
+          z3.object({ child: z3.object({ count: z3.coerce.bigint() }) }),
+          z3.object({ child: container }),
+        ]),
+      }),
+      'strict',
+    );
+
+    const bounds = { minimum: Number.MIN_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER };
+    expect(format.json_schema.schema).toHaveProperty('properties.outsideNumber', { type: 'number' });
+    expect(format.json_schema.schema).toHaveProperty('properties.outsideContainer.properties.count', {
+      type: 'number',
+    });
+    expect(format.json_schema.schema).toHaveProperty(
+      'properties.direct.anyOf.1.properties.count.allOf.1',
+      bounds,
+    );
+    expect(format.json_schema.schema).toHaveProperty(
+      'properties.nested.anyOf.1.properties.child.allOf.1.properties.count',
+      bounds,
+    );
+  });
+
+  it.each(['leaf-first', 'holder-first'] as const)(
+    'revalidates a registered definition after a late raw edge in %s order',
+    (order) => {
+      const leaf = z3.object({ when: z3.date() });
+      const holder = z3.object({ leaf });
+      const definitions =
+        order === 'leaf-first' ? { Leaf: leaf, Holder: holder } : { Holder: holder, Leaf: leaf };
+
+      expect(() =>
+        zodResponseFormat(
+          z3.object({ converted: z3.preprocess(convertLeafDate, leaf), raw: holder }),
+          'strict',
+          { schemaDefinitions: definitions },
+        ),
+      ).toThrow('ZodDate');
+    },
+  );
 });
 
 describe.each(strictHelpers)('$name strict numeric input capability analysis', ({ create }) => {

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -1277,6 +1277,44 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
   });
 
   it.each([
+    { name: 'direct', producer: () => z3.coerce.bigint() },
+    { name: 'readonly', producer: () => z3.coerce.bigint().readonly() },
+    { name: 'lazy', producer: () => z3.lazy(() => z3.coerce.bigint()) },
+    { name: 'bounded', producer: () => z3.coerce.bigint().max(10n) },
+  ])('preserves fractional fallback after an earlier $name coercing BigInt producer', ({ producer }) => {
+    const result = create(z3.object({ value: z3.union([producer(), z3.number()]) }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1.type', 'number');
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
+    expect(result.$parseRaw('{"value":1.5}')).toEqual({ value: 1.5 });
+  });
+
+  it.each([
+    {
+      name: 'object property',
+      producer: () => z3.object({ count: z3.coerce.bigint() }),
+      consumer: () => z3.object({ count: z3.number() }),
+      fractional: { count: 1.5 },
+      path: 'properties.value.anyOf.1.properties.count.type',
+    },
+    {
+      name: 'array item',
+      producer: () => z3.array(z3.coerce.bigint()),
+      consumer: () => z3.array(z3.number()),
+      fractional: [1.5],
+      path: 'properties.value.anyOf.1.items.type',
+    },
+  ])(
+    'preserves fractional $name fallback after caught BigInt coercion',
+    ({ producer, consumer, fractional, path }) => {
+      const result = create(z3.object({ value: z3.union([producer(), consumer()]) }));
+
+      expect(strictHelperSchema(result)).toHaveProperty(path, 'number');
+      expect(result.$parseRaw(JSON.stringify({ value: fractional }))).toEqual({ value: fractional });
+    },
+  );
+
+  it.each([
     { name: 'direct', producer: () => z3.number().transform(BigInt) },
     { name: 'readonly', producer: () => z3.number().transform(BigInt).readonly() },
     { name: 'lazy', producer: () => z3.lazy(() => z3.number().transform(BigInt)) },
@@ -1423,6 +1461,76 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
       type: 'number',
       minimum: 1e20,
     });
+  });
+
+  it.each([
+    { name: 'direct', producer: () => z3.string().transform(BigInt) },
+    { name: 'readonly', producer: () => z3.string().transform(BigInt).readonly() },
+    { name: 'lazy', producer: () => z3.lazy(() => z3.string().transform(BigInt)) },
+  ])('narrows string fallback after an earlier $name BigInt transform', ({ producer }) => {
+    const result = create(z3.object({ value: z3.union([producer(), z3.string()]) }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1', {
+      type: 'string',
+      pattern: '^[+-]?[0-9]+$',
+    });
+    expect(result.$parseRaw('{"value":"7"}')).toEqual({ value: 7n });
+    expect(() => result.$parseRaw('{"value":"not-a-bigint"}')).toThrow(SyntaxError);
+  });
+
+  it.each([
+    {
+      name: 'object property',
+      producer: () => z3.object({ count: z3.string().transform(BigInt) }),
+      consumer: () => z3.object({ count: z3.string() }),
+      valid: { count: '7' },
+      invalid: { count: 'not-a-bigint' },
+      output: { count: 7n },
+      path: 'properties.value.anyOf.1.properties.count.pattern',
+    },
+    {
+      name: 'array item',
+      producer: () => z3.array(z3.string().transform(BigInt)),
+      consumer: () => z3.array(z3.string()),
+      valid: ['7'],
+      invalid: ['not-a-bigint'],
+      output: [7n],
+      path: 'properties.value.anyOf.1.items.pattern',
+    },
+  ])(
+    'narrows invalid $name string fallback after an earlier BigInt transform',
+    ({ producer, consumer, valid, invalid, output, path }) => {
+      const result = create(z3.object({ value: z3.union([producer(), consumer()]) }));
+
+      expect(strictHelperSchema(result)).toHaveProperty(path, '^[+-]?[0-9]+$');
+      expect(result.$parseRaw(JSON.stringify({ value: valid }))).toEqual({ value: output });
+      expect(() => result.$parseRaw(JSON.stringify({ value: invalid }))).toThrow(SyntaxError);
+    },
+  );
+
+  it('preserves disjoint string fallback after a length-constrained BigInt transform', () => {
+    const value = z3.union([z3.string().max(2).transform(BigInt), z3.string().min(3)]);
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1', {
+      type: 'string',
+      minLength: 3,
+    });
+    expect(result.$parseRaw('{"value":"not-a-bigint"}')).toEqual({ value: 'not-a-bigint' });
+  });
+
+  it('rejects partially overlapping string fallback that cannot be represented without data loss', () => {
+    const value = z3.union([z3.string().max(2).transform(BigInt), z3.string()]);
+
+    expect(() => create(z3.object({ value }))).toThrow('partially overlapping string fallbacks');
+  });
+
+  it('preserves an unrestricted string branch ordered before a BigInt transform', () => {
+    const value = z3.union([z3.string(), z3.string().transform(BigInt)]);
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.0', { type: 'string' });
+    expect(result.$parseRaw('{"value":"not-a-bigint"}')).toEqual({ value: 'not-a-bigint' });
   });
 
   it.each([

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -1306,6 +1306,19 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     { name: 'RegExp', value: () => /x/u as object },
     { name: 'cross-realm RegExp', value: () => runInNewContext('/x/u') as object },
     { name: 'null-prototype RegExp', value: () => Object.setPrototypeOf(/x/u, null) as object },
+    { name: 'URLSearchParams', value: () => new URLSearchParams('a=1') as object },
+    {
+      name: 'null-prototype URLSearchParams',
+      value: () => Object.setPrototypeOf(new URLSearchParams('a=1'), null) as object,
+    },
+    {
+      name: 'altered-prototype URLSearchParams',
+      value: () => Object.setPrototypeOf(new URLSearchParams('a=1'), Object.create(null) as object) as object,
+    },
+    {
+      name: 'cross-realm URLSearchParams',
+      value: () => runInNewContext("new URLSearchParams('a=1')", { URLSearchParams }) as object,
+    },
     { name: 'WeakMap', value: () => new WeakMap<object, number>() as object },
     { name: 'cross-realm WeakSet', value: () => runInNewContext('new WeakSet()') as object },
     { name: 'Promise', value: () => Promise.resolve(1) as object },
@@ -1325,12 +1338,16 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     );
   });
 
-  it('detects RegExp default slots without invoking hostile accessors or tags', () => {
+  it.each([
+    { name: 'RegExp', value: () => /x/u as object },
+    { name: 'URLSearchParams', value: () => new URLSearchParams('a=1') as object },
+  ])('detects $name default slots without invoking hostile accessors or tags', ({ value: createValue }) => {
     const getter = vi.fn(() => {
       throw new Error('must never run');
     });
     const prototype = Object.defineProperty({}, Symbol.toStringTag, { get: getter });
-    const value = Object.setPrototypeOf(/x/u, prototype);
+    const value = Object.setPrototypeOf(createValue(), prototype);
+    Object.defineProperty(value, 'size', { enumerable: true, get: getter });
     Object.defineProperty(value, 'toJSON', { enumerable: true, get: getter });
 
     expect(() => create(z3.object({ value: z3.any().default(value) }))).toThrow('internal slots');
@@ -1480,6 +1497,115 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     expect(() => create(z3.object({ value: z3.coerce.bigint().multipleOf(multiple) }))).toThrow(
       'strictly positive',
     );
+  });
+
+  it.each([
+    {
+      name: 'descending inclusive minimum',
+      schema: () => z3.number().min(10).min(5),
+      expected: { minimum: 10 },
+      valid: 10,
+      invalid: 7,
+    },
+    {
+      name: 'ascending inclusive minimum',
+      schema: () => z3.number().min(5).min(10),
+      expected: { minimum: 10 },
+      valid: 10,
+      invalid: 7,
+    },
+    {
+      name: 'descending exclusive minimum',
+      schema: () => z3.number().gt(10).gt(5),
+      expected: { exclusiveMinimum: 10 },
+      valid: 11,
+      invalid: 10,
+    },
+    {
+      name: 'ascending inclusive maximum',
+      schema: () => z3.number().max(5).max(10),
+      expected: { maximum: 5 },
+      valid: 5,
+      invalid: 7,
+    },
+    {
+      name: 'descending exclusive maximum',
+      schema: () => z3.number().lt(10).lt(5),
+      expected: { exclusiveMaximum: 5 },
+      valid: 4,
+      invalid: 5,
+    },
+    {
+      name: 'mixed inclusive and exclusive minima',
+      schema: () => z3.number().gt(10).min(5).gt(8),
+      expected: { minimum: 5, exclusiveMinimum: 10 },
+      valid: 11,
+      invalid: 10,
+    },
+    {
+      name: 'mixed inclusive and exclusive maxima',
+      schema: () => z3.number().lt(5).max(10).lt(8),
+      expected: { maximum: 10, exclusiveMaximum: 5 },
+      valid: 4,
+      invalid: 5,
+    },
+    {
+      name: 'integer least common multiple',
+      schema: () => z3.number().multipleOf(2).multipleOf(3),
+      expected: { multipleOf: 6 },
+      valid: 6,
+      invalid: 3,
+    },
+    {
+      name: 'fractional least common multiple',
+      schema: () => z3.number().multipleOf(0.2).multipleOf(0.3),
+      expected: { multipleOf: 0.6 },
+      valid: 0.6,
+      invalid: 0.3,
+    },
+    {
+      name: 'negative repeated multiple',
+      schema: () => z3.number().multipleOf(-2).multipleOf(3),
+      expected: { multipleOf: 6 },
+      valid: -6,
+      invalid: 3,
+    },
+  ])('retains every repeated $name Number constraint', ({ schema, expected, valid, invalid }) => {
+    const result = create(z3.object({ value: schema() }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value', expect.objectContaining(expected));
+    expect(result.$parseRaw(JSON.stringify({ value: valid }))).toEqual({ value: valid });
+    expect(() => result.$parseRaw(JSON.stringify({ value: invalid }))).toThrow();
+  });
+
+  it.each([-2, -0.5])(
+    'normalizes a negative Number multiple %s without changing parsed values',
+    (multiple) => {
+      const result = create(z3.object({ value: z3.number().multipleOf(multiple) }));
+
+      expect(strictHelperSchema(result)).toHaveProperty('properties.value.multipleOf', Math.abs(multiple));
+      expect(result.$parseRaw(JSON.stringify({ value: multiple }))).toEqual({ value: multiple });
+    },
+  );
+
+  it.each([0, -0])('rejects a zero Number multiple %s before emitting JSON Schema', (multiple) => {
+    expect(() => create(z3.object({ value: z3.number().multipleOf(multiple) }))).toThrow('strictly positive');
+  });
+
+  it('rejects an earlier zero Number multiple hidden by a later valid check', () => {
+    expect(() => create(z3.object({ value: z3.number().multipleOf(0).multipleOf(2) }))).toThrow(
+      'strictly positive',
+    );
+  });
+
+  it('rejects an unsafe repeated Number least common multiple', () => {
+    const value = z3.number().multipleOf(Number.MAX_SAFE_INTEGER).multipleOf(2);
+    expect(() => create(z3.object({ value }))).toThrow('multipleOf');
+  });
+
+  it('keeps notation-sensitive scientific Number multiples fail-closed', () => {
+    expect(() => create(z3.object({ value: z3.number().multipleOf(1e-7) }))).toThrow('multipleOf');
+    expect(() => create(z3.object({ value: z3.number().multipleOf(-1e-7) }))).toThrow('multipleOf');
   });
 
   it.each([
@@ -1883,7 +2009,84 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
       schema: () =>
         z3.intersection(z3.union([z3.null(), z3.coerce.bigint()]), z3.union([z3.null(), z3.number()])),
     },
+    {
+      name: 'transparent caught nullable BigInt',
+      schema: () => z3.intersection(z3.coerce.bigint().nullable().catch(null), z3.number().nullable()),
+    },
+    {
+      name: 'transparent caught nullable number',
+      schema: () => z3.intersection(z3.coerce.bigint().nullable(), z3.number().nullable().catch(null)),
+    },
+    {
+      name: 'readonly lazy caught nullable BigInt',
+      schema: () =>
+        z3.intersection(
+          z3.lazy(() => z3.coerce.bigint().nullable().catch(null).readonly()),
+          z3.number().nullable(),
+        ),
+    },
+    {
+      name: 'nested transparent caught nullable property',
+      schema: () =>
+        z3.intersection(
+          z3.object({ count: z3.coerce.bigint().nullable().catch(null) }),
+          z3.object({ count: z3.number().nullable() }),
+        ),
+    },
   ])('rejects incompatible non-null $name intersection outputs', ({ schema }) => {
+    expect(() => create(z3.object({ value: schema() }))).toThrow('incompatible parsed outputs');
+  });
+
+  it.each([
+    {
+      name: 'coercing BigInt and number alternatives',
+      schema: () =>
+        z3.intersection(z3.union([z3.coerce.bigint(), z3.string()]), z3.union([z3.number(), z3.string()])),
+    },
+    {
+      name: 'reversed coercing BigInt and number alternatives',
+      schema: () =>
+        z3.intersection(z3.union([z3.string(), z3.number()]), z3.union([z3.string(), z3.coerce.bigint()])),
+    },
+    {
+      name: 'readonly lazy alternatives',
+      schema: () =>
+        z3.intersection(
+          z3.lazy(() => z3.union([z3.coerce.bigint(), z3.string()]).readonly()),
+          z3.union([z3.number(), z3.string()]),
+        ),
+    },
+    {
+      name: 'nested object union alternatives',
+      schema: () =>
+        z3.intersection(
+          z3.object({ count: z3.union([z3.coerce.bigint(), z3.string()]) }),
+          z3.object({ count: z3.union([z3.number(), z3.string()]) }),
+        ),
+    },
+    {
+      name: 'nested array union alternatives',
+      schema: () =>
+        z3.intersection(
+          z3.array(z3.union([z3.coerce.bigint(), z3.string()])),
+          z3.array(z3.union([z3.number(), z3.string()])),
+        ),
+    },
+    {
+      name: 'matching discriminated numeric alternatives',
+      schema: () =>
+        z3.intersection(
+          z3.discriminatedUnion('kind', [
+            z3.object({ kind: z3.literal('numeric'), count: z3.coerce.bigint() }),
+            z3.object({ kind: z3.literal('text'), count: z3.string() }),
+          ]),
+          z3.discriminatedUnion('kind', [
+            z3.object({ kind: z3.literal('numeric'), count: z3.number() }),
+            z3.object({ kind: z3.literal('text'), count: z3.string() }),
+          ]),
+        ),
+    },
+  ])('rejects overlapping $name with incompatible union intersection outputs', ({ schema }) => {
     expect(() => create(z3.object({ value: schema() }))).toThrow('incompatible parsed outputs');
   });
 
@@ -2935,7 +3138,9 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     { name: 'unsupported scientific decimal precision', input: 1e-7, output: 2e-7 },
   ])('rejects an unsafely representable pipeline $name constraint', ({ input, output }) => {
     const value = z3.number().multipleOf(input).pipe(z3.number().multipleOf(output));
-    expect(() => create(z3.object({ value }))).toThrow('ZodPipeline output constraints');
+    expect(() => create(z3.object({ value }))).toThrow(
+      /ZodPipeline output constraints|strictly positive|multipleOf/u,
+    );
   });
 
   it('keeps notation-sensitive scientific multiples fail-closed under the installed Zod runtime', () => {
@@ -2949,7 +3154,7 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
       expect(pipeline.safeParse(value).success).toBe(false);
     }
     expect(pipeline.safeParse(0.0000012).success).toBe(true);
-    expect(() => create(z3.object({ value: pipeline }))).toThrow('ZodPipeline output constraints');
+    expect(() => create(z3.object({ value: pipeline }))).toThrow('multipleOf');
   });
 
   it.each([
@@ -3064,6 +3269,55 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
       expect(strictHelperSchema(result)).toHaveProperty(`properties.value.${keyword}`, expected);
     },
   );
+
+  it.each([
+    {
+      name: 'nested disjoint union',
+      output: () => z3.union([z3.union([z3.null(), z3.string()]), z3.number()]),
+    },
+    {
+      name: 'deep nested disjoint union',
+      output: () =>
+        z3.union([z3.union([z3.null(), z3.union([z3.boolean(), z3.string()])]), z3.number().min(0)]),
+    },
+    {
+      name: 'nested reachable numeric branch',
+      output: () => z3.union([z3.union([z3.null(), z3.number().min(0)]), z3.string()]),
+    },
+    {
+      name: 'described nested reachable numeric branch',
+      output: () => z3.union([z3.union([z3.null(), z3.number().min(0)]).describe('reachable'), z3.string()]),
+    },
+  ])('projects reachable alternatives through a $name pipeline output', ({ output }) => {
+    const result = create(z3.object({ value: z3.number().min(0).pipe(output()) }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.type', 'number');
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.minimum', 0);
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7 });
+  });
+
+  it('retains nested anyOf annotations on their surviving projected branch', () => {
+    const output = z3.union([
+      z3.union([z3.null(), z3.number().min(0)]).describe('reachable numeric value'),
+      z3.string(),
+    ]);
+    const result = create(z3.object({ value: z3.number().pipe(output) }));
+
+    expect(strictHelperSchema(result)).toHaveProperty(
+      'properties.value.description',
+      'reachable numeric value',
+    );
+  });
+
+  it('rejects an overlapping nested pipeline alternative that cannot be merged', () => {
+    const input = z3.object({ count: z3.number() });
+    const output = z3.union([
+      z3.union([z3.null(), z3.object({ different: z3.number() })]),
+      z3.object({ count: z3.number() }),
+    ]);
+
+    expect(() => create(z3.object({ value: input.pipe(output) }))).toThrow('ZodPipeline output constraints');
+  });
 
   it.each([
     {
@@ -3316,6 +3570,74 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
   ])('preserves an unconstrained $name string pipeline output', ({ input, raw, parsed }) => {
     const result = create(z3.object({ value: input().pipe(z3.string()) }));
     expect(result.$parseRaw(JSON.stringify({ value: raw }))).toEqual({ value: parsed });
+  });
+
+  it.each([
+    {
+      name: 'unconstrained numeric catch',
+      input: () => z3.number().catch(0),
+      output: () => z3.number().min(0),
+      raw: 7,
+      expected: 7,
+      path: 'properties.value.minimum',
+      constraint: 0,
+    },
+    {
+      name: 'constrained numeric catch',
+      input: () => z3.number().min(3).catch(0),
+      output: () => z3.number().min(0),
+      raw: 7,
+      expected: 7,
+      path: 'properties.value.minimum',
+      constraint: 3,
+    },
+    {
+      name: 'readonly lazy numeric catch',
+      input: () => z3.lazy(() => z3.number().catch(0).readonly()),
+      output: () => z3.number().min(0),
+      raw: 7,
+      expected: 7,
+      path: 'properties.value.minimum',
+      constraint: 0,
+    },
+    {
+      name: 'string catch',
+      input: () => z3.string().catch('safe'),
+      output: () => z3.string().min(2),
+      raw: 'valid',
+      expected: 'valid',
+      path: 'properties.value.minLength',
+      constraint: 2,
+    },
+    {
+      name: 'nested object catch',
+      input: () => z3.object({ count: z3.number() }).catch({ count: 0 }),
+      output: () => z3.object({ count: z3.number().min(0) }),
+      raw: { count: 7 },
+      expected: { count: 7 },
+      path: 'properties.value.properties.count.minimum',
+      constraint: 0,
+    },
+  ])(
+    'projects constrained outputs across a value-transparent $name',
+    ({ input, output, raw, expected, path, constraint }) => {
+      const result = create(z3.object({ value: input().pipe(output()) }));
+
+      expect(strictHelperSchema(result)).toHaveProperty(path, constraint);
+      expect(result.$parseRaw(JSON.stringify({ value: raw }))).toEqual({ value: expected });
+    },
+  );
+
+  it('continues rejecting a caught refinement before constrained pipeline output validation', () => {
+    const refine = vi.fn(() => false);
+    const fallback = vi.fn(() => 0);
+    const value = z3.number().refine(refine).catch(fallback).pipe(z3.number().min(0));
+
+    expect(() => create(z3.object({ value }))).toThrow(
+      'cannot be safely projected across an opaque transform',
+    );
+    expect(refine).not.toHaveBeenCalled();
+    expect(fallback).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -1161,6 +1161,50 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     expect(() => result.$parseRaw('{"value":1.5}')).toThrow(RangeError);
   });
 
+  it.each([
+    {
+      name: 'object property',
+      producer: () => z3.object({ count: z3.number().transform(BigInt) }),
+      consumer: () => z3.object({ count: z3.number() }),
+      valid: { count: 7 },
+      fractional: { count: 1.5 },
+      output: { count: 7n },
+      path: 'properties.value.anyOf.1.properties.count.type',
+    },
+    {
+      name: 'array item',
+      producer: () => z3.array(z3.number().transform(BigInt)),
+      consumer: () => z3.array(z3.number()),
+      valid: [7],
+      fractional: [1.5],
+      output: [7n],
+      path: 'properties.value.anyOf.1.items.type',
+    },
+  ])(
+    'narrows fractional $name fallback after an earlier exact BigInt transform',
+    ({ producer, consumer, valid, fractional, output, path }) => {
+      const result = create(z3.object({ value: z3.union([producer(), consumer()]) }));
+
+      expect(strictHelperSchema(result)).toHaveProperty(path, 'integer');
+      expect(result.$parseRaw(JSON.stringify({ value: valid }))).toEqual({ value: output });
+      expect(() => result.$parseRaw(JSON.stringify({ value: fractional }))).toThrow(RangeError);
+    },
+  );
+
+  it('preserves nested fractional fallback after an integer-constrained BigInt transform', () => {
+    const value = z3.union([
+      z3.object({ count: z3.number().int().transform(BigInt) }),
+      z3.object({ count: z3.number() }),
+    ]);
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty(
+      'properties.value.anyOf.1.properties.count.type',
+      'number',
+    );
+    expect(result.$parseRaw('{"value":{"count":1.5}}')).toEqual({ value: { count: 1.5 } });
+  });
+
   it('preserves fractional fallback when the earlier BigInt transform rejects non-integers', () => {
     const value = z3.union([z3.number().int().transform(BigInt), z3.number()]);
     const result = create(z3.object({ value }));
@@ -1222,6 +1266,22 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
           z3.object({ value: z3.number() }),
         ),
     },
+    {
+      name: 'tuple BigInt and number items',
+      schema: () => z3.intersection(z3.tuple([z3.coerce.bigint()]), z3.tuple([z3.number()])),
+    },
+    {
+      name: 'wrapped nested tuple items',
+      schema: () =>
+        z3.intersection(
+          z3.tuple([z3.object({ value: z3.coerce.bigint() })]).readonly(),
+          z3.tuple([z3.object({ value: z3.number() })]),
+        ),
+    },
+    {
+      name: 'tuple and array items',
+      schema: () => z3.intersection(z3.tuple([z3.coerce.bigint()]), z3.array(z3.number())),
+    },
   ])('rejects intersections with incompatible $name parsed outputs', ({ schema }) => {
     expect(() => create(z3.object({ value: schema() }))).toThrow('incompatible parsed outputs');
   });
@@ -1233,6 +1293,31 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
       type: 'number',
       minimum: 1e20,
     });
+  });
+
+  it.each([
+    { name: 'decimal', input: '42', output: 42n },
+    { name: 'positive', input: '+7', output: 7n },
+    { name: 'negative', input: '-9', output: -9n },
+  ])('restricts exact BigInt $name string transforms to integer lexical input', ({ input, output }) => {
+    const result = create(z3.object({ value: z3.string().transform(BigInt) }));
+    const generated = strictHelperSchema(result) as {
+      properties: { value: { type: string; pattern: string } };
+    };
+
+    expect(generated.properties.value).toEqual({ type: 'string', pattern: '^[+-]?[0-9]+$' });
+    expect(new RegExp(generated.properties.value.pattern, 'u').test('not-a-bigint')).toBe(false);
+    expect(new RegExp(generated.properties.value.pattern, 'u').test('1.5')).toBe(false);
+    expect(result.$parseRaw(JSON.stringify({ value: input }))).toEqual({ value: output });
+    expect(() => result.$parseRaw('{"value":"not-a-bigint"}')).toThrow(SyntaxError);
+  });
+
+  it('rejects exact BigInt string transforms whose existing pattern cannot be safely combined', () => {
+    const value = z3
+      .string()
+      .regex(/^[0-9]+$/u)
+      .transform(BigInt);
+    expect(() => create(z3.object({ value }))).toThrow('integer-string pattern');
   });
 
   it('rejects compound inputs that the built-in BigInt transform cannot safely represent', () => {

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -1,3 +1,4 @@
+import { runInNewContext } from 'node:vm';
 import { vi } from 'vitest';
 import {
   zodFunction,
@@ -1244,6 +1245,105 @@ describe('Zod v3 strict schema capability analysis', () => {
 
 describe.each(strictHelpers)('$name strict numeric input capability analysis', ({ create }) => {
   it.each([
+    {
+      name: 'null-prototype Set',
+      type: 'ZodSet',
+      value: () => Object.setPrototypeOf(new Set([1]), null) as object,
+    },
+    {
+      name: 'altered-prototype Set',
+      type: 'ZodSet',
+      value: () => Object.setPrototypeOf(new Set([1]), Object.create(null) as object) as object,
+    },
+    {
+      name: 'cross-realm Set',
+      type: 'ZodSet',
+      value: () => runInNewContext('new Set([1])') as object,
+    },
+    {
+      name: 'null-prototype Map',
+      type: 'ZodMap',
+      value: () => Object.setPrototypeOf(new Map([['value', 1]]), null) as object,
+    },
+    {
+      name: 'altered-prototype Map',
+      type: 'ZodMap',
+      value: () => Object.setPrototypeOf(new Map([['value', 1]]), Object.create(null) as object) as object,
+    },
+    {
+      name: 'cross-realm Map',
+      type: 'ZodMap',
+      value: () => runInNewContext("new Map([['value', 1]])") as object,
+    },
+  ])('rejects a genuine $name default without trusting its prototype', ({ type, value }) => {
+    const native = value();
+    expect(() => create(z3.object({ value: z3.any().default(native) }))).toThrow(type);
+    expect(() => create(z3.object({ value: z3.unknown().default({ nested: native }) }))).toThrow(type);
+  });
+
+  it.each([
+    { name: 'Set', type: 'ZodSet', value: () => new Set([1]) as object },
+    { name: 'Map', type: 'ZodMap', value: () => new Map([['value', 1]]) as object },
+  ])('detects genuine $name default slots without invoking hostile accessors', ({ type, value }) => {
+    const getter = vi.fn(() => {
+      throw new Error('must never run');
+    });
+    const prototype = Object.defineProperty({}, 'size', { get: getter });
+    const native = Object.setPrototypeOf(value(), prototype);
+    Object.defineProperty(native, 'toJSON', { enumerable: true, get: getter });
+
+    expect(() => create(z3.object({ value: z3.any().default(native) }))).toThrow(type);
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: 'coerced minimum', schema: () => z3.coerce.date().min(new Date('2025-01-01T00:00:00.000Z')) },
+    { name: 'coerced maximum', schema: () => z3.coerce.date().max(new Date('2025-12-31T00:00:00.000Z')) },
+    {
+      name: 'coerced minimum and maximum',
+      schema: () =>
+        z3.coerce.date().min(new Date('2025-01-01T00:00:00.000Z')).max(new Date('2025-12-31T00:00:00.000Z')),
+    },
+    {
+      name: 'readonly constrained date',
+      schema: () => z3.coerce.date().min(new Date('2025-01-01T00:00:00.000Z')).readonly(),
+    },
+    {
+      name: 'lazy constrained date',
+      schema: () => z3.lazy(() => z3.coerce.date().max(new Date('2025-12-31T00:00:00.000Z'))),
+    },
+    {
+      name: 'nested object constrained date',
+      schema: () => z3.object({ when: z3.coerce.date().min(new Date('2025-01-01T00:00:00.000Z')) }),
+    },
+    {
+      name: 'nested array constrained date',
+      schema: () => z3.array(z3.coerce.date().max(new Date('2025-12-31T00:00:00.000Z'))),
+    },
+    {
+      name: 'preprocessed native date minimum',
+      schema: () =>
+        z3.preprocess(
+          (value) => new Date(value as string),
+          z3.date().min(new Date('2025-01-01T00:00:00.000Z')),
+        ),
+    },
+  ])('rejects an unrepresentable $name Date bound', ({ schema }) => {
+    expect(() => create(z3.object({ value: schema() }))).toThrow(/ZodDate.*bounds/u);
+  });
+
+  it('preserves an unconstrained coerced Date and its date-time input', () => {
+    const value = '2024-01-01T00:00:00.000Z';
+    const result = create(z3.object({ value: z3.coerce.date() }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value', {
+      type: 'string',
+      format: 'date-time',
+    });
+    expect(result.$parseRaw(JSON.stringify({ value }))).toEqual({ value: new Date(value) });
+  });
+
+  it.each([
     { name: 'literal', schema: (value: number) => z3.literal(value) },
     { name: 'readonly literal', schema: (value: number) => z3.literal(value).readonly() },
     { name: 'nullable literal', schema: (value: number) => z3.literal(value).nullable() },
@@ -1876,6 +1976,64 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     const convert = vi.fn((value: number) => BigInt(value.toString()));
     expect(() => create(z3.object({ value: schema(convert) }))).toThrow('incompatible parsed outputs');
     expect(convert).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: 'BigInt catch before number',
+      schema: () => z3.intersection(z3.coerce.bigint().catch(0n), z3.number()),
+    },
+    {
+      name: 'number before BigInt catch',
+      schema: () => z3.intersection(z3.number(), z3.coerce.bigint().catch(0n)),
+    },
+    {
+      name: 'readonly BigInt catch',
+      schema: () => z3.intersection(z3.coerce.bigint().catch(0n).readonly(), z3.number()),
+    },
+    {
+      name: 'lazy BigInt catch',
+      schema: () =>
+        z3.intersection(
+          z3.lazy(() => z3.coerce.bigint().catch(0n)),
+          z3.number(),
+        ),
+    },
+    {
+      name: 'nested BigInt catch object',
+      schema: () =>
+        z3.intersection(
+          z3.object({ count: z3.coerce.bigint().catch(0n) }),
+          z3.object({ count: z3.number() }),
+        ),
+    },
+    {
+      name: 'nested BigInt catch array',
+      schema: () => z3.intersection(z3.array(z3.coerce.bigint().catch(0n)), z3.array(z3.number())),
+    },
+    {
+      name: 'Date catch before string',
+      schema: () => z3.intersection(z3.coerce.date().catch(new Date(0)), z3.string()),
+    },
+    {
+      name: 'Set catch before array',
+      schema: () => z3.intersection(z3.set(z3.string()).catch(new Set(['fallback'])), z3.array(z3.string())),
+    },
+  ])('rejects incompatible successful $name intersection outputs', ({ schema }) => {
+    expect(() => create(z3.object({ value: schema() }))).toThrow('incompatible parsed outputs');
+  });
+
+  it('inspects caught native intersection outputs without invoking fallback callbacks', () => {
+    const fallback = vi.fn(() => 0n);
+    const value = z3.intersection(z3.coerce.bigint().catch(fallback), z3.number());
+
+    expect(() => create(z3.object({ value }))).toThrow('incompatible parsed outputs');
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it('preserves intersections with a compatible caught numeric output', () => {
+    const result = create(z3.object({ value: z3.intersection(z3.number().catch(0), z3.number()) }));
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7 });
   });
 
   it.each([

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -1,4 +1,10 @@
-import { zodFunction, zodResponseFormat, zodResponsesFunction, zodTextFormat } from 'openai/helpers/zod';
+import {
+  zodFunction,
+  zodRealtimeFunction,
+  zodResponseFormat,
+  zodResponsesFunction,
+  zodTextFormat,
+} from 'openai/helpers/zod';
 import { z as z3 } from 'zod/v3';
 
 const formatFor = (value: z3.ZodTypeAny) => zodResponseFormat(z3.object({ value }), 'strict');
@@ -405,6 +411,66 @@ describe('Zod v3 strict schema capability analysis', () => {
     ).toThrow('ZodDate');
   });
 
+  it('rejects recursive BigInt and number alternatives whose shared references cannot be bounded', () => {
+    const bigintNode: z3.ZodTypeAny = z3.lazy(() =>
+      z3.object({ value: z3.coerce.bigint(), next: bigintNode.nullable() }),
+    );
+    const numberNode: z3.ZodTypeAny = z3.lazy(() =>
+      z3.object({ value: z3.number(), next: numberNode.nullable() }),
+    );
+
+    expect(() => formatFor(z3.union([bigintNode, numberNode]))).toThrow(
+      'Recursive BigInt and number union alternatives cannot safely preserve integer precision',
+    );
+  });
+
+  it('preserves independently recursive and discriminator-separated numeric alternatives', () => {
+    const bigintNode: z3.ZodTypeAny = z3.lazy(() =>
+      z3.object({ kind: z3.literal('bigint'), value: z3.coerce.bigint(), next: bigintNode.nullable() }),
+    );
+    const numberNode: z3.ZodTypeAny = z3.lazy(() =>
+      z3.object({ kind: z3.literal('number'), value: z3.number(), next: numberNode.nullable() }),
+    );
+    const input = { kind: 'number', value: 1e20, next: null };
+
+    expect(formatFor(numberNode).$parseRaw(JSON.stringify({ value: input }))).toEqual({ value: input });
+    expect(formatFor(z3.union([bigintNode, numberNode])).$parseRaw(JSON.stringify({ value: input }))).toEqual(
+      { value: input },
+    );
+  });
+
+  it.each([
+    { name: 'minimum', schema: () => z3.set(z3.string()).min(2) },
+    { name: 'exact size', schema: () => z3.set(z3.string()).size(2) },
+  ])('rejects a preprocessed Set with an unrepresentable $name cardinality constraint', ({ schema }) => {
+    const value = z3.preprocess((input) => new Set(input as string[]), schema());
+    expect(() => formatFor(value)).toThrow(/ZodSet.*uniqueItems/u);
+  });
+
+  it.each([
+    { name: 'unconstrained', schema: () => z3.set(z3.string()) },
+    { name: 'maximum-only', schema: () => z3.set(z3.string()).max(2) },
+    { name: 'zero minimum', schema: () => z3.set(z3.string()).min(0) },
+  ])('preserves duplicate-deduplicating $name Sets', ({ schema }) => {
+    const value = z3.preprocess((input) => new Set(input as string[]), schema());
+    expect(formatFor(value).$parseRaw('{"value":["x","x"]}')).toEqual({ value: new Set(['x']) });
+  });
+
+  it('preserves non-strict constrained Set schemas', () => {
+    const realtime = zodRealtimeFunction({
+      name: 'realtime',
+      parameters: z3.object({
+        value: z3.preprocess((input) => new Set(input as string[]), z3.set(z3.string()).min(2)),
+      }),
+    });
+    expect(realtime.parameters).toHaveProperty('properties.value', {
+      type: 'array',
+      uniqueItems: true,
+      items: { type: 'string' },
+      minItems: 2,
+    });
+  });
+
   it('preserves preprocessing context in extracted recursive lazy definitions', () => {
     const node: z3.ZodType<RecursiveDateNode> = z3.lazy(() =>
       z3.object({ when: z3.date(), next: node.nullable() }),
@@ -600,7 +666,6 @@ describe('Zod v3 strict schema capability analysis', () => {
 describe.each(strictHelpers)('$name strict numeric input capability analysis', ({ create }) => {
   it.each([
     { name: 'direct BigInt', schema: () => z3.number().int().transform(BigInt) },
-    { name: 'opaque BigInt', schema: () => z3.number().transform((value) => BigInt(Math.trunc(value))) },
     {
       name: 'wrapped BigInt',
       schema: () => z3.number().int().transform(BigInt).nullable(),
@@ -620,6 +685,31 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
       maximum: Number.MAX_SAFE_INTEGER,
     });
     expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
+  });
+
+  it.each([
+    { name: 'string', schema: () => z3.number().transform(String), expected: String(1e20) },
+    { name: 'boolean', schema: () => z3.number().transform(Boolean), expected: true },
+    { name: 'number', schema: () => z3.number().transform(Number), expected: 1e20 },
+  ])('preserves unsafe-range numeric inputs for inspectable $name transforms', ({ schema, expected }) => {
+    const result = create(z3.object({ value: schema() }));
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value', { type: 'number' });
+    expect(result.$parseRaw('{"value":100000000000000000000}')).toEqual({ value: expected });
+  });
+
+  it.each([
+    { name: 'BigInt', schema: () => z3.number().transform((value) => BigInt(Math.trunc(value))) },
+    { name: 'string', schema: () => z3.number().transform((value) => `number: ${value}`) },
+  ])('rejects opaque numeric $name transforms without an inspectable output type', ({ schema }) => {
+    expect(() => create(z3.object({ value: schema() }))).toThrow('no inspectable output type');
+  });
+
+  it.each([
+    { name: 'direct', schema: () => z3.promise(z3.string()) },
+    { name: 'lazy', schema: () => z3.lazy(() => z3.promise(z3.string())) },
+    { name: 'pipeline output', schema: () => z3.string().pipe(z3.promise(z3.string())) },
+  ])('rejects a synchronously unparseable $name Promise field', ({ schema }) => {
+    expect(() => create(z3.object({ value: schema() }))).toThrow('ZodPromise');
   });
 
   it.each([
@@ -649,19 +739,6 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
               z3.number(),
             ),
           ),
-    },
-    {
-      name: 'output transform',
-      schema: () =>
-        z3.number().pipe(
-          z3.number().transform((value, context) => {
-            if (Math.abs(value) >= 10) {
-              context.addIssue({ code: z3.ZodIssueCode.custom, message: 'outside range' });
-              return z3.NEVER;
-            }
-            return value;
-          }),
-        ),
     },
     {
       name: 'nested output pipeline',
@@ -802,6 +879,76 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     expect(generated.properties.value.anyOf[0]).not.toHaveProperty('minimum');
     expect(generated.properties.value.anyOf[0]).not.toHaveProperty('maximum');
     expect(result.$parseRaw('{"value":9007199254740993}')).toEqual({ value: 9_007_199_254_740_992 });
+  });
+
+  it.each([
+    {
+      name: 'object property minimum',
+      input: () => z3.object({ count: z3.number() }),
+      output: () => z3.object({ count: z3.number().min(1) }),
+      path: 'properties.value.properties.count.minimum',
+      expected: 1,
+    },
+    {
+      name: 'nested object maximum',
+      input: () => z3.object({ inner: z3.object({ count: z3.number() }) }),
+      output: () => z3.object({ inner: z3.object({ count: z3.number().max(9) }) }),
+      path: 'properties.value.properties.inner.properties.count.maximum',
+      expected: 9,
+    },
+    {
+      name: 'array item minimum',
+      input: () => z3.array(z3.number()),
+      output: () => z3.array(z3.number().min(1)),
+      path: 'properties.value.items.minimum',
+      expected: 1,
+    },
+    {
+      name: 'array length bounds',
+      input: () => z3.array(z3.number()).max(5),
+      output: () => z3.array(z3.number()).min(2),
+      path: 'properties.value.minItems',
+      expected: 2,
+    },
+  ])(
+    'preserves representable structural pipeline output $name constraints',
+    ({ input, output, path, expected }) => {
+      const result = create(z3.object({ value: input().pipe(output()) }));
+      expect(strictHelperSchema(result)).toHaveProperty(path, expected);
+      expect(JSON.stringify(strictHelperSchema(result))).not.toContain('"allOf"');
+    },
+  );
+
+  it.each([
+    {
+      name: 'BigInt maximum',
+      output: () => z3.bigint().max(9n),
+      keyword: 'maximum',
+      expected: 9,
+    },
+    {
+      name: 'BigInt literal',
+      output: () => z3.literal(4n),
+      keyword: 'const',
+      expected: 4,
+    },
+  ])(
+    'projects a converting pipeline output $name constraint onto numeric input',
+    ({ output, keyword, expected }) => {
+      const result = create(z3.object({ value: z3.number().transform(BigInt).pipe(output()) }));
+      expect(strictHelperSchema(result)).toHaveProperty(`properties.value.${keyword}`, expected);
+    },
+  );
+
+  it('rejects converting output constraints that cannot be projected onto their input', () => {
+    const value = z3.string().transform(BigInt).pipe(z3.bigint().max(9n));
+    expect(() => create(z3.object({ value }))).toThrow('ZodPipeline output constraints');
+  });
+
+  it('rejects pipeline output constraints that cannot be structurally represented', () => {
+    const input = z3.object({ value: z3.number() });
+    const output = z3.object({ different: z3.number() });
+    expect(() => create(z3.object({ value: input.pipe(output) }))).toThrow('ZodPipeline output constraints');
   });
 
   it('preserves represented restrictions in pipeline outputs', () => {

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -309,6 +309,54 @@ describe('Zod v3 strict schema capability analysis', () => {
     expect(() => JSON.stringify(format)).not.toThrow();
   });
 
+  it('revalidates shared native default objects against every schema use site', () => {
+    const shared = { count: 4n };
+    const incompatible = z3
+      .object({
+        typed: z3.object({ count: z3.coerce.bigint() }),
+        raw: z3.any(),
+      })
+      .default({ typed: shared, raw: shared });
+    expect(() => formatFor(incompatible)).toThrow('ZodBigInt');
+
+    const compatible = z3
+      .object({
+        first: z3.object({ count: z3.coerce.bigint() }),
+        second: z3.object({ count: z3.coerce.bigint() }),
+      })
+      .default({ first: shared, second: shared });
+    const format = formatFor(compatible);
+    const value = (
+      format.json_schema.schema as {
+        properties: { value: { default: { first: object; second: object } } };
+      }
+    ).properties.value.default;
+    expect(value.first).toEqual({ count: 4 });
+    expect(value.first).toBe(value.second);
+    expect(format.$parseRaw('{}')).toEqual({ value: { first: { count: 4n }, second: { count: 4n } } });
+  });
+
+  it.each([
+    {
+      name: 'self-referencing',
+      create: () => {
+        const proxy: object = new Proxy({}, { getPrototypeOf: () => proxy });
+        return proxy;
+      },
+    },
+    {
+      name: 'unbounded',
+      create: () => {
+        const handler: ProxyHandler<object> = {
+          getPrototypeOf: () => new Proxy({}, handler),
+        };
+        return new Proxy({}, handler);
+      },
+    },
+  ])('rejects a hostile $name Proxy prototype chain without hanging', ({ create }) => {
+    expect(() => formatFor(z3.any().default(create()))).toThrow('prototype chain');
+  });
+
   it.each([
     { name: 'tuple', schema: () => z3.tuple([z3.number()]), message: 'tuple-form' },
     { name: 'record', schema: () => z3.record(z3.number()), message: 'additionalProperties: false' },
@@ -952,6 +1000,12 @@ describe('Zod v3 strict schema capability analysis', () => {
 });
 
 describe.each(strictHelpers)('$name strict numeric input capability analysis', ({ create }) => {
+  it.each([0n, -2n])('rejects an invalid BigInt multiple %s before emitting JSON Schema', (multiple) => {
+    expect(() => create(z3.object({ value: z3.coerce.bigint().multipleOf(multiple) }))).toThrow(
+      'strictly positive',
+    );
+  });
+
   it.each([
     { name: 'direct BigInt', schema: () => z3.number().int().transform(BigInt) },
     { name: 'unrestricted BigInt', schema: () => z3.number().transform(BigInt) },

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -273,6 +273,26 @@ describe('Zod v3 strict schema capability analysis', () => {
   });
 
   it.each([
+    { name: 'BigInt serializer', property: 'toJSON', replacement: (): bigint => 4n },
+    { name: 'malformed serializer', property: 'toJSON', replacement: (): string => 'invalid-date' },
+    { name: 'malformed ISO string', property: 'toISOString', replacement: (): string => 'invalid-date' },
+    { name: 'numeric coercion', property: 'valueOf', replacement: (): number => 0 },
+    { name: 'primitive coercion', property: Symbol.toPrimitive, replacement: (): string => 'invalid-date' },
+  ])('rejects a modified Date prototype $name without invoking it', ({ property, replacement }) => {
+    const methods = Date.prototype as unknown as Record<PropertyKey, () => unknown>;
+    const override = vi.spyOn(methods, property);
+    try {
+      override.mockImplementation(replacement);
+      expect(() => formatFor(z3.coerce.date().default(new Date('2026-08-17T00:00:00.000Z')))).toThrow(
+        'invalid or customized',
+      );
+      expect(override).not.toHaveBeenCalled();
+    } finally {
+      override.mockRestore();
+    }
+  });
+
+  it.each([
     { name: 'string', first: () => z3.string() },
     { name: 'any value', first: () => z3.any() },
     { name: 'wrapped string', first: () => z3.string().readonly() },
@@ -1110,11 +1130,56 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
   ])('bounds later numbers after an exact $name BigInt transform producer', ({ producer }) => {
     const result = create(z3.object({ value: z3.union([producer(), z3.number()]) }));
     expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1', {
-      type: 'number',
+      type: 'integer',
       minimum: Number.MIN_SAFE_INTEGER,
       maximum: Number.MAX_SAFE_INTEGER,
     });
     expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
+    expect(() => result.$parseRaw('{"value":1.5}')).toThrow(RangeError);
+  });
+
+  it('preserves fractional fallback when the earlier BigInt transform rejects non-integers', () => {
+    const value = z3.union([z3.number().int().transform(BigInt), z3.number()]);
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1.type', 'number');
+    expect(result.$parseRaw('{"value":1.5}')).toEqual({ value: 1.5 });
+  });
+
+  it('preserves fractional numbers accepted before a later exact BigInt transform', () => {
+    const value = z3.union([z3.number(), z3.number().transform(BigInt)]);
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.0.type', 'number');
+    expect(result.$parseRaw('{"value":1.5}')).toEqual({ value: 1.5 });
+  });
+
+  it('preserves a disjoint fractional range after a bounded exact BigInt transform', () => {
+    const value = z3.union([z3.number().max(10).transform(BigInt), z3.number().min(20)]);
+    const result = create(z3.object({ value }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.anyOf.1', {
+      type: 'number',
+      minimum: 20,
+    });
+    expect(result.$parseRaw('{"value":20.5}')).toEqual({ value: 20.5 });
+  });
+
+  it.each([
+    {
+      name: 'coerced BigInt before number',
+      schema: () => z3.intersection(z3.coerce.bigint(), z3.number()),
+    },
+    {
+      name: 'number before coerced BigInt',
+      schema: () => z3.intersection(z3.number(), z3.coerce.bigint()),
+    },
+    {
+      name: 'wrapped exact BigInt transform',
+      schema: () => z3.intersection(z3.number().transform(BigInt).readonly(), z3.number()),
+    },
+  ])('rejects intersections with incompatible $name parsed outputs', ({ schema }) => {
+    expect(() => create(z3.object({ value: schema() }))).toThrow('incompatible parsed outputs');
   });
 
   it('preserves numeric intervals disjoint from an exact bounded BigInt transform', () => {

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -98,9 +98,29 @@ describe('Zod v3 strict schema capability analysis', () => {
     });
   });
 
-  it('rejects compound pipelines when one union input does not convert', () => {
-    const value = z3.union([z3.string().transform((input) => new Date(input)), z3.number()]).pipe(z3.date());
-    expect(() => formatFor(value)).toThrow('ZodDate');
+  it.each([
+    {
+      name: 'union',
+      input: () => z3.union([z3.string().transform((value) => new Date(value)), z3.number()]),
+    },
+    {
+      name: 'intersection',
+      input: () =>
+        z3.intersection(
+          z3.string().transform((value) => new Date(value)),
+          z3.string(),
+        ),
+    },
+    {
+      name: 'nested intersection',
+      input: () =>
+        z3.intersection(
+          z3.lazy(() => z3.string().transform((value) => new Date(value))),
+          z3.string(),
+        ),
+    },
+  ])('rejects compound pipelines when one $name input does not convert', ({ input }) => {
+    expect(() => formatFor(input().pipe(z3.date()))).toThrow('ZodDate');
   });
 
   it.each([
@@ -113,19 +133,131 @@ describe('Zod v3 strict schema capability analysis', () => {
     expect(() => formatFor(schema())).toThrow('ZodBigInt');
   });
 
-  it('preserves nested BigInt defaults in typed tuples and records', () => {
+  it('preserves nested BigInt defaults in supported typed arrays and objects', () => {
     const format = zodResponseFormat(
       z3.object({
-        tuple: z3.tuple([z3.coerce.bigint()]).default([4n]),
-        record: z3.record(z3.coerce.bigint()).default({ count: 5n }),
+        values: z3.array(z3.coerce.bigint()).default([4n]),
+        detail: z3.object({ count: z3.coerce.bigint() }).default({ count: 5n }),
       }),
       'strict',
     );
 
     expect(format.json_schema.schema).toMatchObject({
-      properties: { tuple: { default: [4] }, record: { default: { count: 5 } } },
+      properties: { values: { default: [4] }, detail: { default: { count: 5 } } },
     });
-    expect(format.$parseRaw('{}')).toEqual({ tuple: [4n], record: { count: 5n } });
+    expect(format.$parseRaw('{}')).toEqual({ values: [4n], detail: { count: 5n } });
+  });
+
+  it.each([
+    { name: 'tuple', schema: () => z3.tuple([z3.number()]), message: 'tuple-form' },
+    { name: 'record', schema: () => z3.record(z3.number()), message: 'additionalProperties: false' },
+    {
+      name: 'array and tuple union',
+      schema: () => z3.union([z3.array(z3.coerce.bigint()), z3.tuple([z3.number()])]),
+      message: 'tuple-form',
+    },
+    {
+      name: 'preprocessed Map',
+      schema: () =>
+        z3.preprocess((value) => new Map(value as [string, number][]), z3.map(z3.string(), z3.number())),
+      message: 'tuple-form',
+    },
+  ])('rejects unsupported $name representations at the canonical strict boundary', ({ schema, message }) => {
+    expect(() => formatFor(schema())).toThrow(message);
+  });
+
+  it.each([
+    {
+      name: 'direct union',
+      schema: () => z3.union([z3.coerce.bigint(), z3.string()]).default(4n),
+      output: 4n,
+      normalized: 4,
+    },
+    {
+      name: 'string-prefixed union',
+      schema: () => z3.union([z3.string(), z3.coerce.bigint()]).default(4n),
+      output: 4n,
+      normalized: 4,
+    },
+    {
+      name: 'nested object union',
+      schema: () =>
+        z3.union([z3.object({ count: z3.coerce.bigint() }), z3.object({ count: z3.string() })]).default({
+          count: 4n,
+        }),
+      output: { count: 4n },
+      normalized: { count: 4 },
+    },
+    {
+      name: 'discriminated object union',
+      schema: () =>
+        z3
+          .union([
+            z3.object({ kind: z3.literal('number'), count: z3.number() }),
+            z3.object({ kind: z3.literal('bigint'), count: z3.coerce.bigint() }),
+          ])
+          .default({ kind: 'bigint', count: 4n }),
+      output: { kind: 'bigint', count: 4n },
+      normalized: { kind: 'bigint', count: 4 },
+    },
+  ])(
+    'normalizes a safe BigInt default through a compatible $name branch',
+    ({ schema, output, normalized }) => {
+      const format = formatFor(schema());
+      expect(format.json_schema.schema).toHaveProperty('properties.value.default', normalized);
+      expect(format.$parseRaw('{}')).toEqual({ value: output });
+    },
+  );
+
+  it.each([
+    { name: 'number', schema: () => z3.union([z3.number(), z3.coerce.bigint()]).default(4n) },
+    { name: 'any', schema: () => z3.union([z3.any(), z3.coerce.bigint()]).default(4n) },
+    {
+      name: 'nested number',
+      schema: () =>
+        z3
+          .union([z3.object({ count: z3.number() }), z3.object({ count: z3.coerce.bigint() })])
+          .default({ count: 4n }),
+    },
+  ])('rejects BigInt defaults intercepted by an earlier $name union option', ({ schema }) => {
+    expect(() => formatFor(schema())).toThrow('ZodBigInt');
+  });
+
+  it.each([
+    {
+      name: 'Set',
+      type: 'ZodSet',
+      schema: () =>
+        z3
+          .preprocess(
+            (value) => (value instanceof Set ? value : new Set(value as string[])),
+            z3.set(z3.string()),
+          )
+          .default(new Set(['x'])),
+    },
+    {
+      name: 'Map',
+      type: 'ZodMap',
+      schema: () =>
+        z3
+          .preprocess(
+            (value) => (value instanceof Map ? value : new Map(value as [string, number][])),
+            z3.map(z3.string(), z3.number()),
+          )
+          .default(new Map([['x', 1]])),
+    },
+    {
+      name: 'nested Set',
+      type: 'ZodSet',
+      schema: () =>
+        z3
+          .object({
+            values: z3.preprocess((value) => new Set(value as string[]), z3.set(z3.string())),
+          })
+          .default({ values: new Set(['x']) }),
+    },
+  ])('rejects native $name defaults before JSON serialization', ({ schema, type }) => {
+    expect(() => formatFor(schema())).toThrow(type);
   });
 
   it('bounds fallible numeric branches before BigInt coercion', () => {
@@ -143,6 +275,32 @@ describe('Zod v3 strict schema capability analysis', () => {
       },
     });
     expect(format.$parseRaw('{"value":101}')).toEqual({ value: 101n });
+  });
+
+  it.each([
+    {
+      name: 'whole-object refinement',
+      earlier: () => z3.object({ count: z3.number() }).refine((value) => value.count < 100),
+      later: () => z3.object({ count: z3.coerce.bigint() }),
+      input: { count: 101 },
+      output: { count: 101n },
+    },
+    {
+      name: 'sibling refinement',
+      earlier: () =>
+        z3.object({ count: z3.number(), kind: z3.string().refine((value) => value === 'number') }),
+      later: () => z3.object({ count: z3.coerce.bigint(), kind: z3.string() }),
+      input: { count: 101, kind: 'bigint' },
+      output: { count: 101n, kind: 'bigint' },
+    },
+  ])('bounds numeric leaves when an earlier $name can fall through', ({ earlier, later, input, output }) => {
+    const format = formatFor(z3.union([earlier(), later()]));
+    expect(format.json_schema.schema).toHaveProperty('properties.value.anyOf.0.properties.count', {
+      type: 'number',
+      minimum: Number.MIN_SAFE_INTEGER,
+      maximum: Number.MAX_SAFE_INTEGER,
+    });
+    expect(format.$parseRaw(JSON.stringify({ value: input }))).toEqual({ value: output });
   });
 
   it.each([
@@ -174,6 +332,13 @@ describe('Zod v3 strict schema capability analysis', () => {
       branch: { type: 'number' },
       input: 1e20,
     },
+    {
+      name: 'disjoint constrained intersection',
+      bigint: () => z3.intersection(z3.coerce.bigint().max(10n), z3.coerce.bigint()),
+      number: () => z3.number().min(1e20),
+      branch: { type: 'number', minimum: 1e20 },
+      input: 1e20,
+    },
   ])('preserves $name in later number alternatives', ({ bigint, number, branch, input }) => {
     const format = formatFor(z3.union([bigint(), number()]));
     const schema = format.json_schema.schema as {
@@ -184,21 +349,18 @@ describe('Zod v3 strict schema capability analysis', () => {
     expect(format.$parseRaw(JSON.stringify({ value: input }))).toEqual({ value: input });
   });
 
-  it('bounds numbers after Promise-wrapped BigInt producers', async () => {
+  it('does not treat Promise-wrapped BigInt as a synchronous union producer', () => {
     const value = z3.union([z3.promise(z3.coerce.bigint()), z3.number()]);
     const format = formatFor(value);
 
     expect(format.json_schema.schema).toMatchObject({
       properties: {
         value: {
-          anyOf: [
-            expect.anything(),
-            { type: 'number', minimum: Number.MIN_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER },
-          ],
+          anyOf: [expect.anything(), { type: 'number' }],
         },
       },
     });
-    await expect(value.parseAsync(7)).resolves.toBe(7n);
+    expect(format.$parseRaw('{"value":7}')).toEqual({ value: 7 });
   });
 
   it.each([
@@ -209,12 +371,6 @@ describe('Zod v3 strict schema capability analysis', () => {
       schema: () => z3.set(z3.string()).catch(new Set(['fallback'])),
       input: [],
       output: new Set(['fallback']),
-    },
-    {
-      name: 'Map',
-      schema: () => z3.map(z3.string(), z3.number()).catch(new Map([['fallback', 1]])),
-      input: [],
-      output: new Map([['fallback', 1]]),
     },
   ])('treats typed $name catch fallbacks as native conversions', ({ schema, input, output }) => {
     const format = formatFor(schema());
@@ -291,28 +447,12 @@ describe('Zod v3 strict schema capability analysis', () => {
       path: ['items'],
     },
     {
-      name: 'tuple positions',
-      producer: () => z3.tuple([z3.coerce.bigint()]),
-      consumer: () => z3.tuple([z3.number()]),
-      input: [7],
-      output: [7n],
-      path: ['items', 0],
-    },
-    {
       name: 'nested object-array paths',
       producer: () => z3.object({ values: z3.array(z3.object({ count: z3.coerce.bigint() })) }),
       consumer: () => z3.object({ values: z3.array(z3.object({ count: z3.number() })) }),
       input: { values: [{ count: 7 }] },
       output: { values: [{ count: 7n }] },
       path: ['properties', 'values', 'items', 'properties', 'count'],
-    },
-    {
-      name: 'record values',
-      producer: () => z3.record(z3.coerce.bigint()),
-      consumer: () => z3.record(z3.number()),
-      input: { count: 7 },
-      output: { count: 7n },
-      path: ['additionalProperties'],
     },
   ])(
     'bounds unsafe overlap at matching $name in union alternatives',
@@ -348,6 +488,39 @@ describe('Zod v3 strict schema capability analysis', () => {
       type: 'number',
     });
   });
+
+  it.each([
+    {
+      name: 'nested literal',
+      bigint: () => z3.object({ kind: z3.object({ name: z3.literal('bigint') }), count: z3.coerce.bigint() }),
+      number: () =>
+        z3.object({ kind: z3.object({ name: z3.literal('number') }), count: z3.number().min(1e20) }),
+      input: { kind: { name: 'number' }, count: 1e20 },
+    },
+    {
+      name: 'wrapped literal',
+      bigint: () => z3.object({ kind: z3.literal('bigint').readonly(), count: z3.coerce.bigint() }),
+      number: () =>
+        z3.object({ kind: z3.literal('number').brand<'number-kind'>(), count: z3.number().min(1e20) }),
+      input: { kind: 'number', count: 1e20 },
+    },
+    {
+      name: 'enum',
+      bigint: () => z3.object({ kind: z3.enum(['bigint']), count: z3.coerce.bigint() }),
+      number: () => z3.object({ kind: z3.enum(['number']), count: z3.number().min(1e20) }),
+      input: { kind: 'number', count: 1e20 },
+    },
+  ])(
+    'preserves unsafe-range number branches separated by a $name discriminator',
+    ({ bigint, number, input }) => {
+      const format = formatFor(z3.union([bigint(), number()]));
+      expect(format.json_schema.schema).toHaveProperty('properties.value.anyOf.1.properties.count', {
+        type: 'number',
+        minimum: 1e20,
+      });
+      expect(format.$parseRaw(JSON.stringify({ value: input }))).toEqual({ value: input });
+    },
+  );
 
   it('preserves disjoint and one-sided nested numeric interception intervals', () => {
     const disjoint = formatFor(
@@ -391,14 +564,18 @@ describe('Zod v3 strict schema capability analysis', () => {
     expect(format.json_schema.schema).toHaveProperty('properties.outsideContainer.properties.count', {
       type: 'number',
     });
+    expect(format.json_schema.schema).toHaveProperty('properties.direct.anyOf.1.properties.count', {
+      type: 'number',
+      ...bounds,
+    });
     expect(format.json_schema.schema).toHaveProperty(
-      'properties.direct.anyOf.1.properties.count.allOf.1',
-      bounds,
+      'properties.nested.anyOf.1.properties.child.properties.count',
+      {
+        type: 'number',
+        ...bounds,
+      },
     );
-    expect(format.json_schema.schema).toHaveProperty(
-      'properties.nested.anyOf.1.properties.child.allOf.1.properties.count',
-      bounds,
-    );
+    expect(JSON.stringify(format.json_schema.schema)).not.toContain('"allOf"');
   });
 
   it.each(['leaf-first', 'holder-first'] as const)(
@@ -421,6 +598,30 @@ describe('Zod v3 strict schema capability analysis', () => {
 });
 
 describe.each(strictHelpers)('$name strict numeric input capability analysis', ({ create }) => {
+  it.each([
+    { name: 'direct BigInt', schema: () => z3.number().int().transform(BigInt) },
+    { name: 'opaque BigInt', schema: () => z3.number().transform((value) => BigInt(Math.trunc(value))) },
+    {
+      name: 'wrapped BigInt',
+      schema: () => z3.number().int().transform(BigInt).nullable(),
+    },
+  ])('conservatively bounds numeric $name transforms', ({ schema }) => {
+    const result = create(z3.object({ value: schema() }));
+    const generated = strictHelperSchema(result) as {
+      properties: { value: Record<string, unknown> };
+    };
+    const property = generated.properties.value;
+    const value = Array.isArray(property['anyOf'])
+      ? (property['anyOf'][0] as Record<string, unknown>)
+      : property;
+
+    expect(value).toMatchObject({
+      minimum: Number.MIN_SAFE_INTEGER,
+      maximum: Number.MAX_SAFE_INTEGER,
+    });
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
+  });
+
   it.each([
     {
       name: 'output refinement',
@@ -611,8 +812,6 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
       properties: { value: { anyOf: Record<string, unknown>[] } };
     };
 
-    expect(generated.properties.value.anyOf[0]).toEqual({
-      allOf: [{ type: 'number' }, { type: 'number', maximum: 9 }],
-    });
+    expect(generated.properties.value.anyOf[0]).toEqual({ type: 'number', maximum: 9 });
   });
 });

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -10,6 +10,7 @@ import {
 import { z as z3 } from 'zod/v3';
 
 const formatFor = (value: z3.ZodTypeAny) => zodResponseFormat(z3.object({ value }), 'strict');
+const undefinedLiteral = new Map<string, never>().get('missing');
 
 const nestedSchemaAt = (schema: unknown, path: readonly (string | number)[]): unknown => {
   let current = schema;
@@ -1477,6 +1478,59 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     expect(() => create(z3.object({ value: schema() }))).toThrow('non-finite');
   });
 
+  it.each([
+    { name: 'undefined', literal: () => undefinedLiteral },
+    { name: 'symbol', literal: () => Symbol('value') },
+    { name: 'function', literal: () => () => 'value' },
+    { name: 'object', literal: () => ({ value: 'same reference' }) },
+    { name: 'array', literal: () => ['same reference'] },
+    { name: 'Date', literal: () => new Date('2026-01-01T00:00:00.000Z') },
+  ])('rejects a non-JSON $name literal instead of advertising an object schema', ({ literal }) => {
+    const value = () => z3.literal(literal() as never);
+
+    expect(() => create(z3.object({ value: value() }))).toThrow(/ZodLiteral.*non-JSON/u);
+    expect(() => create(z3.object({ nested: z3.object({ value: value().readonly() }) }))).toThrow(
+      /ZodLiteral.*non-JSON/u,
+    );
+    expect(() => create(z3.object({ value: z3.union([z3.literal('valid'), value()]) }))).toThrow(
+      /ZodLiteral.*non-JSON/u,
+    );
+  });
+
+  it('rejects an object-identity literal without invoking its getters', () => {
+    const getter = vi.fn(() => {
+      throw new Error('must never run');
+    });
+    const value = Object.defineProperty({}, 'toJSON', { enumerable: true, get: getter });
+
+    expect(() => create(z3.object({ value: z3.literal(value as never) }))).toThrow(/ZodLiteral.*non-JSON/u);
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  it('rejects an undefined literal in a downstream pipeline output', () => {
+    expect(() => create(z3.object({ value: z3.any().pipe(z3.literal(undefinedLiteral)) }))).toThrow(
+      /ZodLiteral.*non-JSON/u,
+    );
+  });
+
+  it('preserves JSON primitive string, number, boolean, and null literals', () => {
+    const result = create(
+      z3.object({
+        text: z3.literal('safe'),
+        count: z3.literal(7),
+        enabled: z3.literal(true),
+        empty: z3.literal(null),
+      }),
+    );
+
+    expect(result.$parseRaw('{"text":"safe","count":7,"enabled":true,"empty":null}')).toEqual({
+      text: 'safe',
+      count: 7,
+      enabled: true,
+      empty: null,
+    });
+  });
+
   it('preserves finite literals, compact literal unions, and native enum values', () => {
     const finite = create(
       z3.object({
@@ -2088,6 +2142,98 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     },
   ])('rejects overlapping $name with incompatible union intersection outputs', ({ schema }) => {
     expect(() => create(z3.object({ value: schema() }))).toThrow('incompatible parsed outputs');
+  });
+
+  it.each([
+    {
+      name: 'trim before an unchanged string',
+      schema: () => z3.intersection(z3.string().trim(), z3.string()),
+    },
+    {
+      name: 'an unchanged string before trim',
+      schema: () => z3.intersection(z3.string(), z3.string().trim()),
+    },
+    {
+      name: 'lowercase before an unchanged string',
+      schema: () => z3.intersection(z3.string().toLowerCase(), z3.string()),
+    },
+    {
+      name: 'uppercase before an unchanged string',
+      schema: () => z3.intersection(z3.string().toUpperCase(), z3.string()),
+    },
+    {
+      name: 'lowercase before uppercase',
+      schema: () => z3.intersection(z3.string().toLowerCase(), z3.string().toUpperCase()),
+    },
+    {
+      name: 'different string transformation order',
+      schema: () => z3.intersection(z3.string().trim().toLowerCase(), z3.string().toLowerCase().trim()),
+    },
+    {
+      name: 'readonly lazy trim before an unchanged string',
+      schema: () =>
+        z3.intersection(
+          z3.lazy(() => z3.string().trim().readonly()),
+          z3.string(),
+        ),
+    },
+    {
+      name: 'nullable lowercase before an unchanged nullable string',
+      schema: () => z3.intersection(z3.string().toLowerCase().nullable(), z3.string().nullable()),
+    },
+    {
+      name: 'a transformed nested object property',
+      schema: () =>
+        z3.intersection(z3.object({ text: z3.string().trim() }), z3.object({ text: z3.string() })),
+    },
+    {
+      name: 'a transformed nested array item',
+      schema: () => z3.intersection(z3.array(z3.string().toUpperCase()), z3.array(z3.string())),
+    },
+  ])('rejects incompatible $name intersection outputs', ({ schema }) => {
+    expect(() => create(z3.object({ value: schema() }))).toThrow('incompatible parsed outputs');
+  });
+
+  it.each([
+    {
+      name: 'matching trim',
+      left: () => z3.string().trim(),
+      right: () => z3.string().trim(),
+      raw: ' safe ',
+      expected: 'safe',
+    },
+    {
+      name: 'matching lowercase',
+      left: () => z3.string().toLowerCase(),
+      right: () => z3.string().toLowerCase(),
+      raw: 'SAFE',
+      expected: 'safe',
+    },
+    {
+      name: 'matching uppercase',
+      left: () => z3.string().toUpperCase(),
+      right: () => z3.string().toUpperCase(),
+      raw: 'safe',
+      expected: 'SAFE',
+    },
+    {
+      name: 'matching ordered transformations',
+      left: () => z3.string().trim().toLowerCase(),
+      right: () => z3.string().trim().toLowerCase(),
+      raw: ' SAFE ',
+      expected: 'safe',
+    },
+    {
+      name: 'matching readonly lazy transformations',
+      left: () => z3.lazy(() => z3.string().trim().readonly()),
+      right: () => z3.string().trim(),
+      raw: ' safe ',
+      expected: 'safe',
+    },
+  ])('preserves a provably matching $name intersection', ({ left, right, raw, expected }) => {
+    const result = create(z3.object({ value: z3.intersection(left(), right()) }));
+
+    expect(result.$parseRaw(JSON.stringify({ value: raw }))).toEqual({ value: expected });
   });
 
   it('preserves compatible nullable numeric intersection outputs', () => {
@@ -3497,6 +3643,110 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
   ])('preserves a provably compatible $name pipeline output', ({ schema, expected }) => {
     const result = create(z3.object({ value: schema() }));
     expect(result.$parseRaw('{"value":7}')).toEqual({ value: expected });
+  });
+
+  it.each([
+    {
+      name: 'a checked string and any',
+      input: () => z3.string().min(2),
+      output: () => z3.any(),
+      raw: 'safe',
+      expected: 'safe',
+      schema: { type: 'string', minLength: 2 },
+    },
+    {
+      name: 'a checked string and unknown',
+      input: () => z3.string().min(2),
+      output: () => z3.unknown(),
+      raw: 'safe',
+      expected: 'safe',
+      schema: { type: 'string', minLength: 2 },
+    },
+    {
+      name: 'a bounded number and readonly any',
+      input: () => z3.number().min(2),
+      output: () => z3.any().readonly(),
+      raw: 7,
+      expected: 7,
+      schema: { type: 'number', minimum: 2 },
+    },
+    {
+      name: 'a bounded number and optional unknown',
+      input: () => z3.number().min(2),
+      output: () => z3.unknown().optional(),
+      raw: 7,
+      expected: 7,
+      schema: { type: 'number', minimum: 2 },
+    },
+    {
+      name: 'a bounded number and nullable any',
+      input: () => z3.number().min(2),
+      output: () => z3.any().nullable(),
+      raw: 7,
+      expected: 7,
+      schema: { type: 'number', minimum: 2 },
+    },
+    {
+      name: 'a bounded number and defaulted unknown',
+      input: () => z3.number().min(2),
+      output: () => z3.unknown().default(0),
+      raw: 7,
+      expected: 7,
+      schema: { type: 'number', minimum: 2 },
+    },
+    {
+      name: 'a bounded number and caught any',
+      input: () => z3.number().min(2),
+      output: () => z3.any().catch(0),
+      raw: 7,
+      expected: 7,
+      schema: { type: 'number', minimum: 2 },
+    },
+    {
+      name: 'a bounded number and branded any',
+      input: () => z3.number().min(2),
+      output: () => z3.any().brand<'unconstrained'>(),
+      raw: 7,
+      expected: 7,
+      schema: { type: 'number', minimum: 2 },
+    },
+    {
+      name: 'a bounded number and lazy unknown',
+      input: () => z3.number().min(2),
+      output: () => z3.lazy(() => z3.unknown()),
+      raw: 7,
+      expected: 7,
+      schema: { type: 'number', minimum: 2 },
+    },
+    {
+      name: 'a checked array and any',
+      input: () => z3.array(z3.number()).min(1),
+      output: () => z3.any(),
+      raw: [7],
+      expected: [7],
+      schema: { type: 'array', minItems: 1 },
+    },
+    {
+      name: 'an exact BigInt transform and unknown',
+      input: () => z3.number().transform(BigInt),
+      output: () => z3.unknown(),
+      raw: 7,
+      expected: 7n,
+      schema: { type: 'integer' },
+    },
+  ])('preserves typed pipeline input through $name output', ({ input, output, raw, expected, schema }) => {
+    const result = create(z3.object({ value: input().pipe(output()) }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value', expect.objectContaining(schema));
+    expect(result.$parseRaw(JSON.stringify({ value: raw }))).toEqual({ value: expected });
+  });
+
+  it('keeps rejecting a refined any pipeline output without invoking its refinement', () => {
+    const refinement = vi.fn((value: unknown) => value === 'safe');
+    const output = z3.any().refine(refinement);
+
+    expect(() => create(z3.object({ value: z3.string().pipe(output) }))).toThrow('cannot be represented');
+    expect(refinement).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/tests/helpers/zod-strict-schema-capabilities.test.ts
+++ b/tests/helpers/zod-strict-schema-capabilities.test.ts
@@ -1319,6 +1319,83 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
   });
 
   it.each([
+    {
+      name: 'descending inclusive minimum',
+      schema: () => z3.coerce.bigint().min(10n).min(5n),
+      expected: { minimum: 10 },
+      valid: 10,
+      invalid: 7,
+    },
+    {
+      name: 'ascending inclusive minimum',
+      schema: () => z3.coerce.bigint().min(5n).min(10n),
+      expected: { minimum: 10 },
+      valid: 10,
+      invalid: 7,
+    },
+    {
+      name: 'descending exclusive minimum',
+      schema: () => z3.coerce.bigint().gt(10n).gt(5n),
+      expected: { exclusiveMinimum: 10 },
+      valid: 11,
+      invalid: 10,
+    },
+    {
+      name: 'ascending inclusive maximum',
+      schema: () => z3.coerce.bigint().max(5n).max(10n),
+      expected: { maximum: 5 },
+      valid: 5,
+      invalid: 7,
+    },
+    {
+      name: 'descending inclusive maximum',
+      schema: () => z3.coerce.bigint().max(10n).max(5n),
+      expected: { maximum: 5 },
+      valid: 5,
+      invalid: 7,
+    },
+    {
+      name: 'ascending exclusive maximum',
+      schema: () => z3.coerce.bigint().lt(5n).lt(10n),
+      expected: { exclusiveMaximum: 5 },
+      valid: 4,
+      invalid: 5,
+    },
+    {
+      name: 'mixed inclusive and exclusive minima',
+      schema: () => z3.coerce.bigint().gt(10n).min(5n).gt(8n),
+      expected: { minimum: 5, exclusiveMinimum: 10 },
+      valid: 11,
+      invalid: 10,
+    },
+    {
+      name: 'mixed inclusive and exclusive maxima',
+      schema: () => z3.coerce.bigint().lt(5n).max(10n).lt(8n),
+      expected: { maximum: 10, exclusiveMaximum: 5 },
+      valid: 4,
+      invalid: 5,
+    },
+    {
+      name: 'combined divisibility',
+      schema: () => z3.coerce.bigint().multipleOf(2n).multipleOf(3n),
+      expected: { multipleOf: 6 },
+      valid: 6,
+      invalid: 3,
+    },
+  ])('retains every repeated $name BigInt constraint', ({ schema, expected, valid, invalid }) => {
+    const result = create(z3.object({ value: schema() }));
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value', expect.objectContaining(expected));
+    expect(result.$parseRaw(JSON.stringify({ value: valid }))).toEqual({ value: BigInt(valid) });
+    expect(() => result.$parseRaw(JSON.stringify({ value: invalid }))).toThrow();
+  });
+
+  it('rejects repeated BigInt bounds whose strongest constraint leaves no safe integers', () => {
+    const value = z3.coerce.bigint().min(10n).max(9n).max(20n);
+    expect(() => create(z3.object({ value }))).toThrow('no safe JSON integer');
+  });
+
+  it.each([
     { name: 'direct BigInt', schema: () => z3.number().int().transform(BigInt) },
     { name: 'unrestricted BigInt', schema: () => z3.number().transform(BigInt) },
     {
@@ -1621,6 +1698,50 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
       schema: () => z3.intersection(z3.number().transform(BigInt).readonly(), z3.number()),
     },
     {
+      name: 'opaque BigInt transform before number',
+      schema: () =>
+        z3.intersection(
+          z3.number().transform((value) => BigInt(value.toString())),
+          z3.number(),
+        ),
+    },
+    {
+      name: 'number before opaque BigInt transform',
+      schema: () =>
+        z3.intersection(
+          z3.number(),
+          z3.number().transform((value) => BigInt(value.toString())),
+        ),
+    },
+    {
+      name: 'wrapped opaque BigInt transform',
+      schema: () =>
+        z3.intersection(
+          z3
+            .number()
+            .transform((value) => BigInt(value.toString()))
+            .readonly()
+            .optional(),
+          z3.number(),
+        ),
+    },
+    {
+      name: 'nested opaque BigInt transform',
+      schema: () =>
+        z3.intersection(
+          z3.object({ count: z3.number().transform((value) => BigInt(value.toString())) }),
+          z3.object({ count: z3.number() }),
+        ),
+    },
+    {
+      name: 'two unclassified output transforms',
+      schema: () =>
+        z3.intersection(
+          z3.number().transform((value) => BigInt(value.toString())),
+          z3.number().transform((value) => value.toString()),
+        ),
+    },
+    {
       name: 'optional coerced BigInt before number',
       schema: () => z3.intersection(z3.coerce.bigint().optional(), z3.number()),
     },
@@ -1710,6 +1831,27 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
 
     expect(strictHelperSchema(result)).toHaveProperty('properties.value.type', 'number');
     expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7 });
+  });
+
+  it.each([
+    {
+      name: 'number',
+      schema: () => z3.intersection(z3.number().transform(Number), z3.number()),
+      input: 7,
+    },
+    {
+      name: 'string',
+      schema: () => z3.intersection(z3.string().transform(String), z3.string()),
+      input: 'safe',
+    },
+    {
+      name: 'boolean',
+      schema: () => z3.intersection(z3.boolean().transform(Boolean), z3.boolean()),
+      input: true,
+    },
+  ])('preserves an intersection with a known compatible $name transform output', ({ schema, input }) => {
+    const result = create(z3.object({ value: schema() }));
+    expect(result.$parseRaw(JSON.stringify({ value: input }))).toEqual({ value: input });
   });
 
   it.each([
@@ -2237,6 +2379,43 @@ describe.each(strictHelpers)('$name strict numeric input capability analysis', (
     expect(generated.properties.value.anyOf[0]).not.toHaveProperty('minimum');
     expect(generated.properties.value.anyOf[0]).not.toHaveProperty('maximum');
     expect(result.$parseRaw('{"value":9007199254740993}')).toEqual({ value: 9_007_199_254_740_992 });
+  });
+
+  it.each([
+    { name: 'ascending integer factors', input: 2, output: 4, expected: 4 },
+    { name: 'descending integer factors', input: 4, output: 2, expected: 4 },
+    { name: 'integer least common multiple', input: 4, output: 6, expected: 12 },
+    { name: 'fractional factor', input: 0.1, output: 0.2, expected: 0.2 },
+    { name: 'fractional least common multiple', input: 0.2, output: 0.3, expected: 0.6 },
+    { name: 'mixed decimal factors', input: 0.1, output: 0.25, expected: 0.5 },
+  ])('merges compatible pipeline $name constraints', ({ input, output, expected }) => {
+    const result = create(
+      z3.object({ value: z3.number().multipleOf(input).pipe(z3.number().multipleOf(output)) }),
+    );
+
+    expect(strictHelperSchema(result)).toHaveProperty('properties.value.multipleOf', expected);
+    expect(result.$parseRaw(JSON.stringify({ value: expected }))).toEqual({ value: expected });
+  });
+
+  it('merges nested numeric pipeline divisibility constraints', () => {
+    const input = z3.object({ values: z3.array(z3.number().multipleOf(2)) });
+    const output = z3.object({ values: z3.array(z3.number().multipleOf(3)) });
+    const result = create(z3.object({ value: input.pipe(output) }));
+
+    expect(strictHelperSchema(result)).toHaveProperty(
+      'properties.value.properties.values.items.multipleOf',
+      6,
+    );
+    expect(result.$parseRaw('{"value":{"values":[6,12]}}')).toEqual({ value: { values: [6, 12] } });
+  });
+
+  it.each([
+    { name: 'zero divisor', input: 0, output: 2 },
+    { name: 'unsafe integer least common multiple', input: Number.MAX_SAFE_INTEGER, output: 2 },
+    { name: 'unsupported scientific decimal precision', input: 1e-7, output: 2e-7 },
+  ])('rejects an unsafely representable pipeline $name constraint', ({ input, output }) => {
+    const value = z3.number().multipleOf(input).pipe(z3.number().multipleOf(output));
+    expect(() => create(z3.object({ value }))).toThrow('ZodPipeline output constraints');
   });
 
   it.each([

--- a/tests/helpers/zod-unrepresentable-types.test.ts
+++ b/tests/helpers/zod-unrepresentable-types.test.ts
@@ -282,6 +282,18 @@ describe.each(strictHelpers)('$name with Zod v3 non-JSON-native types', ({ creat
   });
 
   it.each([
+    { name: 'lazy', schema: () => z3.lazy(() => z3.coerce.bigint()) },
+    {
+      name: 'intersection',
+      schema: () => z3.intersection(z3.coerce.bigint(), z3.coerce.bigint()),
+    },
+    {
+      name: 'shared intersection',
+      schema: () => {
+        const count = z3.coerce.bigint();
+        return z3.intersection(count, count);
+      },
+    },
     { name: 'nullable', schema: () => z3.coerce.bigint().nullable() },
     { name: 'branded', schema: () => z3.coerce.bigint().brand<'safe-bigint'>() },
     { name: 'readonly', schema: () => z3.coerce.bigint().readonly() },
@@ -319,6 +331,41 @@ describe.each(strictHelpers)('$name with Zod v3 non-JSON-native types', ({ creat
     expect(() => JSON.stringify(result)).not.toThrow();
   });
 
+  it('preserves productive recursive lazy BigInt definitions', () => {
+    const recursive: z3.ZodTypeAny = z3.lazy(() =>
+      z3.union([z3.coerce.bigint(), z3.object({ next: recursive })]),
+    );
+    const result = create(z3.object({ value: z3.union([recursive, z3.number()]) }));
+
+    expect(getStrictHelperSchema(result)).toMatchObject({
+      properties: {
+        value: {
+          anyOf: [
+            expect.anything(),
+            { type: 'number', minimum: Number.MIN_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER },
+          ],
+        },
+      },
+    });
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
+    expect(result.$parseRaw('{"value":{"next":7}}')).toEqual({ value: { next: 7n } });
+  });
+
+  it('preserves productive recursive lazy number definitions', () => {
+    const recursive: z3.ZodTypeAny = z3.lazy(() => z3.union([z3.number(), z3.object({ next: recursive })]));
+    const result = create(z3.object({ value: z3.union([z3.coerce.bigint(), recursive]) }));
+
+    expect(getStrictHelperSchema(result)).toMatchObject({
+      properties: {
+        value: {
+          anyOf: [expect.anything(), { minimum: Number.MIN_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER }],
+        },
+      },
+    });
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
+    expect(result.$parseRaw('{"value":{"next":7}}')).toEqual({ value: { next: 7 } });
+  });
+
   it('bounds shared number references locally without changing other fields', () => {
     const sharedNumber = z3.number();
     const result = create(
@@ -351,6 +398,29 @@ describe.each(strictHelpers)('$name with Zod v3 non-JSON-native types', ({ creat
     {
       name: 'nested constrained',
       schema: () => z3.union([z3.number().min(0), z3.string()]),
+    },
+    {
+      name: 'lazy',
+      schema: () => z3.lazy(() => z3.number()),
+    },
+    {
+      name: 'intersection',
+      schema: () => z3.intersection(z3.number(), z3.number()),
+    },
+    {
+      name: 'shared intersection',
+      schema: () => {
+        const number = z3.number();
+        return z3.intersection(number, number);
+      },
+    },
+    {
+      name: 'promise',
+      schema: () => z3.promise(z3.number()),
+    },
+    {
+      name: 'numeric native enum',
+      schema: () => z3.nativeEnum({ Unsafe: 9_007_199_254_740_992 } as const),
     },
   ])('bounds numeric branches inside $name unions after BigInt alternatives', ({ name, schema }) => {
     const result = create(z3.object({ value: z3.union([z3.coerce.bigint(), schema()]) }));
@@ -458,6 +528,48 @@ describe.each(strictHelpers)('$name with Zod v3 non-JSON-native types', ({ creat
     });
     expect(result.$parseRaw('{}')).toEqual({ value: 4n });
     expect(result.$parseRaw('{"value":null}')).toEqual({ value: null });
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it.each([
+    { name: 'direct', schema: (count: z3.ZodBigInt) => count.default(4n) },
+    { name: 'nullable', schema: (count: z3.ZodBigInt) => count.nullable().default(4n) },
+    { name: 'lazy', schema: (count: z3.ZodBigInt) => z3.lazy(() => count).default(4n) },
+  ])('preserves $name BigInt defaults when the underlying schema is shared', ({ schema }) => {
+    const count = z3.coerce.bigint();
+    const result = create(
+      z3.object({
+        first: count,
+        second: schema(count),
+      }),
+    );
+
+    expect(getStrictHelperSchema(result)).toMatchObject({
+      properties: {
+        first: { type: 'integer', minimum: Number.MIN_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER },
+        second: { default: 4 },
+      },
+    });
+    expect(result.$parseRaw('{"first":7}')).toEqual({ first: 7n, second: 4n });
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it('preserves shared preprocessed BigInt-literal defaults', () => {
+    const count = z3.preprocess(
+      (value) => (typeof value === 'number' ? BigInt(value) : value),
+      z3.literal(4n),
+    );
+    const result = create(
+      z3.object({
+        first: count,
+        second: count.default(4n),
+      }),
+    );
+
+    expect(getStrictHelperSchema(result)).toMatchObject({
+      properties: { second: { default: 4 } },
+    });
+    expect(result.$parseRaw('{"first":4}')).toEqual({ first: 4n, second: 4n });
     expect(() => JSON.stringify(result)).not.toThrow();
   });
 
@@ -705,6 +817,32 @@ describe('Zod v3 BigInt coercion JSON Schema serialization', () => {
       },
       definitions: { SharedNumber: { type: 'number' } },
     });
+  });
+
+  it('preserves registered shared BigInt definitions while normalizing defaults', () => {
+    const count = z3.coerce.bigint();
+    const format = zodResponseFormat(
+      z3.object({
+        first: count,
+        second: count.default(4n),
+        nullable: count.nullable().default(5n),
+      }),
+      'strict',
+      { schemaDefinitions: { Count: count } },
+    );
+
+    expect(format.json_schema.schema).toMatchObject({
+      properties: {
+        first: { $ref: '#/definitions/Count' },
+        second: { $ref: '#/definitions/Count', default: 4 },
+        nullable: { anyOf: [{ $ref: '#/definitions/Count' }, { type: 'null' }], default: 5 },
+      },
+      definitions: {
+        Count: { type: 'integer', minimum: Number.MIN_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER },
+      },
+    });
+    expect(format.$parseRaw('{"first":7}')).toEqual({ first: 7n, second: 4n, nullable: 5n });
+    expect(() => JSON.stringify(format)).not.toThrow();
   });
 
   it('normalizes safe BigInt constraints inside shared schema definitions', () => {

--- a/tests/helpers/zod-unrepresentable-types.test.ts
+++ b/tests/helpers/zod-unrepresentable-types.test.ts
@@ -111,6 +111,58 @@ describe.each(strictHelpers)('$name with Zod v3 non-JSON-native types', ({ creat
       expect(() => JSON.stringify(result)).not.toThrow();
     },
   );
+  it.each([
+    {
+      name: 'ZodDate',
+      schema: () =>
+        z3
+          .string()
+          .transform((value) => new Date(value))
+          .pipe(z3.date()),
+      input: '2026-08-17T00:00:00.000Z',
+      expected: (): Date => new Date('2026-08-17T00:00:00.000Z'),
+    },
+    {
+      name: 'ZodBigInt',
+      schema: () => z3.number().transform(BigInt).pipe(z3.bigint()),
+      input: 7,
+      expected: (): bigint => 7n,
+    },
+    {
+      name: 'ZodSet',
+      schema: () =>
+        z3
+          .array(z3.string())
+          .transform((value) => new Set(value))
+          .pipe(z3.set(z3.string())),
+      input: ['value'],
+      expected: (): Set<string> => new Set(['value']),
+    },
+    {
+      name: 'ZodMap',
+      schema: () =>
+        z3
+          .array(z3.tuple([z3.string(), z3.number()]))
+          .transform((value) => new Map(value))
+          .pipe(z3.map(z3.string(), z3.number())),
+      input: [['value', 7]],
+      expected: (): Map<string, number> => new Map([['value', 7]]),
+    },
+  ])('preserves pipeline transforms that construct $name values', ({ schema, input, expected }) => {
+    const result = create(z3.object({ value: schema() }));
+
+    expect(result.$parseRaw(JSON.stringify({ value: input }))).toEqual({ value: expected() });
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it('does not treat a refinement-only pipeline as native-value conversion', () => {
+    const value = z3
+      .string()
+      .refine((input) => input.length > 0)
+      .pipe(z3.date());
+
+    expect(() => create(z3.object({ value }))).toThrow('ZodDate');
+  });
 
   it.each([
     { name: 'nullable BigInt', schema: () => z3.bigint().nullable() },
@@ -140,6 +192,31 @@ describe.each(strictHelpers)('$name with Zod v3 non-JSON-native types', ({ creat
       first: new Date('2026-08-17T00:00:00.000Z'),
       second: new Date('2026-08-18T00:00:00.000Z'),
     });
+  });
+
+  it('preserves preprocessing context for shared native-value containers', () => {
+    const shared = z3.object({ when: z3.date() });
+    const convert = (value: unknown) => {
+      if (typeof value !== 'object' || value === null) {
+        return value;
+      }
+
+      const input = value as { when?: unknown };
+      return { ...input, when: preprocessDateValue(input.when) };
+    };
+    const first = z3.preprocess(convert, shared);
+    const second = z3.preprocess(convert, shared);
+    const result = create(z3.object({ first, second }));
+
+    expect(
+      result.$parseRaw(
+        '{"first":{"when":"2026-08-17T00:00:00.000Z"},"second":{"when":"2026-08-18T00:00:00.000Z"}}',
+      ),
+    ).toEqual({
+      first: { when: new Date('2026-08-17T00:00:00.000Z') },
+      second: { when: new Date('2026-08-18T00:00:00.000Z') },
+    });
+    expect(() => create(z3.object({ converted: first, raw: shared }))).toThrow('ZodDate');
   });
 
   it('normalizes JSON-compatible preprocessed BigInt literals', () => {
@@ -229,6 +306,45 @@ describe('Zod v3 BigInt coercion JSON Schema serialization', () => {
       },
     });
     expect(() => JSON.stringify(format.json_schema.schema)).not.toThrow();
+  });
+  it('bounds shared and wrapped number branches without changing their other uses', () => {
+    const number = z3.number();
+    const narrower = z3.number().min(-2).max(2);
+    const schema = z3.object({
+      unrestricted: number,
+      reference: z3.union([z3.coerce.bigint(), number]),
+      nullable: z3.union([z3.coerce.bigint(), number.nullable()]),
+      defaulted: z3.union([z3.coerce.bigint(), number.default(1)]).default(1),
+      branded: z3.union([z3.coerce.bigint(), number.brand<'counter'>()]),
+      narrower: z3.union([z3.coerce.bigint(), narrower]),
+    });
+    const format = zodResponseFormat(schema, 'strict');
+    const safeInteger = {
+      minimum: Number.MIN_SAFE_INTEGER,
+      maximum: Number.MAX_SAFE_INTEGER,
+    };
+
+    expect(format.json_schema.schema).toMatchObject({
+      properties: {
+        unrestricted: { type: 'number' },
+        reference: { anyOf: [{ type: 'integer' }, { type: 'number', ...safeInteger }] },
+        nullable: {
+          anyOf: [{ type: 'integer' }, { type: 'number', nullable: true, ...safeInteger }],
+        },
+        defaulted: { anyOf: [{ type: 'integer' }, { type: 'number', default: 1, ...safeInteger }] },
+        branded: { anyOf: [{ type: 'integer' }, { type: 'number', ...safeInteger }] },
+        narrower: { anyOf: [{ type: 'integer' }, { type: 'number', minimum: -2, maximum: 2 }] },
+      },
+    });
+    const { unrestricted } = (format.json_schema.schema as { properties: Record<string, unknown> })
+      .properties;
+    expect(unrestricted).not.toHaveProperty('minimum');
+    expect(unrestricted).not.toHaveProperty('maximum');
+    expect(
+      format.$parseRaw(
+        '{"unrestricted":9007199254740992,"reference":7,"nullable":null,"defaulted":8,"branded":9,"narrower":1}',
+      ),
+    ).toMatchObject({ unrestricted: 9_007_199_254_740_992, nullable: null });
   });
 
   it('serializes safe constraints and defaults as JSON numbers', () => {

--- a/tests/helpers/zod-unrepresentable-types.test.ts
+++ b/tests/helpers/zod-unrepresentable-types.test.ts
@@ -68,16 +68,6 @@ const preprocessedTypes = [
     input: ['value'],
     expected: () => new Set(['value']),
   },
-  {
-    name: 'ZodMap',
-    schema: () =>
-      z3.preprocess(
-        (value) => (Array.isArray(value) ? new Map(value as [string, number][]) : value),
-        z3.map(z3.string(), z3.number()),
-      ),
-    input: [['value', 7]],
-    expected: () => new Map([['value', 7]]),
-  },
 ];
 
 describe.each(strictHelpers)('$name with Zod v3 non-JSON-native types', ({ create }) => {
@@ -151,16 +141,6 @@ describe.each(strictHelpers)('$name with Zod v3 non-JSON-native types', ({ creat
           .pipe(z3.set(z3.string())),
       input: ['value'],
       expected: (): Set<string> => new Set(['value']),
-    },
-    {
-      name: 'ZodMap',
-      schema: () =>
-        z3
-          .array(z3.tuple([z3.string(), z3.number()]))
-          .transform((value) => new Map(value))
-          .pipe(z3.map(z3.string(), z3.number())),
-      input: [['value', 7]],
-      expected: (): Map<string, number> => new Map([['value', 7]]),
     },
   ])('preserves pipeline transforms that construct $name values', ({ schema, input, expected }) => {
     const result = create(z3.object({ value: schema() }));

--- a/tests/helpers/zod-unrepresentable-types.test.ts
+++ b/tests/helpers/zod-unrepresentable-types.test.ts
@@ -1,0 +1,188 @@
+import {
+  zodFunction,
+  zodRealtimeFunction,
+  zodResponseFormat,
+  zodResponsesFunction,
+  zodTextFormat,
+} from 'openai/helpers/zod';
+import { z as z3 } from 'zod/v3';
+import { z as z4 } from 'zod/v4';
+
+const strictHelpers = [
+  { name: 'zodResponseFormat', create: (schema: z3.ZodTypeAny) => zodResponseFormat(schema, 'strict') },
+  { name: 'zodTextFormat', create: (schema: z3.ZodTypeAny) => zodTextFormat(schema, 'strict') },
+  {
+    name: 'zodFunction',
+    create: (schema: z3.ZodTypeAny) => zodFunction({ name: 'strict', parameters: schema }),
+  },
+  {
+    name: 'zodResponsesFunction',
+    create: (schema: z3.ZodTypeAny) => zodResponsesFunction({ name: 'strict', parameters: schema }),
+  },
+];
+
+const unrepresentableTypes = [
+  { name: 'ZodDate', schema: () => z3.date(), v4: () => z4.date() },
+  { name: 'ZodSet', schema: () => z3.set(z3.string()), v4: () => z4.set(z4.string()) },
+  {
+    name: 'ZodMap',
+    schema: () => z3.map(z3.string(), z3.number()),
+    v4: () => z4.map(z4.string(), z4.number()),
+  },
+  { name: 'ZodBigInt', schema: () => z3.bigint(), v4: () => z4.bigint() },
+];
+
+describe.each(strictHelpers)('$name with Zod v3 non-JSON-native types', ({ create }) => {
+  it.each(unrepresentableTypes)(
+    'rejects nested $name fields before creating a request',
+    ({ name, schema }) => {
+      const root = z3.object({ payload: z3.object({ value: schema() }) });
+
+      expect(() => create(root)).toThrow(
+        `Zod field at \`#/definitions/strict/properties/payload/properties/value\` uses \`${name}\``,
+      );
+    },
+  );
+
+  it('preserves JSON-parseable Date and BigInt coercions', () => {
+    const schema = z3.object({
+      date: z3.coerce.date(),
+      count: z3.coerce.bigint(),
+    });
+    const result = create(schema);
+
+    expect(result.$parseRaw('{"date":"2026-08-17T00:00:00.000Z","count":7}')).toEqual({
+      date: new Date('2026-08-17T00:00:00.000Z'),
+      count: 7n,
+    });
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it('preserves JSON-input transformations to non-JSON output values', () => {
+    const schema = z3.object({
+      date: z3.string().transform((value) => new Date(value)),
+    });
+
+    expect(create(schema).$parseRaw('{"date":"2026-08-17T00:00:00.000Z"}')).toEqual({
+      date: new Date('2026-08-17T00:00:00.000Z'),
+    });
+  });
+
+  it.each([
+    {
+      name: 'minimum',
+      schema: () => z3.coerce.bigint().min(9_007_199_254_740_992n),
+    },
+    {
+      name: 'maximum',
+      schema: () => z3.coerce.bigint().max(-9_007_199_254_740_992n),
+    },
+    {
+      name: 'multipleOf',
+      schema: () => z3.coerce.bigint().multipleOf(9_007_199_254_740_992n),
+    },
+    {
+      name: 'default',
+      schema: () => z3.coerce.bigint().default(9_007_199_254_740_992n),
+    },
+  ])('rejects unsafe BigInt $name values before JSON serialization', ({ name, schema }) => {
+    expect(() => create(z3.object({ value: schema() }))).toThrow(
+      `cannot represent the \`${name}\` value as a safe JSON integer`,
+    );
+  });
+});
+
+describe('Zod v3 BigInt coercion JSON Schema serialization', () => {
+  it('serializes safe constraints and defaults as JSON numbers', () => {
+    const schema = z3.object({
+      bounded: z3.coerce.bigint().min(2n).max(8n).multipleOf(2n),
+      exclusive: z3.coerce.bigint().gt(1n).lt(9n),
+      defaulted: z3.coerce.bigint().default(4n),
+    });
+    const format = zodResponseFormat(schema, 'strict');
+
+    expect(format.json_schema.schema).toMatchObject({
+      properties: {
+        bounded: { type: 'integer', minimum: 2, maximum: 8, multipleOf: 2 },
+        exclusive: { type: 'integer', exclusiveMinimum: 1, exclusiveMaximum: 9 },
+        defaulted: { type: 'integer', default: 4 },
+      },
+    });
+    expect(() => JSON.stringify(format.json_schema.schema)).not.toThrow();
+    expect(format.$parseRaw('{"bounded":4,"exclusive":3,"defaulted":6}')).toEqual({
+      bounded: 4n,
+      exclusive: 3n,
+      defaulted: 6n,
+    });
+  });
+
+  it('normalizes safe BigInt constraints inside shared schema definitions', () => {
+    const shared = z3.object({ count: z3.coerce.bigint().min(1n) });
+    const schema = z3.object({ first: shared, second: shared });
+    const format = zodResponseFormat(schema, 'strict', {
+      schemaDefinitions: { Shared: shared },
+    });
+
+    expect(format.json_schema.schema).toMatchObject({
+      definitions: {
+        Shared: {
+          properties: { count: { type: 'integer', minimum: 1 } },
+        },
+      },
+    });
+    expect(() => JSON.stringify(format.json_schema.schema)).not.toThrow();
+    expect(format.$parseRaw('{"first":{"count":2},"second":{"count":3}}')).toEqual({
+      first: { count: 2n },
+      second: { count: 3n },
+    });
+  });
+});
+
+describe('Zod v3 non-JSON-native compatibility boundaries', () => {
+  it.each(unrepresentableTypes)('matches Zod v4 fail-fast behavior for $name', ({ name, schema, v4 }) => {
+    expect(() => zodResponseFormat(z3.object({ value: schema() }), 'strict')).toThrow(name);
+    expect(() => zodResponseFormat(z4.object({ value: v4() }), 'strict')).toThrow(
+      'cannot be represented in JSON Schema',
+    );
+  });
+
+  it('rejects non-JSON-native types underneath defaults', () => {
+    expect(() =>
+      zodResponseFormat(
+        z3.object({ value: z3.date().default(new Date('2026-08-17T00:00:00.000Z')) }),
+        'strict',
+      ),
+    ).toThrow('uses `ZodDate`');
+  });
+
+  it('reports the materialized definition path for registered unsupported schemas', () => {
+    const shared = z3.date();
+
+    expect(() =>
+      zodResponseFormat(z3.object({ value: shared }), 'strict', {
+        schemaDefinitions: { Shared: shared },
+      }),
+    ).toThrow('Zod field at `#/definitions/Shared` uses `ZodDate`');
+  });
+
+  it.each(unrepresentableTypes)('keeps non-strict Realtime $name schemas unchanged', ({ schema }) => {
+    const tool = zodRealtimeFunction({
+      name: 'realtime',
+      parameters: z3.object({ value: schema() }),
+    });
+
+    expect(tool).not.toHaveProperty('strict');
+    expect(tool.parameters).toHaveProperty('properties.value.type');
+  });
+
+  it('does not rewrite native BigInt constraints in non-strict Realtime schemas', () => {
+    const tool = zodRealtimeFunction({
+      name: 'realtime',
+      parameters: z3.object({ value: z3.coerce.bigint().min(2n) }),
+    });
+
+    expect(tool.parameters).toMatchObject({
+      properties: { value: { minimum: 2n } },
+    });
+  });
+});

--- a/tests/helpers/zod-unrepresentable-types.test.ts
+++ b/tests/helpers/zod-unrepresentable-types.test.ts
@@ -21,6 +21,20 @@ const strictHelpers = [
   },
 ];
 
+const getStrictHelperSchema = (helper: ReturnType<(typeof strictHelpers)[number]['create']>) => {
+  if ('json_schema' in helper) {
+    return helper.json_schema.schema;
+  }
+  if ('schema' in helper) {
+    return helper.schema;
+  }
+  if ('function' in helper) {
+    return helper.function.parameters;
+  }
+
+  return helper.parameters;
+};
+
 const unrepresentableTypes = [
   { name: 'ZodDate', schema: () => z3.date(), v4: () => z4.date() },
   { name: 'ZodSet', schema: () => z3.set(z3.string()), v4: () => z4.set(z4.string()) },
@@ -242,6 +256,278 @@ describe.each(strictHelpers)('$name with Zod v3 non-JSON-native types', ({ creat
   });
 
   it.each([
+    { name: 'nullable', schema: () => z3.coerce.bigint().nullable() },
+    { name: 'branded', schema: () => z3.coerce.bigint().brand<'safe-bigint'>() },
+    { name: 'readonly', schema: () => z3.coerce.bigint().readonly() },
+    {
+      name: 'preprocessed',
+      schema: () =>
+        z3.preprocess((value) => (typeof value === 'number' ? BigInt(value) : value), z3.bigint()),
+    },
+    {
+      name: 'transform pipeline',
+      schema: () => z3.number().transform(BigInt).pipe(z3.bigint()),
+    },
+    {
+      name: 'nested wrappers',
+      schema: () => z3.coerce.bigint().brand<'safe-bigint'>().readonly().nullable(),
+    },
+    {
+      name: 'nested union',
+      schema: () => z3.union([z3.coerce.bigint(), z3.string()]),
+    },
+  ])('bounds overlapping number alternatives after $name BigInt schemas', ({ schema }) => {
+    const result = create(z3.object({ value: z3.union([schema(), z3.number()]) }));
+
+    expect(getStrictHelperSchema(result)).toMatchObject({
+      properties: {
+        value: {
+          anyOf: [
+            expect.anything(),
+            { type: 'number', minimum: Number.MIN_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER },
+          ],
+        },
+      },
+    });
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it('bounds shared number references locally without changing other fields', () => {
+    const sharedNumber = z3.number();
+    const result = create(
+      z3.object({
+        outside: sharedNumber,
+        value: z3.union([z3.coerce.bigint(), sharedNumber]),
+      }),
+    );
+    const schema = getStrictHelperSchema(result) as {
+      properties: { outside: Record<string, unknown>; value: { anyOf: Record<string, unknown>[] } };
+    };
+
+    expect(schema.properties.outside).toEqual({ type: 'number' });
+    expect(schema.properties.value.anyOf[1]).toMatchObject({
+      type: 'number',
+      minimum: Number.MIN_SAFE_INTEGER,
+      maximum: Number.MAX_SAFE_INTEGER,
+    });
+    expect(result.$parseRaw('{"outside":9007199254740992,"value":7}')).toEqual({
+      outside: 9_007_199_254_740_992,
+      value: 7n,
+    });
+  });
+
+  it.each([
+    {
+      name: 'compact primitive',
+      schema: () => z3.union([z3.number(), z3.string()]),
+    },
+    {
+      name: 'nested constrained',
+      schema: () => z3.union([z3.number().min(0), z3.string()]),
+    },
+  ])('bounds numeric branches inside $name unions after BigInt alternatives', ({ name, schema }) => {
+    const result = create(z3.object({ value: z3.union([z3.coerce.bigint(), schema()]) }));
+    const generated = getStrictHelperSchema(result) as {
+      properties: {
+        value: { anyOf: { minimum?: number; maximum?: number; anyOf?: Record<string, unknown>[] }[] };
+      };
+    };
+    const [, branch] = generated.properties.value.anyOf;
+
+    expect(branch).toMatchObject({
+      minimum: Number.MIN_SAFE_INTEGER,
+      maximum: Number.MAX_SAFE_INTEGER,
+    });
+    if (name === 'nested constrained') {
+      expect(branch?.anyOf?.[0]).toMatchObject({ minimum: 0 });
+    }
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
+  });
+
+  it('tightens existing number bounds that exceed the safe integer range', () => {
+    const result = create(
+      z3.object({
+        value: z3.union([z3.coerce.bigint(), z3.number().min(-1e20).max(1e20)]),
+      }),
+    );
+
+    expect(getStrictHelperSchema(result)).toMatchObject({
+      properties: {
+        value: {
+          anyOf: [
+            expect.anything(),
+            { type: 'number', minimum: Number.MIN_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER },
+          ],
+        },
+      },
+    });
+  });
+
+  it.each([
+    { name: 'any', schema: () => z3.any() },
+    { name: 'unknown', schema: () => z3.unknown() },
+  ])('bounds later $name branches while preserving nonnumeric JSON inputs', ({ schema }) => {
+    const result = create(z3.object({ value: z3.union([z3.coerce.bigint(), schema()]) }));
+
+    expect(getStrictHelperSchema(result)).toMatchObject({
+      properties: {
+        value: {
+          anyOf: [expect.anything(), { minimum: Number.MIN_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER }],
+        },
+      },
+    });
+    expect(result.$parseRaw('{"value":"unchanged"}')).toEqual({ value: 'unchanged' });
+  });
+
+  it('bounds trailing number branches when an earlier number cannot always win', () => {
+    const result = create(
+      z3.object({
+        value: z3.union([z3.number().max(10), z3.coerce.bigint(), z3.number()]),
+      }),
+    );
+
+    expect(getStrictHelperSchema(result)).toMatchObject({
+      properties: {
+        value: {
+          anyOf: [
+            { type: 'number', maximum: 10 },
+            { type: 'integer', minimum: Number.MIN_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER },
+            { type: 'number', minimum: Number.MIN_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER },
+          ],
+        },
+      },
+    });
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7 });
+    expect(result.$parseRaw('{"value":12}')).toEqual({ value: 12n });
+  });
+
+  it('preserves number alternatives that win before wrapped BigInt branches', () => {
+    const result = create(
+      z3.object({
+        value: z3.union([z3.number(), z3.coerce.bigint().nullable()]),
+      }),
+    );
+    const schema = getStrictHelperSchema(result) as {
+      properties: { value: { anyOf: Record<string, unknown>[] } };
+    };
+
+    expect(schema.properties.value.anyOf[0]).toEqual({ type: 'number' });
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7 });
+  });
+
+  it('preserves and serializes safe nullable BigInt defaults', () => {
+    const result = create(z3.object({ value: z3.coerce.bigint().nullable().default(4n) }));
+
+    expect(getStrictHelperSchema(result)).toMatchObject({
+      properties: {
+        value: {
+          anyOf: [
+            { type: 'integer', minimum: Number.MIN_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER },
+            { type: 'null' },
+          ],
+          default: 4,
+        },
+      },
+    });
+    expect(result.$parseRaw('{}')).toEqual({ value: 4n });
+    expect(result.$parseRaw('{"value":null}')).toEqual({ value: null });
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it('normalizes nested object and array BigInt defaults without mutating caller values', () => {
+    const objectDefault = { count: 4n, nested: { count: 5n } };
+    const arrayDefault = [6n, 7n];
+    const result = create(
+      z3.object({
+        object: z3
+          .object({
+            count: z3.coerce.bigint(),
+            nested: z3.object({ count: z3.coerce.bigint() }),
+          })
+          .default(objectDefault),
+        array: z3.array(z3.coerce.bigint()).default(arrayDefault),
+      }),
+    );
+
+    expect(getStrictHelperSchema(result)).toMatchObject({
+      properties: {
+        object: { default: { count: 4, nested: { count: 5 } } },
+        array: { default: [6, 7] },
+      },
+    });
+    expect(objectDefault).toEqual({ count: 4n, nested: { count: 5n } });
+    expect(arrayDefault).toEqual([6n, 7n]);
+    expect(result.$parseRaw('{}')).toEqual({ object: objectDefault, array: arrayDefault });
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it('preserves existing Date and ordinary object defaults by reference', () => {
+    const dateDefault = new Date('2026-08-17T00:00:00.000Z');
+    const objectDefault = { label: 'unchanged' };
+    const result = create(
+      z3.object({
+        date: z3.coerce.date().default(dateDefault),
+        object: z3.object({ label: z3.string() }).default(objectDefault),
+      }),
+    );
+    const schema = getStrictHelperSchema(result) as {
+      properties: { date: { default: unknown }; object: { default: unknown } };
+    };
+
+    expect(schema.properties.date.default).toBe(dateDefault);
+    expect(schema.properties.object.default).toBe(objectDefault);
+    expect(result.$parseRaw('{}')).toEqual({ date: dateDefault, object: objectDefault });
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it.each([
+    {
+      name: 'object property',
+      schema: () => z3.object({ count: z3.coerce.bigint() }).default({ count: 9_007_199_254_740_992n }),
+      keyword: 'default.count',
+    },
+    {
+      name: 'array item',
+      schema: () => z3.array(z3.coerce.bigint()).default([9_007_199_254_740_992n]),
+      keyword: 'default[0]',
+    },
+  ])('rejects unsafe nested BigInt defaults at the $name path', ({ schema, keyword }) => {
+    expect(() => create(z3.object({ value: schema() }))).toThrow(
+      `cannot represent the \`${keyword}\` value as a safe JSON integer`,
+    );
+  });
+
+  it.each([
+    {
+      name: 'exclusive maximum safe value',
+      schema: () => z3.coerce.bigint().gt(BigInt(Number.MAX_SAFE_INTEGER)),
+    },
+    {
+      name: 'exclusive minimum safe value',
+      schema: () => z3.coerce.bigint().lt(BigInt(Number.MIN_SAFE_INTEGER)),
+    },
+    { name: 'inverted inclusive bounds', schema: () => z3.coerce.bigint().min(5n).max(4n) },
+    { name: 'adjacent exclusive bounds', schema: () => z3.coerce.bigint().gt(4n).lt(5n) },
+    { name: 'equal exclusive and inclusive bounds', schema: () => z3.coerce.bigint().gt(5n).max(5n) },
+  ])('rejects $name when no safe JSON integer satisfies a BigInt schema', ({ schema }) => {
+    expect(() => create(z3.object({ value: schema() }))).toThrow('no safe JSON integer values');
+  });
+
+  it('preserves nonempty exclusive BigInt bounds at the safe integer edge', () => {
+    const result = create(z3.object({ value: z3.coerce.bigint().gt(BigInt(Number.MAX_SAFE_INTEGER) - 1n) }));
+
+    expect(getStrictHelperSchema(result)).toMatchObject({
+      properties: {
+        value: { exclusiveMinimum: Number.MAX_SAFE_INTEGER - 1, maximum: Number.MAX_SAFE_INTEGER },
+      },
+    });
+    expect(result.$parseRaw(`{"value":${Number.MAX_SAFE_INTEGER}}`)).toEqual({
+      value: BigInt(Number.MAX_SAFE_INTEGER),
+    });
+  });
+
+  it.each([
     {
       name: 'minimum',
       schema: () => z3.coerce.bigint().min(9_007_199_254_740_992n),
@@ -367,6 +653,31 @@ describe('Zod v3 BigInt coercion JSON Schema serialization', () => {
       bounded: 4n,
       exclusive: 3n,
       defaulted: 6n,
+    });
+  });
+
+  it('bounds registered shared number definitions only inside later union branches', () => {
+    const sharedNumber = z3.number();
+    const format = zodResponseFormat(
+      z3.object({
+        outside: sharedNumber,
+        value: z3.union([z3.coerce.bigint(), sharedNumber]),
+      }),
+      'strict',
+      { schemaDefinitions: { SharedNumber: sharedNumber } },
+    );
+
+    expect(format.json_schema.schema).toMatchObject({
+      properties: {
+        outside: { $ref: '#/definitions/SharedNumber' },
+        value: {
+          anyOf: [
+            { type: 'integer', minimum: Number.MIN_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER },
+            { type: 'number', minimum: Number.MIN_SAFE_INTEGER, maximum: Number.MAX_SAFE_INTEGER },
+          ],
+        },
+      },
+      definitions: { SharedNumber: { type: 'number' } },
     });
   });
 

--- a/tests/helpers/zod-unrepresentable-types.test.ts
+++ b/tests/helpers/zod-unrepresentable-types.test.ts
@@ -179,6 +179,32 @@ describe.each(strictHelpers)('$name with Zod v3 non-JSON-native types', ({ creat
   });
 
   it.each([
+    { name: 'coerced string to Date', schema: () => z3.coerce.string().pipe(z3.date()), native: 'ZodDate' },
+    { name: 'coerced number to Date', schema: () => z3.coerce.number().pipe(z3.date()), native: 'ZodDate' },
+    {
+      name: 'coerced string to BigInt',
+      schema: () => z3.coerce.string().pipe(z3.bigint()),
+      native: 'ZodBigInt',
+    },
+  ])('rejects incompatible built-in $name pipeline coercion', ({ schema, native }) => {
+    expect(() => create(z3.object({ value: schema() }))).toThrow(native);
+  });
+
+  it('preserves built-in pipeline coercions that produce their native output type', () => {
+    const schema = z3.object({
+      date: z3.coerce.date().pipe(z3.date()),
+      count: z3.coerce.bigint().pipe(z3.bigint()),
+    });
+    const result = create(schema);
+
+    expect(result.$parseRaw('{"date":"2026-08-17T00:00:00.000Z","count":7}')).toEqual({
+      date: new Date('2026-08-17T00:00:00.000Z'),
+      count: 7n,
+    });
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it.each([
     { name: 'nullable BigInt', schema: () => z3.bigint().nullable() },
     { name: 'primitive BigInt union', schema: () => z3.union([z3.bigint(), z3.string()]) },
     { name: 'BigInt literal', schema: () => z3.literal(1n) },
@@ -728,6 +754,64 @@ describe('Zod v3 non-JSON-native compatibility boundaries', () => {
         schemaDefinitions: { Shared: shared },
       }),
     ).toThrow('Zod field at `#/definitions/Shared` uses `ZodDate`');
+  });
+
+  it('preserves preprocessing context for registered shared native containers', () => {
+    const shared = z3.object({ when: z3.date() });
+    const convert = (value: unknown) => {
+      if (typeof value !== 'object' || value === null) {
+        return value;
+      }
+
+      const input = value as { when?: unknown };
+      return { ...input, when: preprocessDateValue(input.when) };
+    };
+    const format = zodResponseFormat(
+      z3.object({
+        first: z3.preprocess(convert, shared),
+        second: z3.preprocess(convert, shared),
+      }),
+      'strict',
+      { schemaDefinitions: { Shared: shared } },
+    );
+
+    expect(format.json_schema.schema).toMatchObject({
+      properties: {
+        first: { $ref: '#/definitions/Shared' },
+        second: { $ref: '#/definitions/Shared' },
+      },
+      definitions: {
+        Shared: {
+          properties: { when: { type: 'string', format: 'date-time' } },
+        },
+      },
+    });
+    expect(
+      format.$parseRaw(
+        '{"first":{"when":"2026-08-17T00:00:00.000Z"},"second":{"when":"2026-08-18T00:00:00.000Z"}}',
+      ),
+    ).toEqual({
+      first: { when: new Date('2026-08-17T00:00:00.000Z') },
+      second: { when: new Date('2026-08-18T00:00:00.000Z') },
+    });
+  });
+
+  it('rejects registered definitions shared between converted and raw inputs', () => {
+    const shared = z3.object({ when: z3.date() });
+    const converted = z3.preprocess((value) => {
+      if (typeof value !== 'object' || value === null) {
+        return value;
+      }
+
+      const input = value as { when?: unknown };
+      return { ...input, when: preprocessDateValue(input.when) };
+    }, shared);
+
+    expect(() =>
+      zodResponseFormat(z3.object({ converted, raw: shared }), 'strict', {
+        schemaDefinitions: { Shared: shared },
+      }),
+    ).toThrow('ZodDate');
   });
 
   it.each(unrepresentableTypes)('keeps non-strict Realtime $name schemas unchanged', ({ schema }) => {

--- a/tests/helpers/zod-unrepresentable-types.test.ts
+++ b/tests/helpers/zod-unrepresentable-types.test.ts
@@ -32,6 +32,40 @@ const unrepresentableTypes = [
   { name: 'ZodBigInt', schema: () => z3.bigint(), v4: () => z4.bigint() },
 ];
 
+const preprocessDateValue = (value: unknown) => (typeof value === 'string' ? new Date(value) : value);
+
+const preprocessedTypes = [
+  {
+    name: 'ZodDate',
+    schema: () => z3.preprocess(preprocessDateValue, z3.date()),
+    input: '2026-08-17T00:00:00.000Z',
+    expected: () => new Date('2026-08-17T00:00:00.000Z'),
+  },
+  {
+    name: 'ZodBigInt',
+    schema: () => z3.preprocess((value) => (typeof value === 'number' ? BigInt(value) : value), z3.bigint()),
+    input: 7,
+    expected: () => 7n,
+  },
+  {
+    name: 'ZodSet',
+    schema: () =>
+      z3.preprocess((value) => (Array.isArray(value) ? new Set(value) : value), z3.set(z3.string())),
+    input: ['value'],
+    expected: () => new Set(['value']),
+  },
+  {
+    name: 'ZodMap',
+    schema: () =>
+      z3.preprocess(
+        (value) => (Array.isArray(value) ? new Map(value as [string, number][]) : value),
+        z3.map(z3.string(), z3.number()),
+      ),
+    input: [['value', 7]],
+    expected: () => new Map([['value', 7]]),
+  },
+];
+
 describe.each(strictHelpers)('$name with Zod v3 non-JSON-native types', ({ create }) => {
   it.each(unrepresentableTypes)(
     'rejects nested $name fields before creating a request',
@@ -68,6 +102,68 @@ describe.each(strictHelpers)('$name with Zod v3 non-JSON-native types', ({ creat
     });
   });
 
+  it.each(preprocessedTypes)(
+    'preserves JSON-input preprocessors that construct $name values',
+    ({ schema, input, expected }) => {
+      const result = create(z3.object({ value: schema() }));
+
+      expect(result.$parseRaw(JSON.stringify({ value: input }))).toEqual({ value: expected() });
+      expect(() => JSON.stringify(result)).not.toThrow();
+    },
+  );
+
+  it.each([
+    { name: 'nullable BigInt', schema: () => z3.bigint().nullable() },
+    { name: 'primitive BigInt union', schema: () => z3.union([z3.bigint(), z3.string()]) },
+    { name: 'BigInt literal', schema: () => z3.literal(1n) },
+    { name: 'BigInt literal union', schema: () => z3.union([z3.literal(1n), z3.literal('value')]) },
+  ])('rejects $name before primitive fast paths or serialization', ({ schema }) => {
+    expect(() => create(z3.object({ value: schema() }))).toThrow(/Zod(?:BigInt|Literal)/u);
+  });
+
+  it('does not allow an unprocessed schema after its shared definition was preprocessed', () => {
+    const native = z3.date();
+    const converted = z3.preprocess((value) => (typeof value === 'string' ? new Date(value) : value), native);
+
+    expect(() => create(z3.object({ converted, native }))).toThrow('#/definitions/strict/properties/native');
+  });
+
+  it('keeps shared native definitions inside their separate preprocessor contexts', () => {
+    const native = z3.date();
+    const first = z3.preprocess(preprocessDateValue, native);
+    const second = z3.preprocess(preprocessDateValue, native);
+    const result = create(z3.object({ first, second }));
+
+    expect(
+      result.$parseRaw('{"first":"2026-08-17T00:00:00.000Z","second":"2026-08-18T00:00:00.000Z"}'),
+    ).toEqual({
+      first: new Date('2026-08-17T00:00:00.000Z'),
+      second: new Date('2026-08-18T00:00:00.000Z'),
+    });
+  });
+
+  it('normalizes JSON-compatible preprocessed BigInt literals', () => {
+    const value = z3.preprocess(
+      (input) => (typeof input === 'number' ? BigInt(input) : input),
+      z3.literal(7n),
+    );
+    const result = create(z3.object({ value }));
+
+    expect(result.$parseRaw('{"value":7}')).toEqual({ value: 7n });
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it('rejects unsafe preprocessed BigInt literals before serialization', () => {
+    const value = z3.preprocess(
+      (input) => (typeof input === 'number' ? BigInt(input) : input),
+      z3.literal(9_007_199_254_740_992n),
+    );
+
+    expect(() => create(z3.object({ value }))).toThrow(
+      'cannot represent the `const` value as a safe JSON integer',
+    );
+  });
+
   it.each([
     {
       name: 'minimum',
@@ -93,6 +189,48 @@ describe.each(strictHelpers)('$name with Zod v3 non-JSON-native types', ({ creat
 });
 
 describe('Zod v3 BigInt coercion JSON Schema serialization', () => {
+  it('bounds every JSON-coerced BigInt branch to the safe integer range', () => {
+    const schema = z3.object({
+      direct: z3.coerce.bigint(),
+      minimum: z3.coerce.bigint().min(1n),
+      maximum: z3.coerce.bigint().max(9n),
+      nullable: z3.coerce.bigint().nullable(),
+      stringUnion: z3.union([z3.coerce.bigint(), z3.string()]),
+      numberUnion: z3.union([z3.coerce.bigint(), z3.number()]),
+      numberFirstUnion: z3.union([z3.number(), z3.coerce.bigint()]),
+      preprocessed: z3.preprocess(
+        (value) => (typeof value === 'number' ? BigInt(value) : value),
+        z3.bigint(),
+      ),
+    });
+    const format = zodResponseFormat(schema, 'strict');
+    const safeInteger = {
+      minimum: Number.MIN_SAFE_INTEGER,
+      maximum: Number.MAX_SAFE_INTEGER,
+    };
+
+    expect(format.json_schema.schema).toMatchObject({
+      properties: {
+        direct: { type: 'integer', ...safeInteger },
+        minimum: { type: 'integer', minimum: 1, maximum: Number.MAX_SAFE_INTEGER },
+        maximum: { type: 'integer', minimum: Number.MIN_SAFE_INTEGER, maximum: 9 },
+        nullable: { anyOf: [{ type: 'integer', ...safeInteger }, { type: 'null' }] },
+        stringUnion: { anyOf: [{ type: 'integer', ...safeInteger }, { type: 'string' }] },
+        numberUnion: {
+          anyOf: [
+            { type: 'integer', ...safeInteger },
+            { type: 'number', ...safeInteger },
+          ],
+        },
+        numberFirstUnion: {
+          anyOf: [{ type: 'number' }, { type: 'integer', ...safeInteger }],
+        },
+        preprocessed: { type: 'integer', ...safeInteger },
+      },
+    });
+    expect(() => JSON.stringify(format.json_schema.schema)).not.toThrow();
+  });
+
   it('serializes safe constraints and defaults as JSON numbers', () => {
     const schema = z3.object({
       bounded: z3.coerce.bigint().min(2n).max(8n).multipleOf(2n),

--- a/tests/helpers/zod-unrepresentable-types.test.ts
+++ b/tests/helpers/zod-unrepresentable-types.test.ts
@@ -395,10 +395,6 @@ describe.each(strictHelpers)('$name with Zod v3 non-JSON-native types', ({ creat
       },
     },
     {
-      name: 'promise',
-      schema: () => z3.promise(z3.number()),
-    },
-    {
       name: 'numeric native enum',
       schema: () => z3.nativeEnum({ Unsafe: 9_007_199_254_740_992 } as const),
     },

--- a/tests/helpers/zod.test.ts
+++ b/tests/helpers/zod.test.ts
@@ -703,7 +703,6 @@ describe.each([
       const branded = z.string().brand<'BlockId'>();
       const caught = z.string().catch('fallback');
       const defaulted = z.string().default('fallback');
-      const promised = z.promise(z.string());
       const readonly = z.string().readonly();
       const optionalNullable = z.string().nullable().optional();
       const lazy = z.lazy(() => z.string());
@@ -718,8 +717,6 @@ describe.each([
           caughtSecond: caught,
           defaultedFirst: defaulted,
           defaultedSecond: defaulted,
-          promisedFirst: promised,
-          promisedSecond: promised,
           readonlyFirst: readonly,
           readonlySecond: readonly,
           optionalNullableFirst: optionalNullable,


### PR DESCRIPTION
## Summary
- Reject plain Zod v3 Date, Set, Map, and BigInt fields while generating strict structured-output schemas, with actionable field paths.
- Preserve JSON-parseable Date and BigInt coercions and non-strict Realtime schemas.
- Serialize safely representable coerced BigInt constraints/defaults as JSON numbers and reject values outside the safe integer range.
- Cover all four public strict helpers, nested/defaulted/shared schemas, Zod v4 parity, coercions, and Realtime compatibility.

## Why
The vendored Zod v3 converter currently advertises JSON representations for native Date, Set, Map, and BigInt values that JSON.parse can never produce, so successful model responses always fail validation. BigInt constraints and defaults can also insert native bigint values into request schemas, making JSON.stringify fail before the request is sent. Zod v4 already rejects the corresponding non-JSON-native schemas.

## Validation
- Regression first: 40 failing and 13 passing cases before the fix; all 53 pass afterward.
- Full handwritten suite: 2,927 passing tests across 96 files.
- Focused Zod compatibility suites: 182 passing tests across three files.
- `./scripts/lint`
- `./node_modules/.bin/tsc --project tsconfig.json --noEmit`
- `./scripts/build`
- `node node_modules/typescript-4-9/bin/tsc --project dist/src/tsconfig.json --noEmit`
- `node node_modules/typescript/bin/tsc --project dist/src/tsconfig.json --noEmit`
- `node --experimental-strip-types scripts/test-packed-package.ts` — CommonJS, ESM, and 266/303 source checks across 1,212 source maps.