### PR TITLE
fix(security): respect configured logger for Assistants stream errors

### DIFF
--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -129,8 +129,8 @@ export class Stream<Item> implements AsyncIterable<Item> {
             try {
               data = JSON.parse(sse.data);
             } catch (e) {
-              console.error(`Could not parse message into JSON:`, sse.data);
-              console.error(`From chunk:`, sse.raw);
+              logger.error(`Could not parse message into JSON:`, sse.data);
+              logger.error(`From chunk:`, sse.raw);
               throw e;
             }
             // SSE error events surface as APIError instances.

--- a/tests/lib/streaming-sensitive-logger.test.ts
+++ b/tests/lib/streaming-sensitive-logger.test.ts
@@ -1,0 +1,169 @@
+import { vi } from 'vitest';
+import OpenAI, { APIError } from 'openai';
+
+const syntheticPatient = 'synthetic-patient-123-45-6789';
+const syntheticCredential = 'synthetic-private-token-7f3e';
+const malformedData = `{"patient":"${syntheticPatient}","credential":"${syntheticCredential}"`;
+
+function createLogger() {
+  return {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+function createClient({
+  event,
+  data = malformedData,
+  logger,
+  logLevel,
+}: {
+  event: string;
+  data?: string;
+  logger?: ReturnType<typeof createLogger>;
+  logLevel?: 'off' | 'error';
+}) {
+  return new OpenAI({
+    apiKey: 'synthetic-client-api-key',
+    maxRetries: 0,
+    ...(logger ? { logger } : {}),
+    ...(logLevel ? { logLevel } : {}),
+    fetch: async () =>
+      new Response(`event: ${event}\ndata: ${data}\n\n`, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      }),
+  });
+}
+
+async function createRun(client: OpenAI) {
+  return client.beta.threads.runs.create('thread_synthetic', {
+    assistant_id: 'asst_synthetic',
+    stream: true,
+  });
+}
+
+async function collect(stream: AsyncIterable<unknown>) {
+  const events: unknown[] = [];
+  for await (const event of stream) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe('Assistants streaming diagnostic privacy', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test.each(['thread.message.delta', 'thread.run.created'])(
+    'honors disabled logging for malformed %s events',
+    async (event) => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const logger = createLogger();
+      const stream = await createRun(createClient({ event, logger, logLevel: 'off' }));
+
+      await expect(collect(stream)).rejects.toThrow(SyntaxError);
+
+      expect(stream.controller.signal.aborted).toBe(true);
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(consoleError).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(['thread.message.delta', 'thread.run.created'])(
+    'routes malformed %s events through the configured redacting logger',
+    async (event) => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const redactedMessages: string[] = [];
+      const logger = createLogger();
+      logger.error.mockImplementation((message) => {
+        redactedMessages.push(String(message));
+      });
+
+      const stream = await createRun(createClient({ event, logger, logLevel: 'error' }));
+
+      await expect(collect(stream)).rejects.toThrow(SyntaxError);
+
+      expect(stream.controller.signal.aborted).toBe(true);
+      expect(logger.error).toHaveBeenCalledTimes(2);
+      expect(redactedMessages).toEqual(['Could not parse message into JSON:', 'From chunk:']);
+      expect(redactedMessages.join('\n')).not.toContain(syntheticPatient);
+      expect(redactedMessages.join('\n')).not.toContain(syntheticCredential);
+      expect(consoleError).not.toHaveBeenCalled();
+    },
+  );
+
+  test('continues to honor disabled logging for ordinary response events', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const logger = createLogger();
+    const stream = await createRun(
+      createClient({ event: 'response.output_text.delta', logger, logLevel: 'off' }),
+    );
+
+    await expect(collect(stream)).rejects.toThrow(SyntaxError);
+
+    expect(stream.controller.signal.aborted).toBe(true);
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  test('continues to route ordinary response events through a configured logger', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const logger = createLogger();
+    const stream = await createRun(
+      createClient({ event: 'response.output_text.delta', logger, logLevel: 'error' }),
+    );
+
+    await expect(collect(stream)).rejects.toThrow(SyntaxError);
+
+    expect(logger.error).toHaveBeenCalledTimes(2);
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  test('preserves the default console logger and its two diagnostic messages', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const stream = await createRun(createClient({ event: 'thread.message.delta', logLevel: 'error' }));
+
+    await expect(collect(stream)).rejects.toThrow(SyntaxError);
+
+    expect(consoleError).toHaveBeenCalledTimes(2);
+  });
+
+  test.each(['thread.message.delta', 'thread.run.created'])(
+    'preserves valid %s event envelopes',
+    async (event) => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const logger = createLogger();
+      const stream = await createRun(
+        createClient({ event, data: '{"id":"event_synthetic"}', logger, logLevel: 'error' }),
+      );
+
+      await expect(collect(stream)).resolves.toEqual([{ event, data: { id: 'event_synthetic' } }]);
+
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(consoleError).not.toHaveBeenCalled();
+    },
+  );
+
+  test('preserves typed stream errors and request cancellation', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const logger = createLogger();
+    const stream = await createRun(
+      createClient({
+        event: 'response.error',
+        data: '{"error":{"message":"synthetic upstream failure","code":"invalid_request"}}',
+        logger,
+        logLevel: 'error',
+      }),
+    );
+
+    await expect(collect(stream)).rejects.toThrow(APIError);
+
+    expect(stream.controller.signal.aborted).toBe(true);
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Summary

- Route malformed Assistants `thread.*` streaming events through the client's existing configured logger instead of writing raw model data directly to `console.error`.
- Respect `logLevel: 'off'` and caller-provided redacting loggers, preventing sensitive response content from bypassing application logging controls.
- Preserve ordinary streaming diagnostics, the default console logger, clientless stream behavior, syntax errors, cancellation, valid thread-event envelopes, and typed API errors.
- Close the remaining Assistants-specific gap in the configured-logger behavior reported in #1338 without changing generated endpoints or public APIs.

## Validation

- Regression first: four public `beta.threads.runs.create({ stream: true })` privacy cases failed before the two-line production fix; all ten focused privacy and compatibility cases now pass.
- Existing streaming coverage: 82 tests across four focused suites; the existing clientless four-console-message assertion remains unchanged.
- Minimum supported Node.js 22: 64 focused streaming tests passed.
- Full handwritten suite: 101 files / 2,994 tests passed.
- Full generated suite: 82 suites / 559 tests passed against a local Steady mock.
- Full repository formatting and lint: 646 formatted files, 357 linted files, 415 rules, zero findings.
- Repository TypeScript, CommonJS/ESM production build, and published TypeScript 4.9/current compatibility checks passed.
- Packed npm artifact passed CommonJS, ESM, and 266/303 source checks across 1,212 source maps.
- Node-version policy check passed.

Only the existing handwritten streaming owner and one new focused handwritten public-entrypoint test are changed.