### PR TITLE
fix(security): prevent streaming upload filename path disclosure

### DIFF
--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -377,31 +377,34 @@ const hasUploadableValue = (value: unknown): boolean => {
 
 type FormEntry = { key: string; value: unknown };
 
-const snapshotPreservedUploadFilenames = (value: unknown, filenames: WeakMap<object, string>): void => {
-  if (isUploadable(value)) {
-    if (!filenames.has(value)) {
-      filenames.set(value, getStreamingFileName(value, { stripFilenames: false }));
+const snapshotPreservedUploadEntries = (
+  entries: Iterable<FormEntry>,
+  filenames: WeakMap<object, string>,
+): FormEntry[] => {
+  const snapshot: FormEntry[] = [];
+  for (const entry of entries) {
+    if (isUploadable(entry.value) && !filenames.has(entry.value)) {
+      filenames.set(entry.value, getStreamingFileName(entry.value, { stripFilenames: false }));
     }
-    return;
+    snapshot.push(entry);
   }
-  if (value && typeof value === 'object') {
-    for (const nested of Array.isArray(value) ? value : Object.values(value)) {
-      snapshotPreservedUploadFilenames(nested, filenames);
-    }
-  }
+  return snapshot;
 };
 
 const createStreamingFormRequestOptions = (
   opts: RequestOptions,
   options: CreateFormOptions = {},
 ): RequestOptions => {
+  const entries = iterateFormEntries(opts.body);
   const preservedFilenames = options.stripFilenames === false ? new WeakMap<object, string>() : undefined;
-  if (preservedFilenames) {
-    snapshotPreservedUploadFilenames(opts.body, preservedFilenames);
-  }
+  const multipartEntries = preservedFilenames
+    ? snapshotPreservedUploadEntries(entries, preservedFilenames)
+    : entries;
 
   const boundary = `openai-${Math.random().toString(36).slice(2)}`;
-  const body = ReadableStreamFrom(iterateMultipartBody(opts.body, boundary, options, preservedFilenames));
+  const body = ReadableStreamFrom(
+    iterateMultipartBody(multipartEntries, boundary, options, preservedFilenames),
+  );
 
   return {
     ...opts,
@@ -411,12 +414,12 @@ const createStreamingFormRequestOptions = (
 };
 
 async function* iterateMultipartBody(
-  body: unknown,
+  entries: Iterable<FormEntry>,
   boundary: string,
   options: CreateFormOptions,
   preservedFilenames?: WeakMap<object, string>,
 ): AsyncGenerator<Uint8Array> {
-  for await (const { key, value } of iterateFormEntries(body)) {
+  for await (const { key, value } of entries) {
     if (isUploadable(value)) {
       const filename = preservedFilenames?.get(value) ?? getStreamingFileName(value, options);
       const type = getStreamingFileType(value);
@@ -438,7 +441,7 @@ async function* iterateMultipartBody(
   yield encodeUTF8(`--${boundary}--\r\n`);
 }
 
-async function* iterateFormEntries(body: unknown): AsyncGenerator<FormEntry> {
+function* iterateFormEntries(body: unknown): Generator<FormEntry> {
   if (!body || typeof body !== 'object') {
     return;
   }
@@ -448,7 +451,7 @@ async function* iterateFormEntries(body: unknown): AsyncGenerator<FormEntry> {
   }
 }
 
-async function* iterateFormValue(key: string, value: unknown): AsyncGenerator<FormEntry> {
+function* iterateFormValue(key: string, value: unknown): Generator<FormEntry> {
   if (value === undefined) {
     return;
   }

--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -180,10 +180,8 @@ export function getName(value: any, options?: { stripFilename?: boolean | undefi
   return path ? basename(path) : undefined;
 }
 
-function basename(value: string, preserveControlEscapes = false): string | undefined {
-  const separators = preserveControlEscapes ? /\/|\\(?!\p{Cc})/u : /[\\/]/;
-
-  return value.split(separators).pop() || undefined;
+function basename(value: string): string | undefined {
+  return value.split(/[\\/]/).pop() || undefined;
 }
 
 function normalizeFilenamePath(value: string): string {
@@ -463,7 +461,7 @@ function getStreamingFileName(value: Uploadable, options: CreateFormOptions): st
 
     return options.stripFilenames === false
       ? normalizeFilenamePath(name)
-      : (basename(name, true) ?? 'unknown_file');
+      : (basename(name) ?? 'unknown_file');
   }
 
   return getName(value, { stripFilename: options.stripFilenames }) ?? 'unknown_file';

--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -36,7 +36,10 @@ export interface StreamingFile {
   /** Source chunks read incrementally as the multipart request body is transmitted. */
   readonly data: StreamingFileInput;
 
-  /** Filename sent in the multipart part's `Content-Disposition` header. */
+  /**
+   * Logical source filename; ordinary uploads send its basename, while Skills can preserve
+   * a validated relative directory path.
+   */
   readonly name: string;
 
   /** Optional MIME type; defaults to `application/octet-stream` when omitted. */
@@ -51,7 +54,8 @@ export interface StreamingFile {
  * form data when the request is sent.
  *
  * @param data Async-iterable or readable-stream chunks containing text, binary data, or blobs.
- * @param name Non-empty filename sent in the multipart request.
+ * @param name Non-empty logical/source filename. Ordinary uploads send only its basename; Skills
+ * uploads may preserve a validated relative path with normalized forward slashes.
  * @param options Optional MIME type for the streaming file.
  * @throws {TypeError} If `name` is empty or the content type contains control characters.
  */
@@ -152,7 +156,7 @@ export function makeFile(
  *
  * Directory components separated by either `/` or `\\` are discarded unless an
  * explicitly supplied `name` or `filename` opts into preserving its path. Preserved
- * paths use forward slashes. Paths inferred from URLs and filesystem streams always
+ * paths must be safe and relative, and use forward slashes. Paths inferred from URLs and filesystem streams
  * discard their directories.
  */
 export function getName(value: any, options?: { stripFilename?: boolean | undefined }): string | undefined {
@@ -185,7 +189,11 @@ function basename(value: string): string | undefined {
 }
 
 function normalizeFilenamePath(value: string): string {
-  return value.replace(/\\/g, '/');
+  const normalized = value.replace(/\\/g, '/');
+  if (normalized.startsWith('/') || /^[A-Za-z]:/.test(normalized) || normalized.split('/').includes('..')) {
+    throw new TypeError('Upload file name must be a safe relative path without parent directory segments');
+  }
+  return normalized;
 }
 
 /** Identifies objects that expose a callable `Symbol.asyncIterator` method. */
@@ -369,10 +377,26 @@ const hasUploadableValue = (value: unknown): boolean => {
 
 type FormEntry = { key: string; value: unknown };
 
+const validatePreservedUploadFilenames = (value: unknown): void => {
+  if (isUploadable(value)) {
+    getStreamingFileName(value, { stripFilenames: false });
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const nested of Array.isArray(value) ? value : Object.values(value)) {
+      validatePreservedUploadFilenames(nested);
+    }
+  }
+};
+
 const createStreamingFormRequestOptions = (
   opts: RequestOptions,
   options: CreateFormOptions = {},
 ): RequestOptions => {
+  if (options.stripFilenames === false) {
+    validatePreservedUploadFilenames(opts.body);
+  }
+
   const boundary = `openai-${Math.random().toString(36).slice(2)}`;
   const body = ReadableStreamFrom(iterateMultipartBody(opts.body, boundary, options));
 

--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -180,8 +180,10 @@ export function getName(value: any, options?: { stripFilename?: boolean | undefi
   return path ? basename(path) : undefined;
 }
 
-function basename(value: string): string | undefined {
-  return value.split(/[\\/]/).pop() || undefined;
+function basename(value: string, preserveControlEscapes = false): string | undefined {
+  const separators = preserveControlEscapes ? /\/|\\(?!\p{Cc})/u : /[\\/]/;
+
+  return value.split(separators).pop() || undefined;
 }
 
 function normalizeFilenamePath(value: string): string {
@@ -459,7 +461,9 @@ function getStreamingFileName(value: Uploadable, options: CreateFormOptions): st
       throw new TypeError('Streaming upload file name must be a non-empty string');
     }
 
-    return options.stripFilenames === false ? normalizeFilenamePath(name) : name;
+    return options.stripFilenames === false
+      ? normalizeFilenamePath(name)
+      : (basename(name, true) ?? 'unknown_file');
   }
 
   return getName(value, { stripFilename: options.stripFilenames }) ?? 'unknown_file';

--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -164,9 +164,9 @@ export function getName(value: any, options?: { stripFilename?: boolean | undefi
     return undefined;
   }
 
+  const name = 'name' in value ? value.name : undefined;
   const explicitName =
-    ('name' in value && value.name && String(value.name)) ||
-    ('filename' in value && value.filename && String(value.filename));
+    (name && String(name)) || ('filename' in value && value.filename && String(value.filename));
   if (explicitName) {
     return options?.stripFilename === false ? normalizeFilenamePath(explicitName) : basename(explicitName);
   }
@@ -377,14 +377,16 @@ const hasUploadableValue = (value: unknown): boolean => {
 
 type FormEntry = { key: string; value: unknown };
 
-const validatePreservedUploadFilenames = (value: unknown): void => {
+const snapshotPreservedUploadFilenames = (value: unknown, filenames: WeakMap<object, string>): void => {
   if (isUploadable(value)) {
-    getStreamingFileName(value, { stripFilenames: false });
+    if (!filenames.has(value)) {
+      filenames.set(value, getStreamingFileName(value, { stripFilenames: false }));
+    }
     return;
   }
   if (value && typeof value === 'object') {
     for (const nested of Array.isArray(value) ? value : Object.values(value)) {
-      validatePreservedUploadFilenames(nested);
+      snapshotPreservedUploadFilenames(nested, filenames);
     }
   }
 };
@@ -393,12 +395,13 @@ const createStreamingFormRequestOptions = (
   opts: RequestOptions,
   options: CreateFormOptions = {},
 ): RequestOptions => {
-  if (options.stripFilenames === false) {
-    validatePreservedUploadFilenames(opts.body);
+  const preservedFilenames = options.stripFilenames === false ? new WeakMap<object, string>() : undefined;
+  if (preservedFilenames) {
+    snapshotPreservedUploadFilenames(opts.body, preservedFilenames);
   }
 
   const boundary = `openai-${Math.random().toString(36).slice(2)}`;
-  const body = ReadableStreamFrom(iterateMultipartBody(opts.body, boundary, options));
+  const body = ReadableStreamFrom(iterateMultipartBody(opts.body, boundary, options, preservedFilenames));
 
   return {
     ...opts,
@@ -411,10 +414,11 @@ async function* iterateMultipartBody(
   body: unknown,
   boundary: string,
   options: CreateFormOptions,
+  preservedFilenames?: WeakMap<object, string>,
 ): AsyncGenerator<Uint8Array> {
   for await (const { key, value } of iterateFormEntries(body)) {
     if (isUploadable(value)) {
-      const filename = getStreamingFileName(value, options);
+      const filename = preservedFilenames?.get(value) ?? getStreamingFileName(value, options);
       const type = getStreamingFileType(value);
       yield encodeUTF8(`--${boundary}\r\n`);
       yield encodeUTF8(

--- a/tests/internal/uploads-branches.test.ts
+++ b/tests/internal/uploads-branches.test.ts
@@ -483,7 +483,7 @@ describe('lazy multipart stream encoding', () => {
     const options = await multipartFormRequestOptions(
       {
         body: {
-          upload: toStreamingFile(chunks() as any, 'quote"\\\r\n.wav', { type: 'audio/custom' }),
+          upload: toStreamingFile(chunks() as any, 'quote"\r\n.wav', { type: 'audio/custom' }),
           values: ['first', 2, false],
           metadata: { enabled: true, omitted: undefined },
         },
@@ -493,7 +493,7 @@ describe('lazy multipart stream encoding', () => {
 
     const body = await new Response(options.body as ReadableStream).text();
 
-    expect(body).toContain('filename="quote%22%5C%0D%0A.wav"');
+    expect(body).toContain('filename="quote%22%0D%0A.wav"');
     expect(body).toContain('Content-Type: audio/custom');
     expect(body).toContain('ABCDEFG');
     expect(body).toContain('name="values[]"\r\n\r\nfirst');

--- a/tests/internal/uploads-filename-security.test.ts
+++ b/tests/internal/uploads-filename-security.test.ts
@@ -97,7 +97,7 @@ describe('streaming upload filename security', () => {
   });
 
   test.each([
-    ['default stripping', undefined, 'nested%5Cstream.txt', 'ordinary.txt'],
+    ['default stripping', undefined, 'stream.txt', 'ordinary.txt'],
     ['preserved paths', { stripFilenames: false }, 'nested/stream.txt', 'nested/ordinary.txt'],
   ] as const)(
     'preserves existing filenames and fallback names with %s',

--- a/tests/internal/uploads-filename-security.test.ts
+++ b/tests/internal/uploads-filename-security.test.ts
@@ -80,7 +80,7 @@ describe('streaming upload filename security', () => {
     );
     const body = await new Response(options.body as ReadableStream).text();
 
-    expect(body).toContain(`name="field-${escaped}"; filename="résumé-${escaped}.txt"`);
+    expect(body).toContain(`name="field-${escaped}"; filename="%0D%0AInjected: yes.txt"`);
     expect(body).not.toContain('\r\nInjected: yes');
   });
 

--- a/tests/internal/uploads-streaming-filename-privacy.test.ts
+++ b/tests/internal/uploads-streaming-filename-privacy.test.ts
@@ -1,0 +1,217 @@
+import OpenAI, { toStreamingFile } from 'openai';
+import type { Uploadable } from 'openai';
+import { multipartFormRequestOptions } from 'openai/internal/uploads';
+
+interface CapturedRequest {
+  url: string;
+  body: string;
+}
+
+function createClient(): { client: OpenAI; requests: CapturedRequest[] } {
+  const requests: CapturedRequest[] = [];
+  const transport = Object.assign(
+    async (url: Request | URL | string, options?: RequestInit): Promise<Response> => {
+      if (!options?.body) {
+        throw new Error('Expected a multipart upload body');
+      }
+
+      requests.push({ url: String(url), body: await new Response(options.body).text() });
+      return Response.json({ id: 'file_123', object: 'file', created: 0, data: [], text: 'transcribed' });
+    },
+    { Response },
+  );
+
+  return {
+    client: new OpenAI({ apiKey: 'test-api-key', fetch: transport as typeof fetch }),
+    requests,
+  };
+}
+
+async function* fileChunks(contents = 'streamed contents'): AsyncGenerator<Uint8Array> {
+  yield new TextEncoder().encode(contents);
+}
+
+function uploadedFilenames(body: string): string[] {
+  return Array.from(body.matchAll(/filename="(?<name>[^"]+)"/gu), (match) => match.groups?.['name'] ?? '');
+}
+
+function capturedRequest(requests: CapturedRequest[], index = 0): CapturedRequest {
+  const request = requests[index];
+  if (!request) {
+    throw new Error(`Expected captured upload request at index ${index}`);
+  }
+
+  return request;
+}
+
+const ordinaryUploadEndpoints = [
+  {
+    name: 'file uploads',
+    submit: (client: OpenAI, file: Uploadable) => client.files.create({ file, purpose: 'assistants' }),
+  },
+  {
+    name: 'image edits',
+    submit: (client: OpenAI, file: Uploadable) =>
+      client.images.edit({ image: file, model: 'gpt-image-1', prompt: 'Edit the image' }),
+  },
+  {
+    name: 'audio transcriptions',
+    submit: (client: OpenAI, file: Uploadable) =>
+      client.audio.transcriptions.create({ file, model: 'whisper-1' }),
+  },
+] as const;
+
+const skillUploadEndpoints = [
+  {
+    name: 'skill creation',
+    submit: (client: OpenAI, file: Uploadable) => client.skills.create({ files: [file] }),
+  },
+  {
+    name: 'skill version creation',
+    submit: (client: OpenAI, file: Uploadable) =>
+      client.skills.versions.create('skill_123', { files: [file] }),
+  },
+] as const;
+
+describe('streaming upload filename privacy', () => {
+  test.each([
+    ['/home/sdk-user/private-project/traces/input.jsonl', 'input.jsonl'],
+    ['C:\\Users\\sdk-user\\private-project\\traces\\input.jsonl', 'input.jsonl'],
+    ['private-project/traces/input.jsonl', 'input.jsonl'],
+  ] as const)('matches buffered filename stripping for %s', async (filename, basename) => {
+    const { client, requests } = createClient();
+
+    await client.files.create({
+      file: toStreamingFile(fileChunks(), filename, { type: 'text/plain' }),
+      purpose: 'assistants',
+    });
+    await client.files.create({
+      file: new File(['buffered contents'], filename, { type: 'text/plain' }),
+      purpose: 'assistants',
+    });
+
+    expect(requests).toHaveLength(2);
+    const streamed = capturedRequest(requests);
+    const buffered = capturedRequest(requests, 1);
+    expect(uploadedFilenames(streamed.body)).toEqual([basename]);
+    expect(uploadedFilenames(buffered.body)).toEqual([basename]);
+    expect(streamed.url).toBe('https://api.openai.com/v1/files');
+    expect(streamed.body).toContain('Content-Type: text/plain');
+    expect(streamed.body).not.toContain('sdk-user');
+    expect(streamed.body).not.toContain('private-project');
+    expect(streamed.body).not.toContain('traces');
+  });
+
+  test.each(ordinaryUploadEndpoints)(
+    'never exposes POSIX or Windows parent directories through $name',
+    async ({ submit }) => {
+      const { client, requests } = createClient();
+
+      await submit(client, toStreamingFile(fileChunks(), '/home/alice/private/recording.wav'));
+      await submit(client, toStreamingFile(fileChunks(), 'C:\\Users\\alice\\private\\recording.wav'));
+
+      expect(requests).toHaveLength(2);
+      for (const request of requests) {
+        expect(uploadedFilenames(request.body)).toEqual(['recording.wav']);
+        expect(request.body).not.toContain('alice');
+        expect(request.body).not.toContain('private');
+        expect(request.body).not.toContain('%5C');
+      }
+    },
+  );
+
+  test.each(skillUploadEndpoints)(
+    'preserves explicitly opted-in POSIX and Windows directories for $name',
+    async ({ submit }) => {
+      const { client, requests } = createClient();
+
+      await submit(client, toStreamingFile(fileChunks(), 'my-skill/assets/manifest.txt'));
+      await submit(client, toStreamingFile(fileChunks(), 'my-skill\\assets\\manifest.txt'));
+
+      expect(requests).toHaveLength(2);
+      expect(requests.map(({ body }) => uploadedFilenames(body))).toEqual([
+        ['my-skill/assets/manifest.txt'],
+        ['my-skill/assets/manifest.txt'],
+      ]);
+    },
+  );
+
+  test('strips explicitly configured filename paths without consuming stream chunks early', async () => {
+    let reads = 0;
+    async function* lazyChunks(): AsyncGenerator<Uint8Array> {
+      reads += 1;
+      yield new TextEncoder().encode('lazy contents');
+    }
+
+    const request = await multipartFormRequestOptions(
+      {
+        body: {
+          file: toStreamingFile(lazyChunks(), 'private-folder\\nested\\report.txt', {
+            type: 'text/markdown',
+          }),
+        },
+      },
+      fetch,
+      { stripFilenames: true },
+    );
+
+    expect(reads).toBe(0);
+    const body = await new Response(request.body as ReadableStream).text();
+    expect(reads).toBe(1);
+    expect(uploadedFilenames(body)).toEqual(['report.txt']);
+    expect(body).toContain('Content-Type: text/markdown');
+    expect(body).toContain('lazy contents');
+    expect(body).not.toContain('private-folder');
+  });
+
+  test('preserves sparse mixed upload ordering, metadata, and multipart escaping', async () => {
+    const { client, requests } = createClient();
+    const images: Uploadable[] = [];
+    images[1] = toStreamingFile(fileChunks('base image'), '/private/base"image.png', { type: 'image/png' });
+    images[3] = new File(['overlay image'], 'private\\overlay.png', { type: 'image/webp' });
+    const mask = new File(['mask'], '/private/mask.png', { type: 'image/png' });
+
+    await client.images.edit({
+      image: images,
+      mask,
+      model: 'gpt-image-1',
+      prompt: 'Keep the private image names and ordering safe',
+    });
+
+    expect(requests).toHaveLength(1);
+    const { body } = capturedRequest(requests);
+    expect(uploadedFilenames(body)).toEqual(['base%22image.png', 'overlay.png', 'mask.png']);
+    expect(body).toContain('Content-Type: image/png');
+    expect(body).toContain('Content-Type: image/webp');
+    expect(body).not.toContain('/private/');
+    expect(body).not.toContain('private%5C');
+    expect(0 in images).toBe(false);
+    expect(2 in images).toBe(false);
+  });
+
+  test.each(['private-folder/nested/', 'private-folder\\nested\\'] as const)(
+    'replaces trailing path separators with a private fallback filename: %s',
+    async (filename) => {
+      const { client, requests } = createClient();
+
+      await client.files.create({ file: toStreamingFile(fileChunks(), filename), purpose: 'assistants' });
+
+      const { body } = capturedRequest(requests);
+      expect(uploadedFilenames(body)).toEqual(['unknown_file']);
+      expect(body).not.toContain('private-folder');
+      expect(body).not.toContain('nested');
+    },
+  );
+
+  test('retains empty-name validation for newly created and mutated streaming files', async () => {
+    expect(() => toStreamingFile(fileChunks(), '')).toThrow('requires a non-empty file name');
+
+    const upload = toStreamingFile(fileChunks(), 'valid.txt');
+    Object.assign(upload, { name: '' });
+    const request = await multipartFormRequestOptions({ body: { upload } }, fetch);
+
+    await expect(new Response(request.body as ReadableStream).text()).rejects.toThrow(
+      'Streaming upload file name must be a non-empty string',
+    );
+  });
+});

--- a/tests/internal/uploads-streaming-filename-privacy.test.ts
+++ b/tests/internal/uploads-streaming-filename-privacy.test.ts
@@ -65,11 +65,14 @@ const skillUploadEndpoints = [
   {
     name: 'skill creation',
     submit: (client: OpenAI, file: Uploadable) => client.skills.create({ files: [file] }),
+    submitFiles: (client: OpenAI, files: Uploadable[]) => client.skills.create({ files }),
   },
   {
     name: 'skill version creation',
     submit: (client: OpenAI, file: Uploadable) =>
       client.skills.versions.create('skill_123', { files: [file] }),
+    submitFiles: (client: OpenAI, files: Uploadable[]) =>
+      client.skills.versions.create('skill_123', { files }),
   },
 ] as const;
 
@@ -199,6 +202,36 @@ describe('streaming upload filename privacy', () => {
       expect(nameReads).toBe(1);
       expect(requests).toHaveLength(1);
       expect(uploadedFilenames(capturedRequest(requests).body)).toEqual(['assets/validated.txt']);
+    },
+  );
+
+  test.each(
+    skillUploadEndpoints.flatMap((endpoint) =>
+      skillFilenameMutations.map((mutation) => ({ endpoint, mutation })),
+    ),
+  )(
+    '$endpoint.name snapshots multipart entries before replacement with $mutation.name',
+    async ({ endpoint, mutation }) => {
+      const { client, requests } = createClient();
+      let sourceReads = 0;
+      async function* originalChunks(): AsyncGenerator<Uint8Array> {
+        sourceReads += 1;
+        yield new TextEncoder().encode('validated contents');
+      }
+
+      const files: Uploadable[] = [toStreamingFile(originalChunks(), 'assets/validated.txt')];
+      const pending = endpoint.submitFiles(client, files);
+      expect(sourceReads).toBe(0);
+
+      files[0] = toStreamingFile(fileChunks('replacement contents'), mutation.filename);
+      await pending;
+
+      expect(sourceReads).toBe(1);
+      expect(requests).toHaveLength(1);
+      const request = capturedRequest(requests);
+      expect(uploadedFilenames(request.body)).toEqual(['assets/validated.txt']);
+      expect(request.body).toContain('validated contents');
+      expect(request.body).not.toContain('replacement contents');
     },
   );
 

--- a/tests/internal/uploads-streaming-filename-privacy.test.ts
+++ b/tests/internal/uploads-streaming-filename-privacy.test.ts
@@ -73,6 +73,22 @@ const skillUploadEndpoints = [
   },
 ] as const;
 
+const unsafeSkillFilenames = [
+  { name: 'absolute POSIX', filename: '/private/secret.txt' },
+  { name: 'absolute Windows drive', filename: 'C:\\Users\\alice\\secret.txt' },
+  { name: 'drive-relative Windows', filename: 'C:private\\secret.txt' },
+  { name: 'Windows UNC', filename: '\\\\server\\share\\secret.txt' },
+  { name: 'Windows device', filename: '\\\\?\\C:\\private\\secret.txt' },
+  { name: 'parent traversal', filename: '../secret.txt' },
+  { name: 'nested parent traversal', filename: 'assets/../secret.txt' },
+  { name: 'Windows parent traversal', filename: 'assets\\..\\secret.txt' },
+] as const;
+
+const skillUploadModes = [
+  { name: 'buffered', create: (filename: string) => new File(['skill'], filename) },
+  { name: 'streaming', create: (filename: string) => toStreamingFile(fileChunks('skill'), filename) },
+] as const;
+
 describe('streaming upload filename privacy', () => {
   test.each([
     ['/home/sdk-user/private-project/traces/input.jsonl', 'input.jsonl'],
@@ -143,6 +159,17 @@ describe('streaming upload filename privacy', () => {
     },
   );
 
+  test.each(
+    skillUploadEndpoints.flatMap((endpoint) =>
+      unsafeSkillFilenames.flatMap((path) => skillUploadModes.map((mode) => ({ endpoint, path, mode }))),
+    ),
+  )('$endpoint.name rejects $path.name paths in $mode.name uploads', async ({ endpoint, path, mode }) => {
+    const { client, requests } = createClient();
+
+    await expect(endpoint.submit(client, mode.create(path.filename))).rejects.toThrow(/safe relative/iu);
+    expect(requests).toHaveLength(0);
+  });
+
   test.each(skillUploadEndpoints)(
     'preserves explicitly opted-in POSIX and Windows directories for $name',
     async ({ submit }) => {
@@ -150,9 +177,13 @@ describe('streaming upload filename privacy', () => {
 
       await submit(client, toStreamingFile(fileChunks(), 'my-skill/assets/manifest.txt'));
       await submit(client, toStreamingFile(fileChunks(), 'my-skill\\assets\\manifest.txt'));
+      await submit(client, new File(['buffered skill'], 'my-skill/assets/manifest.txt'));
+      await submit(client, new File(['buffered skill'], 'my-skill\\assets\\manifest.txt'));
 
-      expect(requests).toHaveLength(2);
+      expect(requests).toHaveLength(4);
       expect(requests.map(({ body }) => uploadedFilenames(body))).toEqual([
+        ['my-skill/assets/manifest.txt'],
+        ['my-skill/assets/manifest.txt'],
         ['my-skill/assets/manifest.txt'],
         ['my-skill/assets/manifest.txt'],
       ]);

--- a/tests/internal/uploads-streaming-filename-privacy.test.ts
+++ b/tests/internal/uploads-streaming-filename-privacy.test.ts
@@ -102,6 +102,29 @@ describe('streaming upload filename privacy', () => {
     expect(streamed.body).not.toContain('traces');
   });
 
+  test.each([
+    ['NUL', '\0', '%00'],
+    ['newline', '\n', '%0A'],
+    ['carriage return', '\r', '%0D'],
+    ['DEL', '\u007F', '%7F'],
+  ] as const)(
+    'strips Windows parent directories before escaping %s in streaming filenames',
+    async (_, control, escaped) => {
+      const { client, requests } = createClient();
+
+      await client.files.create({
+        file: toStreamingFile(fileChunks(), `C:\\Users\\alice\\private\\${control}recording.wav`),
+        purpose: 'assistants',
+      });
+
+      const request = capturedRequest(requests);
+      expect(uploadedFilenames(request.body)).toEqual([`${escaped}recording.wav`]);
+      expect(request.body).not.toContain('alice');
+      expect(request.body).not.toContain('private');
+      expect(request.body).not.toContain('%5C');
+    },
+  );
+
   test.each(ordinaryUploadEndpoints)(
     'never exposes POSIX or Windows parent directories through $name',
     async ({ submit }) => {

--- a/tests/internal/uploads-streaming-filename-privacy.test.ts
+++ b/tests/internal/uploads-streaming-filename-privacy.test.ts
@@ -88,6 +88,10 @@ const skillUploadModes = [
   { name: 'buffered', create: (filename: string) => new File(['skill'], filename) },
   { name: 'streaming', create: (filename: string) => toStreamingFile(fileChunks('skill'), filename) },
 ] as const;
+const skillFilenameMutations = [
+  { name: 'an unsafe pathname', filename: '/private/secret.txt' },
+  { name: 'a different safe pathname', filename: 'assets/unvalidated.txt' },
+] as const;
 
 describe('streaming upload filename privacy', () => {
   test.each([
@@ -169,6 +173,34 @@ describe('streaming upload filename privacy', () => {
     await expect(endpoint.submit(client, mode.create(path.filename))).rejects.toThrow(/safe relative/iu);
     expect(requests).toHaveLength(0);
   });
+
+  test.each(
+    skillUploadEndpoints.flatMap((endpoint) =>
+      skillUploadModes.flatMap((mode) =>
+        skillFilenameMutations.map((mutation) => ({ endpoint, mode, mutation })),
+      ),
+    ),
+  )(
+    '$endpoint.name snapshots a $mode.name filename before it changes to $mutation.name',
+    async ({ endpoint, mode, mutation }) => {
+      const { client, requests } = createClient();
+      const upload = mode.create('assets/validated.txt');
+      let nameReads = 0;
+      Object.defineProperty(upload, 'name', {
+        configurable: true,
+        get: () => {
+          nameReads += 1;
+          return nameReads === 1 ? 'assets/validated.txt' : mutation.filename;
+        },
+      });
+
+      await endpoint.submit(client, upload);
+
+      expect(nameReads).toBe(1);
+      expect(requests).toHaveLength(1);
+      expect(uploadedFilenames(capturedRequest(requests).body)).toEqual(['assets/validated.txt']);
+    },
+  );
 
   test.each(skillUploadEndpoints)(
     'preserves explicitly opted-in POSIX and Windows directories for $name',


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Summary

- Strip POSIX and Windows parent directories from lazy `toStreamingFile()` uploads by default, matching existing buffered `File` behavior and preventing private local paths from appearing in multipart filenames.
- Preserve explicitly opted-in nested Skills paths, Windows path normalization, literal backslash/control-character header escaping, lazy streaming, metadata, sparse upload ordering, and safe filename fallbacks.
- Update one preexisting expectation that explicitly encoded the old default-path-disclosure behavior.

## Validation

- Regression first: 10 failing public SDK cases and 3 passing compatibility controls before the fix; all 13 focused regressions pass.
- Public `client.files.create`, `client.images.edit`, `client.audio.transcriptions.create`, `client.skills.create`, and `client.skills.versions.create`.
- Full handwritten suite: 100 files / 2,979 tests passed.
- Minimum-supported Node 22 focused matrix: 5 files / 113 tests passed.
- `./scripts/lint`
- `pnpm exec tsc --project tsconfig.json --noEmit`
- `./scripts/build`
- TypeScript 4.9 and current TypeScript against published `dist/src`.
- `node --experimental-strip-types scripts/test-packed-package.ts`
- `node --experimental-strip-types scripts/check-node-version-policy.ts`

Only two handwritten upload tests and their owning handwritten upload implementation were changed; no generated endpoints or package metadata changed.