### PR TITLE
fix(security): require OIDC for npm publishing

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -182,8 +182,8 @@ format-on-save and lint-autofix editor settings.
 
 ## Publishing and releases
 
-Changes made to this repository via the automated release PR pipeline should publish to npm automatically. If
-the changes aren't made through the automated pipeline, you may want to make releases manually.
+Changes made to this repository via the automated release PR pipeline publish to npm automatically. Publishing
+requires GitHub Actions OIDC trusted publishing; local token-based publishing is not supported.
 
 ### Override an automated release version
 
@@ -206,8 +206,3 @@ Release Please will then regenerate the release PR files and title with that ver
 The [`Create releases` GitHub Actions workflow](https://github.com/openai/openai-node/actions/workflows/create-releases.yml)
 publishes releases after changes land on `main`. If publication fails, rerun the failed workflow to retain the
 protected `publish` environment, immutable release checkout, and npm OIDC trusted publishing.
-
-### Publish manually
-
-If you need to manually release a package, you can run the `bin/publish-npm` script with an `NPM_TOKEN` set on
-the environment.

--- a/bin/publish-npm
+++ b/bin/publish-npm
@@ -12,10 +12,9 @@ elif [[ $VERSION_STATUS -ne 1 ]]; then
   exit "$VERSION_STATUS"
 fi
 
-if [[ ${NPM_TOKEN:-} ]]; then
-  npm config set '//registry.npmjs.org/:_authToken' "$NPM_TOKEN"
-elif [[ ! ${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-} ]]; then
-  echo "ERROR: NPM_TOKEN must be set if not running in a Github Action with id-token permission"
+if [[ ${GITHUB_ACTIONS:-} != true || -z ${ACTIONS_ID_TOKEN_REQUEST_URL:-} ||
+  -z ${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-} ]]; then
+  echo "ERROR: npm publishing requires GitHub Actions OIDC with id-token: write" >&2
   exit 1
 fi
 


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Require GitHub Actions and both OIDC request credentials before `bin/publish-npm` can publish.
- Remove the legacy `NPM_TOKEN` authentication fallback and its persistent npm-configuration write.
- Remove unsupported local token-publishing instructions while retaining protected `Create releases` retry guidance.
- Preserve `.github/workflows/create-releases.yml`, protected release environments, npm version pinning, registry selection, and stable/prerelease tags unchanged.

## Validation

- `bash -n bin/publish-npm`
- `git diff --check origin/main...HEAD`
- Exact pinned Oxfmt 0.62.0 check for `.github/CONTRIBUTING.md`.
- Ten focused mocked publishing scenarios: already-published no-op; propagated preflight failure; missing GitHub Actions, OIDC URL, or OIDC token; rejected token-only publishing; successful stable and prerelease OIDC publishing; and ignored legacy tokens.
- Independent validation covered 13 scenarios, including beta/first-prerelease tags and npm install/publish failure propagation.
- Parsed the unchanged production workflow and verified protected `publish` environment, `contents: read`, `id-token: write`, immutable action pins, and the existing publisher invocation.

## Integration note

An existing publisher-hardening change still retains and tests the removed fallback; reconcile it separately while preserving its independent OIDC credential-isolation improvements.