### PR TITLE
fix(security): redact malformed Realtime WebSocket error causes

### DIFF
--- a/src/beta/realtime/internal-base.ts
+++ b/src/beta/realtime/internal-base.ts
@@ -8,6 +8,19 @@ import { OpenAIError } from '../../error';
 import type OpenAI from '../../index';
 import { AzureOpenAI } from '../../index';
 
+/** Parses frame data without exposing malformed payloads through JSON syntax errors. */
+export function parseRealtimeEvent(data: string): RealtimeServerEvent {
+  try {
+    return JSON.parse(data) as RealtimeServerEvent;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new SyntaxError('Could not parse Realtime WebSocket event data as JSON.');
+    }
+
+    throw error;
+  }
+}
+
 function safeErrorValue(value: unknown): string {
   try {
     return String(value);
@@ -105,10 +118,6 @@ export abstract class OpenAIRealtimeEmitter extends EventEmitter<RealtimeEvents>
   protected _onError(event: null, message: string, cause: any): void;
   protected _onError(event: ErrorEvent, message?: string | undefined): void;
   protected _onError(event: ErrorEvent | null, message?: string | undefined, cause?: any): void {
-    if (event === null && message === 'could not parse websocket event' && cause instanceof SyntaxError) {
-      cause = new SyntaxError('Could not parse Realtime WebSocket event data as JSON.');
-    }
-
     message = event?.error
       ? `${safeErrorValue(event.error.message)} code=${safeErrorValue(event.error.code)} param=${safeErrorValue(event.error.param)} type=${safeErrorValue(event.error.type)} event_id=${safeErrorValue(event.error.event_id)}`
       : (message ?? 'unknown error');

--- a/src/beta/realtime/internal-base.ts
+++ b/src/beta/realtime/internal-base.ts
@@ -105,6 +105,10 @@ export abstract class OpenAIRealtimeEmitter extends EventEmitter<RealtimeEvents>
   protected _onError(event: null, message: string, cause: any): void;
   protected _onError(event: ErrorEvent, message?: string | undefined): void;
   protected _onError(event: ErrorEvent | null, message?: string | undefined, cause?: any): void {
+    if (event === null && message === 'could not parse websocket event' && cause instanceof SyntaxError) {
+      cause = new SyntaxError('Could not parse Realtime WebSocket event data as JSON.');
+    }
+
     message = event?.error
       ? `${safeErrorValue(event.error.message)} code=${safeErrorValue(event.error.code)} param=${safeErrorValue(event.error.param)} type=${safeErrorValue(event.error.type)} event_id=${safeErrorValue(event.error.event_id)}`
       : (message ?? 'unknown error');

--- a/src/beta/realtime/websocket.ts
+++ b/src/beta/realtime/websocket.ts
@@ -2,8 +2,8 @@ import type { AzureOpenAI } from '../../index';
 import { assertBedrockWebSocketOrigin } from '../../internal/bedrock';
 import { OpenAI } from '../../index';
 import { OpenAIError } from '../../error';
-import type { RealtimeClientEvent, RealtimeServerEvent } from '../../resources/beta/realtime/realtime';
-import { OpenAIRealtimeEmitter, buildRealtimeURL, isAzure } from './internal-base';
+import type { RealtimeClientEvent } from '../../resources/beta/realtime/realtime';
+import { OpenAIRealtimeEmitter, buildRealtimeURL, isAzure, parseRealtimeEvent } from './internal-base';
 import type { RealtimeConnectionConfig } from './internal-base';
 import { isRunningInBrowser } from '../../internal/detect-platform';
 
@@ -120,7 +120,7 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     this.socket.addEventListener('message', (websocketEvent: MessageEvent) => {
       const event = (() => {
         try {
-          const parsedEvent = JSON.parse(websocketEvent.data.toString()) as RealtimeServerEvent;
+          const parsedEvent = parseRealtimeEvent(websocketEvent.data.toString());
 
           if (
             typeof parsedEvent !== 'object' ||

--- a/src/beta/realtime/ws.ts
+++ b/src/beta/realtime/ws.ts
@@ -3,8 +3,8 @@ import { assertBedrockWebSocketOrigin } from '../../internal/bedrock';
 import { protectWebSocketOptionsFromCredentialRedirects } from '../../internal/ws';
 import type { AzureOpenAI } from '../../index';
 import { OpenAI } from '../../index';
-import type { RealtimeClientEvent, RealtimeServerEvent } from '../../resources/beta/realtime/realtime';
-import { OpenAIRealtimeEmitter, buildRealtimeURL, isAzure } from './internal-base';
+import type { RealtimeClientEvent } from '../../resources/beta/realtime/realtime';
+import { OpenAIRealtimeEmitter, buildRealtimeURL, isAzure, parseRealtimeEvent } from './internal-base';
 import type { RealtimeConnectionConfig } from './internal-base';
 
 /**
@@ -81,7 +81,7 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
     this.socket.on('message', (wsEvent) => {
       const event = (() => {
         try {
-          const parsedEvent = JSON.parse(wsEvent.toString()) as RealtimeServerEvent;
+          const parsedEvent = parseRealtimeEvent(wsEvent.toString());
 
           if (
             typeof parsedEvent !== 'object' ||

--- a/src/realtime/internal-base.ts
+++ b/src/realtime/internal-base.ts
@@ -109,6 +109,10 @@ export abstract class OpenAIRealtimeEmitter extends EventEmitter<RealtimeEvents>
   protected _onError(event: null, message: string, cause: any): void;
   protected _onError(event: RealtimeErrorEvent, message?: string | undefined): void;
   protected _onError(event: RealtimeErrorEvent | null, message?: string | undefined, cause?: any): void {
+    if (event === null && message === 'could not parse websocket event' && cause instanceof SyntaxError) {
+      cause = new SyntaxError('Could not parse Realtime WebSocket event data as JSON.');
+    }
+
     message = event?.error
       ? `${safeErrorValue(event.error.message)} code=${safeErrorValue(event.error.code)} param=${safeErrorValue(event.error.param)} type=${safeErrorValue(event.error.type)} event_id=${safeErrorValue(event.error.event_id)}`
       : (message ?? 'unknown error');

--- a/src/realtime/internal-base.ts
+++ b/src/realtime/internal-base.ts
@@ -9,6 +9,19 @@ import { OpenAIError } from '../error';
 import type OpenAI from '../index';
 import { AzureOpenAI } from '../index';
 
+/** Parses frame data without exposing malformed payloads through JSON syntax errors. */
+export function parseRealtimeEvent(data: string): RealtimeServerEvent {
+  try {
+    return JSON.parse(data) as RealtimeServerEvent;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new SyntaxError('Could not parse Realtime WebSocket event data as JSON.');
+    }
+
+    throw error;
+  }
+}
+
 function safeErrorValue(value: unknown): string {
   try {
     return String(value);
@@ -109,10 +122,6 @@ export abstract class OpenAIRealtimeEmitter extends EventEmitter<RealtimeEvents>
   protected _onError(event: null, message: string, cause: any): void;
   protected _onError(event: RealtimeErrorEvent, message?: string | undefined): void;
   protected _onError(event: RealtimeErrorEvent | null, message?: string | undefined, cause?: any): void {
-    if (event === null && message === 'could not parse websocket event' && cause instanceof SyntaxError) {
-      cause = new SyntaxError('Could not parse Realtime WebSocket event data as JSON.');
-    }
-
     message = event?.error
       ? `${safeErrorValue(event.error.message)} code=${safeErrorValue(event.error.code)} param=${safeErrorValue(event.error.param)} type=${safeErrorValue(event.error.type)} event_id=${safeErrorValue(event.error.event_id)}`
       : (message ?? 'unknown error');

--- a/src/realtime/websocket.ts
+++ b/src/realtime/websocket.ts
@@ -2,12 +2,13 @@ import type { AzureOpenAI } from '../index';
 import { assertBedrockWebSocketOrigin } from '../internal/bedrock';
 import { OpenAI } from '../index';
 import { OpenAIError } from '../error';
-import type { RealtimeClientEvent, RealtimeServerEvent } from '../resources/realtime/realtime';
+import type { RealtimeClientEvent } from '../resources/realtime/realtime';
 import {
   OpenAIRealtimeEmitter,
   buildRealtimeURL,
   getAzureRealtimeConnection,
   isAzure,
+  parseRealtimeEvent,
 } from './internal-base';
 import type { AzureRealtimeConnectionConfig, RealtimeConnectionConfig } from './internal-base';
 import { isRunningInBrowser } from '../internal/detect-platform';
@@ -115,7 +116,7 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     this.socket.addEventListener('message', (websocketEvent: MessageEvent) => {
       const event = (() => {
         try {
-          const parsedEvent = JSON.parse(websocketEvent.data.toString()) as RealtimeServerEvent;
+          const parsedEvent = parseRealtimeEvent(websocketEvent.data.toString());
 
           if (
             typeof parsedEvent !== 'object' ||

--- a/src/realtime/ws.ts
+++ b/src/realtime/ws.ts
@@ -3,12 +3,13 @@ import { assertBedrockWebSocketOrigin } from '../internal/bedrock';
 import { protectWebSocketOptionsFromCredentialRedirects } from '../internal/ws';
 import type { AzureOpenAI } from '../index';
 import { OpenAI } from '../index';
-import type { RealtimeClientEvent, RealtimeServerEvent } from '../resources/realtime/realtime';
+import type { RealtimeClientEvent } from '../resources/realtime/realtime';
 import {
   OpenAIRealtimeEmitter,
   buildRealtimeURL,
   getAzureRealtimeConnection,
   isAzure,
+  parseRealtimeEvent,
 } from './internal-base';
 import type { AzureRealtimeConnectionConfig, RealtimeConnectionConfig } from './internal-base';
 
@@ -76,7 +77,7 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
     this.socket.on('message', (wsEvent) => {
       const event = (() => {
         try {
-          const parsedEvent = JSON.parse(wsEvent.toString()) as RealtimeServerEvent;
+          const parsedEvent = parseRealtimeEvent(wsEvent.toString());
 
           if (
             typeof parsedEvent !== 'object' ||

--- a/tests/realtime-malformed-frame-privacy.test.ts
+++ b/tests/realtime-malformed-frame-privacy.test.ts
@@ -1,0 +1,313 @@
+import { vi } from 'vitest';
+
+import OpenAI from 'openai';
+import { OpenAIRealtimeError as StableRealtimeError } from 'openai/realtime';
+import { OpenAIRealtimeWebSocket as StableNativeRealtime } from 'openai/realtime/websocket';
+import { OpenAIRealtimeWS as StableNodeRealtime } from 'openai/realtime/ws';
+import { OpenAIRealtimeError as BetaRealtimeError } from 'openai/beta/realtime';
+import { OpenAIRealtimeWebSocket as BetaNativeRealtime } from 'openai/beta/realtime/websocket';
+import { OpenAIRealtimeWS as BetaNodeRealtime } from 'openai/beta/realtime/ws';
+
+type Listener = (event: any) => void;
+
+interface FakeSocket {
+  dispatch: (event: string, value: unknown) => void;
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+}
+
+interface RealtimeFailure {
+  message: string;
+  stack?: string | undefined;
+  cause?: unknown;
+  error?: unknown;
+  event_id?: string | undefined;
+}
+
+vi.mock('ws', () => {
+  function FakeNodeSocket() {
+    const listeners = new Map<string, Listener>();
+
+    return {
+      on: (event: string, listener: Listener) => listeners.set(event, listener),
+      send: vi.fn(),
+      close: vi.fn(),
+      dispatch: (event: string, value: unknown) => listeners.get(event)?.(value),
+    };
+  }
+
+  return { WebSocket: FakeNodeSocket };
+});
+
+class FakeNativeSocket implements FakeSocket {
+  private readonly listeners = new Map<string, Listener>();
+
+  readonly send = vi.fn();
+  readonly close = vi.fn();
+
+  addEventListener(event: string, listener: Listener): void {
+    this.listeners.set(event, listener);
+  }
+
+  dispatch(event: string, value: unknown): void {
+    this.listeners.get(event)?.(value);
+  }
+}
+
+const originalWebSocket = Object.getOwnPropertyDescriptor(globalThis, 'WebSocket');
+const sensitiveFrames = [
+  { name: 'an API credential', value: 'sk-private-91a7' },
+  { name: 'a patient identifier', value: 'patient-123-45-6789' },
+  { name: 'a private voice transcript', value: 'private-voice-91a7' },
+] as const;
+const privateSyntaxMessage = 'Could not parse Realtime WebSocket event data as JSON.';
+
+function onRealtimeEvent(realtime: unknown, event: string, listener: Listener): void {
+  (realtime as { on: (event: string, listener: Listener) => unknown }).on(event, listener);
+}
+
+function dispatchFrame(socket: FakeSocket, transport: 'native' | 'node', data: unknown): void {
+  socket.dispatch('message', transport === 'native' ? { data } : data);
+}
+
+function dispatchSensitiveFrame(
+  socket: FakeSocket,
+  transport: 'native' | 'node',
+  value: string,
+): SyntaxError {
+  const parseJSON = JSON.parse;
+  let original: SyntaxError | undefined;
+
+  vi.spyOn(JSON, 'parse').mockImplementationOnce((input: string) => {
+    try {
+      return parseJSON(input);
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) {
+        throw error;
+      }
+
+      original = error;
+      throw error;
+    }
+  });
+
+  dispatchFrame(socket, transport, value);
+
+  if (!original) {
+    throw new Error('The sensitive frame did not produce a JSON syntax error.');
+  }
+
+  expect(original.message).toContain(value);
+  expect(original.stack).toContain(value);
+  return original;
+}
+
+function expectPrivateFailure(
+  failure: RealtimeFailure,
+  secret: string,
+  original: SyntaxError,
+  unhandled = false,
+): void {
+  if (unhandled) {
+    expect(failure.message).toContain('could not parse websocket event');
+    expect(failure.message).toContain('bind an `error` callback');
+  } else {
+    expect(failure.message).toBe('could not parse websocket event');
+  }
+
+  expect(failure.error).toBeUndefined();
+  expect(failure.event_id).toBeUndefined();
+  expect(failure.cause).toBeInstanceOf(SyntaxError);
+  expect(failure.cause).not.toBe(original);
+
+  const cause = failure.cause as SyntaxError & { cause?: unknown };
+  expect(cause.message).toBe(privateSyntaxMessage);
+  expect(cause.cause).toBeUndefined();
+
+  for (const value of [failure.message, failure.stack ?? '', cause.message, cause.stack ?? '']) {
+    expect(value).not.toContain(secret);
+  }
+}
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, 'WebSocket', {
+    configurable: true,
+    value: FakeNativeSocket,
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+
+  if (originalWebSocket) {
+    Object.defineProperty(globalThis, 'WebSocket', originalWebSocket);
+  } else {
+    Reflect.deleteProperty(globalThis, 'WebSocket');
+  }
+});
+
+describe.each([
+  {
+    name: 'stable native',
+    Realtime: StableNativeRealtime,
+    RealtimeError: StableRealtimeError,
+    transport: 'native' as const,
+  },
+  {
+    name: 'stable Node',
+    Realtime: StableNodeRealtime,
+    RealtimeError: StableRealtimeError,
+    transport: 'node' as const,
+  },
+  {
+    name: 'beta native',
+    Realtime: BetaNativeRealtime,
+    RealtimeError: BetaRealtimeError,
+    transport: 'native' as const,
+  },
+  {
+    name: 'beta Node',
+    Realtime: BetaNodeRealtime,
+    RealtimeError: BetaRealtimeError,
+    transport: 'node' as const,
+  },
+])('$name malformed-frame diagnostic privacy', ({ Realtime, RealtimeError, transport }) => {
+  function connect() {
+    const realtime = new Realtime(
+      { model: 'gpt-realtime' },
+      new OpenAI({ apiKey: 'safe-client-key', baseURL: 'https://example.com/v1/' }),
+    );
+
+    return { realtime, socket: realtime.socket as unknown as FakeSocket };
+  }
+
+  test.each(sensitiveFrames)(
+    'never exposes $name through registered error listeners',
+    ({ value: secret }) => {
+      const { realtime, socket } = connect();
+      const errors = vi.fn();
+      const events = vi.fn();
+      onRealtimeEvent(realtime, 'error', errors);
+      onRealtimeEvent(realtime, 'event', events);
+
+      const original = dispatchSensitiveFrame(socket, transport, secret);
+
+      expect(events).not.toHaveBeenCalled();
+      expect(errors).toHaveBeenCalledTimes(1);
+
+      const [[failure] = []] = errors.mock.calls;
+      expect(failure).toBeInstanceOf(RealtimeError);
+      expectPrivateFailure(failure, secret, original);
+    },
+  );
+
+  test.each(sensitiveFrames)(
+    'never exposes $name through unhandled error rejections',
+    ({ value: secret }) => {
+      const { socket } = connect();
+      const reject = vi.spyOn(Promise, 'reject').mockReturnValue(Promise.resolve() as Promise<never>);
+
+      const original = dispatchSensitiveFrame(socket, transport, secret);
+
+      expect(reject).toHaveBeenCalledTimes(1);
+      const [[failure] = []] = reject.mock.calls;
+      expect(failure).toBeInstanceOf(RealtimeError);
+      expectPrivateFailure(failure as RealtimeFailure, secret, original, true);
+    },
+  );
+
+  test('preserves the exact error caused by an unreadable transport frame', () => {
+    const { realtime, socket } = connect();
+    const errors = vi.fn();
+    const frameFailure = new Error('frame could not be decoded');
+    onRealtimeEvent(realtime, 'error', errors);
+
+    dispatchFrame(socket, transport, {
+      toString: () => {
+        throw frameFailure;
+      },
+    });
+
+    expect(errors).toHaveBeenCalledTimes(1);
+    const [[failure] = []] = errors.mock.calls;
+    expect(failure.message).toBe('could not parse websocket event');
+    expect(failure.cause).toBe(frameFailure);
+  });
+
+  test('preserves safe invalid-discriminator TypeError causes', () => {
+    const { realtime, socket } = connect();
+    const errors = vi.fn();
+    onRealtimeEvent(realtime, 'error', errors);
+
+    dispatchFrame(socket, transport, JSON.stringify({ type: null, transcript: 'private-voice-91a7' }));
+
+    expect(errors).toHaveBeenCalledTimes(1);
+    const [[failure] = []] = errors.mock.calls;
+    expect(failure.cause).toBeInstanceOf(TypeError);
+    expect(failure.cause.message).toBe('Realtime WebSocket event must be an object with a string type.');
+  });
+
+  test('preserves SyntaxError identity outside malformed-frame parsing', () => {
+    const { realtime, socket } = connect();
+    const errors = vi.fn();
+    const transportFailure = new SyntaxError('transport failed before send');
+    socket.send.mockImplementationOnce(() => {
+      throw transportFailure;
+    });
+    onRealtimeEvent(realtime, 'error', errors);
+
+    realtime.send({ type: 'response.create' });
+
+    expect(errors).toHaveBeenCalledTimes(1);
+    const [[failure] = []] = errors.mock.calls;
+    expect(failure.message).toBe('could not send data');
+    expect(failure.cause).toBe(transportFailure);
+  });
+
+  test('preserves normal server error data and event identifiers', () => {
+    const { realtime, socket } = connect();
+    const errors = vi.fn();
+    const events = vi.fn();
+    const event = {
+      type: 'error',
+      event_id: 'evt_server',
+      error: {
+        message: 'request rejected',
+        code: 'invalid_request',
+        param: null,
+        type: 'invalid_request_error',
+        event_id: 'evt_request',
+      },
+    };
+    onRealtimeEvent(realtime, 'error', errors);
+    onRealtimeEvent(realtime, 'event', events);
+
+    dispatchFrame(socket, transport, JSON.stringify(event));
+
+    expect(events).toHaveBeenCalledWith(event);
+    expect(errors).toHaveBeenCalledTimes(1);
+    const [[failure] = []] = errors.mock.calls;
+    expect(failure).toBeInstanceOf(RealtimeError);
+    expect(failure.message).toBe(
+      'request rejected code=invalid_request param=null type=invalid_request_error event_id=evt_request',
+    );
+    expect(failure.event_id).toBe('evt_server');
+    expect(failure.error).toEqual(event.error);
+  });
+
+  test('continues dispatching valid events after a sanitized malformed frame', () => {
+    const { realtime, socket } = connect();
+    const errors = vi.fn();
+    const events = vi.fn();
+    const event = { type: 'response.created', id: 'evt_valid' };
+    onRealtimeEvent(realtime, 'error', errors);
+    onRealtimeEvent(realtime, 'event', events);
+
+    dispatchSensitiveFrame(socket, transport, 'patient-123-45-6789');
+    dispatchFrame(socket, transport, JSON.stringify(event));
+
+    expect(errors).toHaveBeenCalledTimes(1);
+    expect(events).toHaveBeenCalledWith(event);
+  });
+});

--- a/tests/realtime-malformed-frame-privacy.test.ts
+++ b/tests/realtime-malformed-frame-privacy.test.ts
@@ -235,6 +235,43 @@ describe.each([
     expect(failure.cause).toBe(frameFailure);
   });
 
+  test('preserves the exact SyntaxError caused by an unreadable transport frame', () => {
+    const { realtime, socket } = connect();
+    const errors = vi.fn();
+    const frameFailure = new SyntaxError('frame contains an invalid transport byte sequence');
+    onRealtimeEvent(realtime, 'error', errors);
+
+    dispatchFrame(socket, transport, {
+      toString: () => {
+        throw frameFailure;
+      },
+    });
+
+    expect(errors).toHaveBeenCalledTimes(1);
+    const [[failure] = []] = errors.mock.calls;
+    expect(failure).toBeInstanceOf(RealtimeError);
+    expect(failure.message).toBe('could not parse websocket event');
+    expect(failure.cause).toBe(frameFailure);
+  });
+
+  test('preserves unreadable transport SyntaxError causes in unhandled rejections', () => {
+    const { socket } = connect();
+    const frameFailure = new SyntaxError('frame contains an invalid transport byte sequence');
+    const reject = vi.spyOn(Promise, 'reject').mockReturnValue(Promise.resolve() as Promise<never>);
+
+    dispatchFrame(socket, transport, {
+      toString: () => {
+        throw frameFailure;
+      },
+    });
+
+    expect(reject).toHaveBeenCalledTimes(1);
+    const [[failure] = []] = reject.mock.calls;
+    expect(failure).toBeInstanceOf(RealtimeError);
+    expect(failure.message).toContain('could not parse websocket event');
+    expect(failure.cause).toBe(frameFailure);
+  });
+
   test('preserves safe invalid-discriminator TypeError causes', () => {
     const { realtime, socket } = connect();
     const errors = vi.fn();


### PR DESCRIPTION
## Summary

- Sanitize malformed Realtime WebSocket JSON parsing errors before they reach configured error listeners or unhandled promise rejections.
- Keep a fresh, constant-message `SyntaxError` cause without retaining raw WebSocket frames, API credentials, patient identifiers, transcripts, or nested causes.
- Preserve stable and beta native/Node client behavior, server error metadata, valid event dispatch, and original transport, send, and invalid-discriminator error causes.

## Validation

- Regression-first: 24 public privacy cases failed on untouched `main`; all 44 dedicated cases now pass across stable/beta × native/Node transports and listener/unhandled paths.
- 368 existing Realtime, WebSocket, and Bedrock regression tests.
- Full handwritten suite: 3,556 passed across 115 test files.
- Full generated suite: 559 passed across 82 test suites.
- Full repository lint and strict TypeScript check.
- CJS/ESM package build, TypeScript 4.9 and current declaration compatibility, package lint, and packed-package consumer smoke test.