### PR TITLE
ci(security): run CodeQL for pull requests and merge groups

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,7 @@ on:
     types:
       - opened
       - synchronize
+      - edited
       - reopened
       - ready_for_review
   merge_group:
@@ -79,7 +80,20 @@ jobs:
 
             finding_count="$(jq '[.runs[] | .results // [] | .[]] | length' "${sarif_file}")"
             if [[ ${finding_count} -ne 0 ]]; then
-              jq -r '.runs[] | .results[] | "::error::CodeQL finding: \(.ruleId // "unknown")"' "${sarif_file}"
+              jq -r '
+                def escape_data:
+                  tostring | gsub("%"; "%25") | gsub("\r"; "%0D") | gsub("\n"; "%0A");
+                def escape_property:
+                  escape_data | gsub(":"; "%3A") | gsub(","; "%2C");
+
+                .runs[] | .results[] |
+                (.ruleId // "unknown" | escape_property) as $rule |
+                (.message.text // .message.markdown // "CodeQL finding" | escape_data) as $message |
+                (.locations[0].physicalLocation.artifactLocation.uri // "unknown" | escape_property) as $file |
+                (.locations[0].physicalLocation.region.startLine // 1 |
+                  if type == "number" and . > 0 then floor else 1 end) as $line |
+                "::error file=\($file),line=\($line),title=\($rule)::\($message)"
+              ' "${sarif_file}"
               exit 1
             fi
           done

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,85 @@
+name: CodeQL merge protection
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  merge_group:
+    types:
+      - checks_requested
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - javascript-typescript
+
+    steps:
+      - name: Check out the proposed merge commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      # Default CodeQL setup already publishes same-repository pull request
+      # findings and rejects additional CodeQL SARIF uploads. Keep it enabled,
+      # and gate fork pull requests and merge groups on real local analysis.
+      - name: Perform CodeQL analysis
+        id: analyze
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: /merge-protection:${{ matrix.language }}
+          output: ${{ runner.temp }}/codeql-results/${{ matrix.language }}
+          upload: never
+          upload-database: false
+
+      - name: Reject CodeQL findings
+        env:
+          CODEQL_LANGUAGE: ${{ matrix.language }}
+          SARIF_DIRECTORY: ${{ steps.analyze.outputs.sarif-output }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          sarif_files=("${SARIF_DIRECTORY}"/*.sarif)
+          if [[ ${#sarif_files[@]} -eq 0 ]]; then
+            echo "::error::CodeQL produced no SARIF results for ${CODEQL_LANGUAGE}."
+            exit 1
+          fi
+
+          for sarif_file in "${sarif_files[@]}"; do
+            if ! jq -e \
+              '(.runs | type == "array" and length > 0) and all(.runs[]; .results | type == "array")' \
+              "${sarif_file}" > /dev/null; then
+              echo "::error::CodeQL produced invalid SARIF for ${CODEQL_LANGUAGE}."
+              exit 1
+            fi
+
+            finding_count="$(jq '[.runs[] | .results // [] | .[]] | length' "${sarif_file}")"
+            if [[ ${finding_count} -ne 0 ]]; then
+              jq -r '.runs[] | .results[] | "::error::CodeQL finding: \(.ruleId // "unknown")"' "${sarif_file}"
+              exit 1
+            fi
+          done


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Add a single SHA-pinned CodeQL workflow that performs real GitHub Actions and JavaScript/TypeScript analysis for every eligible pull request and `merge_group: checks_requested` event.
- Fail closed when CodeQL produces missing or malformed SARIF, or when any analysis reports a finding.
- Preserve the existing GitHub-managed default CodeQL scanner by explicitly disabling duplicate SARIF/database uploads; use only read permissions, avoid secrets, and keep fork pull requests safe.
- Leave merge-queue required-check rules unchanged until both new checks are observed succeeding on pull requests and actual merge-group commits.

## Additional context & links

GitHub rejects uploaded CodeQL SARIF while default setup is enabled. This workflow runs the actual CodeQL queries locally and gates on their results without disabling or replacing the existing scanner.

Validation:
- `actionlint v1.7.12 .github/workflows/codeql.yml`
- Repository-pinned `oxfmt --check` on the new workflow.
- YAML/event/matrix/immutable-action-pin/least-privilege assertions plus eight clean, vulnerable, missing, malformed, and multi-file SARIF fixtures.
- `git diff --check`; confirmed the current merge-queue ruleset and existing default CodeQL configuration remain unchanged.

Proposed eventual required contexts, only after successful PR and real merge-group verification: `CodeQL (actions)` and `CodeQL (javascript-typescript)`.