### PR TITLE
fix: settle concurrent stream event waiters in linear time

### DIFF
--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -65,7 +65,7 @@ export class EventStream<EventTypes extends BaseEvents> {
   #abortListeners: { signal: AbortSignal; listener: () => void }[] = [];
   #emittedListenerRegistrations = new WeakMap<
     object,
-    { event: PropertyKey; registration: { removed?: boolean } }
+    { event: PropertyKey; registration: { removed?: boolean; detached?: boolean } }
   >();
   #pendingListenerCleanup = new Set<PropertyKey>();
   #listenerDispatchDepth = 0;
@@ -201,7 +201,11 @@ export class EventStream<EventTypes extends BaseEvents> {
     }
 
     const emittedRegistration = this.#emittedListenerRegistrations.get(listener as object);
-    if (emittedRegistration?.event === event && !emittedRegistration.registration.removed) {
+    if (
+      emittedRegistration?.event === event &&
+      !emittedRegistration.registration.removed &&
+      !emittedRegistration.registration.detached
+    ) {
       this.#removeEmittedListener(
         event,
         emittedRegistration.registration as EventListeners<EventTypes, Event>[number],
@@ -231,10 +235,17 @@ export class EventStream<EventTypes extends BaseEvents> {
     event: Event,
     listener: EventListener<EventTypes, Event>,
   ): void {
+    const previousListeners = this.#listeners[event];
+    const previousLength = previousListeners?.length ?? 0;
     this.once(event, listener);
     const listeners = this.#listeners[event];
     const [registration] = listeners?.slice(-1) ?? [];
-    if (registration?.listener === listener) {
+    if (
+      (previousListeners === undefined || listeners === previousListeners) &&
+      listeners?.length === previousLength + 1 &&
+      registration?.listener === listener &&
+      registration.once
+    ) {
       this.#emittedListenerRegistrations.set(listener as object, { event, registration });
     }
   }
@@ -524,7 +535,12 @@ export class EventStream<EventTypes extends BaseEvents> {
 
     const listeners: EventListeners<EventTypes, Event> | undefined = this.#listeners[event];
     if (listeners) {
-      this.#listeners[event] = listeners.filter((listener) => !listener.once && !listener.removed) as any;
+      this.#listeners[event] = listeners.filter((listener) => {
+        if (listener.once) {
+          listener.detached = true;
+        }
+        return !listener.once && !listener.removed;
+      }) as any;
       this.#listenerDispatchDepth += 1;
       try {
         for (const registration of listeners as any) {
@@ -583,6 +599,7 @@ type EventListeners<Events, EventType extends keyof Events> = {
   listener: EventListener<Events, EventType>;
   once?: boolean;
   removed?: boolean;
+  detached?: boolean;
 }[];
 
 /** The positional listener arguments associated with a named event. */

--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -63,6 +63,12 @@ export class EventStream<EventTypes extends BaseEvents> {
     [Event in keyof EventTypes]?: EventListeners<EventTypes, Event>;
   } = Object.create(null);
   #abortListeners: { signal: AbortSignal; listener: () => void }[] = [];
+  #emittedListenerRegistrations = new WeakMap<
+    object,
+    { event: PropertyKey; registration: { removed?: boolean } }
+  >();
+  #pendingListenerCleanup = new Set<PropertyKey>();
+  #listenerDispatchDepth = 0;
 
   #ended = false;
   #errored = false;
@@ -193,7 +199,17 @@ export class EventStream<EventTypes extends BaseEvents> {
     if (!listeners) {
       return this;
     }
-    const index = listeners.findIndex((l) => l.listener === listener);
+
+    const emittedRegistration = this.#emittedListenerRegistrations.get(listener as object);
+    if (emittedRegistration?.event === event && !emittedRegistration.registration.removed) {
+      this.#removeEmittedListener(
+        event,
+        emittedRegistration.registration as EventListeners<EventTypes, Event>[number],
+      );
+      return this;
+    }
+
+    const index = listeners.findIndex((l) => !l.removed && l.listener === listener);
     if (index !== -1) {
       listeners.splice(index, 1);
     }
@@ -209,6 +225,45 @@ export class EventStream<EventTypes extends BaseEvents> {
     const listeners: EventListeners<EventTypes, Event> = (this.#listeners[event] ||= []);
     listeners.push({ listener, once: true });
     return this;
+  }
+
+  #onceForEmitted<Event extends keyof EventTypes>(
+    event: Event,
+    listener: EventListener<EventTypes, Event>,
+  ): void {
+    this.once(event, listener);
+    const listeners = this.#listeners[event];
+    const [registration] = listeners?.slice(-1) ?? [];
+    if (registration?.listener === listener) {
+      this.#emittedListenerRegistrations.set(listener as object, { event, registration });
+    }
+  }
+
+  #removeEmittedListener<Event extends keyof EventTypes>(
+    event: Event,
+    registration: EventListeners<EventTypes, Event>[number],
+  ): void {
+    if (registration.removed) {
+      return;
+    }
+
+    registration.removed = true;
+    this.#emittedListenerRegistrations.delete(registration.listener as object);
+    this.#pendingListenerCleanup.add(event);
+    if (this.#listenerDispatchDepth === 0) {
+      this.#cleanupEmittedListeners();
+    }
+  }
+
+  #cleanupEmittedListeners(): void {
+    for (const event of this.#pendingListenerCleanup) {
+      const eventType = event as keyof EventTypes;
+      const listeners = this.#listeners[eventType];
+      if (listeners) {
+        this.#listeners[eventType] = listeners.filter((listener) => !listener.removed) as any;
+      }
+    }
+    this.#pendingListenerCleanup.clear();
   }
 
   /**
@@ -247,9 +302,9 @@ export class EventStream<EventTypes extends BaseEvents> {
       };
 
       if (event !== 'error') {
-        this.once('error', onError);
+        this.#onceForEmitted('error', onError as EventListener<EventTypes, 'error'>);
       }
-      this.once(event, onEvent as EventListener<EventTypes, Event>);
+      this.#onceForEmitted(event, onEvent as EventListener<EventTypes, Event>);
     });
   }
 
@@ -443,7 +498,7 @@ export class EventStream<EventTypes extends BaseEvents> {
 
   /** Returns whether an event currently has one or more registered listeners. */
   protected _hasListeners<Event extends keyof EventTypes>(event: Event): boolean {
-    return Boolean(this.#listeners[event]?.length);
+    return Boolean(this.#listeners[event]?.some((listener) => !listener.removed));
   }
 
   /** Dispatches a connection, failure, cancellation, or completion lifecycle event. */
@@ -469,9 +524,19 @@ export class EventStream<EventTypes extends BaseEvents> {
 
     const listeners: EventListeners<EventTypes, Event> | undefined = this.#listeners[event];
     if (listeners) {
-      this.#listeners[event] = listeners.filter((l) => !l.once) as any;
-      for (const { listener } of listeners as any) {
-        listener(...(args as any));
+      this.#listeners[event] = listeners.filter((listener) => !listener.once && !listener.removed) as any;
+      this.#listenerDispatchDepth += 1;
+      try {
+        for (const registration of listeners as any) {
+          if (!registration.removed) {
+            registration.listener(...(args as any));
+          }
+        }
+      } finally {
+        this.#listenerDispatchDepth -= 1;
+        if (this.#listenerDispatchDepth === 0) {
+          this.#cleanupEmittedListeners();
+        }
       }
     }
 
@@ -517,6 +582,7 @@ type EventListener<Events, EventType extends keyof Events> = Events[EventType];
 type EventListeners<Events, EventType extends keyof Events> = {
   listener: EventListener<Events, EventType>;
   once?: boolean;
+  removed?: boolean;
 }[];
 
 /** The positional listener arguments associated with a named event. */

--- a/tests/lib/event-stream-emitted-performance.test.ts
+++ b/tests/lib/event-stream-emitted-performance.test.ts
@@ -1,0 +1,345 @@
+import { vi } from 'vitest';
+import { APIUserAbortError, OpenAIError } from 'openai/error';
+import { EventStream } from 'openai/lib/EventStream';
+import type { BaseEvents } from 'openai/lib/EventStream';
+
+const WAITER_COUNT = 4096;
+
+interface EmittedEvents extends BaseEvents {
+  value: (value: number) => void;
+  other: (value: string) => void;
+  pair: (left: string, right: number) => void;
+  __proto__: (value: number) => void;
+}
+
+class EmittedTestStream extends EventStream<EmittedEvents> {
+  emitValue(value: number): void {
+    this._emit('value', value);
+  }
+
+  emitOther(value: string): void {
+    this._emit('other', value);
+  }
+
+  emitPair(left: string, right: number): void {
+    this._emit('pair', left, right);
+  }
+
+  emitPrototype(value: number): void {
+    this._emit('__proto__', value);
+  }
+
+  emitFailure(error: OpenAIError): void {
+    this._emit('error', error);
+  }
+
+  emitAbort(error: APIUserAbortError): void {
+    this._emit('abort', error);
+  }
+
+  end(): void {
+    this._emit('end');
+  }
+
+  hasListener(event: keyof EmittedEvents): boolean {
+    return this._hasListeners(event);
+  }
+}
+
+function measureListenerMovement<T>(operation: () => T): {
+  result: T;
+  elementMoves: number;
+  spliceCalls: number;
+} {
+  const originalSplice = Array.prototype.splice;
+  const originalFilter = Array.prototype.filter;
+  let elementMoves = 0;
+  let spliceCalls = 0;
+
+  function trackedSplice(this: unknown[], start: number, deleteCount?: number, ...items: unknown[]) {
+    if (deleteCount === 1 && items.length === 0) {
+      elementMoves += Math.max(this.length - start - deleteCount, 0);
+      spliceCalls += 1;
+    }
+    if (deleteCount === undefined) {
+      return Reflect.apply(originalSplice, this, [start]);
+    }
+    return originalSplice.call(this, start, deleteCount, ...items);
+  }
+
+  function trackedFilter(
+    this: unknown[],
+    predicate: (value: unknown, index: number, values: unknown[]) => unknown,
+    thisArg?: unknown,
+  ) {
+    const result = originalFilter.call(this, predicate, thisArg);
+    elementMoves += result.length;
+    return result;
+  }
+
+  Reflect.set(Array.prototype, 'splice', trackedSplice);
+  Reflect.set(Array.prototype, 'filter', trackedFilter);
+  try {
+    return { result: operation(), elementMoves, spliceCalls };
+  } finally {
+    Reflect.set(Array.prototype, 'filter', originalFilter);
+    Reflect.set(Array.prototype, 'splice', originalSplice);
+  }
+}
+
+async function captureRejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+    return undefined;
+  } catch (error) {
+    return error;
+  }
+}
+
+describe('EventStream.emitted companion-listener performance', () => {
+  test('settles concurrent event waiters with linear listener movement', async () => {
+    const stream = new EmittedTestStream();
+    const pending = Array.from({ length: WAITER_COUNT }, () => stream.emitted('value'));
+
+    const { elementMoves, spliceCalls } = measureListenerMovement(() => stream.emitValue(42));
+
+    await expect(Promise.all(pending)).resolves.toEqual(Array.from({ length: WAITER_COUNT }, () => 42));
+    expect(elementMoves).toBeLessThanOrEqual(WAITER_COUNT * 4);
+    expect(spliceCalls).toBe(0);
+    expect(stream.hasListener('value')).toBe(false);
+    expect(stream.hasListener('error')).toBe(false);
+  });
+
+  test('rejects concurrent event waiters with linear listener movement when an error arrives first', async () => {
+    const stream = new EmittedTestStream();
+    const failure = new OpenAIError('stream failed');
+    const pending = Array.from({ length: WAITER_COUNT }, () => captureRejection(stream.emitted('value')));
+
+    const { elementMoves, spliceCalls } = measureListenerMovement(() => stream.emitFailure(failure));
+
+    const rejected = await Promise.all(pending);
+    expect(rejected).toHaveLength(WAITER_COUNT);
+    expect(rejected.every((error) => error === failure)).toBe(true);
+    expect(elementMoves).toBeLessThanOrEqual(WAITER_COUNT * 4);
+    expect(spliceCalls).toBe(0);
+    expect(stream.hasListener('value')).toBe(false);
+    expect(stream.hasListener('error')).toBe(false);
+  });
+
+  test('cleans only settled companions while preserving mixed events and user error listeners', async () => {
+    const stream = new EmittedTestStream();
+    const userError = vi.fn();
+    stream.on('error', userError);
+    const first = stream.emitted('value');
+    const second = stream.emitted('other');
+    const third = stream.emitted('value');
+
+    stream.emitValue(7);
+
+    await expect(Promise.all([first, third])).resolves.toEqual([7, 7]);
+    expect(stream.hasListener('value')).toBe(false);
+    expect(stream.hasListener('other')).toBe(true);
+    expect(stream.hasListener('error')).toBe(true);
+
+    stream.emitOther('ready');
+    await expect(second).resolves.toBe('ready');
+    expect(stream.hasListener('other')).toBe(false);
+    expect(stream.hasListener('error')).toBe(true);
+
+    stream.off('error', userError);
+    expect(stream.hasListener('error')).toBe(false);
+    expect(userError).not.toHaveBeenCalled();
+  });
+
+  test('preserves error callback registration order across mixed pending events', async () => {
+    const stream = new EmittedTestStream();
+    const order: string[] = [];
+    const failure = new OpenAIError('failure');
+    stream.on('error', () => {
+      order.push('first');
+    });
+    const first = captureRejection(stream.emitted('value'));
+    stream.on('error', () => {
+      order.push('second');
+    });
+    const second = captureRejection(stream.emitted('other'));
+
+    stream.emitFailure(failure);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([failure, failure]);
+    expect(order).toEqual(['first', 'second']);
+    expect(stream.hasListener('value')).toBe(false);
+    expect(stream.hasListener('other')).toBe(false);
+  });
+
+  test('preserves observable public once and off hooks for companion listeners', async () => {
+    const stream = new EmittedTestStream();
+    const register = vi.spyOn(stream, 'once');
+    const remove = vi.spyOn(stream, 'off');
+    const pending = stream.emitted('value');
+
+    expect(register).toHaveBeenCalledWith('error', expect.any(Function));
+    expect(register).toHaveBeenCalledWith('value', expect.any(Function));
+
+    stream.emitValue(13);
+
+    await expect(pending).resolves.toBe(13);
+    expect(remove).toHaveBeenCalledWith('error', expect.any(Function));
+  });
+
+  test('preserves duplicate user callbacks, once listeners, and immediate off semantics', async () => {
+    const stream = new EmittedTestStream();
+    const duplicate = vi.fn();
+    stream.on('value', duplicate);
+    stream.on('value', duplicate);
+    stream.once('value', duplicate);
+    const pending = stream.emitted('value');
+
+    stream.off('value', duplicate);
+    stream.emitValue(1);
+    await expect(pending).resolves.toBe(1);
+    expect(duplicate).toHaveBeenCalledTimes(2);
+
+    stream.emitValue(2);
+    expect(duplicate).toHaveBeenCalledTimes(3);
+    stream.off('value', duplicate);
+    expect(stream.hasListener('value')).toBe(false);
+  });
+
+  test('preserves listener snapshots, nested emits, and registrations during dispatch', async () => {
+    const stream = new EmittedTestStream();
+    const order: string[] = [];
+    const removed = () => {
+      order.push('removed');
+    };
+    const added = () => {
+      order.push('added');
+    };
+    stream.on('value', (value) => {
+      order.push('first');
+      if (value === 1) {
+        stream.off('value', removed);
+        stream.on('value', added);
+        stream.emitOther('nested');
+      }
+    });
+    stream.on('value', removed);
+    const value = stream.emitted('value');
+    const nested = stream.emitted('other');
+
+    stream.emitValue(1);
+
+    await expect(value).resolves.toBe(1);
+    await expect(nested).resolves.toBe('nested');
+    expect(order).toEqual(['first', 'removed']);
+    expect(stream.hasListener('error')).toBe(false);
+
+    stream.emitValue(2);
+    expect(order).toEqual(['first', 'removed', 'first', 'added']);
+  });
+
+  test('preserves event and error settlement order across nested emissions', async () => {
+    const rejectedStream = new EmittedTestStream();
+    const failure = new OpenAIError('nested failure');
+    rejectedStream.on('value', () => {
+      rejectedStream.emitFailure(failure);
+    });
+    const rejected = captureRejection(rejectedStream.emitted('value'));
+
+    rejectedStream.emitValue(1);
+
+    await expect(rejected).resolves.toBe(failure);
+    expect(rejectedStream.hasListener('value')).toBe(true);
+    expect(rejectedStream.hasListener('error')).toBe(false);
+
+    const resolvedStream = new EmittedTestStream();
+    resolvedStream.on('error', () => {
+      resolvedStream.emitValue(2);
+    });
+    const resolved = resolvedStream.emitted('value');
+
+    resolvedStream.emitFailure(failure);
+
+    await expect(resolved).resolves.toBe(2);
+    expect(resolvedStream.hasListener('value')).toBe(false);
+  });
+
+  test('keeps earlier settled promises resolved when a later event fails', async () => {
+    const stream = new EmittedTestStream();
+    const resolved = stream.emitted('value');
+    const failure = new OpenAIError('later failure');
+    const rejected = captureRejection(stream.emitted('other'));
+
+    stream.emitValue(3);
+    stream.emitFailure(failure);
+
+    await expect(resolved).resolves.toBe(3);
+    await expect(rejected).resolves.toBe(failure);
+    expect(stream.hasListener('value')).toBe(false);
+    expect(stream.hasListener('other')).toBe(false);
+  });
+
+  test('preserves multi-argument, error-event, abort, and end promise semantics', async () => {
+    const paired = new EmittedTestStream();
+    const pair = paired.emitted('pair');
+    paired.emitPair('left', 9);
+    await expect(pair).resolves.toEqual(['left', 9]);
+    expect(paired.hasListener('error')).toBe(false);
+
+    const errored = new EmittedTestStream();
+    const failure = new OpenAIError('event value');
+    const error = errored.emitted('error');
+    errored.emitFailure(failure);
+    await expect(error).resolves.toBe(failure);
+
+    const aborted = new EmittedTestStream();
+    const reason = new APIUserAbortError();
+    const abort = aborted.emitted('abort');
+    aborted.emitAbort(reason);
+    await expect(abort).resolves.toBe(reason);
+    expect(aborted.hasListener('error')).toBe(false);
+
+    const ended = new EmittedTestStream();
+    const done = ended.emitted('end');
+    ended.end();
+    await expect(done).resolves.toBeUndefined();
+    expect(ended.hasListener('error')).toBe(false);
+  });
+
+  test('cleans settled companions if a subsequent user listener throws', async () => {
+    const stream = new EmittedTestStream();
+    const pending = stream.emitted('value');
+    const failure = new Error('listener failed');
+    stream.on('value', () => {
+      throw failure;
+    });
+
+    expect(() => stream.emitValue(5)).toThrow(failure);
+    await expect(pending).resolves.toBe(5);
+    expect(stream.hasListener('error')).toBe(false);
+  });
+
+  test('supports prototype-like event names without listener collisions', async () => {
+    const stream = new EmittedTestStream();
+    const pending = stream.emitted('__proto__');
+
+    stream.emitPrototype(11);
+
+    await expect(pending).resolves.toBe(11);
+    expect(stream.hasListener('__proto__')).toBe(false);
+    expect(stream.hasListener('error')).toBe(false);
+  });
+
+  test('continues reporting genuinely unhandled stream errors', () => {
+    const stream = new EmittedTestStream();
+    const failure = new OpenAIError('unhandled');
+    const reject = vi.spyOn(Promise, 'reject').mockImplementation(() => Promise.resolve() as Promise<never>);
+
+    try {
+      stream.emitFailure(failure);
+      expect(reject).toHaveBeenCalledWith(failure);
+    } finally {
+      reject.mockRestore();
+    }
+  });
+});

--- a/tests/lib/event-stream-emitted-performance.test.ts
+++ b/tests/lib/event-stream-emitted-performance.test.ts
@@ -187,6 +187,113 @@ describe('EventStream.emitted companion-listener performance', () => {
     expect(remove).toHaveBeenCalledWith('error', expect.any(Function));
   });
 
+  test('preserves captured emitted event listeners removed during their dispatch snapshot', async () => {
+    const stream = new EmittedTestStream();
+    const register = vi.spyOn(stream, 'once');
+    stream.on('value', () => {
+      const callback = register.mock.calls.find(([event]) => event === 'value')?.[1] as
+        | ((value: number) => void)
+        | undefined;
+      if (!callback) {
+        throw new Error('Expected an emitted event listener');
+      }
+      stream.off('value', callback);
+    });
+    const pending = stream.emitted('value');
+    const settled = vi.fn();
+    void pending.then(settled);
+
+    stream.emitValue(4);
+    await Promise.resolve();
+
+    expect(settled).toHaveBeenCalledWith(4);
+    expect(stream.hasListener('error')).toBe(false);
+  });
+
+  test('preserves captured emitted error listeners removed during their dispatch snapshot', async () => {
+    const stream = new EmittedTestStream();
+    const register = vi.spyOn(stream, 'once');
+    const failure = new OpenAIError('snapshot failure');
+    stream.on('error', () => {
+      const callback = register.mock.calls.find(([event]) => event === 'error')?.[1] as
+        | ((error: OpenAIError) => void)
+        | undefined;
+      if (!callback) {
+        throw new Error('Expected an emitted error listener');
+      }
+      stream.off('error', callback);
+    });
+    const pending = stream.emitted('value');
+    const rejected = vi.fn();
+    void pending.catch(rejected);
+
+    stream.emitFailure(failure);
+    await Promise.resolve();
+
+    expect(rejected).toHaveBeenCalledWith(failure);
+    expect(stream.hasListener('value')).toBe(false);
+  });
+
+  test('preserves captured emitted listeners removed from a nested dispatch', async () => {
+    const stream = new EmittedTestStream();
+    const register = vi.spyOn(stream, 'once');
+    stream.on('value', () => {
+      stream.emitOther('nested');
+    });
+    stream.on('other', () => {
+      const callback = register.mock.calls.find(([event]) => event === 'value')?.[1] as
+        | ((value: number) => void)
+        | undefined;
+      if (!callback) {
+        throw new Error('Expected an emitted event listener');
+      }
+      stream.off('value', callback);
+    });
+    const pending = stream.emitted('value');
+    const settled = vi.fn();
+    void pending.then(settled);
+
+    stream.emitValue(5);
+    await Promise.resolve();
+
+    expect(settled).toHaveBeenCalledWith(5);
+    expect(stream.hasListener('error')).toBe(false);
+  });
+
+  test.each(['before', 'after'] as const)(
+    'preserves first-match listener removal when public once registers a duplicate %s its callback',
+    async (order) => {
+      const stream = new EmittedTestStream();
+      const originalOnce = stream.once.bind(stream);
+      const register = vi.spyOn(stream, 'once').mockImplementation((event, listener) => {
+        if (event === 'value' && order === 'before') {
+          stream.on(event, listener);
+        }
+
+        const result = originalOnce(event, listener);
+        if (event === 'value' && order === 'after') {
+          stream.on(event, listener);
+        }
+        return result;
+      });
+
+      const pending = stream.emitted('value');
+      const callback = register.mock.calls.find(([event]) => event === 'value')?.[1] as
+        | ((value: number) => void)
+        | undefined;
+      if (!callback) {
+        throw new Error('Expected a duplicated emitted listener');
+      }
+
+      stream.off('value', callback);
+      stream.emitValue(7);
+
+      await expect(pending).resolves.toBe(7);
+      expect(stream.hasListener('value')).toBe(order === 'after');
+      expect(stream.hasListener('error')).toBe(false);
+    },
+  );
+
   test('preserves duplicate user callbacks, once listeners, and immediate off semantics', async () => {
     const stream = new EmittedTestStream();
     const duplicate = vi.fn();


### PR DESCRIPTION
## Summary
- avoid quadratic listener-array shifts when many public `EventStream.emitted()` waiters settle on an event or an error
- index internal companion registrations with weak references, preserve the existing observable public `once()`/`off()` hooks, and compact cancelled listeners once after nested dispatch completes
- keep duplicate listeners, registration order, synchronous removal, nested/reentrant events, error/abort/end handling, and prototype-like event names compatible

## Verification
- regression-first success and error cases each reproduced 8,386,560 shifted elements with 4,096 waiters
- 65,536 successful waiters improved from 4,845 ms and 2,147,450,880 shifted elements to 51.5 ms and zero shifts; error-first waiters finish in 84.9 ms with zero shifts
- 94 focused listener and streaming tests
- all 2,979 handwritten unit tests across 100 files
- changed-file formatter and all 415 lint rules
- repository TypeScript, CommonJS/ESM build, published TypeScript 4.9/current checks, and packed-package verification