### PR TITLE
Harden Dependabot workflow conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,12 +290,12 @@ jobs:
         run: ./scripts/bootstrap
 
       - name: Run ecosystem tests without live credentials
-        if: >- # zizmor: ignore[bot-conditions] github.actor determines Dependabot secret availability
+        if: >-
           ${{
-            github.actor == 'dependabot[bot]' ||
-            (github.event_name == 'pull_request' &&
-            (github.event.pull_request.user.login == 'dependabot[bot]' ||
-            github.event.pull_request.head.repo.full_name != github.repository))
+            !(github.actor != 'dependabot[bot]' &&
+            (github.event_name != 'pull_request' ||
+            (github.event.pull_request.user.login != 'dependabot[bot]' &&
+            github.event.pull_request.head.repo.full_name == github.repository)))
           }}
         run: |
           pnpm tsn ecosystem-tests/cli.ts --verbose --parallel --jobs=4 --retry=3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,9 +292,11 @@ jobs:
       - name: Run ecosystem tests without live credentials
         if: >-
           ${{
-            github.actor == 'dependabot[bot]' ||
             (github.event_name == 'pull_request' &&
-            github.event.pull_request.head.repo.full_name != github.repository)
+            (github.event.pull_request.user.login == 'dependabot[bot]' ||
+            github.event.pull_request.head.repo.full_name != github.repository)) ||
+            (github.event_name != 'pull_request' &&
+            github.event.sender.login == 'dependabot[bot]')
           }}
         run: |
           pnpm tsn ecosystem-tests/cli.ts --verbose --parallel --jobs=4 --retry=3
@@ -306,7 +308,10 @@ jobs:
       - name: Run ecosystem tests with live credentials
         if: >-
           ${{
-            github.actor != 'dependabot[bot]' &&
+            ((github.event_name == 'pull_request' &&
+            github.event.pull_request.user.login != 'dependabot[bot]') ||
+            (github.event_name != 'pull_request' &&
+            github.event.sender.login != 'dependabot[bot]')) &&
             (github.event_name != 'pull_request' ||
             github.event.pull_request.head.repo.full_name == github.repository)
           }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,13 +290,12 @@ jobs:
         run: ./scripts/bootstrap
 
       - name: Run ecosystem tests without live credentials
-        if: >-
+        if: >- # zizmor: ignore[bot-conditions] github.actor determines Dependabot secret availability
           ${{
+            github.actor == 'dependabot[bot]' ||
             (github.event_name == 'pull_request' &&
             (github.event.pull_request.user.login == 'dependabot[bot]' ||
-            github.event.pull_request.head.repo.full_name != github.repository)) ||
-            (github.event_name != 'pull_request' &&
-            github.event.sender.login == 'dependabot[bot]')
+            github.event.pull_request.head.repo.full_name != github.repository))
           }}
         run: |
           pnpm tsn ecosystem-tests/cli.ts --verbose --parallel --jobs=4 --retry=3
@@ -308,12 +307,10 @@ jobs:
       - name: Run ecosystem tests with live credentials
         if: >-
           ${{
-            ((github.event_name == 'pull_request' &&
-            github.event.pull_request.user.login != 'dependabot[bot]') ||
-            (github.event_name != 'pull_request' &&
-            github.event.sender.login != 'dependabot[bot]')) &&
+            github.actor != 'dependabot[bot]' &&
             (github.event_name != 'pull_request' ||
-            github.event.pull_request.head.repo.full_name == github.repository)
+            (github.event.pull_request.user.login != 'dependabot[bot]' &&
+            github.event.pull_request.head.repo.full_name == github.repository))
           }}
         run: |
           pnpm tsn ecosystem-tests/cli.ts --live --verbose --parallel --jobs=4 --retry=3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
@@ -52,6 +54,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
@@ -92,6 +96,8 @@ jobs:
       matrix: ${{ steps.policy.outputs.matrix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -116,6 +122,8 @@ jobs:
       matrix: ${{ fromJSON(needs.node_matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
@@ -217,6 +225,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
@@ -256,6 +266,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Compare the release title with the generated version
         env:
@@ -62,6 +63,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Validate pending release PR versions
         env:
@@ -110,6 +112,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check whether the current release needs publishing
         id: check
@@ -188,6 +191,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ needs.publication-check.outputs.release_sha }}
+          persist-credentials: false
 
       - name: Verify release commit
         env:

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           # Keep the checkout shallow; fetch the exact comparison base below.
           fetch-depth: ${{ env.FETCH_DEPTH }}
+          persist-credentials: false
 
       - name: Fetch comparison base
         run: git fetch --no-tags --depth=1 origin "$BASE_SHA"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4

--- a/tests/ecosystem-cli.test.ts
+++ b/tests/ecosystem-cli.test.ts
@@ -61,7 +61,7 @@ describe('ecosystem test CLI', () => {
     expect(liveStep).toContain('secrets.OPENAI_API_KEY');
 
     expect(workflowCondition(nonLiveStep)).toBe(
-      "github.actor == 'dependabot[bot]' || (github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.head.repo.full_name != github.repository))",
+      "!(github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository)))",
     );
     expect(nonLiveStep).toContain('pnpm tsn ecosystem-tests/cli.ts --verbose --parallel --jobs=4 --retry=3');
     expect(nonLiveStep).not.toContain('--live');

--- a/tests/ecosystem-cli.test.ts
+++ b/tests/ecosystem-cli.test.ts
@@ -52,7 +52,7 @@ describe('ecosystem test CLI', () => {
       steps.find((step) => step.startsWith('Run ecosystem tests without live credentials\n')) ?? '';
 
     expect(workflowCondition(liveStep)).toBe(
-      "((github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') || (github.event_name != 'pull_request' && github.event.sender.login != 'dependabot[bot]')) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)",
+      "github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || (github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))",
     );
     expect(liveStep).toContain(
       'pnpm tsn ecosystem-tests/cli.ts --live --verbose --parallel --jobs=4 --retry=3',
@@ -61,7 +61,7 @@ describe('ecosystem test CLI', () => {
     expect(liveStep).toContain('secrets.OPENAI_API_KEY');
 
     expect(workflowCondition(nonLiveStep)).toBe(
-      "(github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.head.repo.full_name != github.repository)) || (github.event_name != 'pull_request' && github.event.sender.login == 'dependabot[bot]')",
+      "github.actor == 'dependabot[bot]' || (github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.head.repo.full_name != github.repository))",
     );
     expect(nonLiveStep).toContain('pnpm tsn ecosystem-tests/cli.ts --verbose --parallel --jobs=4 --retry=3');
     expect(nonLiveStep).not.toContain('--live');
@@ -88,21 +88,22 @@ describe('ecosystem test CLI', () => {
       'dependabot[bot]',
       'octocat',
       'openai/openai-node',
-      true,
+      false,
     ],
     ['fork pull request', 'pull_request', 'octocat', 'octocat', 'octocat/openai-node', false],
     ['pull request with a missing head', 'pull_request', 'octocat', 'octocat', undefined, false],
   ])(
     'selects exactly one ecosystem mode for a %s',
-    (_event, eventName, sender, pullRequestAuthor, headRepository, trusted) => {
+    (_event, eventName, actor, pullRequestAuthor, headRepository, trusted) => {
       const repository = 'openai/openai-node';
-      const eventOriginator = eventName === 'pull_request' ? pullRequestAuthor : sender;
       const keyless =
-        eventOriginator === 'dependabot[bot]' ||
-        (eventName === 'pull_request' && headRepository !== repository);
+        actor === 'dependabot[bot]' ||
+        (eventName === 'pull_request' &&
+          (pullRequestAuthor === 'dependabot[bot]' || headRepository !== repository));
       const live =
-        eventOriginator !== 'dependabot[bot]' &&
-        (eventName !== 'pull_request' || headRepository === repository);
+        actor !== 'dependabot[bot]' &&
+        (eventName !== 'pull_request' ||
+          (pullRequestAuthor !== 'dependabot[bot]' && headRepository === repository));
 
       expect({ keyless, live }).toEqual({ keyless: !trusted, live: trusted });
       expect([keyless, live].filter(Boolean)).toHaveLength(1);

--- a/tests/ecosystem-cli.test.ts
+++ b/tests/ecosystem-cli.test.ts
@@ -52,7 +52,7 @@ describe('ecosystem test CLI', () => {
       steps.find((step) => step.startsWith('Run ecosystem tests without live credentials\n')) ?? '';
 
     expect(workflowCondition(liveStep)).toBe(
-      "github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)",
+      "((github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]') || (github.event_name != 'pull_request' && github.event.sender.login != 'dependabot[bot]')) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)",
     );
     expect(liveStep).toContain(
       'pnpm tsn ecosystem-tests/cli.ts --live --verbose --parallel --jobs=4 --retry=3',
@@ -61,7 +61,7 @@ describe('ecosystem test CLI', () => {
     expect(liveStep).toContain('secrets.OPENAI_API_KEY');
 
     expect(workflowCondition(nonLiveStep)).toBe(
-      "github.actor == 'dependabot[bot]' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)",
+      "(github.event_name == 'pull_request' && (github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.head.repo.full_name != github.repository)) || (github.event_name != 'pull_request' && github.event.sender.login == 'dependabot[bot]')",
     );
     expect(nonLiveStep).toContain('pnpm tsn ecosystem-tests/cli.ts --verbose --parallel --jobs=4 --retry=3');
     expect(nonLiveStep).not.toContain('--live');
@@ -70,24 +70,44 @@ describe('ecosystem test CLI', () => {
   });
 
   test.each([
-    ['Dependabot push', 'dependabot[bot]', 'push', undefined, false],
-    ['Dependabot pull request', 'dependabot[bot]', 'pull_request', 'openai/openai-node', false],
-    ['human push', 'octocat', 'push', undefined, true],
-    ['merge group', 'octocat', 'merge_group', undefined, true],
-    ['workflow dispatch', 'octocat', 'workflow_dispatch', undefined, true],
-    ['same-repository pull request', 'octocat', 'pull_request', 'openai/openai-node', true],
-    ['fork pull request', 'octocat', 'pull_request', 'octocat/openai-node', false],
-    ['pull request with a missing head', 'octocat', 'pull_request', undefined, false],
-  ])('selects exactly one ecosystem mode for a %s', (_event, actor, eventName, headRepository, trusted) => {
-    const repository = 'openai/openai-node';
-    const keyless =
-      actor === 'dependabot[bot]' || (eventName === 'pull_request' && headRepository !== repository);
-    const live =
-      actor !== 'dependabot[bot]' && (eventName !== 'pull_request' || headRepository === repository);
+    ['Dependabot push', 'push', 'dependabot[bot]', undefined, undefined, false],
+    [
+      'Dependabot pull request synchronized by a human',
+      'pull_request',
+      'octocat',
+      'dependabot[bot]',
+      'openai/openai-node',
+      false,
+    ],
+    ['human push', 'push', 'octocat', undefined, undefined, true],
+    ['merge group', 'merge_group', 'octocat', undefined, undefined, true],
+    ['workflow dispatch', 'workflow_dispatch', 'octocat', undefined, undefined, true],
+    [
+      'same-repository pull request synchronized by Dependabot',
+      'pull_request',
+      'dependabot[bot]',
+      'octocat',
+      'openai/openai-node',
+      true,
+    ],
+    ['fork pull request', 'pull_request', 'octocat', 'octocat', 'octocat/openai-node', false],
+    ['pull request with a missing head', 'pull_request', 'octocat', 'octocat', undefined, false],
+  ])(
+    'selects exactly one ecosystem mode for a %s',
+    (_event, eventName, sender, pullRequestAuthor, headRepository, trusted) => {
+      const repository = 'openai/openai-node';
+      const eventOriginator = eventName === 'pull_request' ? pullRequestAuthor : sender;
+      const keyless =
+        eventOriginator === 'dependabot[bot]' ||
+        (eventName === 'pull_request' && headRepository !== repository);
+      const live =
+        eventOriginator !== 'dependabot[bot]' &&
+        (eventName !== 'pull_request' || headRepository === repository);
 
-    expect({ keyless, live }).toEqual({ keyless: !trusted, live: trusted });
-    expect([keyless, live].filter(Boolean)).toHaveLength(1);
-  });
+      expect({ keyless, live }).toEqual({ keyless: !trusted, live: trusted });
+      expect([keyless, live].filter(Boolean)).toHaveLength(1);
+    },
+  );
 
   test.each(['--live', '--deploy'])('rejects keyless %s before running projects', (option) => {
     const result = runCli([option]);


### PR DESCRIPTION
<!-- Thank you for contributing to this project! -->
<!-- The code in this repository is all auto-generated, and is not meant to be edited manually. -->
<!-- We recommend opening an Issue instead, but you are still welcome to open a PR to share for -->
<!-- an improvement if you wish, just note that we are unlikely to merge it as-is. -->

- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

This tweaks some bot conditions so that they fire consistently on the principal that opened the PR or otherwise initiated the event, not the principal for the last commit on the PR.

## Additional context & links

https://docs.zizmor.sh/audits/#bot-conditions

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>