### PR TITLE
fix(security): redact unsupported Responses stream event payloads

### DIFF
--- a/src/internal/responses/response-accumulator.ts
+++ b/src/internal/responses/response-accumulator.ts
@@ -208,7 +208,14 @@ function getShellOutputContent(
   return getContent(output.output, commandIndex);
 }
 
-const supportedResponseEventTypes = new Set<ResponseAccumulatorEvent['type']>([
+function createSupportedResponseEventTypes<EventTypes extends readonly ResponseAccumulatorEvent['type'][]>(
+  eventTypes: EventTypes &
+    (Exclude<ResponseAccumulatorEvent['type'], EventTypes[number]> extends never ? unknown : never),
+): ReadonlySet<ResponseAccumulatorEvent['type']> {
+  return new Set(eventTypes);
+}
+
+const supportedResponseEventTypes = createSupportedResponseEventTypes([
   'response.output_item.added',
   'response.output_item.done',
   'response.content_part.added',
@@ -268,7 +275,7 @@ const supportedResponseEventTypes = new Set<ResponseAccumulatorEvent['type']>([
   'response.mcp_list_tools.failed',
   'keepalive',
   'error',
-]);
+] as const);
 
 function assertNever(_value: never): never {
   throw new OpenAIError('Unhandled response stream event: unknown');
@@ -290,14 +297,11 @@ function sanitizeResponseEvent(event: ResponseAccumulatorEvent): ResponseAccumul
     return assertNever(event as never);
   }
 
-  return Object.create(event, {
-    type: {
-      configurable: true,
-      enumerable: true,
-      value: type,
-      writable: false,
+  return new Proxy(event, {
+    get(target, property) {
+      return property === 'type' ? type : Reflect.get(target, property, target);
     },
-  }) as ResponseAccumulatorEvent;
+  });
 }
 
 function accumulateOutputItemEvent(

--- a/src/internal/responses/response-accumulator.ts
+++ b/src/internal/responses/response-accumulator.ts
@@ -208,23 +208,96 @@ function getShellOutputContent(
   return getContent(output.output, commandIndex);
 }
 
-function assertNever(value: never): never {
-  let eventType: unknown;
+const supportedResponseEventTypes = new Set<ResponseAccumulatorEvent['type']>([
+  'response.output_item.added',
+  'response.output_item.done',
+  'response.content_part.added',
+  'response.content_part.done',
+  'response.output_text.delta',
+  'response.output_text.done',
+  'response.output_text.annotation.added',
+  'response.refusal.delta',
+  'response.refusal.done',
+  'response.function_call_arguments.delta',
+  'response.function_call_arguments.done',
+  'response.custom_tool_call_input.delta',
+  'response.custom_tool_call_input.done',
+  'response.mcp_call_arguments.delta',
+  'response.mcp_call_arguments.done',
+  'response.shell_call_command.added',
+  'response.shell_call_command.done',
+  'response.shell_call_command.delta',
+  'response.shell_call_output_content.delta',
+  'response.shell_call_output_content.done',
+  'response.reasoning_text.delta',
+  'response.reasoning_text.done',
+  'response.reasoning_summary_part.added',
+  'response.reasoning_summary_part.done',
+  'response.reasoning_summary_text.delta',
+  'response.reasoning_summary_text.done',
+  'response.code_interpreter_call_code.delta',
+  'response.code_interpreter_call_code.done',
+  'response.code_interpreter_call.in_progress',
+  'response.code_interpreter_call.interpreting',
+  'response.code_interpreter_call.completed',
+  'response.file_search_call.in_progress',
+  'response.file_search_call.searching',
+  'response.file_search_call.completed',
+  'response.web_search_call.in_progress',
+  'response.web_search_call.searching',
+  'response.web_search_call.completed',
+  'response.image_generation_call.in_progress',
+  'response.image_generation_call.generating',
+  'response.image_generation_call.completed',
+  'response.mcp_call.in_progress',
+  'response.mcp_call.completed',
+  'response.mcp_call.failed',
+  'response.created',
+  'response.queued',
+  'response.in_progress',
+  'response.completed',
+  'response.failed',
+  'response.incomplete',
+  'response.audio.delta',
+  'response.audio.done',
+  'response.audio.transcript.delta',
+  'response.audio.transcript.done',
+  'response.image_generation_call.partial_image',
+  'response.mcp_list_tools.in_progress',
+  'response.mcp_list_tools.completed',
+  'response.mcp_list_tools.failed',
+  'keepalive',
+  'error',
+]);
 
+function assertNever(_value: never): never {
+  throw new OpenAIError('Unhandled response stream event: unknown');
+}
+
+function sanitizeResponseEvent(event: ResponseAccumulatorEvent): ResponseAccumulatorEvent {
+  let descriptor: PropertyDescriptor | undefined;
   try {
-    eventType = Object.getOwnPropertyDescriptor(value, 'type')?.value;
+    descriptor = Object.getOwnPropertyDescriptor(event, 'type');
   } catch {
-    eventType = undefined;
+    return assertNever(event as never);
   }
 
-  const safeEventType =
-    typeof eventType === 'string' &&
-    eventType.length <= 128 &&
-    /^response\.(?:[a-z][a-z0-9_]*)(?:\.[a-z][a-z0-9_]*)*$/u.test(eventType)
-      ? eventType
-      : 'unknown';
+  const type: unknown = descriptor?.value;
+  if (
+    typeof type !== 'string' ||
+    !supportedResponseEventTypes.has(type as ResponseAccumulatorEvent['type'])
+  ) {
+    return assertNever(event as never);
+  }
 
-  throw new OpenAIError(`Unhandled response stream event: ${safeEventType}`);
+  return Object.create(event, {
+    type: {
+      configurable: true,
+      enumerable: true,
+      value: type,
+      writable: false,
+    },
+  }) as ResponseAccumulatorEvent;
 }
 
 function accumulateOutputItemEvent(
@@ -810,51 +883,53 @@ export function accumulateResponseWithContext(
   snapshot: Response | undefined,
   context: ResponseAccumulatorContext,
 ): Response {
+  const dispatchEvent = sanitizeResponseEvent(event);
+
   if (!snapshot) {
-    if (event.type !== 'response.created') {
+    if (dispatchEvent.type !== 'response.created') {
       throw new OpenAIError(
-        `When snapshot hasn't been set yet, expected 'response.created' event, got ${event.type}`,
+        `When snapshot hasn't been set yet, expected 'response.created' event, got ${dispatchEvent.type}`,
       );
     }
-    return cloneResponse(context, event.response);
+    return cloneResponse(context, dispatchEvent.response);
   }
 
-  if (accumulateOutputItemEvent(event, snapshot, context)) {
+  if (accumulateOutputItemEvent(dispatchEvent, snapshot, context)) {
     return snapshot;
   }
-  if (accumulateContentPartAddedEvent(event, snapshot, context)) {
+  if (accumulateContentPartAddedEvent(dispatchEvent, snapshot, context)) {
     return snapshot;
   }
-  if (accumulateContentPartDoneEvent(event, snapshot, context)) {
+  if (accumulateContentPartDoneEvent(dispatchEvent, snapshot, context)) {
     return snapshot;
   }
-  if (accumulateOutputTextEvent(event, snapshot, context)) {
+  if (accumulateOutputTextEvent(dispatchEvent, snapshot, context)) {
     return snapshot;
   }
-  if (accumulateRefusalAndArgumentsEvent(event, snapshot)) {
+  if (accumulateRefusalAndArgumentsEvent(dispatchEvent, snapshot)) {
     return snapshot;
   }
-  if (accumulateShellEvent(event, snapshot)) {
+  if (accumulateShellEvent(dispatchEvent, snapshot)) {
     return snapshot;
   }
-  if (accumulateReasoningEvent(event, snapshot)) {
+  if (accumulateReasoningEvent(dispatchEvent, snapshot)) {
     return snapshot;
   }
-  if (accumulateCodeInterpreterEvent(event, snapshot)) {
+  if (accumulateCodeInterpreterEvent(dispatchEvent, snapshot)) {
     return snapshot;
   }
-  if (accumulateSearchStatusEvent(event, snapshot)) {
+  if (accumulateSearchStatusEvent(dispatchEvent, snapshot)) {
     return snapshot;
   }
-  if (accumulateImageAndMcpStatusEvent(event, snapshot)) {
+  if (accumulateImageAndMcpStatusEvent(dispatchEvent, snapshot)) {
     return snapshot;
   }
 
-  if (isResponseLifecycleEvent(event)) {
-    return cloneResponse(context, event.response);
+  if (isResponseLifecycleEvent(dispatchEvent)) {
+    return cloneResponse(context, dispatchEvent.response);
   }
-  if (isIgnoredResponseEvent(event)) {
+  if (isIgnoredResponseEvent(dispatchEvent)) {
     return snapshot;
   }
-  return assertNever(event);
+  return assertNever(dispatchEvent);
 }

--- a/src/internal/responses/response-accumulator.ts
+++ b/src/internal/responses/response-accumulator.ts
@@ -209,7 +209,22 @@ function getShellOutputContent(
 }
 
 function assertNever(value: never): never {
-  throw new OpenAIError(`Unhandled response stream event: ${JSON.stringify(value)}`);
+  let eventType: unknown;
+
+  try {
+    eventType = Object.getOwnPropertyDescriptor(value, 'type')?.value;
+  } catch {
+    eventType = undefined;
+  }
+
+  const safeEventType =
+    typeof eventType === 'string' &&
+    eventType.length <= 128 &&
+    /^response\.(?:[a-z][a-z0-9_]*)(?:\.[a-z][a-z0-9_]*)*$/u.test(eventType)
+      ? eventType
+      : 'unknown';
+
+  throw new OpenAIError(`Unhandled response stream event: ${safeEventType}`);
 }
 
 function accumulateOutputItemEvent(

--- a/tests/lib/response-stream-unsupported-event-privacy.test.ts
+++ b/tests/lib/response-stream-unsupported-event-privacy.test.ts
@@ -237,6 +237,71 @@ describe('unsupported Responses event diagnostic privacy', () => {
     },
   );
 
+  test.each(['first', 'subsequent'] as const)(
+    'preserves the original receiver for a %s-frame own response accessor',
+    (position) => {
+      const response = makeResponse();
+      const event =
+        position === 'first'
+          ? { type: 'response.created' as const, sequence_number: 0, response }
+          : { type: 'response.completed' as const, sequence_number: 1, response };
+      const receivedOriginalEvent: boolean[] = [];
+      const getter = vi.fn(function recordOriginalEventReceiver(this: typeof event) {
+        receivedOriginalEvent.push(this === event);
+        return response;
+      });
+
+      Object.defineProperty(event, 'response', {
+        configurable: true,
+        enumerable: true,
+        get: getter,
+      });
+
+      const snapshot = position === 'first' ? undefined : createSnapshot();
+
+      expect(accumulateResponse(event, snapshot).id).toBe('resp_synthetic');
+      expect(getter).toHaveBeenCalledTimes(1);
+      expect(receivedOriginalEvent).toEqual([true]);
+    },
+  );
+
+  test.each(['first', 'subsequent'] as const)(
+    'preserves a %s-frame private-field response accessor',
+    (position) => {
+      class ReceiverSensitiveEvent<Type extends 'response.created' | 'response.completed'> {
+        readonly type: Type;
+        readonly sequence_number = 0;
+        #response = makeResponse();
+
+        constructor(type: Type) {
+          this.type = type;
+        }
+
+        get response(): APIResponse {
+          return this.#response;
+        }
+      }
+
+      const event =
+        position === 'first'
+          ? new ReceiverSensitiveEvent('response.created')
+          : new ReceiverSensitiveEvent('response.completed');
+      const snapshot = position === 'first' ? undefined : createSnapshot();
+
+      expect(accumulateResponse(event, snapshot).id).toBe('resp_synthetic');
+    },
+  );
+
+  test.each(['response.mcp_list_tools.failed', 'response.audio.transcript.done'] as const)(
+    'continues dispatching the generated %s discriminator',
+    (type) => {
+      const snapshot = createSnapshot();
+      const event = { type, sequence_number: 1 } as ResponseStreamEvent;
+
+      expect(accumulateResponse(event, snapshot)).toBe(snapshot);
+    },
+  );
+
   test.each([
     [
       'a circular event payload',

--- a/tests/lib/response-stream-unsupported-event-privacy.test.ts
+++ b/tests/lib/response-stream-unsupported-event-privacy.test.ts
@@ -1,0 +1,375 @@
+import { vi } from 'vitest';
+
+import OpenAI, { APIError, OpenAIError } from 'openai';
+import { accumulateResponse } from 'openai/lib/responses/ResponseAccumulator';
+import { ResponseStream } from 'openai/lib/responses/ResponseStream';
+import type { Response as APIResponse, ResponseStreamEvent } from 'openai/resources/responses/responses';
+
+const syntheticCredential = 'sk-synthetic-private-response-token-7f3e';
+const syntheticPatient = 'synthetic-patient-123-45-6789';
+const syntheticPrompt = 'synthetic confidential customer transcript';
+const unsupportedPrefix = 'Unhandled response stream event: ';
+const futureEventType = 'response.future_feature.delta';
+
+function makeResponse(): APIResponse {
+  return {
+    id: 'resp_synthetic',
+    object: 'response',
+    created_at: 1,
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    metadata: null,
+    model: 'gpt-5',
+    output: [],
+    output_text: '',
+    parallel_tool_calls: false,
+    status: 'in_progress',
+    temperature: null,
+    tool_choice: 'auto',
+    tools: [],
+    top_p: null,
+  } as APIResponse;
+}
+
+function createdEvent(): ResponseStreamEvent {
+  return {
+    type: 'response.created',
+    sequence_number: 0,
+    response: makeResponse(),
+  } as ResponseStreamEvent;
+}
+
+function unsupportedEvent(type: unknown = futureEventType): Record<string, unknown> {
+  return {
+    type,
+    sequence_number: 1,
+    tool_call: {
+      id: 'call_sensitive',
+      function: {
+        arguments: JSON.stringify({
+          api_key: syntheticCredential,
+          patient: syntheticPatient,
+          transcript: syntheticPrompt,
+        }),
+      },
+    },
+    headers: {
+      authorization: `Bearer ${syntheticCredential}`,
+      cookie: `session=${syntheticCredential}`,
+    },
+  };
+}
+
+function createSnapshot(): APIResponse {
+  return accumulateResponse(createdEvent());
+}
+
+function expectPrivateFailure(error: unknown, expectedType: string): asserts error is OpenAIError {
+  expect(error).toBeInstanceOf(OpenAIError);
+  expect((error as OpenAIError).constructor).toBe(OpenAIError);
+  expect((error as OpenAIError).message).toBe(unsupportedPrefix + expectedType);
+  expect((error as OpenAIError).message).not.toContain(syntheticCredential);
+  expect((error as OpenAIError).message).not.toContain(syntheticPatient);
+  expect((error as OpenAIError).message).not.toContain(syntheticPrompt);
+  expect((error as OpenAIError).message).not.toContain('{');
+  expect((error as OpenAIError).stack).not.toContain(syntheticCredential);
+  expect((error as OpenAIError).stack).not.toContain(syntheticPatient);
+  expect((error as OpenAIError).stack).not.toContain(syntheticPrompt);
+}
+
+function applyUnsupported(event: unknown, snapshot: APIResponse): unknown {
+  try {
+    accumulateResponse(event as ResponseStreamEvent, snapshot);
+  } catch (error) {
+    return error;
+  }
+
+  throw new Error('Expected an unsupported response event to be rejected.');
+}
+
+function readableStream(events: Record<string, unknown>[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`));
+      }
+      controller.close();
+    },
+  });
+}
+
+function createLogger() {
+  return {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+describe('unsupported Responses event diagnostic privacy', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('does not expose nested credentials or patient data through the public accumulator', () => {
+    const snapshot = createSnapshot();
+    const originalSnapshot = structuredClone(snapshot);
+    const event = unsupportedEvent();
+
+    const failure = applyUnsupported(event, snapshot);
+
+    expectPrivateFailure(failure, futureEventType);
+    expect(snapshot).toEqual(originalSnapshot);
+  });
+
+  test.each([
+    [
+      'a circular event payload',
+      (event: Record<string, unknown>) => {
+        event['self'] = event;
+      },
+    ],
+    [
+      'a BigInt event payload',
+      (event: Record<string, unknown>) => {
+        event['count'] = 42n;
+      },
+    ],
+  ])('preserves the SDK error for %s', (_name, addPayload) => {
+    const snapshot = createSnapshot();
+    const event = unsupportedEvent();
+    addPayload(event);
+
+    const failure = applyUnsupported(event, snapshot);
+
+    expectPrivateFailure(failure, futureEventType);
+    expect(failure).not.toBeInstanceOf(TypeError);
+  });
+
+  test('does not inspect or invoke an attacker-controlled toJSON getter', () => {
+    const snapshot = createSnapshot();
+    const event = unsupportedEvent();
+    const getter = vi.fn(() => {
+      throw new Error(`sensitive toJSON getter: ${syntheticCredential}`);
+    });
+
+    Object.defineProperty(event, 'toJSON', {
+      configurable: true,
+      get: getter,
+    });
+
+    const failure = applyUnsupported(event, snapshot);
+
+    expectPrivateFailure(failure, futureEventType);
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  test('does not invoke an attacker-controlled toJSON function', () => {
+    const snapshot = createSnapshot();
+    const event = unsupportedEvent();
+    const toJSON = vi.fn(() => {
+      throw new Error(`sensitive toJSON callback: ${syntheticCredential}`);
+    });
+
+    Object.defineProperty(event, 'toJSON', {
+      configurable: true,
+      value: toJSON,
+    });
+
+    const failure = applyUnsupported(event, snapshot);
+
+    expectPrivateFailure(failure, futureEventType);
+    expect(toJSON).not.toHaveBeenCalled();
+  });
+
+  test('does not expose a throwing proxy descriptor trap', () => {
+    const snapshot = createSnapshot();
+    const descriptorFailure = new Error(`sensitive descriptor: ${syntheticCredential}`);
+    const event = new Proxy(unsupportedEvent(), {
+      getOwnPropertyDescriptor(target, property) {
+        if (property === 'type') {
+          throw descriptorFailure;
+        }
+
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      },
+    });
+
+    const failure = applyUnsupported(event, snapshot);
+
+    expectPrivateFailure(failure, 'unknown');
+    expect(failure).not.toBe(descriptorFailure);
+  });
+
+  test('does not trust an inherited discriminator for diagnostic output', () => {
+    const snapshot = createSnapshot();
+    const event = Object.create({ type: futureEventType }) as Record<string, unknown>;
+    event['sequence_number'] = 1;
+    event['private_data'] = syntheticCredential;
+
+    const failure = applyUnsupported(event, snapshot);
+
+    expectPrivateFailure(failure, 'unknown');
+  });
+
+  test.each([
+    ['a credential', syntheticCredential],
+    ['a bearer value', `Bearer ${syntheticCredential}`],
+    ['a newline', `response.future\n${syntheticCredential}`],
+    ['a carriage return', `response.future\r${syntheticPatient}`],
+    ['an ANSI escape', 'response.future\u001B[31m'],
+    ['Unicode', 'response.futur\u00E9'],
+    ['a URL', `https://attacker.invalid/${syntheticCredential}`],
+    ['a hyphenated token segment', 'response.sk-synthetic-secret'],
+    ['an uppercase segment', 'response.Future'],
+    ['a numeric segment', 'response.123'],
+    ['a missing namespace', 'future_feature'],
+    ['an empty discriminator', ''],
+    ['a null discriminator', null],
+    ['a numeric discriminator', 42],
+    ['a boolean discriminator', true],
+    ['a noncoercible discriminator', { toString: null, valueOf: null }],
+    ['an array discriminator', ['response.future_feature']],
+    ['an oversized discriminator', `response.${'a'.repeat(120)}`],
+  ])('replaces %s with a generic diagnostic', (_name, type) => {
+    const snapshot = createSnapshot();
+
+    const failure = applyUnsupported(unsupportedEvent(type), snapshot);
+
+    expectPrivateFailure(failure, 'unknown');
+  });
+
+  test('preserves the longest safe future event discriminator', () => {
+    const type = `response.${'a'.repeat(119)}`;
+    const snapshot = createSnapshot();
+
+    const failure = applyUnsupported(unsupportedEvent(type), snapshot);
+
+    expect(type).toHaveLength(128);
+    expectPrivateFailure(failure, type);
+  });
+
+  test.each(['done', 'finalResponse'] as const)(
+    'keeps restored readable-stream %s failures private',
+    async (completionMethod) => {
+      const created = createdEvent();
+      const event = unsupportedEvent();
+      const stream = ResponseStream.fromReadableStream(
+        readableStream([created as unknown as Record<string, unknown>, event]),
+      );
+      const events = vi.fn();
+      const errors = vi.fn();
+
+      stream.on('event', events);
+      stream.on('error', errors);
+
+      const completion = completionMethod === 'done' ? stream.done() : stream.finalResponse();
+      const failure = await completion.then(
+        () => {
+          throw new Error('Expected the restored stream to reject.');
+        },
+        (error: unknown) => error,
+      );
+
+      expectPrivateFailure(failure, futureEventType);
+      expect(events).toHaveBeenCalledTimes(1);
+      expect(events).toHaveBeenCalledWith(created);
+      expect(errors).toHaveBeenCalledTimes(1);
+      expect(errors).toHaveBeenCalledWith(failure);
+      expect(stream.ended).toBe(true);
+      expect(stream.errored).toBe(true);
+      expect(stream.aborted).toBe(false);
+    },
+  );
+
+  test.each([
+    ['off', 'done'],
+    ['off', 'finalResponse'],
+    ['error', 'done'],
+    ['error', 'finalResponse'],
+  ] as const)('keeps public client %s logger / %s failures private', async (logLevel, completionMethod) => {
+    const created = createdEvent();
+    const event = unsupportedEvent();
+    const body = `${[created, event]
+      .map((streamEvent) => `data: ${JSON.stringify(streamEvent)}`)
+      .join('\n\n')}\n\ndata: [DONE]\n\n`;
+    const fetch = vi.fn(
+      async () =>
+        new Response(body, {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        }),
+    );
+    const logger = createLogger();
+    const client = new OpenAI({
+      apiKey: 'sk-synthetic-client-key',
+      fetch,
+      logger,
+      logLevel,
+      maxRetries: 0,
+    });
+    const stream = client.responses.stream({
+      model: 'gpt-5',
+      input: 'synthetic request',
+    });
+    const events = vi.fn();
+    const errors = vi.fn();
+
+    stream.on('event', events);
+    stream.on('error', errors);
+
+    const completion = completionMethod === 'done' ? stream.done() : stream.finalResponse();
+    const failure = await completion.then(
+      () => {
+        throw new Error('Expected the public response stream to reject.');
+      },
+      (error: unknown) => error,
+    );
+
+    expectPrivateFailure(failure, futureEventType);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(events).toHaveBeenCalledTimes(1);
+    expect(events).toHaveBeenCalledWith(created);
+    expect(errors).toHaveBeenCalledTimes(1);
+    expect(errors).toHaveBeenCalledWith(failure);
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(stream.ended).toBe(true);
+    expect(stream.errored).toBe(true);
+    expect(stream.aborted).toBe(false);
+  });
+
+  test('preserves documented provider API-error diagnostics', async () => {
+    const payload = {
+      type: 'invalid_request_error',
+      code: 'rate_limit_exceeded',
+      message: 'The provider rejected the streamed response.',
+      param: 'input',
+    };
+    const stream = ResponseStream.fromReadableStream(
+      readableStream([
+        createdEvent() as unknown as Record<string, unknown>,
+        { type: 'error', sequence_number: 1, error: payload },
+      ]),
+    );
+
+    const failure = await stream.finalResponse().then(
+      () => {
+        throw new Error('Expected the provider API error to reject.');
+      },
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(APIError);
+    expect(failure).toMatchObject({
+      message: payload.message,
+      code: payload.code,
+      param: payload.param,
+      type: payload.type,
+      error: payload,
+    });
+  });
+});

--- a/tests/lib/response-stream-unsupported-event-privacy.test.ts
+++ b/tests/lib/response-stream-unsupported-event-privacy.test.ts
@@ -8,6 +8,7 @@ import type { Response as APIResponse, ResponseStreamEvent } from 'openai/resour
 const syntheticCredential = 'sk-synthetic-private-response-token-7f3e';
 const syntheticPatient = 'synthetic-patient-123-45-6789';
 const syntheticPrompt = 'synthetic confidential customer transcript';
+const syntheticPassword = 'hunter2';
 const unsupportedPrefix = 'Unhandled response stream event: ';
 const futureEventType = 'response.future_feature.delta';
 
@@ -72,13 +73,15 @@ function expectPrivateFailure(error: unknown, expectedType: string): asserts err
   expect((error as OpenAIError).message).not.toContain(syntheticCredential);
   expect((error as OpenAIError).message).not.toContain(syntheticPatient);
   expect((error as OpenAIError).message).not.toContain(syntheticPrompt);
+  expect((error as OpenAIError).message).not.toContain(syntheticPassword);
   expect((error as OpenAIError).message).not.toContain('{');
   expect((error as OpenAIError).stack).not.toContain(syntheticCredential);
   expect((error as OpenAIError).stack).not.toContain(syntheticPatient);
   expect((error as OpenAIError).stack).not.toContain(syntheticPrompt);
+  expect((error as OpenAIError).stack).not.toContain(syntheticPassword);
 }
 
-function applyUnsupported(event: unknown, snapshot: APIResponse): unknown {
+function applyUnsupported(event: unknown, snapshot?: APIResponse): unknown {
   try {
     accumulateResponse(event as ResponseStreamEvent, snapshot);
   } catch (error) {
@@ -122,9 +125,117 @@ describe('unsupported Responses event diagnostic privacy', () => {
 
     const failure = applyUnsupported(event, snapshot);
 
-    expectPrivateFailure(failure, futureEventType);
+    expectPrivateFailure(failure, 'unknown');
     expect(snapshot).toEqual(originalSnapshot);
   });
+
+  test.each(['first', 'subsequent'] as const)(
+    'redacts namespace-matching private discriminators in a %s frame',
+    (position) => {
+      for (const type of ['response.patient.ssn123456789', `response.password.${syntheticPassword}`]) {
+        const snapshot = position === 'first' ? undefined : createSnapshot();
+        const failure = applyUnsupported(unsupportedEvent(type), snapshot);
+
+        expectPrivateFailure(failure, 'unknown');
+        expect((failure as OpenAIError).message).not.toContain('ssn123456789');
+        expect((failure as OpenAIError).stack).not.toContain('ssn123456789');
+      }
+    },
+  );
+
+  test.each(['first', 'subsequent'] as const)(
+    'never invokes a credential-throwing discriminator getter in a %s frame',
+    (position) => {
+      const event = unsupportedEvent();
+      const getter = vi.fn(() => {
+        throw new Error(`sensitive discriminator getter: ${syntheticCredential}`);
+      });
+      Object.defineProperty(event, 'type', {
+        configurable: true,
+        enumerable: true,
+        get: getter,
+      });
+
+      const snapshot = position === 'first' ? undefined : createSnapshot();
+      const failure = applyUnsupported(event, snapshot);
+
+      expectPrivateFailure(failure, 'unknown');
+      expect(getter).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(['first', 'subsequent'] as const)(
+    'never invokes a credential-throwing discriminator proxy get trap in a %s frame',
+    (position) => {
+      const getter = vi.fn(() => {
+        throw new Error(`sensitive discriminator proxy: ${syntheticCredential}`);
+      });
+      const event = new Proxy(unsupportedEvent(), {
+        get(target, property, receiver) {
+          if (property === 'type') {
+            return getter();
+          }
+          return Reflect.get(target, property, receiver);
+        },
+      });
+
+      const snapshot = position === 'first' ? undefined : createSnapshot();
+      const failure = applyUnsupported(event, snapshot);
+
+      expectPrivateFailure(failure, 'unknown');
+      expect(getter).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(['first', 'subsequent'] as const)(
+    'normalizes a throwing descriptor trap before any %s-frame dispatch',
+    (position) => {
+      const descriptorFailure = new Error(`sensitive descriptor: ${syntheticCredential}`);
+      const event = new Proxy(unsupportedEvent(), {
+        getOwnPropertyDescriptor(target, property) {
+          if (property === 'type') {
+            throw descriptorFailure;
+          }
+          return Reflect.getOwnPropertyDescriptor(target, property);
+        },
+      });
+
+      const snapshot = position === 'first' ? undefined : createSnapshot();
+      const failure = applyUnsupported(event, snapshot);
+
+      expectPrivateFailure(failure, 'unknown');
+      expect(failure).not.toBe(descriptorFailure);
+    },
+  );
+
+  test.each(['first', 'subsequent'] as const)(
+    'dispatches a supported %s-frame data discriminator without invoking its proxy getter',
+    (position) => {
+      const snapshot = position === 'first' ? undefined : createSnapshot();
+      const original =
+        position === 'first' ? createdEvent() : ({ type: 'keepalive', sequence_number: 1 } as const);
+      const getter = vi.fn(() => {
+        throw new Error(`sensitive supported discriminator: ${syntheticCredential}`);
+      });
+      const event = new Proxy(original, {
+        get(target, property, receiver) {
+          if (property === 'type') {
+            return getter();
+          }
+          return Reflect.get(target, property, receiver);
+        },
+      });
+
+      const result = accumulateResponse(event, snapshot);
+
+      expect(getter).not.toHaveBeenCalled();
+      if (snapshot) {
+        expect(result).toBe(snapshot);
+      } else {
+        expect(result.id).toBe('resp_synthetic');
+      }
+    },
+  );
 
   test.each([
     [
@@ -146,7 +257,7 @@ describe('unsupported Responses event diagnostic privacy', () => {
 
     const failure = applyUnsupported(event, snapshot);
 
-    expectPrivateFailure(failure, futureEventType);
+    expectPrivateFailure(failure, 'unknown');
     expect(failure).not.toBeInstanceOf(TypeError);
   });
 
@@ -164,7 +275,7 @@ describe('unsupported Responses event diagnostic privacy', () => {
 
     const failure = applyUnsupported(event, snapshot);
 
-    expectPrivateFailure(failure, futureEventType);
+    expectPrivateFailure(failure, 'unknown');
     expect(getter).not.toHaveBeenCalled();
   });
 
@@ -182,7 +293,7 @@ describe('unsupported Responses event diagnostic privacy', () => {
 
     const failure = applyUnsupported(event, snapshot);
 
-    expectPrivateFailure(failure, futureEventType);
+    expectPrivateFailure(failure, 'unknown');
     expect(toJSON).not.toHaveBeenCalled();
   });
 
@@ -243,15 +354,38 @@ describe('unsupported Responses event diagnostic privacy', () => {
     expectPrivateFailure(failure, 'unknown');
   });
 
-  test('preserves the longest safe future event discriminator', () => {
+  test('redacts even a syntactically valid maximum-length unsupported discriminator', () => {
     const type = `response.${'a'.repeat(119)}`;
     const snapshot = createSnapshot();
 
     const failure = applyUnsupported(unsupportedEvent(type), snapshot);
 
     expect(type).toHaveLength(128);
-    expectPrivateFailure(failure, type);
+    expectPrivateFailure(failure, 'unknown');
   });
+
+  test.each(['response.patient.ssn123456789', `response.password.${syntheticPassword}`] as const)(
+    'keeps a first-frame readable-stream discriminator %s private',
+    async (type) => {
+      const stream = ResponseStream.fromReadableStream(readableStream([unsupportedEvent(type)]));
+      const events = vi.fn();
+      const errors = vi.fn();
+      stream.on('event', events);
+      stream.on('error', errors);
+
+      const failure = await stream.finalResponse().then(
+        () => {
+          throw new Error('Expected the first response event to be rejected.');
+        },
+        (error: unknown) => error,
+      );
+
+      expectPrivateFailure(failure, 'unknown');
+      expect((failure as OpenAIError).message).not.toContain('ssn123456789');
+      expect(events).not.toHaveBeenCalled();
+      expect(errors).toHaveBeenCalledWith(failure);
+    },
+  );
 
   test.each(['done', 'finalResponse'] as const)(
     'keeps restored readable-stream %s failures private',
@@ -275,7 +409,7 @@ describe('unsupported Responses event diagnostic privacy', () => {
         (error: unknown) => error,
       );
 
-      expectPrivateFailure(failure, futureEventType);
+      expectPrivateFailure(failure, 'unknown');
       expect(events).toHaveBeenCalledTimes(1);
       expect(events).toHaveBeenCalledWith(created);
       expect(errors).toHaveBeenCalledTimes(1);
@@ -287,60 +421,65 @@ describe('unsupported Responses event diagnostic privacy', () => {
   );
 
   test.each([
-    ['off', 'done'],
-    ['off', 'finalResponse'],
-    ['error', 'done'],
-    ['error', 'finalResponse'],
-  ] as const)('keeps public client %s logger / %s failures private', async (logLevel, completionMethod) => {
-    const created = createdEvent();
-    const event = unsupportedEvent();
-    const body = `${[created, event]
-      .map((streamEvent) => `data: ${JSON.stringify(streamEvent)}`)
-      .join('\n\n')}\n\ndata: [DONE]\n\n`;
-    const fetch = vi.fn(
-      async () =>
-        new Response(body, {
-          status: 200,
-          headers: { 'content-type': 'text/event-stream' },
-        }),
-    );
-    const logger = createLogger();
-    const client = new OpenAI({
-      apiKey: 'sk-synthetic-client-key',
-      fetch,
-      logger,
-      logLevel,
-      maxRetries: 0,
-    });
-    const stream = client.responses.stream({
-      model: 'gpt-5',
-      input: 'synthetic request',
-    });
-    const events = vi.fn();
-    const errors = vi.fn();
+    ['off', 'done', futureEventType],
+    ['off', 'finalResponse', 'response.patient.ssn123456789'],
+    ['error', 'done', `response.password.${syntheticPassword}`],
+    ['error', 'finalResponse', futureEventType],
+  ] as const)(
+    'keeps public client %s logger / %s failures private for %s',
+    async (logLevel, completionMethod, type) => {
+      const created = createdEvent();
+      const event = unsupportedEvent(type);
+      const body = `${[created, event]
+        .map((streamEvent) => `data: ${JSON.stringify(streamEvent)}`)
+        .join('\n\n')}\n\ndata: [DONE]\n\n`;
+      const fetch = vi.fn(
+        async () =>
+          new Response(body, {
+            status: 200,
+            headers: { 'content-type': 'text/event-stream' },
+          }),
+      );
+      const logger = createLogger();
+      const client = new OpenAI({
+        apiKey: 'sk-synthetic-client-key',
+        fetch,
+        logger,
+        logLevel,
+        maxRetries: 0,
+      });
+      const stream = client.responses.stream({
+        model: 'gpt-5',
+        input: 'synthetic request',
+      });
+      const events = vi.fn();
+      const errors = vi.fn();
 
-    stream.on('event', events);
-    stream.on('error', errors);
+      stream.on('event', events);
+      stream.on('error', errors);
 
-    const completion = completionMethod === 'done' ? stream.done() : stream.finalResponse();
-    const failure = await completion.then(
-      () => {
-        throw new Error('Expected the public response stream to reject.');
-      },
-      (error: unknown) => error,
-    );
+      const completion = completionMethod === 'done' ? stream.done() : stream.finalResponse();
+      const failure = await completion.then(
+        () => {
+          throw new Error('Expected the public response stream to reject.');
+        },
+        (error: unknown) => error,
+      );
 
-    expectPrivateFailure(failure, futureEventType);
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(events).toHaveBeenCalledTimes(1);
-    expect(events).toHaveBeenCalledWith(created);
-    expect(errors).toHaveBeenCalledTimes(1);
-    expect(errors).toHaveBeenCalledWith(failure);
-    expect(logger.error).not.toHaveBeenCalled();
-    expect(stream.ended).toBe(true);
-    expect(stream.errored).toBe(true);
-    expect(stream.aborted).toBe(false);
-  });
+      expectPrivateFailure(failure, 'unknown');
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(events).toHaveBeenCalledTimes(1);
+      expect(events).toHaveBeenCalledWith(created);
+      expect(errors).toHaveBeenCalledTimes(1);
+      expect(errors).toHaveBeenCalledWith(failure);
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(stream.ended).toBe(true);
+      expect(stream.errored).toBe(true);
+      expect(stream.aborted).toBe(false);
+      expect(JSON.stringify(logger.error.mock.calls)).not.toContain('ssn123456789');
+      expect(JSON.stringify(logger.error.mock.calls)).not.toContain(syntheticPassword);
+    },
+  );
 
   test('preserves documented provider API-error diagnostics', async () => {
     const payload = {


### PR DESCRIPTION
## Summary

- Prevent unsupported Responses streaming events from serializing their full contents into `OpenAIError.message` and stack traces, where nested tool arguments, credentials, patient details, and prompts could otherwise escape application redaction.
- Preserve the existing diagnostic prefix and only include a bounded, own-property Responses event discriminator that matches the current protocol namespace; use `unknown` for malformed, inherited, oversized, or unsafe values.
- Avoid invoking event getters, proxy descriptor traps, attacker-controlled `toJSON`, circular serialization, or BigInt serialization while preserving documented provider errors and stream lifecycle behavior.

## Regression coverage

- Regression-first: **32 of 33** new privacy/security cases fail against unmodified main; all **33** pass with this change.
- Exercise the actual public `client.responses.stream(...).done()` and `.finalResponse()` flows with SSE, both disabled/error logging, `ResponseStream.fromReadableStream(...)`, and exported `accumulateResponse`.
- Cover nested synthetic credentials/PII/tool arguments, snapshot integrity, listener identity/event ordering, circular/BigInt payloads, throwing `toJSON` and proxy traps, inherited values, 18 malformed discriminator classes, and 128/129-character boundaries.
- Verify existing valid provider `APIError` metadata and unsupported-event prefix compatibility.

## Validation

- `OPENAI_TEST_SUITE=unit pnpm test -- --silent`: **3,199 passed across 106 handwritten suites**.
- `pnpm run test:generated -- --runInBand`: **559 passed across 82 generated suites; 12 snapshots passed**.
- Focused Responses compatibility/security: **196 passed across 5 suites**.
- `pnpm run lint`: 415 rules, zero warnings/errors; formatting verified.
- `pnpm exec tsc --noEmit --project tsconfig.json`: passed.
- `pnpm run build`: CommonJS and ESM builds passed.
- Packed npm artifact: CommonJS, ESM, TypeScript 4.9/current consumers, and **267/304 source checks across 1,216 source maps** passed on Node.js 22.
