### PR TITLE
fix(streaming): reject named SSE provider error events

### DIFF
--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -119,6 +119,10 @@ export class Stream<Item> implements AsyncIterable<Item> {
               throw new SyntaxError('Could not parse server-sent event data as JSON.');
             }
 
+            if (sse.event === 'error') {
+              throw new APIError(undefined, data?.error ?? data, undefined, response.headers);
+            }
+
             if (data && data.error) {
               throw new APIError(undefined, data.error, undefined, response.headers);
             }
@@ -132,10 +136,6 @@ export class Stream<Item> implements AsyncIterable<Item> {
               logger.error(`Could not parse message into JSON:`);
               logger.error(`From chunk:`);
               throw new SyntaxError('Could not parse server-sent event data as JSON.');
-            }
-            // SSE error events surface as APIError instances.
-            if (sse.event === 'error') {
-              throw new APIError(undefined, data.error, data.message, undefined);
             }
             yield { event: sse.event, data } as any;
           }

--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -116,7 +116,7 @@ export class Stream<Item> implements AsyncIterable<Item> {
             } catch {
               logger.error(`Could not parse message into JSON:`);
               logger.error(`From chunk:`);
-              throw new SyntaxError('Could not parse server-sent event data as JSON.');
+              throw new SyntaxError('Error reading response: malformed server-sent event JSON.');
             }
 
             if (sse.event === 'error') {
@@ -135,7 +135,7 @@ export class Stream<Item> implements AsyncIterable<Item> {
             } catch {
               logger.error(`Could not parse message into JSON:`);
               logger.error(`From chunk:`);
-              throw new SyntaxError('Could not parse server-sent event data as JSON.');
+              throw new SyntaxError('Error reading response: malformed server-sent event JSON.');
             }
             yield { event: sse.event, data } as any;
           }

--- a/tests/lib/streaming-named-error-events.test.ts
+++ b/tests/lib/streaming-named-error-events.test.ts
@@ -280,6 +280,37 @@ describe('named SSE provider errors', () => {
     expect(controller.signal.aborted).toBe(false);
   });
 
+  it.each(publicSurfaces)(
+    'keeps malformed $name events private and compatible with streaming consumers',
+    async (surface) => {
+      const credential = 'sk-synthetic-malformed-stream-compatibility-secret';
+      const logger = createLogger();
+      const event = {
+        chat: undefined,
+        responses: 'response.output_text.delta',
+        assistants: 'thread.message.delta',
+      }[surface.surface];
+      const eventLine = event === undefined ? '' : `event: ${event}\n`;
+      const validEvent = record(event, { id: 'safe-event', type: event ?? 'chat.completion.chunk' });
+      const response = responseForWire(`${validEvent}${eventLine}data: {"credential":"${credential}"\n\n`);
+      const stream = await publicStream(surface, response, logger);
+      const error = await rejection(stream);
+
+      expect(error).toBeInstanceOf(SyntaxError);
+      expect((error as SyntaxError).message).toBe(
+        'Error reading response: malformed server-sent event JSON.',
+      );
+      expect((error as SyntaxError).message).toMatch(
+        /Expected depth to be zero|unexpected end of JSON input|Error reading response|Unexpected end of JSON input|Expecting value|unexpected token/u,
+      );
+      expect((error as SyntaxError).message).not.toContain(credential);
+      expect((error as SyntaxError).stack).not.toContain(credential);
+      expect((error as SyntaxError & { cause?: unknown }).cause).toBeUndefined();
+      expect(stream.controller.signal.aborted).toBe(true);
+      expect(logger.error).not.toHaveBeenCalled();
+    },
+  );
+
   it('preserves malformed named-error diagnostic privacy and disabled logging', async () => {
     const credential = 'sk-synthetic-malformed-named-error-secret';
     const logger = createLogger();
@@ -288,7 +319,7 @@ describe('named SSE provider errors', () => {
     const error = await rejection(stream);
 
     expect(error).toBeInstanceOf(SyntaxError);
-    expect((error as SyntaxError).message).toBe('Could not parse server-sent event data as JSON.');
+    expect((error as SyntaxError).message).toBe('Error reading response: malformed server-sent event JSON.');
     expect((error as SyntaxError).message).not.toContain(credential);
     expect((error as SyntaxError).stack).not.toContain(credential);
     expect((error as SyntaxError & { cause?: unknown }).cause).toBeUndefined();

--- a/tests/lib/streaming-named-error-events.test.ts
+++ b/tests/lib/streaming-named-error-events.test.ts
@@ -1,0 +1,298 @@
+import { vi } from 'vitest';
+
+import OpenAI, { APIError } from 'openai';
+import { Stream } from 'openai/streaming';
+
+const encoder = new TextEncoder();
+const requestID = 'req_synthetic_named_stream_error';
+const providerError = {
+  message: 'The synthetic provider rejected this streamed request.',
+  code: 'provider_error',
+  param: 'input',
+  type: 'server_error',
+};
+
+const publicSurfaces = [
+  { name: 'Chat Completions', surface: 'chat' },
+  { name: 'Responses', surface: 'responses' },
+  { name: 'Assistants', surface: 'assistants' },
+] as const;
+
+type PublicSurface = (typeof publicSurfaces)[number];
+type PublicStream = AsyncIterable<unknown> & { controller: AbortController };
+
+function createLogger() {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function record(event: string | undefined, data: unknown): string {
+  const eventLine = event === undefined ? '' : `event: ${event}\n`;
+
+  return `${eventLine}data: ${JSON.stringify(data)}\n\n`;
+}
+
+function responseForWire(wire: string): Response {
+  return new Response(wire, {
+    status: 200,
+    headers: {
+      'content-type': 'text/event-stream',
+      'x-request-id': requestID,
+    },
+  });
+}
+
+async function publicStream(
+  surface: PublicSurface,
+  response: Response,
+  logger = createLogger(),
+): Promise<PublicStream> {
+  const client = new OpenAI({
+    apiKey: 'sk-synthetic-named-stream-error',
+    maxRetries: 0,
+    logLevel: 'off',
+    logger,
+    fetch: async () => response,
+  });
+
+  if (surface.surface === 'assistants') {
+    return await client.beta.threads.runs.create('thread_synthetic', {
+      assistant_id: 'asst_synthetic',
+      stream: true,
+    });
+  }
+
+  if (surface.surface === 'responses') {
+    return await client.responses.create({
+      model: 'gpt-synthetic',
+      input: 'hello',
+      stream: true,
+    });
+  }
+
+  return await client.chat.completions.create({
+    model: 'gpt-synthetic',
+    messages: [{ role: 'user', content: 'hello' }],
+    stream: true,
+  });
+}
+
+async function collect(stream: AsyncIterable<unknown>): Promise<unknown[]> {
+  const events: unknown[] = [];
+
+  for await (const event of stream) {
+    events.push(event);
+  }
+
+  return events;
+}
+
+async function rejection(stream: AsyncIterable<unknown>): Promise<unknown> {
+  return await collect(stream).then(
+    () => null,
+    (error: unknown) => error,
+  );
+}
+
+function expectProviderError(error: unknown, response: Response): asserts error is APIError {
+  expect(error).toBeInstanceOf(APIError);
+  expect(error).toMatchObject({
+    message: providerError.message,
+    code: providerError.code,
+    param: providerError.param,
+    type: providerError.type,
+    requestID,
+    error: providerError,
+  });
+
+  const apiError = error as APIError;
+  expect(apiError.status).toBeUndefined();
+  expect(apiError.headers).toBe(response.headers);
+}
+
+describe('named SSE provider errors', () => {
+  it.each(publicSurfaces)(
+    'rejects flat named provider errors on the public $name streaming API',
+    async (surface) => {
+      const logger = createLogger();
+      const response = responseForWire(record('error', providerError));
+      const stream = await publicStream(surface, response, logger);
+      const error = await rejection(stream);
+
+      expectProviderError(error, response);
+      expect(stream.controller.signal.aborted).toBe(true);
+      expect(logger.error).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([false, true])(
+    'rejects flat named errors from the exported stream with event synthesis set to %s',
+    async (synthesizeEventData) => {
+      const response = responseForWire(record('error', providerError));
+      const controller = new AbortController();
+      const stream = Stream.fromSSEResponse(response, controller, undefined, synthesizeEventData);
+      const error = await rejection(stream);
+
+      expectProviderError(error, response);
+      expect(controller.signal.aborted).toBe(true);
+    },
+  );
+
+  it('cancels and releases an open response body before propagating a named error', async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>(
+      {
+        start(controller) {
+          controller.enqueue(encoder.encode(record('error', providerError)));
+        },
+        cancel,
+      },
+      { highWaterMark: 0 },
+    );
+    const response = new Response(body, {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream', 'x-request-id': requestID },
+    });
+    const controller = new AbortController();
+    const iterator = Stream.fromSSEResponse(response, controller)[Symbol.asyncIterator]();
+
+    try {
+      const caught = await iterator.next().then(
+        () => null,
+        (error: unknown) => error,
+      );
+
+      expectProviderError(caught, response);
+      expect(controller.signal.aborted).toBe(true);
+      expect(cancel).toHaveBeenCalledTimes(1);
+      expect(body.locked).toBe(false);
+    } finally {
+      await iterator.return?.();
+      controller.abort();
+    }
+  });
+
+  it('never yields a named error after delivering an earlier successful event', async () => {
+    const successfulEvent = { id: 'safe-event', content: 'safe content' };
+    const response = responseForWire(
+      record('response.output_text.delta', successfulEvent) + record('error', providerError),
+    );
+    const controller = new AbortController();
+    const stream = Stream.fromSSEResponse(response, controller);
+    const received: unknown[] = [];
+
+    const caught = await (async () => {
+      for await (const event of stream) {
+        received.push(event);
+      }
+    })().then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expectProviderError(caught, response);
+    expect(received).toEqual([successfulEvent]);
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it.each([
+    { name: 'named', event: 'error' },
+    { name: 'unnamed', event: undefined },
+  ])('preserves existing $name nested provider error metadata and headers', async ({ event }) => {
+    const response = responseForWire(record(event, { error: providerError }));
+    const controller = new AbortController();
+    const error = await rejection(Stream.fromSSEResponse(response, controller));
+
+    expectProviderError(error, response);
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it('preserves existing nested-error formatting when its wrapper supplies a message', async () => {
+    const nested = { code: 'nested_provider_error', param: 'input', type: 'server_error' };
+    const wrapper = { message: 'The wrapper supplied the provider failure.', error: nested };
+    const response = responseForWire(record('error', wrapper));
+    const controller = new AbortController();
+    const error = await rejection(Stream.fromSSEResponse(response, controller));
+
+    expect(error).toBeInstanceOf(APIError);
+    expect(error).toMatchObject({
+      message: JSON.stringify(nested),
+      code: nested.code,
+      param: nested.param,
+      type: nested.type,
+      requestID,
+      error: nested,
+    });
+    expect((error as APIError).headers).toBe(response.headers);
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it.each([
+    { name: 'null', value: null },
+    { name: 'string', value: 'a provider failed without structured metadata' },
+    { name: 'number', value: 42 },
+  ])('raises a typed named error even when its payload is $name', async ({ value }) => {
+    const response = responseForWire(record('error', value));
+    const controller = new AbortController();
+    const error = await rejection(Stream.fromSSEResponse(response, controller));
+
+    expect(error).toBeInstanceOf(APIError);
+    expect(error).toMatchObject({ requestID, error: value });
+    expect((error as APIError).headers).toBe(response.headers);
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it.each([false, true])(
+    'preserves ordinary named nonerror events with event synthesis set to %s',
+    async (synthesizeEventData) => {
+      const data = { delta: 'hello' };
+      const event = 'response.output_text.delta';
+      const response = responseForWire(record(event, data));
+      const controller = new AbortController();
+      const stream = Stream.fromSSEResponse(response, controller, undefined, synthesizeEventData);
+
+      await expect(collect(stream)).resolves.toEqual([synthesizeEventData ? { event, data } : data]);
+      expect(controller.signal.aborted).toBe(false);
+    },
+  );
+
+  it.each(['thread.message.delta', 'thread.error'])(
+    'preserves the existing %s Assistant event envelope',
+    async (event) => {
+      const data = { id: 'safe-thread-event' };
+      const response = responseForWire(record(event, data));
+      const controller = new AbortController();
+
+      await expect(collect(Stream.fromSSEResponse(response, controller))).resolves.toEqual([{ event, data }]);
+      expect(controller.signal.aborted).toBe(false);
+    },
+  );
+
+  it('continues ignoring named errors after the completion sentinel', async () => {
+    const response = responseForWire(`data: [DONE]\n\n${record('error', providerError)}`);
+    const controller = new AbortController();
+
+    await expect(collect(Stream.fromSSEResponse(response, controller))).resolves.toEqual([]);
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  it('preserves malformed named-error diagnostic privacy and disabled logging', async () => {
+    const credential = 'sk-synthetic-malformed-named-error-secret';
+    const logger = createLogger();
+    const response = responseForWire(`event: error\ndata: {"credential":"${credential}"\n\n`);
+    const stream = await publicStream(publicSurfaces[0], response, logger);
+    const error = await rejection(stream);
+
+    expect(error).toBeInstanceOf(SyntaxError);
+    expect((error as SyntaxError).message).toBe('Could not parse server-sent event data as JSON.');
+    expect((error as SyntaxError).message).not.toContain(credential);
+    expect((error as SyntaxError).stack).not.toContain(credential);
+    expect((error as SyntaxError & { cause?: unknown }).cause).toBeUndefined();
+    expect(stream.controller.signal.aborted).toBe(true);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Reject named SSE `event: error` frames as typed `APIError`s instead of yielding flat provider failures as successful Chat Completions, Responses, and Assistants stream events.
- Preserve nested provider errors, request headers and request IDs, cancellation, ordinary named events, Assistant event envelopes, completion sentinels, and private malformed-event diagnostics.
- Remove the unreachable error check from the Assistant-only branch and add 19 public-API and exported-stream regression cases.

## Validation
- Regression-first on untouched main: all three actual `new OpenAI({ fetch })` public streaming APIs and both exported event-synthesis modes incorrectly fulfilled before the fix.
- `OPENAI_TEST_SUITE=unit pnpm test -- --maxWorkers=6` — **3,531 handwritten tests passed**.
- `OPENAI_TEST_SUITE=generated pnpm test -- --runInBand` — **559 generated tests passed**.
- `pnpm lint` — zero errors and warnings.
- `pnpm exec tsc --pretty false`; `pnpm build`.
- Published source type-checked with TypeScript **4.9** and **6**.
- `pnpm exec publint dist`; packed-package CommonJS, ESM, and 267 source checks passed on Node **22.23.2** and **26.7.0**.
- Dedicated 19-case streaming regression passed on Node 22 and Node 26.