### PR TITLE
fix(security): scope Cloudflare ecosystem API key files

### DIFF
--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -107,6 +107,8 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
   let created = false;
   let published = false;
   let staged = false;
+  let stagedSecretPresent = false;
+  let pendingIntegrityError: CloudflareCredentialIntegrityError | undefined;
   let cleanup: Promise<void> | undefined;
   let staging: Promise<void> | undefined;
 
@@ -137,6 +139,11 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
     return Buffer.concat(chunks);
   };
 
+  const scrubCredentialFile = async (handle: Awaited<ReturnType<typeof fs.open>>): Promise<void> => {
+    await handle.truncate(0);
+    stagedSecretPresent = false;
+  };
+
   const preserveChangedContents = async (
     handle: Awaited<ReturnType<typeof fs.open>>,
     contents: Buffer,
@@ -154,8 +161,9 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
       }
     }
 
+    stagedSecretPresent = false;
     if (!cloudflareCredentialMatchesIdentity(credentialPath, identity)) {
-      await handle.truncate(0);
+      await scrubCredentialFile(handle);
       throw new CloudflareCredentialIntegrityError(
         'The Cloudflare credential path was replaced while credentials were staged.',
       );
@@ -180,10 +188,11 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
     try {
       contents = await readCloudflareCredentialSnapshot(handle, metadata.size);
     } catch {
-      await handle.truncate(0);
-      throw new CloudflareCredentialIntegrityError(
+      await scrubCredentialFile(handle);
+      pendingIntegrityError = new CloudflareCredentialIntegrityError(
         'The Cloudflare credential contents changed beyond the safe size limit.',
       );
+      return false;
     }
 
     if (!contents.equals(expectedContents)) {
@@ -197,8 +206,34 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
     return changedMode;
   };
 
+  const restoreOriginalCredentialPath = (identity: CloudflareCredentialIdentity): void => {
+    if (!cloudflareCredentialMatchesIdentity(credentialPath, identity)) {
+      throw new CloudflareCredentialIntegrityError(
+        'The Cloudflare credential path was replaced while credentials were staged.',
+      );
+    }
+
+    if (created) {
+      unlinkSync(credentialPath);
+      return;
+    }
+
+    if (backupPath && backupIdentity) {
+      if (!cloudflareCredentialMatchesIdentity(backupPath, backupIdentity)) {
+        throw new CloudflareCredentialIntegrityError(
+          'The original Cloudflare credential backup was replaced.',
+        );
+      }
+      renameSync(backupPath, credentialPath);
+      backupPath = undefined;
+    }
+  };
+
   const cleanupArtifacts = async (): Promise<void> => {
     try {
+      if (stagedSecretPresent && file && (created || file !== originalFile)) {
+        await scrubCredentialFile(file);
+      }
       if (temporaryPath && stagingIdentity && file && file !== originalFile) {
         await file.truncate(0);
         unlinkCloudflareCredentialArtifact(temporaryPath, stagingIdentity);
@@ -231,31 +266,33 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
           return;
         }
 
-        if (!cloudflareCredentialMatchesIdentity(credentialPath, stagingIdentity)) {
-          await file.truncate(0);
+        try {
+          if (!cloudflareCredentialMatchesIdentity(credentialPath, stagingIdentity)) {
+            throw new CloudflareCredentialIntegrityError(
+              'The Cloudflare credential path was replaced while credentials were staged.',
+            );
+          }
+        } catch (error) {
+          await scrubCredentialFile(file);
+          try {
+            restoreOriginalCredentialPath(stagingIdentity);
+          } catch {
+            // An inaccessible or replaced pathname must never block descriptor scrubbing.
+          }
+          if (error instanceof CloudflareCredentialIntegrityError) {
+            throw error;
+          }
           throw new CloudflareCredentialIntegrityError(
-            'The Cloudflare credential path was replaced while credentials were staged.',
+            'The Cloudflare credential path could not be validated safely.',
           );
         }
 
         const changedMode = await validateStagedContents(file, stagingIdentity);
-        await file.truncate(0);
-        if (!cloudflareCredentialMatchesIdentity(credentialPath, stagingIdentity)) {
-          throw new CloudflareCredentialIntegrityError(
-            'The Cloudflare credential path was replaced while credentials were staged.',
-          );
-        }
+        await scrubCredentialFile(file);
+        restoreOriginalCredentialPath(stagingIdentity);
 
-        if (created) {
-          unlinkSync(credentialPath);
-        } else if (backupPath && backupIdentity) {
-          if (!cloudflareCredentialMatchesIdentity(backupPath, backupIdentity)) {
-            throw new CloudflareCredentialIntegrityError(
-              'The original Cloudflare credential backup was replaced.',
-            );
-          }
-          renameSync(backupPath, credentialPath);
-          backupPath = undefined;
+        if (pendingIntegrityError) {
+          throw pendingIntegrityError;
         }
 
         if (changedMode) {
@@ -329,6 +366,7 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
       }
 
       await file.chmod(0o600);
+      stagedSecretPresent = true;
       await writeCloudflareCredentialFile(file, expectedContents);
       staged = true;
 

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -10,6 +10,9 @@ const TAR_NAME = 'openai.tgz';
 const PACK_FOLDER = '.pack';
 const PACK_FILE = `${PACK_FOLDER}/${TAR_NAME}`;
 const IS_CI = Boolean(process.env['CI'] && process.env['CI'] !== 'false');
+const MAX_CLOUDFLARE_CREDENTIAL_BYTES = 64 * 1024;
+
+let activeCloudflareCredentialCleanup: (() => Promise<void>) | undefined;
 
 async function defaultNodeRunner() {
   await installPackage();
@@ -35,6 +38,28 @@ async function writeCloudflareCredentialFile(
   }
 }
 
+async function readCloudflareCredentialSnapshot(
+  file: Awaited<ReturnType<typeof fs.open>>,
+  size: number,
+): Promise<Buffer> {
+  if (!Number.isSafeInteger(size) || size > MAX_CLOUDFLARE_CREDENTIAL_BYTES) {
+    throw new Error('The Cloudflare credential file exceeds the maximum size of 64 KiB.');
+  }
+
+  const contents = Buffer.alloc(MAX_CLOUDFLARE_CREDENTIAL_BYTES + 1);
+  let offset = 0;
+
+  while (offset < contents.length) {
+    const { bytesRead } = await file.read(contents, offset, contents.length - offset, offset);
+    if (bytesRead === 0) {
+      return contents.subarray(0, offset);
+    }
+    offset += bytesRead;
+  }
+
+  throw new Error('The Cloudflare credential file exceeds the maximum size of 64 KiB.');
+}
+
 async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Promise<void>): Promise<void> {
   const credentialPath = '.dev.vars';
   const flags = fs.constants.O_RDWR + fs.constants.O_NOFOLLOW + fs.constants.O_NONBLOCK;
@@ -54,32 +79,83 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
 
   let previousContents: Buffer | undefined;
   let previousMode: number | undefined;
+  let originalIdentity: { dev: number; ino: number } | undefined;
+  let cleanup: Promise<void> | undefined;
+
+  const restoreOnce = (): Promise<void> => {
+    cleanup ??= (async () => {
+      try {
+        if (!originalIdentity) {
+          return;
+        }
+
+        let current: Awaited<ReturnType<typeof fs.lstat>> | undefined;
+        let identityError: unknown;
+        try {
+          current = await fs.lstat(credentialPath);
+        } catch (error) {
+          identityError = error;
+        }
+
+        const unchanged =
+          current?.isFile() === true &&
+          current.dev === originalIdentity.dev &&
+          current.ino === originalIdentity.ino;
+
+        if (created) {
+          await file.truncate(0);
+          if (unchanged) {
+            await fs.unlink(credentialPath);
+          }
+        } else if (previousContents !== undefined && previousMode !== undefined) {
+          await writeCloudflareCredentialFile(file, previousContents);
+          await file.chmod(previousMode);
+        }
+
+        if (!unchanged) {
+          if (
+            identityError instanceof Error &&
+            (!('code' in identityError) || identityError.code !== 'ENOENT')
+          ) {
+            throw identityError;
+          }
+          throw new Error('The Cloudflare credential path was replaced while credentials were staged.');
+        }
+      } finally {
+        await file.close();
+      }
+    })();
+    return cleanup;
+  };
 
   try {
     const metadata = await file.stat();
     if (!metadata.isFile() || metadata.nlink !== 1) {
       throw new Error('The Cloudflare credential path must be an unshared regular file.');
     }
+    originalIdentity = { dev: metadata.dev, ino: metadata.ino };
 
     if (!created) {
-      previousContents = await file.readFile();
+      previousContents = await readCloudflareCredentialSnapshot(file, metadata.size);
       previousMode = metadata.mode % 4096;
     }
 
+    const current = await fs.lstat(credentialPath);
+    if (!current.isFile() || current.dev !== originalIdentity.dev || current.ino !== originalIdentity.ino) {
+      throw new Error('The Cloudflare credential path changed before credentials could be staged.');
+    }
+
+    activeCloudflareCredentialCleanup = restoreOnce;
     await file.chmod(0o600);
     await writeCloudflareCredentialFile(file, Buffer.from(`OPENAI_API_KEY='${apiKey}'`));
     await runLiveTest();
   } finally {
     try {
-      if (created) {
-        await file.truncate(0);
-        await fs.unlink(credentialPath);
-      } else if (previousContents !== undefined && previousMode !== undefined) {
-        await writeCloudflareCredentialFile(file, previousContents);
-        await file.chmod(previousMode);
-      }
+      await restoreOnce();
     } finally {
-      await file.close();
+      if (activeCloudflareCredentialCleanup === restoreOnce) {
+        activeCloudflareCredentialCleanup = undefined;
+      }
     }
   }
 }
@@ -402,10 +478,30 @@ async function main() {
     await fs.rm(path.join(tmpFolderPath, 'puppeteer-cache'), { recursive: true, force: true });
   }
 
-  async function runCleanupAndExit() {
-    await runCleanup();
+  let interruptionCleanup: Promise<void> | undefined;
 
-    process.exit(1);
+  function runCleanupAndExit(signal: NodeJS.Signals): void {
+    interruptionCleanup ??= (async () => {
+      try {
+        await activeCloudflareCredentialCleanup?.();
+        if (!args.noCleanup) {
+          await runCleanup();
+        }
+      } catch {
+        console.error('Unable to finish Cloudflare credential cleanup after interruption.');
+        process.exit(1);
+        return;
+      }
+
+      if (args.noCleanup) {
+        process.removeListener('SIGINT', runCleanupAndExit);
+        process.removeListener('SIGTERM', runCleanupAndExit);
+        process.kill(process.pid, signal);
+        return;
+      }
+
+      process.exit(1);
+    })();
   }
 
   if (!(await fileExists(tmpFolderPath))) {
@@ -417,11 +513,12 @@ async function main() {
     jobs = projectsToRun.length;
   }
 
+  process.on('SIGINT', runCleanupAndExit);
+  process.on('SIGTERM', runCleanupAndExit);
+
   if (!args.noCleanup) {
     // The cleanup code is only executed from the parent script that runs
     // multiple projects.
-    process.on('SIGINT', runCleanupAndExit);
-    process.on('SIGTERM', runCleanupAndExit);
     process.on('exit', runCleanup);
 
     await fileCache.cacheFiles(tmpFolderPath);

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -64,19 +64,8 @@ async function readCloudflareCredentialSnapshot(
 async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Promise<void>): Promise<void> {
   const credentialPath = '.dev.vars';
   const flags = fs.constants.O_RDWR + fs.constants.O_NOFOLLOW + fs.constants.O_NONBLOCK;
-  let file: Awaited<ReturnType<typeof fs.open>>;
+  let file: Awaited<ReturnType<typeof fs.open>> | undefined;
   let created = false;
-
-  try {
-    file = await fs.open(credentialPath, flags);
-  } catch (error) {
-    if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') {
-      throw error;
-    }
-
-    file = await fs.open(credentialPath, flags + fs.constants.O_CREAT + fs.constants.O_EXCL, 0o600);
-    created = true;
-  }
 
   let previousContents: Buffer | undefined;
   let previousMode: number | undefined;
@@ -87,16 +76,16 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
   const restoreOnce = (): Promise<void> => {
     cleanup ??= (async () => {
       try {
-        if (!originalIdentity) {
-          return;
-        }
-
         if (staging) {
           try {
             await staging;
           } catch {
             // Its owner rethrows a failed staging operation after restoration.
           }
+        }
+
+        if (!file || !originalIdentity) {
+          return;
         }
 
         if (created) {
@@ -133,36 +122,50 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
           throw new Error('The Cloudflare credential path was replaced while credentials were staged.');
         }
       } finally {
-        await file.close();
+        await file?.close();
       }
     })();
     return cleanup;
   };
 
+  activeCloudflareCredentialCleanup = restoreOnce;
+
   try {
-    const metadata = await file.stat();
-    if (!metadata.isFile() || metadata.nlink !== 1) {
-      throw new Error('The Cloudflare credential path must be an unshared regular file.');
-    }
-    originalIdentity = { dev: metadata.dev, ino: metadata.ino };
-
-    if (!created) {
-      previousContents = await readCloudflareCredentialSnapshot(file, metadata.size);
-      previousMode = metadata.mode % 4096;
-    }
-
-    const current = await fs.lstat(credentialPath);
-    if (!current.isFile() || current.dev !== originalIdentity.dev || current.ino !== originalIdentity.ino) {
-      throw new Error('The Cloudflare credential path changed before credentials could be staged.');
-    }
-
     staging = (async () => {
+      try {
+        file = await fs.open(credentialPath, flags);
+      } catch (error) {
+        if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') {
+          throw error;
+        }
+
+        file = await fs.open(credentialPath, flags + fs.constants.O_CREAT + fs.constants.O_EXCL, 0o600);
+        created = true;
+      }
+
+      const metadata = await file.stat();
+      if (!metadata.isFile() || metadata.nlink !== 1) {
+        throw new Error('The Cloudflare credential path must be an unshared regular file.');
+      }
+      originalIdentity = { dev: metadata.dev, ino: metadata.ino };
+
+      if (!created) {
+        previousContents = await readCloudflareCredentialSnapshot(file, metadata.size);
+        previousMode = metadata.mode % 4096;
+      }
+
+      const current = await fs.lstat(credentialPath);
+      if (!current.isFile() || current.dev !== originalIdentity.dev || current.ino !== originalIdentity.ino) {
+        throw new Error('The Cloudflare credential path changed before credentials could be staged.');
+      }
+
       await file.chmod(0o600);
       await writeCloudflareCredentialFile(file, Buffer.from(`OPENAI_API_KEY='${apiKey}'`));
     })();
-    activeCloudflareCredentialCleanup = restoreOnce;
     await staging;
-    await runLiveTest();
+    if (!cleanup) {
+      await runLiveTest();
+    }
   } finally {
     try {
       await restoreOnce();

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -15,6 +15,7 @@ const IS_CI = Boolean(process.env['CI'] && process.env['CI'] !== 'false');
 const MAX_CLOUDFLARE_CREDENTIAL_BYTES = 64 * 1024;
 
 let activeCloudflareCredentialCleanup: (() => Promise<void>) | undefined;
+let ecosystemInterruptionRequested = false;
 
 async function defaultNodeRunner() {
   await installPackage();
@@ -94,6 +95,10 @@ function unlinkCloudflareCredentialArtifact(candidate: string, identity: Cloudfl
 }
 
 async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Promise<void>): Promise<void> {
+  if (ecosystemInterruptionRequested) {
+    throw new CloudflareCredentialIntegrityError('Cannot stage Cloudflare credentials after interruption.');
+  }
+
   const credentialPath = '.dev.vars';
   const flags = fs.constants.O_RDWR + fs.constants.O_NOFOLLOW + fs.constants.O_NONBLOCK;
   const expectedContents = Buffer.from(`OPENAI_API_KEY='${apiKey}'`);
@@ -717,6 +722,7 @@ async function main() {
   let interruptionCleanup: Promise<void> | undefined;
 
   function runCleanupAndExit(signal: NodeJS.Signals): void {
+    ecosystemInterruptionRequested = true;
     interruptionCleanup ??= (async () => {
       try {
         await activeCloudflareCredentialCleanup?.();
@@ -935,6 +941,10 @@ async function withRetry(
 ): Promise<void> {
   let retriesLeft = retryAmount;
   while (true) {
+    if (ecosystemInterruptionRequested) {
+      throw new CloudflareCredentialIntegrityError('Cannot retry ecosystem tests after interruption.');
+    }
+
     try {
       return await fn();
     } catch (err) {

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -1,4 +1,5 @@
-import { lstatSync, unlinkSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
+import { lstatSync, renameSync, unlinkSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import execa from 'execa';
 import yargs from 'yargs';
@@ -61,17 +62,159 @@ async function readCloudflareCredentialSnapshot(
   throw new Error('The Cloudflare credential file exceeds the maximum size of 64 KiB.');
 }
 
+class CloudflareCredentialIntegrityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CloudflareCredentialIntegrityError';
+  }
+}
+
+type CloudflareCredentialIdentity = { dev: number; ino: number };
+
+function cloudflareCredentialMatchesIdentity(
+  candidate: string,
+  identity: CloudflareCredentialIdentity,
+): boolean {
+  try {
+    const metadata = lstatSync(candidate);
+    return metadata.isFile() && metadata.dev === identity.dev && metadata.ino === identity.ino;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function unlinkCloudflareCredentialArtifact(candidate: string, identity: CloudflareCredentialIdentity): void {
+  if (!cloudflareCredentialMatchesIdentity(candidate, identity)) {
+    throw new CloudflareCredentialIntegrityError('A Cloudflare credential artifact was replaced.');
+  }
+  unlinkSync(candidate);
+}
+
 async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Promise<void>): Promise<void> {
   const credentialPath = '.dev.vars';
   const flags = fs.constants.O_RDWR + fs.constants.O_NOFOLLOW + fs.constants.O_NONBLOCK;
+  const expectedContents = Buffer.from(`OPENAI_API_KEY='${apiKey}'`);
   let file: Awaited<ReturnType<typeof fs.open>> | undefined;
+  let originalFile: Awaited<ReturnType<typeof fs.open>> | undefined;
+  let originalIdentity: CloudflareCredentialIdentity | undefined;
+  let stagingIdentity: CloudflareCredentialIdentity | undefined;
+  let backupIdentity: CloudflareCredentialIdentity | undefined;
+  let backupPath: string | undefined;
+  let temporaryPath: string | undefined;
   let created = false;
-
-  let previousContents: Buffer | undefined;
-  let previousMode: number | undefined;
-  let originalIdentity: { dev: number; ino: number } | undefined;
+  let published = false;
+  let staged = false;
   let cleanup: Promise<void> | undefined;
   let staging: Promise<void> | undefined;
+
+  const removeSecret = (contents: Buffer): Buffer => {
+    let sanitized = contents;
+    let complete = sanitized.indexOf(expectedContents);
+    while (complete !== -1) {
+      sanitized = Buffer.concat([
+        sanitized.subarray(0, complete),
+        sanitized.subarray(complete + expectedContents.length),
+      ]);
+      complete = sanitized.indexOf(expectedContents);
+    }
+
+    const secret = Buffer.from(apiKey);
+    const chunks: Buffer[] = [];
+    let offset = 0;
+    let position = sanitized.indexOf(secret, offset);
+    while (position !== -1) {
+      chunks.push(sanitized.subarray(offset, position), Buffer.from('[REDACTED]'));
+      offset = position + secret.length;
+      position = sanitized.indexOf(secret, offset);
+    }
+    if (chunks.length === 0) {
+      return sanitized;
+    }
+    chunks.push(sanitized.subarray(offset));
+    return Buffer.concat(chunks);
+  };
+
+  const preserveChangedContents = async (
+    handle: Awaited<ReturnType<typeof fs.open>>,
+    contents: Buffer,
+    mode: number,
+    identity: CloudflareCredentialIdentity,
+  ): Promise<never> => {
+    const sanitized = removeSecret(contents);
+    if (!sanitized.equals(contents)) {
+      if (mode !== 0o600) {
+        await handle.chmod(0o600);
+      }
+      await writeCloudflareCredentialFile(handle, sanitized);
+      if (mode !== 0o600) {
+        await handle.chmod(mode);
+      }
+    }
+
+    if (!cloudflareCredentialMatchesIdentity(credentialPath, identity)) {
+      await handle.truncate(0);
+      throw new CloudflareCredentialIntegrityError(
+        'The Cloudflare credential path was replaced while credentials were staged.',
+      );
+    }
+
+    throw new CloudflareCredentialIntegrityError(
+      'The Cloudflare credential contents changed while credentials were staged.',
+    );
+  };
+
+  const validateStagedContents = async (
+    handle: Awaited<ReturnType<typeof fs.open>>,
+    identity: CloudflareCredentialIdentity,
+  ): Promise<boolean> => {
+    if (!staged) {
+      return false;
+    }
+
+    const metadata = await handle.stat();
+    const mode = metadata.mode % 4096;
+    let contents: Buffer;
+    try {
+      contents = await readCloudflareCredentialSnapshot(handle, metadata.size);
+    } catch {
+      await handle.truncate(0);
+      throw new CloudflareCredentialIntegrityError(
+        'The Cloudflare credential contents changed beyond the safe size limit.',
+      );
+    }
+
+    if (!contents.equals(expectedContents)) {
+      await preserveChangedContents(handle, contents, mode, identity);
+    }
+
+    const changedMode = mode !== 0o600;
+    if (changedMode && originalFile) {
+      await originalFile.chmod(mode);
+    }
+    return changedMode;
+  };
+
+  const cleanupArtifacts = async (): Promise<void> => {
+    try {
+      if (temporaryPath && stagingIdentity && file && file !== originalFile) {
+        await file.truncate(0);
+        unlinkCloudflareCredentialArtifact(temporaryPath, stagingIdentity);
+        temporaryPath = undefined;
+      }
+      if (backupPath && backupIdentity) {
+        unlinkCloudflareCredentialArtifact(backupPath, backupIdentity);
+        backupPath = undefined;
+      }
+    } finally {
+      await file?.close();
+      if (originalFile && originalFile !== file) {
+        await originalFile.close();
+      }
+    }
+  };
 
   const restoreOnce = (): Promise<void> => {
     cleanup ??= (async () => {
@@ -80,49 +223,48 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
           try {
             await staging;
           } catch {
-            // Its owner rethrows a failed staging operation after restoration.
+            // The owning operation reports the original staging failure.
           }
         }
 
-        if (!file || !originalIdentity) {
+        if (!file || !stagingIdentity || !published) {
           return;
         }
 
-        if (created) {
+        if (!cloudflareCredentialMatchesIdentity(credentialPath, stagingIdentity)) {
           await file.truncate(0);
-        } else if (previousContents !== undefined && previousMode !== undefined) {
-          await writeCloudflareCredentialFile(file, previousContents);
-          await file.chmod(previousMode);
+          throw new CloudflareCredentialIntegrityError(
+            'The Cloudflare credential path was replaced while credentials were staged.',
+          );
         }
 
-        let current: ReturnType<typeof lstatSync> | undefined;
-        let identityError: unknown;
-        try {
-          current = lstatSync(credentialPath);
-        } catch (error) {
-          identityError = error;
+        const changedMode = await validateStagedContents(file, stagingIdentity);
+        await file.truncate(0);
+        if (!cloudflareCredentialMatchesIdentity(credentialPath, stagingIdentity)) {
+          throw new CloudflareCredentialIntegrityError(
+            'The Cloudflare credential path was replaced while credentials were staged.',
+          );
         }
 
-        const unchanged =
-          current?.isFile() === true &&
-          current.dev === originalIdentity.dev &&
-          current.ino === originalIdentity.ino;
-
-        if (created && unchanged) {
+        if (created) {
           unlinkSync(credentialPath);
+        } else if (backupPath && backupIdentity) {
+          if (!cloudflareCredentialMatchesIdentity(backupPath, backupIdentity)) {
+            throw new CloudflareCredentialIntegrityError(
+              'The original Cloudflare credential backup was replaced.',
+            );
+          }
+          renameSync(backupPath, credentialPath);
+          backupPath = undefined;
         }
 
-        if (!unchanged) {
-          if (
-            identityError instanceof Error &&
-            (!('code' in identityError) || identityError.code !== 'ENOENT')
-          ) {
-            throw identityError;
-          }
-          throw new Error('The Cloudflare credential path was replaced while credentials were staged.');
+        if (changedMode) {
+          throw new CloudflareCredentialIntegrityError(
+            'The Cloudflare credential permissions changed while credentials were staged.',
+          );
         }
       } finally {
-        await file?.close();
+        await cleanupArtifacts();
       }
     })();
     return cleanup;
@@ -148,19 +290,58 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
         throw new Error('The Cloudflare credential path must be an unshared regular file.');
       }
       originalIdentity = { dev: metadata.dev, ino: metadata.ino };
+      stagingIdentity = originalIdentity;
+      published = created;
 
       if (!created) {
-        previousContents = await readCloudflareCredentialSnapshot(file, metadata.size);
-        previousMode = metadata.mode % 4096;
+        await readCloudflareCredentialSnapshot(file, metadata.size);
       }
 
       const current = await fs.lstat(credentialPath);
       if (!current.isFile() || current.dev !== originalIdentity.dev || current.ino !== originalIdentity.ino) {
-        throw new Error('The Cloudflare credential path changed before credentials could be staged.');
+        throw new CloudflareCredentialIntegrityError(
+          'The Cloudflare credential path changed before credentials could be staged.',
+        );
+      }
+
+      if (!created) {
+        originalFile = file;
+        const suffix = randomBytes(16).toString('hex');
+        backupPath = `${credentialPath}.openai-original-${suffix}`;
+        await fs.link(credentialPath, backupPath);
+        const backup = lstatSync(backupPath);
+        backupIdentity = { dev: backup.dev, ino: backup.ino };
+        if (!cloudflareCredentialMatchesIdentity(backupPath, originalIdentity)) {
+          throw new CloudflareCredentialIntegrityError(
+            'The Cloudflare credential path changed while its backup was being created.',
+          );
+        }
+
+        temporaryPath = `${credentialPath}.openai-staging-${suffix}`;
+        file = await fs.open(temporaryPath, flags + fs.constants.O_CREAT + fs.constants.O_EXCL, 0o600);
+        const privateMetadata = await file.stat();
+        if (!privateMetadata.isFile() || privateMetadata.nlink !== 1) {
+          throw new CloudflareCredentialIntegrityError(
+            'The private Cloudflare credential inode is not exclusive.',
+          );
+        }
+        stagingIdentity = { dev: privateMetadata.dev, ino: privateMetadata.ino };
       }
 
       await file.chmod(0o600);
-      await writeCloudflareCredentialFile(file, Buffer.from(`OPENAI_API_KEY='${apiKey}'`));
+      await writeCloudflareCredentialFile(file, expectedContents);
+      staged = true;
+
+      if (temporaryPath && originalIdentity) {
+        if (!cloudflareCredentialMatchesIdentity(credentialPath, originalIdentity)) {
+          throw new CloudflareCredentialIntegrityError(
+            'The Cloudflare credential path changed before private credentials could be published.',
+          );
+        }
+        renameSync(temporaryPath, credentialPath);
+        temporaryPath = undefined;
+        published = true;
+      }
     })();
     await staging;
     if (!cleanup) {
@@ -650,7 +831,13 @@ async function main() {
         console.error('\n');
 
         try {
-          await withRetry(fn, project, state.retry, state.retryDelay);
+          await withRetry(
+            fn,
+            project,
+            state.retry,
+            state.retryDelay,
+            (error) => !(error instanceof CloudflareCredentialIntegrityError),
+          );
           console.error('\n');
           console.error(`✅ ${project}`);
         } catch (err) {

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -19,6 +19,71 @@ async function defaultNodeRunner() {
   }
 }
 
+async function writeCloudflareCredentialFile(
+  file: Awaited<ReturnType<typeof fs.open>>,
+  contents: Buffer,
+): Promise<void> {
+  await file.truncate(0);
+
+  let offset = 0;
+  while (offset < contents.length) {
+    const { bytesWritten } = await file.write(contents, offset, contents.length - offset, offset);
+    if (bytesWritten === 0) {
+      throw new Error('Unable to update the Cloudflare credential file.');
+    }
+    offset += bytesWritten;
+  }
+}
+
+async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Promise<void>): Promise<void> {
+  const credentialPath = '.dev.vars';
+  const flags = fs.constants.O_RDWR + fs.constants.O_NOFOLLOW + fs.constants.O_NONBLOCK;
+  let file: Awaited<ReturnType<typeof fs.open>>;
+  let created = false;
+
+  try {
+    file = await fs.open(credentialPath, flags);
+  } catch (error) {
+    if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') {
+      throw error;
+    }
+
+    file = await fs.open(credentialPath, flags + fs.constants.O_CREAT + fs.constants.O_EXCL, 0o600);
+    created = true;
+  }
+
+  let previousContents: Buffer | undefined;
+  let previousMode: number | undefined;
+
+  try {
+    const metadata = await file.stat();
+    if (!metadata.isFile() || metadata.nlink !== 1) {
+      throw new Error('The Cloudflare credential path must be an unshared regular file.');
+    }
+
+    if (!created) {
+      previousContents = await file.readFile();
+      previousMode = metadata.mode % 4096;
+    }
+
+    await file.chmod(0o600);
+    await writeCloudflareCredentialFile(file, Buffer.from(`OPENAI_API_KEY='${apiKey}'`));
+    await runLiveTest();
+  } finally {
+    try {
+      if (created) {
+        await file.truncate(0);
+        await fs.unlink(credentialPath);
+      } else if (previousContents !== undefined && previousMode !== undefined) {
+        await writeCloudflareCredentialFile(file, previousContents);
+        await file.chmod(previousMode);
+      }
+    } finally {
+      await file.close();
+    }
+  }
+}
+
 const projectRunners = {
   'node-ts-cjs': defaultNodeRunner,
   'node-ts-cjs-web': defaultNodeRunner,
@@ -70,15 +135,14 @@ const projectRunners = {
   },
   'cloudflare-worker': async () => {
     await installPackage();
-
-    const apiKey = process.env['OPENAI_API_KEY'];
-    if (apiKey) {
-      await fs.writeFile('.dev.vars', `OPENAI_API_KEY='${apiKey}'`);
-    }
     await run('npm', ['run', 'tsc']);
 
     if (state.live) {
-      await run('npm', ['run', 'test:ci']);
+      const apiKey = process.env['OPENAI_API_KEY'];
+      assert.ok(apiKey);
+      await withCloudflareCredentials(apiKey, async () => {
+        await run('npm', ['run', 'test:ci']);
+      });
     }
     if (state.deploy) {
       await run('npm', ['run', 'deploy']);

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -1,3 +1,4 @@
+import { lstatSync, unlinkSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import execa from 'execa';
 import yargs from 'yargs';
@@ -81,6 +82,7 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
   let previousMode: number | undefined;
   let originalIdentity: { dev: number; ino: number } | undefined;
   let cleanup: Promise<void> | undefined;
+  let staging: Promise<void> | undefined;
 
   const restoreOnce = (): Promise<void> => {
     cleanup ??= (async () => {
@@ -89,10 +91,25 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
           return;
         }
 
-        let current: Awaited<ReturnType<typeof fs.lstat>> | undefined;
+        if (staging) {
+          try {
+            await staging;
+          } catch {
+            // Its owner rethrows a failed staging operation after restoration.
+          }
+        }
+
+        if (created) {
+          await file.truncate(0);
+        } else if (previousContents !== undefined && previousMode !== undefined) {
+          await writeCloudflareCredentialFile(file, previousContents);
+          await file.chmod(previousMode);
+        }
+
+        let current: ReturnType<typeof lstatSync> | undefined;
         let identityError: unknown;
         try {
-          current = await fs.lstat(credentialPath);
+          current = lstatSync(credentialPath);
         } catch (error) {
           identityError = error;
         }
@@ -102,14 +119,8 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
           current.dev === originalIdentity.dev &&
           current.ino === originalIdentity.ino;
 
-        if (created) {
-          await file.truncate(0);
-          if (unchanged) {
-            await fs.unlink(credentialPath);
-          }
-        } else if (previousContents !== undefined && previousMode !== undefined) {
-          await writeCloudflareCredentialFile(file, previousContents);
-          await file.chmod(previousMode);
+        if (created && unchanged) {
+          unlinkSync(credentialPath);
         }
 
         if (!unchanged) {
@@ -145,9 +156,12 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
       throw new Error('The Cloudflare credential path changed before credentials could be staged.');
     }
 
+    staging = (async () => {
+      await file.chmod(0o600);
+      await writeCloudflareCredentialFile(file, Buffer.from(`OPENAI_API_KEY='${apiKey}'`));
+    })();
     activeCloudflareCredentialCleanup = restoreOnce;
-    await file.chmod(0o600);
-    await writeCloudflareCredentialFile(file, Buffer.from(`OPENAI_API_KEY='${apiKey}'`));
+    await staging;
     await runLiveTest();
   } finally {
     try {
@@ -659,6 +673,10 @@ async function main() {
 
   if (!args.noCleanup) {
     await runCleanup();
+  }
+
+  if (interruptionCleanup) {
+    await interruptionCleanup;
   }
 
   if (failed.length) {

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -42,9 +42,9 @@ async function writeCloudflareCredentialFile(
 
 async function readCloudflareCredentialSnapshot(
   file: Awaited<ReturnType<typeof fs.open>>,
-  size: number,
+  size: bigint,
 ): Promise<Buffer> {
-  if (!Number.isSafeInteger(size) || size > MAX_CLOUDFLARE_CREDENTIAL_BYTES) {
+  if (size < 0n || size > BigInt(MAX_CLOUDFLARE_CREDENTIAL_BYTES)) {
     throw new Error('The Cloudflare credential file exceeds the maximum size of 64 KiB.');
   }
 
@@ -69,14 +69,14 @@ class CloudflareCredentialIntegrityError extends Error {
   }
 }
 
-type CloudflareCredentialIdentity = { dev: number; ino: number };
+type CloudflareCredentialIdentity = { dev: bigint; ino: bigint };
 
 function cloudflareCredentialMatchesIdentity(
   candidate: string,
   identity: CloudflareCredentialIdentity,
 ): boolean {
   try {
-    const metadata = lstatSync(candidate);
+    const metadata = lstatSync(candidate, { bigint: true });
     return metadata.isFile() && metadata.dev === identity.dev && metadata.ino === identity.ino;
   } catch (error) {
     if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
@@ -174,8 +174,8 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
       return false;
     }
 
-    const metadata = await handle.stat();
-    const mode = metadata.mode % 4096;
+    const metadata = await handle.stat({ bigint: true });
+    const mode = Number(metadata.mode % 4096n);
     let contents: Buffer;
     try {
       contents = await readCloudflareCredentialSnapshot(handle, metadata.size);
@@ -285,8 +285,8 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
         created = true;
       }
 
-      const metadata = await file.stat();
-      if (!metadata.isFile() || metadata.nlink !== 1) {
+      const metadata = await file.stat({ bigint: true });
+      if (!metadata.isFile() || metadata.nlink !== 1n) {
         throw new Error('The Cloudflare credential path must be an unshared regular file.');
       }
       originalIdentity = { dev: metadata.dev, ino: metadata.ino };
@@ -297,7 +297,7 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
         await readCloudflareCredentialSnapshot(file, metadata.size);
       }
 
-      const current = await fs.lstat(credentialPath);
+      const current = await fs.lstat(credentialPath, { bigint: true });
       if (!current.isFile() || current.dev !== originalIdentity.dev || current.ino !== originalIdentity.ino) {
         throw new CloudflareCredentialIntegrityError(
           'The Cloudflare credential path changed before credentials could be staged.',
@@ -309,7 +309,7 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
         const suffix = randomBytes(16).toString('hex');
         backupPath = `${credentialPath}.openai-original-${suffix}`;
         await fs.link(credentialPath, backupPath);
-        const backup = lstatSync(backupPath);
+        const backup = lstatSync(backupPath, { bigint: true });
         backupIdentity = { dev: backup.dev, ino: backup.ino };
         if (!cloudflareCredentialMatchesIdentity(backupPath, originalIdentity)) {
           throw new CloudflareCredentialIntegrityError(
@@ -319,8 +319,8 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
 
         temporaryPath = `${credentialPath}.openai-staging-${suffix}`;
         file = await fs.open(temporaryPath, flags + fs.constants.O_CREAT + fs.constants.O_EXCL, 0o600);
-        const privateMetadata = await file.stat();
-        if (!privateMetadata.isFile() || privateMetadata.nlink !== 1) {
+        const privateMetadata = await file.stat({ bigint: true });
+        if (!privateMetadata.isFile() || privateMetadata.nlink !== 1n) {
           throw new CloudflareCredentialIntegrityError(
             'The private Cloudflare credential inode is not exclusive.',
           );
@@ -682,16 +682,26 @@ async function main() {
     interruptionCleanup ??= (async () => {
       try {
         await activeCloudflareCredentialCleanup?.();
-        if (!args.noCleanup) {
-          await runCleanup();
-        }
       } catch {
         console.error('Unable to finish Cloudflare credential cleanup after interruption.');
         process.exit(1);
         return;
       }
 
-      if (args.noCleanup) {
+      if (!args.noCleanup) {
+        try {
+          await runCleanup();
+        } catch {
+          console.error('Unable to finish Cloudflare credential cleanup after interruption.');
+          if (signal !== 'SIGHUP') {
+            process.exit(1);
+            return;
+          }
+        }
+      }
+
+      if (args.noCleanup || signal === 'SIGHUP') {
+        process.removeListener('SIGHUP', runCleanupAndExit);
         process.removeListener('SIGINT', runCleanupAndExit);
         process.removeListener('SIGTERM', runCleanupAndExit);
         process.kill(process.pid, signal);
@@ -711,6 +721,7 @@ async function main() {
     jobs = projectsToRun.length;
   }
 
+  process.on('SIGHUP', runCleanupAndExit);
   process.on('SIGINT', runCleanupAndExit);
   process.on('SIGTERM', runCleanupAndExit);
 

--- a/tests/ecosystem-cli.test.ts
+++ b/tests/ecosystem-cli.test.ts
@@ -171,10 +171,10 @@ describe('ecosystem test CLI', () => {
       expectedVars: existingCloudflareDevVars,
     },
     {
-      name: 'updates Cloudflare credentials when an API key is available',
+      name: 'preserves existing Cloudflare credentials in non-live mode with an API key',
       existingVars: existingCloudflareDevVars,
       apiKey: 'test-api-key',
-      expectedVars: "OPENAI_API_KEY='test-api-key'",
+      expectedVars: existingCloudflareDevVars,
     },
   ])('$name', ({ existingVars, apiKey, expectedVars }) => {
     const fixture = mkdtempSync(path.join(tmpdir(), 'openai-node-ecosystem-cli-'));

--- a/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
+++ b/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
@@ -421,6 +421,79 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
   );
 
   test.each(
+    (['open', 'stat', 'lstat'] as const).flatMap((phase) =>
+      credentialStates.flatMap((state) =>
+        [
+          { signal: 'SIGINT' as const, noCleanup: true },
+          { signal: 'SIGTERM' as const, noCleanup: false },
+        ].map(({ signal, noCleanup }) => ({ phase, state, signal, noCleanup, name: state.name })),
+      ),
+    ),
+  )(
+    'restores $name after $signal interrupts pending $phase with noCleanup=$noCleanup',
+    ({ phase, state, signal, noCleanup }) => {
+      withFixture((fixture) => {
+        setExistingCredentials(fixture, state);
+        const preload = path.join(fixture.directory, 'interrupt-during-acquisition.cjs');
+        writeFileSync(
+          preload,
+          [
+            "const promises = require('node:fs/promises');",
+            'const originalOpen = promises.open;',
+            'const originalLstat = promises.lstat;',
+            'let interrupted = false;',
+            'async function interrupt() {',
+            '  if (interrupted) return;',
+            '  interrupted = true;',
+            '  process.kill(process.pid, process.env.CLOUDFLARE_ACQUISITION_SIGNAL);',
+            '  await new Promise((resolve) => setTimeout(resolve, 30));',
+            '}',
+            'promises.open = async (...args) => {',
+            '  const file = await originalOpen(...args);',
+            "  if (args[0] === '.dev.vars') {",
+            '    const originalStat = file.stat.bind(file);',
+            '    file.stat = async (...statArgs) => {',
+            '      const result = await originalStat(...statArgs);',
+            "      if (process.env.CLOUDFLARE_ACQUISITION_PHASE === 'stat') await interrupt();",
+            '      return result;',
+            '    };',
+            "    if (process.env.CLOUDFLARE_ACQUISITION_PHASE === 'open') await interrupt();",
+            '  }',
+            '  return file;',
+            '};',
+            'promises.lstat = async (...args) => {',
+            '  const result = await originalLstat(...args);',
+            "  if (args[0] === '.dev.vars' && process.env.CLOUDFLARE_ACQUISITION_PHASE === 'lstat') {",
+            '    await interrupt();',
+            '  }',
+            '  return result;',
+            '};',
+          ].join('\n'),
+        );
+        const flags = ['--live', ...(noCleanup ? [] : otherProjects.map((project) => `--skip=${project}`))];
+
+        const result = runCloudflare(
+          fixture,
+          flags,
+          {
+            CLOUDFLARE_ACQUISITION_PHASE: phase,
+            CLOUDFLARE_ACQUISITION_SIGNAL: signal,
+            NODE_OPTIONS: `--require ${preload}`,
+          },
+          noCleanup,
+        );
+
+        expect(result.error).toBeUndefined();
+        expect(result.status === 0 && result.signal === null).toBe(false);
+        expectRestored(fixture, state);
+        if (noCleanup) {
+          expect(result.signal).toBe(signal);
+        }
+      });
+    },
+  );
+
+  test.each(
     (['SIGINT', 'SIGTERM'] as const).flatMap((signal) =>
       [true, false].map((noCleanup) => ({ signal, noCleanup })),
     ),

--- a/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
+++ b/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
@@ -7,6 +7,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
   statSync,
   symlinkSync,
@@ -114,6 +115,19 @@ function withFixture(run: (fixture: Fixture) => void) {
       '      fs.symlinkSync(process.env.CLOUDFLARE_REPLACEMENT_TARGET, vars);',
       '    }',
       '  }',
+      "  if (failure === 'capture-original' || failure === 'edit-original') {",
+      "    const held = '/proc/' + process.ppid + '/fd/' + process.env.CLOUDFLARE_HELD_FD;",
+      "    if (failure === 'capture-original') {",
+      '      fs.writeFileSync(process.env.CLOUDFLARE_HELD_CAPTURE, fs.readFileSync(held), { mode: 0o600 });',
+      '    } else {',
+      '      fs.writeFileSync(held, "original concurrently edited\\n");',
+      '      fs.chmodSync(held, 0o640);',
+      '    }',
+      '  }',
+      "  if (failure === 'edit-staged') fs.writeFileSync(vars, 'concurrent visible edit\\n');",
+      "  if (failure === 'append-staged') fs.appendFileSync(vars, '\\nconcurrent appended edit\\n');",
+      "  if (failure === 'append-staged-duplicate') fs.appendFileSync(vars, '\\nconcurrent appended edit\\n' + process.env.OPENAI_API_KEY + '\\n');",
+      "  if (failure === 'chmod-staged') fs.chmodSync(vars, 0o640);",
       "  if (failure === 'signal-int' || failure === 'signal-term') {",
       "    process.kill(process.ppid, failure === 'signal-int' ? 'SIGINT' : 'SIGTERM');",
       '    setTimeout(() => process.exit(0), 250);',
@@ -137,6 +151,30 @@ function setExistingCredentials(fixture: Fixture, state: CredentialState) {
     writeFileSync(fixture.vars, state.contents);
     chmodSync(fixture.vars, state.mode);
   }
+}
+
+function holdOriginalCredentialDescriptor(fixture: Fixture): string {
+  const preload = path.join(fixture.directory, 'hold-original-credential.cjs');
+  writeFileSync(
+    preload,
+    [
+      "const fs = require('node:fs');",
+      "const promises = require('node:fs/promises');",
+      'const originalOpen = promises.open;',
+      'promises.open = async (...args) => {',
+      '  const file = await originalOpen(...args);',
+      "  if (args[0] === '.dev.vars' && !process.env.CLOUDFLARE_HELD_FD) {",
+      "    process.env.CLOUDFLARE_HELD_FD = String(fs.openSync(args[0], 'r+'));",
+      '  }',
+      '  return file;',
+      '};',
+    ].join('\n'),
+  );
+  return preload;
+}
+
+function expectNoCloudflareCredentialArtifacts(fixture: Fixture) {
+  expect(readdirSync(fixture.worker).filter((name) => name.startsWith('.dev.vars.openai-'))).toEqual([]);
 }
 
 function runCloudflare(
@@ -203,6 +241,7 @@ function expectOriginal(observation: Observation, state: CredentialState) {
 }
 
 function expectRestored(fixture: Fixture, state: CredentialState) {
+  expectNoCloudflareCredentialArtifacts(fixture);
   if (state.contents === undefined) {
     expect(existsSync(fixture.vars)).toBe(false);
     return;
@@ -267,6 +306,96 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
       expect(records.map(({ command }) => command)).toEqual(['install -D openai', 'run tsc', 'run test:ci']);
       expectScopedObservations(records, state);
       expectRestored(fixture, state);
+    });
+  });
+
+  test('never exposes a staged key through a pre-opened readable original inode', () => {
+    withFixture((fixture) => {
+      const state = credentialStates[1] as CredentialState;
+      setExistingCredentials(fixture, state);
+      const preload = holdOriginalCredentialDescriptor(fixture);
+      const capture = path.join(fixture.directory, 'held-original-capture');
+
+      const result = runCloudflare(fixture, ['--live'], {
+        CLOUDFLARE_FAILURE: 'capture-original',
+        CLOUDFLARE_HELD_CAPTURE: capture,
+        NODE_OPTIONS: `--require ${preload}`,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(readFileSync(capture)).toEqual(originalContents);
+      expect(readFileSync(capture).includes(apiKey)).toBe(false);
+      expectRestored(fixture, state);
+      expectNoCloudflareCredentialArtifacts(fixture);
+    });
+  });
+
+  test('preserves concurrent edits and mode changes through the original held inode', () => {
+    withFixture((fixture) => {
+      const state = credentialStates[1] as CredentialState;
+      setExistingCredentials(fixture, state);
+      const preload = holdOriginalCredentialDescriptor(fixture);
+
+      const result = runCloudflare(fixture, ['--live'], {
+        CLOUDFLARE_FAILURE: 'edit-original',
+        NODE_OPTIONS: `--require ${preload}`,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(readFileSync(fixture.vars, 'utf-8')).toBe('original concurrently edited\n');
+      expect(statSync(fixture.vars).mode % 0o1000).toBe(0o640);
+      expect(readFileSync(fixture.vars).includes(apiKey)).toBe(false);
+      expectNoCloudflareCredentialArtifacts(fixture);
+    });
+  });
+
+  test('does not retry a replaced credential path even when retries are enabled', () => {
+    withFixture((fixture) => {
+      const state = credentialStates[1] as CredentialState;
+      setExistingCredentials(fixture, state);
+
+      const result = runCloudflare(fixture, ['--live', '--retry=3', '--retryDelay=0'], {
+        CLOUDFLARE_FAILURE: 'replace-file',
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(readFileSync(fixture.attempts, 'utf-8')).toBe('1');
+      expect(readFileSync(fixture.vars, 'utf-8')).toBe('independently replaced credentials\n');
+      expect(readFileSync(fixture.vars).includes(apiKey)).toBe(false);
+      expectNoCloudflareCredentialArtifacts(fixture);
+    });
+  });
+
+  test.each([
+    { failure: 'edit-staged', contents: 'concurrent visible edit\n', mode: 0o600 },
+    { failure: 'append-staged', contents: '\nconcurrent appended edit\n', mode: 0o600 },
+    {
+      failure: 'append-staged-duplicate',
+      contents: '\nconcurrent appended edit\n[REDACTED]\n',
+      mode: 0o600,
+    },
+    { failure: 'chmod-staged', contents: originalContents, mode: 0o640 },
+  ])('preserves concurrent visible credential changes after $failure', ({ failure, contents, mode }) => {
+    withFixture((fixture) => {
+      const state = credentialStates[1] as CredentialState;
+      setExistingCredentials(fixture, state);
+
+      const result = runCloudflare(fixture, ['--live', '--retry=3', '--retryDelay=0'], {
+        CLOUDFLARE_FAILURE: failure,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(readFileSync(fixture.attempts, 'utf-8')).toBe('1');
+      expect(readFileSync(fixture.vars)).toEqual(
+        typeof contents === 'string' ? Buffer.from(contents) : contents,
+      );
+      expect(statSync(fixture.vars).mode % 0o1000).toBe(mode);
+      expect(readFileSync(fixture.vars).includes(apiKey)).toBe(false);
+      expectNoCloudflareCredentialArtifacts(fixture);
     });
   });
 
@@ -361,10 +490,8 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
         }
 
         const detached = `${fixture.vars}.original`;
-        expect(readFileSync(detached)).toEqual(state.contents ?? Buffer.alloc(0));
-        if (state.contents !== undefined) {
-          expect(statSync(detached).mode % 0o1000).toBe(state.mode);
-        }
+        expect(readFileSync(detached)).toEqual(Buffer.alloc(0));
+        expect(statSync(detached).mode % 0o1000).toBe(0o600);
         expect(readFileSync(detached).includes(apiKey)).toBe(false);
       });
     },
@@ -387,7 +514,7 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
             'let replaced = false;',
             'promises.open = async (...args) => {',
             '  const file = await originalOpen(...args);',
-            "  if (args[0] === '.dev.vars') {",
+            "  if (args[0] === '.dev.vars' || args[0].startsWith('.dev.vars.openai-staging-')) {",
             '    const originalTruncate = file.truncate.bind(file);',
             '    file.truncate = async (...truncateArgs) => {',
             '      const result = await originalTruncate(...truncateArgs);',
@@ -414,7 +541,7 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
         expect(result.error).toBeUndefined();
         expect(result.status).toBe(1);
         expect(readFileSync(fixture.vars, 'utf-8')).toBe('independent replacement');
-        expect(readFileSync(`${fixture.vars}.race-original`)).toEqual(state.contents ?? Buffer.alloc(0));
+        expect(readFileSync(`${fixture.vars}.race-original`)).toEqual(Buffer.alloc(0));
         expect(readFileSync(fixture.vars)).not.toContain(apiKey);
       });
     },
@@ -512,7 +639,7 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
             'let interrupted = false;',
             'promises.open = async (...args) => {',
             '  const file = await originalOpen(...args);',
-            "  if (args[0] === '.dev.vars') {",
+            "  if (args[0] === '.dev.vars' || args[0].startsWith('.dev.vars.openai-staging-')) {",
             '    const originalChmod = file.chmod.bind(file);',
             '    file.chmod = async (...chmodArgs) => {',
             '      if (!interrupted && chmodArgs[0] === 0o600) {',

--- a/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
+++ b/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
@@ -1,0 +1,459 @@
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const repositoryRoot = process.cwd();
+const apiKey = 'sk-synthetic-cloudflare-lifecycle-private-83d4';
+const stagedContents = Buffer.from(`OPENAI_API_KEY='${apiKey}'`);
+const originalContents = Buffer.from([
+  0x4f, 0x50, 0x45, 0x4e, 0x41, 0x49, 0x3d, 0x6f, 0x6c, 0x64, 0x0a, 0xff, 0x00, 0x80,
+]);
+const otherProjects = [
+  'node-ts-cjs',
+  'node-ts-cjs-web',
+  'node-ts-cjs-auto',
+  'node-ts4.5-jest28',
+  'node-ts-esm',
+  'node-ts-esm-web',
+  'node-ts-esm-auto',
+  'node-js',
+  'ts-browser-webpack',
+  'browser-direct-import',
+  'vercel-edge',
+  'bun',
+  'deno',
+];
+
+interface Fixture {
+  directory: string;
+  worker: string;
+  vars: string;
+  observations: string;
+  attempts: string;
+  bin: string;
+}
+
+interface Observation {
+  command: string;
+  exists: boolean;
+  mode?: number;
+  contents?: string;
+}
+
+interface CredentialState {
+  name: string;
+  contents: Buffer | undefined;
+  mode: number;
+}
+
+const credentialStates: CredentialState[] = [
+  { name: 'without an existing credential file', contents: undefined, mode: 0o600 },
+  { name: 'with an existing binary credential file', contents: originalContents, mode: 0o644 },
+];
+
+function withFixture(run: (fixture: Fixture) => void) {
+  const directory = mkdtempSync(path.join(tmpdir(), 'openai-node-cloudflare-lifecycle-'));
+  const worker = path.join(directory, 'ecosystem-tests', 'cloudflare-worker');
+  const bin = path.join(directory, 'bin');
+  const fixture: Fixture = {
+    directory,
+    worker,
+    vars: path.join(worker, '.dev.vars'),
+    observations: path.join(directory, 'observations.jsonl'),
+    attempts: path.join(directory, 'attempts'),
+    bin,
+  };
+
+  try {
+    mkdirSync(worker, { recursive: true });
+    mkdirSync(bin);
+    writeFileSync(path.join(directory, 'package.json'), '{}\n');
+    writeFileSync(path.join(worker, 'package.json'), '{}\n');
+
+    const fakeNpm = [
+      `#!${process.execPath}`,
+      "const fs = require('node:fs');",
+      "const path = require('node:path');",
+      "const command = process.argv.slice(2).join(' ');",
+      "const vars = path.join(process.cwd(), '.dev.vars');",
+      'const observation = { command, exists: fs.existsSync(vars) };',
+      'if (observation.exists) {',
+      '  const metadata = fs.statSync(vars);',
+      '  observation.mode = metadata.mode & 0o777;',
+      '  if (metadata.isFile()) observation.contents = fs.readFileSync(vars).toString("base64");',
+      '}',
+      'fs.appendFileSync(process.env.CLOUDFLARE_OBSERVATIONS, JSON.stringify(observation) + "\\n", { mode: 0o600 });',
+      "const failure = process.env.CLOUDFLARE_FAILURE || '';",
+      "if (failure === 'install' && command === 'install -D openai') process.exit(21);",
+      "if (failure === 'tsc' && command === 'run tsc') process.exit(22);",
+      "if (command === 'run test:ci') {",
+      '  const attempt = Number(fs.existsSync(process.env.CLOUDFLARE_ATTEMPTS) ? fs.readFileSync(process.env.CLOUDFLARE_ATTEMPTS, "utf8") : 0) + 1;',
+      '  fs.writeFileSync(process.env.CLOUDFLARE_ATTEMPTS, String(attempt), { mode: 0o600 });',
+      "  if (failure === 'live' || (failure === 'live-once' && attempt === 1)) process.exit(23);",
+      "  if (failure === 'unlink') fs.chmodSync(process.cwd(), 0o500);",
+      '}',
+      "if (failure === 'deploy' && command === 'run deploy') process.exit(24);",
+    ].join('\n');
+
+    writeFileSync(path.join(bin, 'npm'), fakeNpm, { mode: 0o755 });
+    run(fixture);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function setExistingCredentials(fixture: Fixture, state: CredentialState) {
+  if (state.contents !== undefined) {
+    writeFileSync(fixture.vars, state.contents);
+    chmodSync(fixture.vars, state.mode);
+  }
+}
+
+function runCloudflare(
+  fixture: Fixture,
+  flags: string[],
+  environment: Partial<NodeJS.ProcessEnv> = {},
+  noCleanup = true,
+  timeout = 10_000,
+) {
+  const result = spawnSync(
+    process.execPath,
+    [
+      path.join(repositoryRoot, 'node_modules/ts-node/dist/bin.js'),
+      '-r',
+      path.join(repositoryRoot, 'node_modules/tsconfig-paths/register.js'),
+      path.join(repositoryRoot, 'ecosystem-tests/cli.ts'),
+      'cloudflare-worker',
+      '--fromNpm=openai',
+      '--skipPack',
+      ...(noCleanup ? ['--noCleanup'] : []),
+      ...flags,
+    ],
+    {
+      cwd: fixture.directory,
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        CI: 'false',
+        PATH: fixture.bin,
+        OPENAI_API_KEY: apiKey,
+        CLOUDFLARE_OBSERVATIONS: fixture.observations,
+        CLOUDFLARE_ATTEMPTS: fixture.attempts,
+        DISABLE_V8_COMPILE_CACHE: '1',
+        TS_NODE_PROJECT: path.join(repositoryRoot, 'tsconfig.json'),
+        TS_NODE_TRANSPILE_ONLY: 'true',
+        ...environment,
+      },
+      timeout,
+    },
+  );
+
+  expect(result.stdout).not.toContain(apiKey);
+  expect(result.stderr).not.toContain(apiKey);
+  return result;
+}
+
+function observations(fixture: Fixture): Observation[] {
+  if (!existsSync(fixture.observations)) {
+    return [];
+  }
+
+  return readFileSync(fixture.observations, 'utf-8')
+    .trim()
+    .split('\n')
+    .map((record) => JSON.parse(record) as Observation);
+}
+
+function expectOriginal(observation: Observation, state: CredentialState) {
+  expect(observation.exists).toBe(state.contents !== undefined);
+  if (state.contents !== undefined) {
+    expect(observation.contents).toBe(state.contents.toString('base64'));
+    expect(observation.mode).toBe(state.mode);
+  }
+}
+
+function expectRestored(fixture: Fixture, state: CredentialState) {
+  if (state.contents === undefined) {
+    expect(existsSync(fixture.vars)).toBe(false);
+    return;
+  }
+
+  expect(readFileSync(fixture.vars)).toEqual(state.contents);
+  expect(statSync(fixture.vars).mode % 0o1000).toBe(state.mode);
+}
+
+function expectScopedObservations(records: Observation[], state: CredentialState) {
+  for (const observation of records) {
+    if (observation.command === 'run test:ci') {
+      expect(observation.exists).toBe(true);
+      expect(observation.mode).toBe(0o600);
+      expect(observation.contents).toBe(stagedContents.toString('base64'));
+    } else {
+      expectOriginal(observation, state);
+    }
+  }
+}
+
+describe('Cloudflare ecosystem credential lifecycle', () => {
+  test.each(credentialStates)('does not stage ambient credentials in non-live mode $name', (state) => {
+    withFixture((fixture) => {
+      setExistingCredentials(fixture, state);
+
+      const result = runCloudflare(fixture, []);
+      const records = observations(fixture);
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(records.map(({ command }) => command)).toEqual(['install -D openai', 'run tsc']);
+      expectScopedObservations(records, state);
+      expectRestored(fixture, state);
+    });
+  });
+
+  test.each(credentialStates)('does not stage ambient credentials in deploy-only mode $name', (state) => {
+    withFixture((fixture) => {
+      setExistingCredentials(fixture, state);
+
+      const result = runCloudflare(fixture, ['--deploy']);
+      const records = observations(fixture);
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(records.map(({ command }) => command)).toEqual(['install -D openai', 'run tsc', 'run deploy']);
+      expectScopedObservations(records, state);
+      expectRestored(fixture, state);
+    });
+  });
+
+  test.each(credentialStates)('limits owner-only credentials to the live command $name', (state) => {
+    withFixture((fixture) => {
+      setExistingCredentials(fixture, state);
+
+      const result = runCloudflare(fixture, ['--live']);
+      const records = observations(fixture);
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(records.map(({ command }) => command)).toEqual(['install -D openai', 'run tsc', 'run test:ci']);
+      expectScopedObservations(records, state);
+      expectRestored(fixture, state);
+    });
+  });
+
+  test.each(credentialStates)('restores credentials after a failing live command $name', (state) => {
+    withFixture((fixture) => {
+      setExistingCredentials(fixture, state);
+
+      const result = runCloudflare(fixture, ['--live'], { CLOUDFLARE_FAILURE: 'live' });
+      const records = observations(fixture);
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(records.map(({ command }) => command)).toEqual(['install -D openai', 'run tsc', 'run test:ci']);
+      expectScopedObservations(records, state);
+      expectRestored(fixture, state);
+    });
+  });
+
+  test('erases staged credentials even when the private file cannot be removed', () => {
+    withFixture((fixture) => {
+      try {
+        const result = runCloudflare(fixture, ['--live'], { CLOUDFLARE_FAILURE: 'unlink' });
+        const records = observations(fixture);
+
+        expect(result.error).toBeUndefined();
+        expect(result.status).toBe(1);
+        expect(records.map(({ command }) => command)).toEqual([
+          'install -D openai',
+          'run tsc',
+          'run test:ci',
+        ]);
+        expect(readFileSync(fixture.vars)).toEqual(Buffer.alloc(0));
+        expect(statSync(fixture.vars).mode % 0o1000).toBe(0o600);
+      } finally {
+        chmodSync(fixture.worker, 0o755);
+      }
+    });
+  });
+
+  test.each(credentialStates)('restores credentials before retrying a failed live command $name', (state) => {
+    withFixture((fixture) => {
+      setExistingCredentials(fixture, state);
+
+      const result = runCloudflare(fixture, ['--live', '--retry=1', '--retryDelay=0'], {
+        CLOUDFLARE_FAILURE: 'live-once',
+      });
+      const records = observations(fixture);
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(records.map(({ command }) => command)).toEqual([
+        'install -D openai',
+        'run tsc',
+        'run test:ci',
+        'install -D openai',
+        'run tsc',
+        'run test:ci',
+      ]);
+      expectScopedObservations(records, state);
+      expectRestored(fixture, state);
+    });
+  });
+
+  test.each(credentialStates)('restores credentials before a requested deployment $name', (state) => {
+    withFixture((fixture) => {
+      setExistingCredentials(fixture, state);
+
+      const result = runCloudflare(fixture, ['--live', '--deploy']);
+      const records = observations(fixture);
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(records.map(({ command }) => command)).toEqual([
+        'install -D openai',
+        'run tsc',
+        'run test:ci',
+        'run deploy',
+      ]);
+      expectScopedObservations(records, state);
+      expectRestored(fixture, state);
+    });
+  });
+
+  test.each(credentialStates)('never stages credentials when TypeScript checking fails $name', (state) => {
+    withFixture((fixture) => {
+      setExistingCredentials(fixture, state);
+
+      const result = runCloudflare(fixture, ['--live'], { CLOUDFLARE_FAILURE: 'tsc' });
+      const records = observations(fixture);
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(records.map(({ command }) => command)).toEqual(['install -D openai', 'run tsc']);
+      expectScopedObservations(records, state);
+      expectRestored(fixture, state);
+    });
+  });
+
+  test('removes newly staged credentials when ordinary global cleanup is enabled', () => {
+    withFixture((fixture) => {
+      const flags = ['--live', ...otherProjects.map((project) => `--skip=${project}`)];
+      const result = runCloudflare(fixture, flags, {}, false);
+      const records = observations(fixture);
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      expect(records.map(({ command }) => command)).toEqual(['install -D openai', 'run tsc', 'run test:ci']);
+      expectScopedObservations(records, credentialStates[0] as CredentialState);
+      expect(existsSync(fixture.vars)).toBe(false);
+    });
+  });
+
+  test.each(['--live', '--deploy'])('preserves keyless %s rejection before any commands', (option) => {
+    withFixture((fixture) => {
+      const result = runCloudflare(fixture, [option], { OPENAI_API_KEY: undefined });
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(observations(fixture)).toEqual([]);
+      expect(existsSync(fixture.vars)).toBe(false);
+    });
+  });
+
+  test('rejects symlinked credential files without changing their targets', () => {
+    withFixture((fixture) => {
+      const target = path.join(fixture.directory, 'private-target');
+      writeFileSync(target, originalContents, { mode: 0o640 });
+      symlinkSync(target, fixture.vars);
+
+      const result = runCloudflare(fixture, ['--live']);
+      const records = observations(fixture);
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(records.map(({ command }) => command)).toEqual(['install -D openai', 'run tsc']);
+      expect(readFileSync(target)).toEqual(originalContents);
+      expect(lstatSync(fixture.vars).isSymbolicLink()).toBe(true);
+    });
+  });
+
+  test('rejects dangling credential symlinks without creating their targets', () => {
+    withFixture((fixture) => {
+      const target = path.join(fixture.directory, 'missing-target');
+      symlinkSync(target, fixture.vars);
+
+      const result = runCloudflare(fixture, ['--live']);
+      const records = observations(fixture);
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(records.map(({ command }) => command)).toEqual(['install -D openai', 'run tsc']);
+      expect(existsSync(target)).toBe(false);
+      expect(lstatSync(fixture.vars).isSymbolicLink()).toBe(true);
+    });
+  });
+
+  test('rejects named pipes without blocking', () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    withFixture((fixture) => {
+      const created = spawnSync('mkfifo', [fixture.vars], { encoding: 'utf-8' });
+      expect(created.error).toBeUndefined();
+      expect(created.status).toBe(0);
+
+      const result = runCloudflare(fixture, ['--live']);
+      const records = observations(fixture);
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(records.map(({ command }) => command)).toEqual(['install -D openai', 'run tsc']);
+      expect(statSync(fixture.vars).isFIFO()).toBe(true);
+    });
+  });
+
+  test('rejects hard-linked credential files without exposing their shared targets', () => {
+    withFixture((fixture) => {
+      const target = path.join(fixture.directory, 'private-hardlink-target');
+      writeFileSync(target, originalContents, { mode: 0o640 });
+      linkSync(target, fixture.vars);
+
+      const result = runCloudflare(fixture, ['--live']);
+      const records = observations(fixture);
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(records.map(({ command }) => command)).toEqual(['install -D openai', 'run tsc']);
+      expect(readFileSync(target)).toEqual(originalContents);
+      expect(readFileSync(fixture.vars)).toEqual(originalContents);
+    });
+  });
+
+  test('rejects non-regular credential targets after non-secret preparation', () => {
+    withFixture((fixture) => {
+      mkdirSync(fixture.vars);
+
+      const result = runCloudflare(fixture, ['--live']);
+      const records = observations(fixture);
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(records.map(({ command }) => command)).toEqual(['install -D openai', 'run tsc']);
+      expect(statSync(fixture.vars).isDirectory()).toBe(true);
+    });
+  });
+});

--- a/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
+++ b/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
@@ -128,8 +128,9 @@ function withFixture(run: (fixture: Fixture) => void) {
       "  if (failure === 'append-staged') fs.appendFileSync(vars, '\\nconcurrent appended edit\\n');",
       "  if (failure === 'append-staged-duplicate') fs.appendFileSync(vars, '\\nconcurrent appended edit\\n' + process.env.OPENAI_API_KEY + '\\n');",
       "  if (failure === 'chmod-staged') fs.chmodSync(vars, 0o640);",
-      "  if (failure === 'signal-int' || failure === 'signal-term') {",
-      "    process.kill(process.ppid, failure === 'signal-int' ? 'SIGINT' : 'SIGTERM');",
+      "  if (failure === 'signal-int' || failure === 'signal-term' || failure === 'signal-hup') {",
+      "    const signal = failure === 'signal-int' ? 'SIGINT' : failure === 'signal-term' ? 'SIGTERM' : 'SIGHUP';",
+      '    process.kill(process.ppid, signal);',
       '    setTimeout(() => process.exit(0), 250);',
       '    return;',
       '  }',
@@ -435,6 +436,78 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
     });
   });
 
+  test.each(credentialStates.flatMap((state) => [true, false].map((noCleanup) => ({ state, noCleanup }))))(
+    'restores original credentials before SIGHUP with noCleanup=$noCleanup',
+    ({ state, noCleanup }) => {
+      withFixture((fixture) => {
+        setExistingCredentials(fixture, state);
+        const flags = ['--live', ...(noCleanup ? [] : otherProjects.map((project) => `--skip=${project}`))];
+
+        const result = runCloudflare(fixture, flags, { CLOUDFLARE_FAILURE: 'signal-hup' }, noCleanup);
+
+        expect(result.error).toBeUndefined();
+        expect(result.signal).toBe('SIGHUP');
+        expectRestored(fixture, state);
+      });
+    },
+  );
+
+  test.each(['dev', 'ino'] as const)(
+    'rejects replacements with rounded colliding high-bit $field identifiers',
+    (field) => {
+      withFixture((fixture) => {
+        const preload = path.join(fixture.directory, 'colliding-bigint-identities.cjs');
+        writeFileSync(
+          preload,
+          [
+            "const fs = require('node:fs');",
+            "const promises = require('node:fs/promises');",
+            'const originalLstatSync = fs.lstatSync;',
+            'const originalLstat = promises.lstat;',
+            'const originalOpen = promises.open;',
+            'function applyIdentity(metadata, options, replacement) {',
+            '  const value = 9007199254740992n + BigInt(replacement);',
+            '  const selected = process.env.CLOUDFLARE_IDENTITY_FIELD;',
+            "  metadata.dev = selected === 'dev' ? (options?.bigint ? value : Number(value)) : options?.bigint ? 1n : 1;",
+            "  metadata.ino = selected === 'ino' ? (options?.bigint ? value : Number(value)) : options?.bigint ? 1n : 1;",
+            '  return metadata;',
+            '}',
+            'function isReplacement(candidate) {',
+            "  return candidate === '.dev.vars' &&",
+            "    fs.readFileSync(candidate, 'utf8') === 'independently replaced credentials\\n';",
+            '}',
+            'fs.lstatSync = (candidate, options) =>',
+            '  applyIdentity(originalLstatSync(candidate, options), options, isReplacement(candidate));',
+            'promises.lstat = async (candidate, options) =>',
+            '  applyIdentity(await originalLstat(candidate, options), options, isReplacement(candidate));',
+            'promises.open = async (...args) => {',
+            '  const file = await originalOpen(...args);',
+            "  if (args[0] === '.dev.vars') {",
+            '    const originalStat = file.stat.bind(file);',
+            '    file.stat = async (options) =>',
+            '      applyIdentity(await originalStat(options), options, false);',
+            '  }',
+            '  return file;',
+            '};',
+          ].join('\n'),
+        );
+
+        const result = runCloudflare(fixture, ['--live', '--retry=3', '--retryDelay=0'], {
+          CLOUDFLARE_FAILURE: 'replace-file',
+          CLOUDFLARE_IDENTITY_FIELD: field,
+          NODE_OPTIONS: `--require ${preload}`,
+        });
+
+        expect(result.error).toBeUndefined();
+        expect(result.status).toBe(1);
+        expect(readFileSync(fixture.attempts, 'utf-8')).toBe('1');
+        expect(readFileSync(fixture.vars, 'utf-8')).toBe('independently replaced credentials\n');
+        expect(readFileSync(`${fixture.vars}.original`)).toEqual(Buffer.alloc(0));
+        expectNoCloudflareCredentialArtifacts(fixture);
+      });
+    },
+  );
+
   test.each(
     credentialStates.flatMap((state) =>
       (['SIGINT', 'SIGTERM'] as const).flatMap((signal) =>
@@ -719,7 +792,7 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
           '      if (!grown) {',
           '        grown = true;',
           '        const contents = Buffer.alloc(64 * 1024 + 1, 0x67);',
-          '        await file.write(contents, 0, contents.length, metadata.size);',
+          '        await file.write(contents, 0, contents.length, Number(metadata.size));',
           '      }',
           '      return metadata;',
           '    };',

--- a/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
+++ b/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
@@ -10,6 +10,7 @@ import {
   rmSync,
   statSync,
   symlinkSync,
+  truncateSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -102,6 +103,19 @@ function withFixture(run: (fixture: Fixture) => void) {
       "if (command === 'run test:ci') {",
       '  const attempt = Number(fs.existsSync(process.env.CLOUDFLARE_ATTEMPTS) ? fs.readFileSync(process.env.CLOUDFLARE_ATTEMPTS, "utf8") : 0) + 1;',
       '  fs.writeFileSync(process.env.CLOUDFLARE_ATTEMPTS, String(attempt), { mode: 0o600 });',
+      "  if (failure === 'replace-file' || failure === 'replace-symlink') {",
+      "    fs.renameSync(vars, vars + '.original');",
+      "    if (failure === 'replace-file') {",
+      '      fs.writeFileSync(vars, "independently replaced credentials\\n", { mode: 0o640 });',
+      '    } else {',
+      '      fs.symlinkSync(process.env.CLOUDFLARE_REPLACEMENT_TARGET, vars);',
+      '    }',
+      '  }',
+      "  if (failure === 'signal-int' || failure === 'signal-term') {",
+      "    process.kill(process.ppid, failure === 'signal-int' ? 'SIGINT' : 'SIGTERM');",
+      '    setTimeout(() => process.exit(0), 250);',
+      '    return;',
+      '  }',
       "  if (failure === 'live' || (failure === 'live-once' && attempt === 1)) process.exit(23);",
       "  if (failure === 'unlink') fs.chmodSync(process.cwd(), 0o500);",
       '}',
@@ -286,6 +300,131 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
       } finally {
         chmodSync(fixture.worker, 0o755);
       }
+    });
+  });
+
+  test.each(
+    credentialStates.flatMap((state) =>
+      (['SIGINT', 'SIGTERM'] as const).flatMap((signal) =>
+        [true, false].map((noCleanup) => ({ state, signal, noCleanup })),
+      ),
+    ),
+  )('restores staged credentials after $signal with noCleanup=$noCleanup', ({ state, signal, noCleanup }) => {
+    withFixture((fixture) => {
+      setExistingCredentials(fixture, state);
+      const flags = ['--live', ...(noCleanup ? [] : otherProjects.map((project) => `--skip=${project}`))];
+
+      const result = runCloudflare(
+        fixture,
+        flags,
+        { CLOUDFLARE_FAILURE: signal === 'SIGINT' ? 'signal-int' : 'signal-term' },
+        noCleanup,
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status === 0 && result.signal === null).toBe(false);
+      expectRestored(fixture, state);
+      if (noCleanup) {
+        expect(result.signal).toBe(signal);
+      }
+    });
+  });
+
+  test.each(
+    credentialStates.flatMap((state) =>
+      (['replace-file', 'replace-symlink'] as const).map((replacement) => ({ state, replacement })),
+    ),
+  )(
+    'preserves an independent $replacement without exposing the original staged inode',
+    ({ state, replacement }) => {
+      withFixture((fixture) => {
+        setExistingCredentials(fixture, state);
+        const target = path.join(fixture.directory, 'independent-replacement-target');
+        const replacementContents = 'independent symlink target\\n';
+        writeFileSync(target, replacementContents, { mode: 0o640 });
+
+        const result = runCloudflare(fixture, ['--live'], {
+          CLOUDFLARE_FAILURE: replacement,
+          CLOUDFLARE_REPLACEMENT_TARGET: target,
+        });
+
+        expect(result.error).toBeUndefined();
+        expect(result.status).toBe(1);
+        if (replacement === 'replace-symlink') {
+          expect(lstatSync(fixture.vars).isSymbolicLink()).toBe(true);
+          expect(readFileSync(target, 'utf-8')).toBe(replacementContents);
+        } else {
+          expect(readFileSync(fixture.vars, 'utf-8')).toBe('independently replaced credentials\n');
+        }
+
+        const detached = `${fixture.vars}.original`;
+        expect(readFileSync(detached)).toEqual(state.contents ?? Buffer.alloc(0));
+        if (state.contents !== undefined) {
+          expect(statSync(detached).mode % 0o1000).toBe(state.mode);
+        }
+        expect(readFileSync(detached).includes(apiKey)).toBe(false);
+      });
+    },
+  );
+
+  test.each([
+    { name: 'oversized', sparse: false },
+    { name: 'sparse', sparse: true },
+  ])('rejects an existing $name credential snapshot before staging a key', ({ sparse }) => {
+    withFixture((fixture) => {
+      writeFileSync(fixture.vars, sparse ? Buffer.alloc(0) : Buffer.alloc(64 * 1024 + 1, 0x61), {
+        mode: 0o640,
+      });
+      if (sparse) {
+        truncateSync(fixture.vars, 64 * 1024 + 1);
+      }
+
+      const result = runCloudflare(fixture, ['--live']);
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('64 KiB');
+      expect(statSync(fixture.vars).size).toBe(64 * 1024 + 1);
+      expect(observations(fixture).map(({ command }) => command)).toEqual(['install -D openai', 'run tsc']);
+    });
+  });
+
+  test('bounds snapshots if an existing credential file grows after its descriptor stat', () => {
+    withFixture((fixture) => {
+      writeFileSync(fixture.vars, originalContents, { mode: 0o640 });
+      const preload = path.join(fixture.directory, 'grow-after-stat.cjs');
+      writeFileSync(
+        preload,
+        [
+          "const fs = require('node:fs/promises');",
+          'const originalOpen = fs.open;',
+          'let grown = false;',
+          'fs.open = async (...args) => {',
+          '  const file = await originalOpen(...args);',
+          "  if (args[0] === '.dev.vars' && !grown) {",
+          '    const originalStat = file.stat.bind(file);',
+          '    file.stat = async (...statArgs) => {',
+          '      const metadata = await originalStat(...statArgs);',
+          '      if (!grown) {',
+          '        grown = true;',
+          '        const contents = Buffer.alloc(64 * 1024 + 1, 0x67);',
+          '        await file.write(contents, 0, contents.length, metadata.size);',
+          '      }',
+          '      return metadata;',
+          '    };',
+          '  }',
+          '  return file;',
+          '};',
+        ].join('\n'),
+      );
+
+      const result = runCloudflare(fixture, ['--live'], { NODE_OPTIONS: `--require ${preload}` });
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('64 KiB');
+      expect(statSync(fixture.vars).size).toBe(originalContents.length + 64 * 1024 + 1);
+      expect(observations(fixture).map(({ command }) => command)).toEqual(['install -D openai', 'run tsc']);
     });
   });
 

--- a/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
+++ b/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
@@ -103,6 +103,9 @@ function withFixture(run: (fixture: Fixture) => void) {
       "if (command === 'run test:ci') {",
       '  const attempt = Number(fs.existsSync(process.env.CLOUDFLARE_ATTEMPTS) ? fs.readFileSync(process.env.CLOUDFLARE_ATTEMPTS, "utf8") : 0) + 1;',
       '  fs.writeFileSync(process.env.CLOUDFLARE_ATTEMPTS, String(attempt), { mode: 0o600 });',
+      "  if (failure === 'replace-during-truncate') {",
+      "    fs.writeFileSync(process.env.CLOUDFLARE_REPLACE_READY, 'ready');",
+      '  }',
       "  if (failure === 'replace-file' || failure === 'replace-symlink') {",
       "    fs.renameSync(vars, vars + '.original');",
       "    if (failure === 'replace-file') {",
@@ -363,6 +366,114 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
           expect(statSync(detached).mode % 0o1000).toBe(state.mode);
         }
         expect(readFileSync(detached).includes(apiKey)).toBe(false);
+      });
+    },
+  );
+
+  test.each(credentialStates)(
+    'preserves a replacement installed while the original credential inode is being truncated $name',
+    (state) => {
+      withFixture((fixture) => {
+        setExistingCredentials(fixture, state);
+        const marker = path.join(fixture.directory, 'replacement-ready');
+        const preload = path.join(fixture.directory, 'replace-during-truncate.cjs');
+        writeFileSync(
+          preload,
+          [
+            "const fs = require('node:fs');",
+            "const promises = require('node:fs/promises');",
+            "const path = require('node:path');",
+            'const originalOpen = promises.open;',
+            'let replaced = false;',
+            'promises.open = async (...args) => {',
+            '  const file = await originalOpen(...args);',
+            "  if (args[0] === '.dev.vars') {",
+            '    const originalTruncate = file.truncate.bind(file);',
+            '    file.truncate = async (...truncateArgs) => {',
+            '      const result = await originalTruncate(...truncateArgs);',
+            '      if (!replaced && fs.existsSync(process.env.CLOUDFLARE_REPLACE_READY)) {',
+            '        replaced = true;',
+            "        const vars = path.join(process.cwd(), '.dev.vars');",
+            "        fs.renameSync(vars, vars + '.race-original');",
+            '        fs.writeFileSync(vars, "independent replacement", { mode: 0o640 });',
+            '      }',
+            '      return result;',
+            '    };',
+            '  }',
+            '  return file;',
+            '};',
+          ].join('\n'),
+        );
+
+        const result = runCloudflare(fixture, ['--live'], {
+          CLOUDFLARE_FAILURE: 'replace-during-truncate',
+          CLOUDFLARE_REPLACE_READY: marker,
+          NODE_OPTIONS: `--require ${preload}`,
+        });
+
+        expect(result.error).toBeUndefined();
+        expect(result.status).toBe(1);
+        expect(readFileSync(fixture.vars, 'utf-8')).toBe('independent replacement');
+        expect(readFileSync(`${fixture.vars}.race-original`)).toEqual(state.contents ?? Buffer.alloc(0));
+        expect(readFileSync(fixture.vars)).not.toContain(apiKey);
+      });
+    },
+  );
+
+  test.each(
+    (['SIGINT', 'SIGTERM'] as const).flatMap((signal) =>
+      [true, false].map((noCleanup) => ({ signal, noCleanup })),
+    ),
+  )(
+    'serializes $signal cleanup with in-flight staging when noCleanup=$noCleanup',
+    ({ signal, noCleanup }) => {
+      withFixture((fixture) => {
+        const state = credentialStates[1] as CredentialState;
+        setExistingCredentials(fixture, state);
+        const preload = path.join(fixture.directory, 'interrupt-during-staging.cjs');
+        writeFileSync(
+          preload,
+          [
+            "const promises = require('node:fs/promises');",
+            'const originalOpen = promises.open;',
+            'let interrupted = false;',
+            'promises.open = async (...args) => {',
+            '  const file = await originalOpen(...args);',
+            "  if (args[0] === '.dev.vars') {",
+            '    const originalChmod = file.chmod.bind(file);',
+            '    file.chmod = async (...chmodArgs) => {',
+            '      if (!interrupted && chmodArgs[0] === 0o600) {',
+            '        interrupted = true;',
+            '        process.kill(process.pid, process.env.CLOUDFLARE_STAGING_SIGNAL);',
+            '        await new Promise((resolve) => setTimeout(resolve, 25));',
+            '      }',
+            '      return originalChmod(...chmodArgs);',
+            '    };',
+            '    const originalClose = file.close.bind(file);',
+            '    file.close = async (...closeArgs) => {',
+            '      await new Promise((resolve) => setTimeout(resolve, 100));',
+            '      return originalClose(...closeArgs);',
+            '    };',
+            '  }',
+            '  return file;',
+            '};',
+          ].join('\n'),
+        );
+        const flags = ['--live', ...(noCleanup ? [] : otherProjects.map((project) => `--skip=${project}`))];
+
+        const result = runCloudflare(
+          fixture,
+          flags,
+          { CLOUDFLARE_STAGING_SIGNAL: signal, NODE_OPTIONS: `--require ${preload}` },
+          noCleanup,
+        );
+
+        expect(result.error).toBeUndefined();
+        expect(result.status === 0 && result.signal === null).toBe(false);
+        expectRestored(fixture, state);
+        if (noCleanup) {
+          expect(result.signal).toBe(signal);
+        }
       });
     },
   );

--- a/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
+++ b/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
@@ -128,6 +128,8 @@ function withFixture(run: (fixture: Fixture) => void) {
       "  if (failure === 'append-staged') fs.appendFileSync(vars, '\\nconcurrent appended edit\\n');",
       "  if (failure === 'append-staged-duplicate') fs.appendFileSync(vars, '\\nconcurrent appended edit\\n' + process.env.OPENAI_API_KEY + '\\n');",
       "  if (failure === 'chmod-staged') fs.chmodSync(vars, 0o640);",
+      "  if (failure === 'oversize-staged') fs.writeFileSync(vars, Buffer.alloc(64 * 1024 + 1, 0x6f));",
+      "  if (failure === 'deny-path-validation') fs.writeFileSync(process.env.CLOUDFLARE_DENIAL_READY, 'ready');",
       "  if (failure === 'signal-int' || failure === 'signal-term' || failure === 'signal-hup') {",
       "    const signal = failure === 'signal-int' ? 'SIGINT' : failure === 'signal-term' ? 'SIGTERM' : 'SIGHUP';",
       '    process.kill(process.ppid, signal);',
@@ -397,6 +399,64 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
       expect(statSync(fixture.vars).mode % 0o1000).toBe(mode);
       expect(readFileSync(fixture.vars).includes(apiKey)).toBe(false);
       expectNoCloudflareCredentialArtifacts(fixture);
+    });
+  });
+
+  test.each(credentialStates)(
+    'scrubs staged credentials and restores $name when pathname validation throws EACCES',
+    (state) => {
+      withFixture((fixture) => {
+        setExistingCredentials(fixture, state);
+        const marker = path.join(fixture.directory, 'path-validation-ready');
+        const preload = path.join(fixture.directory, 'deny-path-validation.cjs');
+        writeFileSync(
+          preload,
+          [
+            "const fs = require('node:fs');",
+            'const originalLstatSync = fs.lstatSync;',
+            'let denied = false;',
+            'fs.lstatSync = (candidate, options) => {',
+            "  if (!denied && candidate === '.dev.vars' && fs.existsSync(process.env.CLOUDFLARE_DENIAL_READY)) {",
+            '    denied = true;',
+            '    const directory = process.cwd();',
+            '    fs.chmodSync(directory, 0o600);',
+            '    try {',
+            '      return originalLstatSync(candidate, options);',
+            '    } finally {',
+            '      fs.chmodSync(directory, 0o755);',
+            '    }',
+            '  }',
+            '  return originalLstatSync(candidate, options);',
+            '};',
+          ].join('\n'),
+        );
+
+        const result = runCloudflare(fixture, ['--live', '--retry=3', '--retryDelay=0'], {
+          CLOUDFLARE_FAILURE: 'deny-path-validation',
+          CLOUDFLARE_DENIAL_READY: marker,
+          NODE_OPTIONS: `--require ${preload}`,
+        });
+
+        expect(result.error).toBeUndefined();
+        expect(result.status).toBe(1);
+        expect(readFileSync(fixture.attempts, 'utf-8')).toBe('1');
+        expectRestored(fixture, state);
+      });
+    },
+  );
+
+  test.each(credentialStates)('restores $name after an oversized staged edit', (state) => {
+    withFixture((fixture) => {
+      setExistingCredentials(fixture, state);
+
+      const result = runCloudflare(fixture, ['--live', '--retry=3', '--retryDelay=0'], {
+        CLOUDFLARE_FAILURE: 'oversize-staged',
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(readFileSync(fixture.attempts, 'utf-8')).toBe('1');
+      expectRestored(fixture, state);
     });
   });
 

--- a/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
+++ b/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
@@ -99,11 +99,29 @@ function withFixture(run: (fixture: Fixture) => void) {
       '}',
       'fs.appendFileSync(process.env.CLOUDFLARE_OBSERVATIONS, JSON.stringify(observation) + "\\n", { mode: 0o600 });',
       "const failure = process.env.CLOUDFLARE_FAILURE || '';",
+      "if (failure === 'interrupt-before-lease' && command === process.env.CLOUDFLARE_INTERRUPT_COMMAND) {",
+      '  process.kill(process.ppid, process.env.CLOUDFLARE_INTERRUPT_SIGNAL);',
+      '  setTimeout(() => process.exit(0), 20);',
+      '  return;',
+      '}',
       "if (failure === 'install' && command === 'install -D openai') process.exit(21);",
       "if (failure === 'tsc' && command === 'run tsc') process.exit(22);",
       "if (command === 'run test:ci') {",
       '  const attempt = Number(fs.existsSync(process.env.CLOUDFLARE_ATTEMPTS) ? fs.readFileSync(process.env.CLOUDFLARE_ATTEMPTS, "utf8") : 0) + 1;',
       '  fs.writeFileSync(process.env.CLOUDFLARE_ATTEMPTS, String(attempt), { mode: 0o600 });',
+      "  if (failure === 'interrupt-retry-delay' && attempt === 1) {",
+      "    const notifier = require('node:child_process').spawn(",
+      '      process.execPath,',
+      "      ['-e', 'setTimeout(() => process.kill(Number(process.argv[1]), process.argv[2]), 40)', String(process.ppid), process.env.CLOUDFLARE_INTERRUPT_SIGNAL],",
+      "      { detached: true, stdio: 'ignore', env: { ...process.env, NODE_OPTIONS: '' } },",
+      '    );',
+      '    notifier.unref();',
+      '    process.exit(23);',
+      '  }',
+      "  if (failure === 'interrupt-before-lease' || failure === 'interrupt-retry-delay') {",
+      '    setTimeout(() => process.exit(0), 1000);',
+      '    return;',
+      '  }',
       "  if (failure === 'replace-during-truncate') {",
       "    fs.writeFileSync(process.env.CLOUDFLARE_REPLACE_READY, 'ready');",
       '  }',
@@ -493,6 +511,79 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
       } finally {
         chmodSync(fixture.worker, 0o755);
       }
+    });
+  });
+
+  test.each(
+    [
+      {
+        phase: 'install',
+        command: 'install -D openai',
+        signal: 'SIGINT' as const,
+        failure: 'interrupt-before-lease',
+        liveAttempts: 0,
+      },
+      {
+        phase: 'tsc',
+        command: 'run tsc',
+        signal: 'SIGTERM' as const,
+        failure: 'interrupt-before-lease',
+        liveAttempts: 0,
+      },
+      {
+        phase: 'retry delay',
+        command: '',
+        signal: 'SIGHUP' as const,
+        failure: 'interrupt-retry-delay',
+        liveAttempts: 1,
+      },
+    ].flatMap((interruption) =>
+      credentialStates.map((state) => ({ ...interruption, state, name: state.name })),
+    ),
+  )('does not stage credentials after $signal interrupts $phase $name', (interruption) => {
+    withFixture((fixture) => {
+      setExistingCredentials(fixture, interruption.state);
+      const preload = path.join(fixture.directory, 'delay-interrupted-global-cleanup.cjs');
+      writeFileSync(
+        preload,
+        [
+          "const promises = require('node:fs/promises');",
+          'const originalRename = promises.rename;',
+          'promises.rename = async (...args) => {',
+          "  if (args[0].endsWith('/tmp/cloudflare-worker/package.json')) {",
+          '    await new Promise((resolve) => setTimeout(resolve, 450));',
+          '  }',
+          '  return originalRename(...args);',
+          '};',
+        ].join('\n'),
+      );
+
+      const flags = [
+        '--live',
+        ...otherProjects.map((project) => `--skip=${project}`),
+        ...(interruption.phase === 'retry delay' ? ['--retry=1', '--retryDelay=100'] : []),
+      ];
+      const result = runCloudflare(
+        fixture,
+        flags,
+        {
+          CLOUDFLARE_FAILURE: interruption.failure,
+          CLOUDFLARE_INTERRUPT_COMMAND: interruption.command,
+          CLOUDFLARE_INTERRUPT_SIGNAL: interruption.signal,
+          NODE_OPTIONS: `--require ${preload}`,
+        },
+        false,
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status === 0 && result.signal === null).toBe(false);
+      if (interruption.signal === 'SIGHUP') {
+        expect(result.signal).toBe('SIGHUP');
+      }
+      expect(observations(fixture).filter(({ command }) => command === 'run test:ci')).toHaveLength(
+        interruption.liveAttempts,
+      );
+      expectRestored(fixture, interruption.state);
     });
   });
 


### PR DESCRIPTION
## Summary

- Stage the Cloudflare Worker API key only while the explicitly requested live ecosystem command needs it; ambient credentials no longer create files during dry runs, TypeScript checks, package installation, or deployments.
- Open `.dev.vars` safely with owner-only permissions, no-follow/nonblocking/exclusive file-descriptor operations, and reject symlinks, dangling links, FIFOs, directories, and hardlinked targets.
- Restore existing binary contents and exact permissions or erase/remove newly created credentials after success, command failure, retries, normal cleanup, `--noCleanup`, and failed unlink attempts.
- Update the existing merged baseline that previously required leaking ambient credentials during non-live runs.

## Security impact

The public ecosystem CLI previously copied any ambient `OPENAI_API_KEY` into a persistent plaintext `.dev.vars` file before TypeScript checks even when `--live` was not requested. Default permissions exposed newly created secrets as `0644`, existing configuration was overwritten, symlink and hardlink targets were modified, and the cleanup cache never tracked this credential artifact.

## Validation

- Regression-first: 19 real CLI integration failures on unmodified main (18 security cases plus the previous contradictory baseline).
- Additional red-first unlink-failure regression verified that a failed removal cannot leave plaintext behind.
- 23 dedicated real CLI integration cases exercise mode/lifecycle/byte restoration/failure/retry/`--noCleanup`/deploy ordering/symlink/hardlink/FIFO/directory cases.
- Full handwritten suite: 108 files, 3,316 tests passed.
- Full generated API suite: 559 tests passed (one existing skipped).
- Formatting/lint: zero warnings/errors.
- Repository TypeScript compilation.
- Clean CJS/ESM package build.
- Published declaration checks on TypeScript 4.9 and current TypeScript.
- Packed npm artifact and source-map verification: 267/304 source checks across 1,216 source maps.

Only three handwritten ecosystem runner/test files are changed; active SDK/user-owned PR files remain untouched.