### PR TITLE
docs: encode recurring SDK review feedback in agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,9 @@ explicitly requires it.
   narrowing and inference over broad `any`, assertions, `@ts-ignore`, or casts
   that disguise an unproven contract.
 - Keep handwritten production and test files cohesive. Extract a well-defined owner
-  before a growing file approaches 1,000 lines; do not inflate fixtures or suites to
-  justify an overly complicated implementation.
+  only when the current change materially grows a file and reveals a coherent,
+  distinct responsibility. Keep unrelated cleanup separate, and do not inflate
+  fixtures or suites to justify an overly complicated implementation.
 - Avoid hand-maintained model, endpoint, capability, or schema lists unless the
   contract requires them. Prefer the documented API/schema and server-side
   validation over brittle client-side guesses.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,13 +9,18 @@ explicitly requires it.
 
 ## Start with the actual problem
 
-- Reproduce the reported issue against the current repository and public SDK entrypoint
-  before proposing a fix. Check existing issues, pull requests, the API schema, and
+- For externally observable bug or behavior fixes, reproduce the reported issue
+  against the current repository and public SDK entrypoint before proposing a fix.
+  For all changes, check existing issues, pull requests, the API schema, and
   generated/upstream ownership first; do not duplicate existing work, "fix" intended
   API behavior, or patch a generated symptom that belongs in the schema or generator.
-- Include a focused regression that fails before the change and passes afterward.
-  Type errors need a compile-time reproduction; stream, transport, and packaging bugs
-  need coverage at the actual affected boundary, not merely a passing internal mock.
+- For those behavior fixes, include a focused regression that fails before the change
+  and passes afterward. Type errors need a compile-time reproduction; stream, transport,
+  and packaging bugs need coverage at the actual affected boundary, not merely a
+  passing internal mock.
+- For docs-only, dependency-only, generated, formatting, workflow, or policy changes
+  without an observable bug, use the smallest artifact-appropriate validation, such
+  as link, render, configuration, installation, or build checks.
 
 ## Keep changes small and coherent
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,10 @@ explicitly requires it.
 
 - For externally observable bug or behavior fixes, reproduce the reported issue
   against the current repository and public SDK entrypoint before proposing a fix.
-  For all changes, check existing issues, pull requests, the API schema, and
-  generated/upstream ownership first; do not duplicate existing work, "fix" intended
-  API behavior, or patch a generated symptom that belongs in the schema or generator.
+  Check existing issues and pull requests; inspect the API schema and
+  generated/upstream ownership only when relevant. Do not duplicate existing work,
+  "fix" intended API behavior, or patch a generated symptom that belongs in the
+  schema or generator.
 - For those behavior fixes, include a focused regression that fails before the change
   and passes afterward. Type errors need a compile-time reproduction; stream, transport,
   and packaging bugs need coverage at the actual affected boundary, not merely a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,115 @@ changing generated files. Handwritten policy, automation, tests, and examples
 should remain small and should not alter exported SDK APIs unless the change
 explicitly requires it.
 
+## Start with the actual problem
+
+- Reproduce the reported issue against the current repository and public SDK entrypoint
+  before proposing a fix. Check existing issues, pull requests, the API schema, and
+  generated/upstream ownership first; do not duplicate existing work, "fix" intended
+  API behavior, or patch a generated symptom that belongs in the schema or generator.
+- Include a focused regression that fails before the change and passes afterward.
+  Type errors need a compile-time reproduction; stream, transport, and packaging bugs
+  need coverage at the actual affected boundary, not merely a passing internal mock.
+
+## Keep changes small and coherent
+
+- Solve the narrow problem with the simplest implementation. Avoid unrelated
+  refactors, reformatting, dependency or lockfile churn, generated-file edits,
+  speculative abstractions, compatibility shims, and capabilities not requested.
+- Establish an invariant once at its owning boundary instead of compensating in
+  every caller. Reuse existing parsers, registries, helpers, and compiler/runtime
+  facilities instead of creating parallel infrastructure or a hand-written parser.
+  If successive edge cases keep appearing, reconsider the invariant and ownership
+  rather than adding another special case.
+- Model incomplete API/SSE wire shapes separately from enriched public SDK types.
+  Keep required public snapshot fields accurate before exposing them, or type
+  fields unavailable until later truthfully. Normalize incomplete items at their
+  owning boundary instead of patching downstream consumers. Prefer TypeScript
+  narrowing and inference over broad `any`, assertions, `@ts-ignore`, or casts
+  that disguise an unproven contract.
+- Keep handwritten production and test files cohesive. Extract a well-defined owner
+  before a growing file approaches 1,000 lines; do not inflate fixtures or suites to
+  justify an overly complicated implementation.
+- Avoid hand-maintained model, endpoint, capability, or schema lists unless the
+  contract requires them. Prefer the documented API/schema and server-side
+  validation over brittle client-side guesses.
+
+## Preserve SDK contracts and compatibility
+
+- Compare behavior with the base revision across existing public exports and import
+  subpaths, provider and legacy clients, stable and beta surfaces, and equivalent
+  streaming/non-streaming paths. Preserve published TypeScript declarations,
+  overloads, optional fields, discriminators, object identity, protected hooks,
+  request-option/header precedence, client cloning, and documented defaults unless
+  the task explicitly authorizes a breaking change.
+- Preserve meaningful `0`, `false`, and empty-string values, and distinguish
+  explicit `null` from an omitted or `undefined` value where the contract does.
+  Do not replace presence or nullish checks with truthiness checks.
+- For schema helpers, check supported Zod v3/v4 and Standard Schema integrations,
+  inferred output types, escaped JSON Pointer references, and the actual serialized
+  schema rather than trusting an idealized intermediate TypeScript shape.
+- Verify affected CJS/ESM entrypoints, the exact minimum supported Node version,
+  affected policy-defined Node lines, supported TypeScript versions, and relevant
+  browser, worker, Bun, Deno, bundler, or serverless integrations. The newest CI
+  version passing does not prove compatibility with the minimum supported version.
+- Keep optional integrations isolated from the core SDK. Do not make a provider's
+  optional dependency, environment, credential, or runtime requirement mandatory
+  for unrelated clients; test both installed and absent optional dependencies when
+  the import boundary changes.
+- Update affected canonical docs, executable examples, or meaningful public JSDoc
+  when the public contract changes. Preserve existing documentation URLs and import
+  paths, and make examples runnable with the documented environment and dependencies.
+
+## Security and lifecycle correctness
+
+- Treat provider endpoints, headers, filenames, schemas, and object properties as
+  untrusted. At JSON object-record boundaries, validate the own properties and
+  values actually emitted, accounting for serialization hooks and omitted values;
+  reject or safely preserve dangerous prototype keys. Preserve supported inherited
+  protocols and validate the final request, including normalized host/origin,
+  redirects, protected hooks, custom fetch transports, and both current and legacy
+  entrypoints. Never leak bearer tokens, API keys, certificates, request bodies,
+  or other credentials across trust boundaries.
+- When validation and dispatch must agree, snapshot only the security-critical
+  values or serialized representation, within bounded memory, before irreversible
+  network or request-body side effects. Preserve request-options object identity
+  and protected-hook mutations; never validate one mutable representation and
+  serialize another.
+- Keep workflow tokens, permissions, and secrets at the narrowest required scope.
+  Bind privileged checkout, release, and publication operations to the validated,
+  immutable commit; do not trust floating refs, mutable tags, optional checks, or
+  assumptions about repository settings and app permissions.
+- For streaming, uploads, authentication, retries, timeouts, and cancellation,
+  exercise the complete request/response lifetime: headers, JSON/error/binary/SSE
+  bodies, raw responses, async iterators, redirect handling, abort reasons, retry
+  budgets, concurrent refresh, cleanup, and reader/listener/lock ownership as
+  applicable. Avoid new retained state and accidental quadratic hot paths.
+- Give every cache an explicit owner, complete identity key, lifetime, and
+  invalidation policy. Do not trust caller-mutable snapshots, conflate changed
+  transport/certificate identities, or leak request/client-specific state or
+  credentials across clients, transports, retries, or authentication contexts.
+
+## Tooling, dependencies, and verification
+
+- Follow `.github/CONTRIBUTING.md` and the tool versions pinned by `.nvmrc` and
+  `package.json`. Keep `./scripts/test`, `./scripts/lint`, and `./scripts/format`
+  as the canonical script entrypoints, with package-manager aliases and CI routing
+  through them; preserve both generated and handwritten suite coverage.
+- For dependency changes, update only the requested package and its dependency
+  closure. Check `pnpm install --frozen-lockfile`, module format, supported runtime
+  and TypeScript floors, minimum-release-age/trust policy, and audited lifecycle
+  build permissions; do not hide unrelated transitive upgrades in the lockfile.
+- Make changed files pass the actual pinned formatter and linter. Do not disguise
+  code or weaken a fixture to evade a lint rule. When an intentional public type,
+  compatibility requirement, or regression fixture genuinely conflicts with a
+  rule, use the narrowest documented exception; avoid unnecessary suppressions.
+- Run the focused regression first, then the checks appropriate to the change:
+  `pnpm lint`, `pnpm exec tsc`, `pnpm build`, and `./scripts/test`. Exercise
+  generated tests, packed-package/export checks, supported runtime versions,
+  ecosystem integrations, benchmarks, or workflows when their boundaries change.
+  Report exactly what ran and distinguish verified results from infrastructure
+  failures or checks that could not be run.
+
 ## Node.js version policy
 
 `NODE_VERSION_POLICY.md` is the sole authority for lifecycle, deprecation,


### PR DESCRIPTION
## Why

Agent-generated SDK pull requests repeatedly encounter the same review feedback. Capture those maintainer expectations in `AGENTS.md` so future changes arrive focused, compatible, and ready to merge.

## Review methodology

Analyzed the latest 500 `openai/openai-node` pull requests, created May 1–August 17, 2026, and collected 2,149 inline comments, conversation comments, and submitted reviews from Hayden, Alex Chang, and Justin Beckwith. Excluded comments from each pull request's author, approval/status noise, and inline replies; the resulting high-signal set contains 284 actionable root comments and requested-change reviews across 96 pull requests.

The most common overlapping themes, counted by distinct pull request, were:

- Public contracts and backward compatibility: 68.
- Focused regressions and real public-entrypoint coverage: 64.
- Generated code, schemas, and types: 61; canonical tooling and CI: 61.
- Documentation/examples: 46; runtime and ecosystem compatibility: 44.
- Security boundaries: 33; asynchronous lifecycle correctness: 33.
- Change scope/maintainability: 32; dependency and packaging discipline: 32.
- Streaming and performance: 28.

## Changes

Update only `AGENTS.md` with practical instructions for reproducing issues, keeping diffs small, preserving SDK and TypeScript compatibility, validating security and ownership boundaries, exercising realistic regressions, using canonical repository commands, and checking dependency/runtime policy. Preserve the existing generated-SDK guidance and `NODE_VERSION_POLICY.md` as the sole authority for Node version policy.

## Validation

- `pnpm install --frozen-lockfile` — passed with the repository's pinned dependencies and supply-chain policies.
- `pnpm lint` — passed; checked 641 files.
- `pnpm exec oxfmt --check AGENTS.md` — passed with the currently pinned formatter.
- `git diff --check -- AGENTS.md` — passed.
- Only `AGENTS.md` changed: 109 additions.