### PR TITLE
fix(security): bound SSE frames and NDJSON lines before buffering

### DIFF
--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -4,6 +4,7 @@ import { makeReadableStream, ReadableStreamToAsyncIterable } from '../internal/s
 import { findDoubleNewlineIndex, LineDecoder } from '../internal/decoders/line';
 import { isAbortError } from '../internal/errors';
 import { encodeUTF8 } from '../internal/utils/bytes';
+import { readEnv } from '../internal/utils/env';
 import { loggerFor } from '../internal/utils/log';
 import type { OpenAI } from '../client';
 
@@ -325,6 +326,7 @@ export class Stream<Item> implements AsyncIterable<Item> {
 
 /**
  * Decodes complete SSE records from a response and aborts when its body is absent.
+ * Frames default to an 8 MiB limit, configurable with `OPENAI_MAX_SSE_EVENT_BYTES`.
  *
  * @yields {ServerSentEvent} Each decoded server-sent event in wire order.
  */
@@ -345,11 +347,12 @@ export async function* _iterSSEMessages(
     throw new OpenAIError(`Attempted to iterate over a response with no body`);
   }
 
+  const maxEventBytes = maximumSSEEventBytes();
   const sseDecoder = new SSEDecoder();
-  const lineDecoder = new LineDecoder();
+  const lineDecoder = new LineDecoder({ maxLineBytes: maxEventBytes });
 
   const iter = ReadableStreamToAsyncIterable<Bytes>(response.body);
-  for await (const sseChunk of iterSSEChunks(iter)) {
+  for await (const sseChunk of iterSSEChunks(iter, controller, maxEventBytes)) {
     for (const line of lineDecoder.decode(sseChunk)) {
       const sse = sseDecoder.decode(line);
       if (sse) {
@@ -368,6 +371,46 @@ export async function* _iterSSEMessages(
 
 // A `\r\n\r\n` separator may retain up to three bytes from the previous chunk.
 const DOUBLE_NEWLINE_DELIMITER_MAX_OVERLAP_BYTES = 3;
+const DEFAULT_MAX_SSE_EVENT_BYTES = 8 * 1024 * 1024;
+
+function maximumSSEEventBytes(): number {
+  const configured = readEnv('OPENAI_MAX_SSE_EVENT_BYTES');
+  if (configured === undefined) {
+    return DEFAULT_MAX_SSE_EVENT_BYTES;
+  }
+
+  const maximum = Number(configured);
+  return Number.isSafeInteger(maximum) && maximum >= 4 ? maximum : DEFAULT_MAX_SSE_EVENT_BYTES;
+}
+
+function* binarySSEChunks(chunk: NonNullable<Bytes>, maxEventBytes: number): Generator<Uint8Array> {
+  if (chunk instanceof ArrayBuffer) {
+    yield new Uint8Array(chunk);
+    return;
+  }
+
+  if (typeof chunk !== 'string') {
+    yield chunk;
+    return;
+  }
+
+  // Four bytes per UTF-16 code unit also leaves room for a surrogate pair at the boundary.
+  const maxTextChunkLength = Math.max(1, Math.floor(maxEventBytes / 4));
+  for (let start = 0; start < chunk.length;) {
+    let end = Math.min(start + maxTextChunkLength, chunk.length);
+    if (end < chunk.length && chunk.codePointAt(end - 1)! > 0xff_ff) {
+      end += 1;
+    }
+
+    yield encodeUTF8(chunk.slice(start, end));
+    start = end;
+  }
+}
+
+function throwSSEFrameTooLarge(controller: AbortController, maxEventBytes: number): never {
+  controller.abort();
+  throw new OpenAIError(`Server-sent event exceeded the maximum size of ${maxEventBytes} bytes.`);
+}
 
 /**
  * Given an async iterable iterator, iterates over it and yields full
@@ -375,7 +418,11 @@ const DOUBLE_NEWLINE_DELIMITER_MAX_OVERLAP_BYTES = 3;
  *
  * @yields {Uint8Array} A complete SSE chunk.
  */
-async function* iterSSEChunks(iterator: AsyncIterableIterator<Bytes>): AsyncGenerator<Uint8Array> {
+async function* iterSSEChunks(
+  iterator: AsyncIterableIterator<Bytes>,
+  controller: AbortController,
+  maxEventBytes: number,
+): AsyncGenerator<Uint8Array> {
   let data = new Uint8Array();
   let dataStart = 0;
   let dataEnd = 0;
@@ -386,44 +433,49 @@ async function* iterSSEChunks(iterator: AsyncIterableIterator<Bytes>): AsyncGene
       continue;
     }
 
-    let binaryChunk: Uint8Array;
-    if (chunk instanceof ArrayBuffer) {
-      binaryChunk = new Uint8Array(chunk);
-    } else if (typeof chunk === 'string') {
-      binaryChunk = encodeUTF8(chunk);
-    } else {
-      binaryChunk = chunk;
-    }
+    for (const binaryChunk of binarySSEChunks(chunk, maxEventBytes)) {
+      let chunkStart = 0;
 
-    if (dataEnd + binaryChunk.length > data.length) {
-      const bufferedLength = dataEnd - dataStart;
+      while (chunkStart < binaryChunk.length) {
+        const bufferedLength = dataEnd - dataStart;
+        if (bufferedLength === maxEventBytes) {
+          throwSSEFrameTooLarge(controller, maxEventBytes);
+        }
 
-      // Compact only when it reclaims substantial space without moving a large live tail repeatedly.
-      if (dataStart >= data.length / 2 && bufferedLength + binaryChunk.length <= data.length) {
-        data.copyWithin(0, dataStart, dataEnd);
-      } else {
-        const newData = new Uint8Array(Math.max(data.length * 2, bufferedLength + binaryChunk.length));
-        newData.set(data.subarray(dataStart, dataEnd));
-        data = newData;
+        const chunkLength = Math.min(binaryChunk.length - chunkStart, maxEventBytes - bufferedLength);
+
+        if (dataEnd + chunkLength > data.length) {
+          // Compact only when it reclaims substantial space without moving a large live tail repeatedly.
+          if (dataStart >= data.length / 2 && bufferedLength + chunkLength <= data.length) {
+            data.copyWithin(0, dataStart, dataEnd);
+          } else {
+            const capacity = Math.min(maxEventBytes, Math.max(data.length * 2, bufferedLength + chunkLength));
+            const newData = new Uint8Array(capacity);
+            newData.set(data.subarray(dataStart, dataEnd));
+            data = newData;
+          }
+
+          searchStartIndex -= dataStart;
+          dataStart = 0;
+          dataEnd = bufferedLength;
+        }
+
+        const chunkEnd = chunkStart + chunkLength;
+        data.set(binaryChunk.subarray(chunkStart, chunkEnd), dataEnd);
+        dataEnd += chunkLength;
+        chunkStart = chunkEnd;
+
+        let patternIndex;
+        while ((patternIndex = findDoubleNewlineIndex(data.subarray(searchStartIndex, dataEnd))) !== -1) {
+          patternIndex += searchStartIndex;
+          yield data.slice(dataStart, patternIndex);
+          dataStart = patternIndex;
+          searchStartIndex = dataStart;
+        }
+
+        searchStartIndex = Math.max(dataStart, dataEnd - DOUBLE_NEWLINE_DELIMITER_MAX_OVERLAP_BYTES);
       }
-
-      searchStartIndex -= dataStart;
-      dataStart = 0;
-      dataEnd = bufferedLength;
     }
-
-    data.set(binaryChunk, dataEnd);
-    dataEnd += binaryChunk.length;
-
-    let patternIndex;
-    while ((patternIndex = findDoubleNewlineIndex(data.subarray(searchStartIndex, dataEnd))) !== -1) {
-      patternIndex += searchStartIndex;
-      yield data.slice(dataStart, patternIndex);
-      dataStart = patternIndex;
-      searchStartIndex = dataStart;
-    }
-
-    searchStartIndex = Math.max(dataStart, dataEnd - DOUBLE_NEWLINE_DELIMITER_MAX_OVERLAP_BYTES);
   }
 
   if (dataEnd > dataStart) {

--- a/src/internal/decoders/line.ts
+++ b/src/internal/decoders/line.ts
@@ -1,10 +1,14 @@
+import { OpenAIError } from '../../core/error';
 import { decodeUTF8, encodeUTF8 } from '../utils/bytes';
+import { readEnv } from '../utils/env';
 
 /** Text or UTF-8 bytes accepted by the incremental line decoder. */
 export type Bytes = string | ArrayBuffer | Uint8Array | null | undefined;
 
 /** Maximum backing-buffer capacity retained when completed lines leave little active data. */
 const MAX_RETAINED_BUFFER_BYTES = 64 * 1024;
+const DEFAULT_MAX_LINE_BYTES = 8 * 1024 * 1024;
+const MAX_LINE_ENDING_BYTES = 2;
 
 /**
  * Incrementally decodes UTF-8 text into lines without losing partial characters
@@ -29,9 +33,39 @@ export class LineDecoder {
   #end: number;
   #searchIndex: number;
   #skipLeadingLF: boolean;
+  #maxLineBytes: number;
+  #maxBufferedBytes: number;
 
-  /** Creates a decoder with no buffered bytes or pending newline continuation. */
-  constructor() {
+  /**
+   * Creates an empty decoder with an optional maximum UTF-8 line size.
+   *
+   * Defaults to 8 MiB unless `OPENAI_MAX_NDJSON_LINE_BYTES` supplies a valid
+   * positive integer. Explicit limits take precedence; invalid limits throw
+   * `RangeError`, and decoding a line above the limit throws `OpenAIError`.
+   */
+  constructor(options?: { maxLineBytes?: number }) {
+    const configuredMaximum = options?.maxLineBytes;
+    if (configuredMaximum === undefined) {
+      const configuredEnvironmentMaximum = readEnv('OPENAI_MAX_NDJSON_LINE_BYTES');
+      const environmentMaximum = Number(configuredEnvironmentMaximum);
+      this.#maxLineBytes =
+        configuredEnvironmentMaximum !== undefined &&
+        Number.isSafeInteger(environmentMaximum) &&
+        environmentMaximum > 0 &&
+        environmentMaximum <= Number.MAX_SAFE_INTEGER - MAX_LINE_ENDING_BYTES
+          ? environmentMaximum
+          : DEFAULT_MAX_LINE_BYTES;
+    } else {
+      if (
+        !Number.isSafeInteger(configuredMaximum) ||
+        configuredMaximum <= 0 ||
+        configuredMaximum > Number.MAX_SAFE_INTEGER - MAX_LINE_ENDING_BYTES
+      ) {
+        throw new RangeError('The maximum line size must be a positive safe integer.');
+      }
+      this.#maxLineBytes = configuredMaximum;
+    }
+    this.#maxBufferedBytes = this.#maxLineBytes + MAX_LINE_ENDING_BYTES;
     this.#buffer = new Uint8Array();
     this.#start = 0;
     this.#end = 0;
@@ -52,32 +86,140 @@ export class LineDecoder {
       return [];
     }
 
-    let binaryChunk: Uint8Array;
     if (chunk instanceof ArrayBuffer) {
-      binaryChunk = new Uint8Array(chunk);
-    } else if (typeof chunk === 'string') {
-      binaryChunk = encodeUTF8(chunk);
-    } else {
-      binaryChunk = chunk;
+      return this.#decodeBinaryChunk(new Uint8Array(chunk));
     }
 
+    if (typeof chunk === 'string') {
+      return this.#decodeTextChunk(chunk);
+    }
+
+    return this.#decodeBinaryChunk(chunk);
+  }
+
+  #decodeTextChunk(chunk: string): string[] {
+    if (chunk.length === 0) {
+      return [];
+    }
+
+    const activeLength = this.#end - this.#start;
+    if (activeLength + chunk.length * 3 <= this.#maxLineBytes) {
+      return this.#decodeBinaryChunk(encodeUTF8(chunk));
+    }
+
+    const byteLength = this.#validateTextChunk(chunk);
+    if (byteLength <= this.#maxBufferedBytes) {
+      return this.#decodeBinaryChunk(encodeUTF8(chunk));
+    }
+
+    const lines: string[] = [];
+    let segmentStart = 0;
+    let segmentLength = 0;
+
+    for (let index = 0; index < chunk.length;) {
+      const codePoint = chunk.codePointAt(index) ?? 0;
+      const codeUnits = codePoint > 0xff_ff ? 2 : 1;
+      const bytes = utf8CodePointByteLength(codePoint);
+
+      if (segmentLength + bytes > this.#maxBufferedBytes) {
+        for (const line of this.#decodeBinaryChunk(encodeUTF8(chunk.slice(segmentStart, index)))) {
+          lines.push(line);
+        }
+        segmentStart = index;
+        segmentLength = 0;
+      }
+
+      segmentLength += bytes;
+      index += codeUnits;
+    }
+
+    if (segmentStart < chunk.length) {
+      for (const line of this.#decodeBinaryChunk(encodeUTF8(chunk.slice(segmentStart)))) {
+        lines.push(line);
+      }
+    }
+
+    return lines;
+  }
+
+  #validateTextChunk(chunk: string): number {
+    let activeLength = this.#end - this.#start;
+    let byteLength = 0;
+
+    for (let index = 0; index < chunk.length;) {
+      const codePoint = chunk.codePointAt(index) ?? 0;
+      index += codePoint > 0xff_ff ? 2 : 1;
+      if (codePoint === 0x0a || codePoint === 0x0d) {
+        activeLength = 0;
+        byteLength += 1;
+        continue;
+      }
+
+      const bytes = utf8CodePointByteLength(codePoint);
+      if (bytes > this.#maxLineBytes - activeLength) {
+        this.#throwLineTooLarge();
+      }
+
+      activeLength += bytes;
+      byteLength += bytes;
+    }
+
+    return byteLength;
+  }
+
+  #decodeBinaryChunk(binaryChunk: Uint8Array): string[] {
     if (binaryChunk.length === 0) {
       return [];
     }
 
-    if (this.#skipLeadingLF) {
-      this.#skipLeadingLF = false;
-      if (binaryChunk[0] === 0x0a) {
-        binaryChunk = binaryChunk.subarray(1);
-      }
-      if (binaryChunk.length === 0) {
-        return [];
-      }
-    }
-
-    this.#append(binaryChunk);
+    this.#validateBinaryChunk(binaryChunk);
 
     const lines: string[] = [];
+    let offset = 0;
+
+    while (offset < binaryChunk.length) {
+      if (this.#skipLeadingLF) {
+        this.#skipLeadingLF = false;
+        if (binaryChunk[offset] === 0x0a) {
+          offset += 1;
+          if (offset === binaryChunk.length) {
+            break;
+          }
+        }
+      }
+
+      const activeLength = this.#end - this.#start;
+      const end = Math.min(binaryChunk.length, offset + this.#maxBufferedBytes - activeLength);
+      const segment =
+        offset === 0 && end === binaryChunk.length ? binaryChunk : binaryChunk.subarray(offset, end);
+      this.#append(segment);
+      this.#extractLines(lines);
+      offset = end;
+    }
+
+    return lines;
+  }
+
+  #validateBinaryChunk(chunk: Uint8Array): void {
+    let activeLength = this.#end - this.#start;
+    if (activeLength + chunk.length <= this.#maxLineBytes) {
+      return;
+    }
+
+    for (const byte of chunk) {
+      if (byte === 0x0a || byte === 0x0d) {
+        activeLength = 0;
+      } else {
+        if (activeLength === this.#maxLineBytes) {
+          this.#throwLineTooLarge();
+        }
+        activeLength += 1;
+      }
+    }
+  }
+
+  #extractLines(lines: string[]): void {
+    const originalLineCount = lines.length;
     let patternIndex;
     while ((patternIndex = findNewlineIndex(this.#buffer, this.#searchIndex, this.#end)) != null) {
       const line = decodeUTF8(this.#buffer.subarray(this.#start, patternIndex.preceding));
@@ -102,13 +244,15 @@ export class LineDecoder {
       if (this.#buffer.length > MAX_RETAINED_BUFFER_BYTES) {
         this.#buffer = new Uint8Array();
       }
-    } else if (lines.length > 0 && this.#buffer.length > MAX_RETAINED_BUFFER_BYTES) {
+    } else if (lines.length > originalLineCount && this.#buffer.length > MAX_RETAINED_BUFFER_BYTES) {
       const length = this.#end - this.#start;
       if (length <= MAX_RETAINED_BUFFER_BYTES || this.#buffer.length > length * 4) {
-        const capacity =
+        const capacity = Math.min(
           length <= MAX_RETAINED_BUFFER_BYTES
             ? Math.min(Math.max(length * 2, 256), MAX_RETAINED_BUFFER_BYTES)
-            : length * 2;
+            : length * 2,
+          this.#maxBufferedBytes,
+        );
         const buffer = new Uint8Array(capacity);
         buffer.set(this.#buffer.subarray(this.#start, this.#end));
         this.#buffer = buffer;
@@ -117,17 +261,23 @@ export class LineDecoder {
         this.#searchIndex = length;
       }
     }
-
-    return lines;
   }
 
   #append(chunk: Uint8Array): void {
+    const activeLength = this.#end - this.#start;
+    if (activeLength + chunk.length > this.#maxBufferedBytes) {
+      this.#throwLineTooLarge();
+    }
+
     if (this.#end + chunk.length > this.#buffer.length) {
-      const length = this.#end - this.#start;
+      const length = activeLength;
       if (this.#start >= this.#buffer.length / 2 && length + chunk.length <= this.#buffer.length) {
         this.#buffer.copyWithin(0, this.#start, this.#end);
       } else {
-        const capacity = Math.max(this.#buffer.length * 2, length + chunk.length, 256);
+        const capacity = Math.min(
+          Math.max(this.#buffer.length * 2, length + chunk.length, 256),
+          this.#maxBufferedBytes,
+        );
         const buffer = new Uint8Array(capacity);
         buffer.set(this.#buffer.subarray(this.#start, this.#end));
         this.#buffer = buffer;
@@ -142,6 +292,10 @@ export class LineDecoder {
     this.#end += chunk.length;
   }
 
+  #throwLineTooLarge(): never {
+    throw new OpenAIError(`Line exceeds the maximum size of ${this.#maxLineBytes} bytes.`);
+  }
+
   /** Emits the remaining unterminated line, or returns an empty array when idle. */
   flush(): string[] {
     this.#skipLeadingLF = false;
@@ -150,6 +304,19 @@ export class LineDecoder {
     }
     return this.decode('\n');
   }
+}
+
+function utf8CodePointByteLength(codePoint: number): number {
+  if (codePoint <= 0x7f) {
+    return 1;
+  }
+  if (codePoint <= 0x7_ff) {
+    return 2;
+  }
+  if (codePoint <= 0xff_ff) {
+    return 3;
+  }
+  return 4;
 }
 
 /**

--- a/src/internal/utils/env.ts
+++ b/src/internal/utils/env.ts
@@ -6,11 +6,15 @@
  * Will return undefined if the environment variable doesn't exist or cannot be accessed.
  */
 export const readEnv = (env: string): string | undefined => {
-  if (typeof (globalThis as any).process !== 'undefined') {
-    return (globalThis as any).process.env?.[env]?.trim() || undefined;
-  }
-  if (typeof (globalThis as any).Deno !== 'undefined') {
-    return (globalThis as any).Deno.env?.get?.(env)?.trim() || undefined;
+  try {
+    if (typeof (globalThis as any).process !== 'undefined') {
+      return (globalThis as any).process.env?.[env]?.trim() || undefined;
+    }
+    if (typeof (globalThis as any).Deno !== 'undefined') {
+      return (globalThis as any).Deno.env?.get?.(env)?.trim() || undefined;
+    }
+  } catch {
+    return undefined;
   }
   return undefined;
 };

--- a/tests/core/streaming-security.test.ts
+++ b/tests/core/streaming-security.test.ts
@@ -2,6 +2,8 @@ import { afterEach, vi } from 'vitest';
 
 import { OpenAIError } from 'openai/core/error';
 import { Stream, _iterSSEMessages } from 'openai/core/streaming';
+import { LineDecoder } from 'openai/internal/decoders/line';
+import { readEnv } from 'openai/internal/utils/env';
 
 const encoder = new TextEncoder();
 
@@ -36,6 +38,128 @@ function responseForChunks(chunks: Uint8Array[]) {
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
+});
+
+function withDenoEnvironment<T>(get: (name: string) => string | undefined, run: () => T): T {
+  const originalProcess = Object.getOwnPropertyDescriptor(globalThis, 'process');
+  const originalDeno = Object.getOwnPropertyDescriptor(globalThis, 'Deno');
+
+  try {
+    Object.defineProperty(globalThis, 'Deno', { configurable: true, value: { env: { get } } });
+    Object.defineProperty(globalThis, 'process', { configurable: true, value: undefined });
+    return run();
+  } finally {
+    if (originalProcess) {
+      Object.defineProperty(globalThis, 'process', originalProcess);
+    } else {
+      Reflect.deleteProperty(globalThis, 'process');
+    }
+    if (originalDeno) {
+      Object.defineProperty(globalThis, 'Deno', originalDeno);
+    } else {
+      Reflect.deleteProperty(globalThis, 'Deno');
+    }
+  }
+}
+
+function inaccessibleEnvironment(name: string): never {
+  const error = new Error('Environment access has been denied or revoked.');
+  error.name = name;
+  throw error;
+}
+
+describe('streaming without environment permissions', () => {
+  test.each(['PermissionDenied', 'NotCapable'])(
+    'treats a revoked Deno %s permission as an absent environment variable',
+    (errorName) => {
+      let permitted = true;
+      const values = withDenoEnvironment(
+        () => (permitted ? '  configured  ' : inaccessibleEnvironment(errorName)),
+        () => {
+          const configured = readEnv('OPENAI_MAX_SSE_EVENT_BYTES');
+          permitted = false;
+          return [configured, readEnv('OPENAI_MAX_SSE_EVENT_BYTES')];
+        },
+      );
+
+      expect(values).toEqual(['configured', undefined]);
+    },
+  );
+
+  test('treats an inaccessible process.env getter as absent', () => {
+    const originalProcess = Object.getOwnPropertyDescriptor(globalThis, 'process');
+    let configured: string | undefined;
+
+    try {
+      Object.defineProperty(globalThis, 'process', {
+        configurable: true,
+        value: {
+          get env() {
+            return inaccessibleEnvironment('PermissionDenied');
+          },
+        },
+      });
+      configured = readEnv('OPENAI_MAX_NDJSON_LINE_BYTES');
+    } finally {
+      if (originalProcess) {
+        Object.defineProperty(globalThis, 'process', originalProcess);
+      } else {
+        Reflect.deleteProperty(globalThis, 'process');
+      }
+    }
+
+    expect(configured).toBeUndefined();
+  });
+
+  test('decodes the public SSE stream after Deno environment permission is revoked', async () => {
+    const { response } = responseForChunks([encoder.encode('data: {"value":"safe"}\n\n')]);
+    const denied = vi.fn(() => inaccessibleEnvironment('PermissionDenied'));
+    const stream = Stream.fromSSEResponse<{ value: string }>(response, new AbortController());
+    const values = withDenoEnvironment(denied, () => collect(stream));
+
+    await expect(values).resolves.toEqual([{ value: 'safe' }]);
+    expect(denied).toHaveBeenCalledWith('OPENAI_MAX_SSE_EVENT_BYTES');
+  });
+
+  test('decodes the public NDJSON stream after Deno environment permission is revoked', async () => {
+    const { body } = responseForChunks([encoder.encode('{"value":"safe"}\n')]);
+    const denied = vi.fn(() => inaccessibleEnvironment('NotCapable'));
+    const stream = Stream.fromReadableStream<{ value: string }>(body, new AbortController());
+    const values = withDenoEnvironment(denied, () => collect(stream));
+
+    await expect(values).resolves.toEqual([{ value: 'safe' }]);
+    expect(denied).toHaveBeenCalledWith('OPENAI_MAX_NDJSON_LINE_BYTES');
+  });
+
+  test('retains the secure default SSE frame limit when Deno denies environment access', async () => {
+    const { response, cancel } = responseForChunks([new Uint8Array(8 * 1024 * 1024 + 1)]);
+    const denied = vi.fn(() => inaccessibleEnvironment('PermissionDenied'));
+    const stream = Stream.fromSSEResponse(response, new AbortController());
+    const values = withDenoEnvironment(denied, () => collect(stream));
+
+    await expect(values).rejects.toThrow(/8388608.*bytes/iu);
+    expect(denied).toHaveBeenCalledWith('OPENAI_MAX_SSE_EVENT_BYTES');
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  test('retains the secure default line limit when Deno denies environment access', () => {
+    const decoder = withDenoEnvironment(
+      () => inaccessibleEnvironment('PermissionDenied'),
+      () => new LineDecoder(),
+    );
+
+    expect(() => decoder.decode(new Uint8Array(8 * 1024 * 1024 + 1))).toThrow(/8388608.*bytes/iu);
+  });
+
+  test('preserves valid permitted Deno overrides and rejects oversized lines', () => {
+    const decoder = withDenoEnvironment(
+      () => '  4  ',
+      () => new LineDecoder(),
+    );
+
+    expect(decoder.decode(encoder.encode('four\n'))).toEqual(['four']);
+    expect(() => decoder.decode('large')).toThrow(/line.*4.*bytes/iu);
+  });
 });
 
 describe('server-sent event framing limits', () => {

--- a/tests/core/streaming-security.test.ts
+++ b/tests/core/streaming-security.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, vi } from 'vitest';
+
+import { OpenAIError } from 'openai/core/error';
+import { Stream, _iterSSEMessages } from 'openai/core/streaming';
+
+const encoder = new TextEncoder();
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+
+  for await (const value of iterable) {
+    values.push(value);
+  }
+
+  return values;
+}
+
+function responseForChunks(chunks: Uint8Array[]) {
+  let nextChunk = 0;
+  const cancel = vi.fn();
+  const pull = vi.fn((controller: ReadableStreamDefaultController<Uint8Array>) => {
+    const chunk = chunks[nextChunk];
+    nextChunk += 1;
+
+    if (chunk) {
+      controller.enqueue(chunk);
+    } else {
+      controller.close();
+    }
+  });
+  const body = new ReadableStream<Uint8Array>({ pull, cancel }, { highWaterMark: 0 });
+
+  return { response: new Response(body), body, cancel, pull };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe('server-sent event framing limits', () => {
+  test('rejects one oversized chunk before copying it and cancels its upstream reader', async () => {
+    vi.stubEnv('OPENAI_MAX_SSE_EVENT_BYTES', '32');
+
+    const oversized = encoder.encode(`data: ${'secret'.repeat(16)}\n\n`);
+    const { response, body, cancel } = responseForChunks([oversized]);
+    const controller = new AbortController();
+    const copy = vi.spyOn(Uint8Array.prototype, 'set');
+
+    await expect(_iterSSEMessages(response, controller).next()).rejects.toThrow(
+      'Server-sent event exceeded the maximum size of 32 bytes',
+    );
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(body.locked).toBe(false);
+    expect(copy.mock.calls.every(([bytes]) => bytes.length <= 32)).toBe(true);
+  });
+
+  test('stops a delimiter-free event fragmented into many tiny chunks', async () => {
+    vi.stubEnv('OPENAI_MAX_SSE_EVENT_BYTES', '32');
+
+    const bytes = encoder.encode(`data: ${'x'.repeat(80)}\n\n`);
+    const { response, body, cancel, pull } = responseForChunks(
+      Array.from(bytes, (byte) => Uint8Array.of(byte)),
+    );
+    const controller = new AbortController();
+
+    await expect(_iterSSEMessages(response, controller).next()).rejects.toThrow(OpenAIError);
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(body.locked).toBe(false);
+    expect(pull.mock.calls.length).toBeLessThanOrEqual(33);
+  });
+
+  test('surfaces framing overflows through the public response stream', async () => {
+    vi.stubEnv('OPENAI_MAX_SSE_EVENT_BYTES', '40');
+
+    const oversized = encoder.encode(`data: {"value":"${'x'.repeat(80)}"}\n\n`);
+    const { response, cancel } = responseForChunks([oversized]);
+    const controller = new AbortController();
+    const stream = Stream.fromSSEResponse(response, controller);
+
+    await expect(collect(stream)).rejects.toThrow('maximum size of 40 bytes');
+    expect(controller.signal.aborted).toBe(true);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  test('accepts an aggregate chunk larger than the limit when its individual frames fit', async () => {
+    vi.stubEnv('OPENAI_MAX_SSE_EVENT_BYTES', '18');
+
+    const aggregate = encoder.encode('data: first\n\ndata: second\n\ndata: third\n\n');
+    const { response, cancel } = responseForChunks([aggregate]);
+
+    await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toMatchObject([
+      { event: null, data: 'first' },
+      { event: null, data: 'second' },
+      { event: null, data: 'third' },
+    ]);
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  test('accepts a complete frame exactly at the configured byte limit', async () => {
+    const frame = encoder.encode('data: exact-boundary\n\n');
+    vi.stubEnv('OPENAI_MAX_SSE_EVENT_BYTES', String(frame.byteLength));
+
+    const { response } = responseForChunks([frame]);
+
+    await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toMatchObject([
+      { event: null, data: 'exact-boundary' },
+    ]);
+  });
+
+  test('keeps the SSE limit independent from the configured NDJSON line limit', async () => {
+    vi.stubEnv('OPENAI_MAX_SSE_EVENT_BYTES', '64');
+    vi.stubEnv('OPENAI_MAX_NDJSON_LINE_BYTES', '8');
+
+    const { response } = responseForChunks([encoder.encode('data: independent frame limit\n\n')]);
+
+    await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toMatchObject([
+      { event: null, data: 'independent frame limit' },
+    ]);
+  });
+
+  test('encodes oversized string chunks in bounded segments before rejecting them', async () => {
+    vi.stubEnv('OPENAI_MAX_SSE_EVENT_BYTES', '32');
+
+    const cancel = vi.fn();
+    const body = new ReadableStream<string>(
+      {
+        start(controller) {
+          controller.enqueue(`data: ${'😀'.repeat(40)}\n\n`);
+        },
+        cancel,
+      },
+      { highWaterMark: 0 },
+    );
+    const encode = vi.spyOn(TextEncoder.prototype, 'encode');
+    const controller = new AbortController();
+
+    await expect(_iterSSEMessages({ body } as unknown as Response, controller).next()).rejects.toThrow(
+      'maximum size of 32 bytes',
+    );
+
+    expect(encode).toHaveBeenCalled();
+    expect(encode.mock.calls.every(([value]) => (value?.length ?? 0) <= 9)).toBe(true);
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  test('preserves surrogate pairs when bounded text segments split an SSE frame', async () => {
+    const frame = 'data: 😀😀😀\n\n';
+    vi.stubEnv('OPENAI_MAX_SSE_EVENT_BYTES', String(encoder.encode(frame).byteLength));
+
+    const body = new ReadableStream<string>({
+      start(controller) {
+        controller.enqueue(frame);
+        controller.close();
+      },
+    });
+
+    await expect(
+      collect(_iterSSEMessages({ body } as unknown as Response, new AbortController())),
+    ).resolves.toMatchObject([{ event: null, data: '😀😀😀' }]);
+  });
+});

--- a/tests/internal/decoders/line-security.test.ts
+++ b/tests/internal/decoders/line-security.test.ts
@@ -1,0 +1,191 @@
+import { vi } from 'vitest';
+
+import { Stream } from 'openai/core/streaming';
+import { LineDecoder } from 'openai/internal/decoders/line';
+import * as bytes from 'openai/internal/utils/bytes';
+
+const originalLineLimit = process.env['OPENAI_MAX_NDJSON_LINE_BYTES'];
+
+afterEach(() => {
+  if (originalLineLimit === undefined) {
+    delete process.env['OPENAI_MAX_NDJSON_LINE_BYTES'];
+  } else {
+    process.env['OPENAI_MAX_NDJSON_LINE_BYTES'] = originalLineLimit;
+  }
+  vi.restoreAllMocks();
+});
+
+describe('bounded incremental line decoding', () => {
+  test('rejects one oversized byte chunk before allocating, compacting, or copying it', () => {
+    const decoder = new LineDecoder({ maxLineBytes: 16 });
+    const oversized = new Uint8Array(17).fill(0x61);
+    const NativeUint8Array = Uint8Array;
+    const copies = vi.spyOn(NativeUint8Array.prototype, 'set');
+    const compactions = vi.spyOn(NativeUint8Array.prototype, 'copyWithin');
+    const allocations = vi.spyOn(globalThis, 'Uint8Array').mockImplementation(function trackAllocation(
+      ...args: unknown[]
+    ) {
+      return Reflect.construct(NativeUint8Array, args) as Uint8Array;
+    } as unknown as typeof Uint8Array);
+
+    expect(() => decoder.decode(oversized)).toThrow(/line.*16.*bytes/iu);
+    expect(allocations).not.toHaveBeenCalled();
+    expect(copies).not.toHaveBeenCalled();
+    expect(compactions).not.toHaveBeenCalled();
+  });
+
+  test('rejects an oversized ArrayBuffer without copying its contents', () => {
+    const decoder = new LineDecoder({ maxLineBytes: 8 });
+    const oversized = new Uint8Array(9).fill(0x61).buffer;
+    const copies = vi.spyOn(Uint8Array.prototype, 'set');
+
+    expect(() => decoder.decode(oversized)).toThrow(/line.*8.*bytes/iu);
+    expect(copies).not.toHaveBeenCalled();
+  });
+
+  test('rejects an oversized text chunk before allocating its UTF-8 representation', () => {
+    const decoder = new LineDecoder({ maxLineBytes: 8 });
+    const encode = vi.spyOn(bytes, 'encodeUTF8');
+
+    expect(() => decoder.decode('a'.repeat(9))).toThrow(/line.*8.*bytes/iu);
+    expect(encode).not.toHaveBeenCalled();
+  });
+
+  test('rejects a line assembled from many one-byte chunks before the overflowing copy', () => {
+    const decoder = new LineDecoder({ maxLineBytes: 16 });
+    const chunk = Uint8Array.of(0x61);
+
+    for (let index = 0; index < 16; index += 1) {
+      expect(decoder.decode(chunk)).toEqual([]);
+    }
+
+    const copies = vi.spyOn(Uint8Array.prototype, 'set');
+    const compactions = vi.spyOn(Uint8Array.prototype, 'copyWithin');
+
+    expect(() => decoder.decode(chunk)).toThrow(/line.*16.*bytes/iu);
+    expect(copies).not.toHaveBeenCalled();
+    expect(compactions).not.toHaveBeenCalled();
+  });
+
+  test('rejects a line assembled from many tiny string chunks before UTF-8 encoding', () => {
+    const decoder = new LineDecoder({ maxLineBytes: 4 });
+
+    expect(decoder.decode('ab')).toEqual([]);
+    expect(decoder.decode('cd')).toEqual([]);
+
+    const encode = vi.spyOn(bytes, 'encodeUTF8');
+    expect(() => decoder.decode('e')).toThrow(/line.*4.*bytes/iu);
+    expect(encode).not.toHaveBeenCalled();
+  });
+
+  test('counts UTF-8 bytes, including surrogate pairs and incomplete byte fragments', () => {
+    const decoder = new LineDecoder({ maxLineBytes: 4 });
+
+    expect(decoder.decode('💙')).toEqual([]);
+    expect(() => decoder.decode('é')).toThrow(/line.*4.*bytes/iu);
+    expect(decoder.flush()).toEqual(['💙']);
+
+    const fragments = new LineDecoder({ maxLineBytes: 4 });
+    expect(fragments.decode(Uint8Array.of(0xf0, 0x9f))).toEqual([]);
+    expect(fragments.decode(Uint8Array.of(0x92, 0x99))).toEqual([]);
+    expect(fragments.decode('\n')).toEqual(['💙']);
+  });
+
+  test('accepts exactly the configured payload limit with CRLF and unterminated lines', () => {
+    const terminated = new LineDecoder({ maxLineBytes: 4 });
+    expect(terminated.decode('abcd\r\n')).toEqual(['abcd']);
+
+    const unterminated = new LineDecoder({ maxLineBytes: 4 });
+    expect(unterminated.decode('abcd')).toEqual([]);
+    expect(unterminated.flush()).toEqual(['abcd']);
+  });
+
+  test('accepts large byte chunks containing only short lines without oversized backing allocations', () => {
+    const decoder = new LineDecoder({ maxLineBytes: 4 });
+    const chunk = new TextEncoder().encode('abcd\n'.repeat(20));
+    const NativeUint8Array = Uint8Array;
+    const allocations = vi.spyOn(globalThis, 'Uint8Array').mockImplementation(function trackAllocation(
+      ...args: unknown[]
+    ) {
+      return Reflect.construct(NativeUint8Array, args) as Uint8Array;
+    } as unknown as typeof Uint8Array);
+
+    expect(decoder.decode(chunk)).toEqual(Array.from({ length: 20 }, () => 'abcd'));
+    expect(allocations).toHaveBeenCalled();
+    expect(
+      allocations.mock.calls.every((args) => {
+        const [length] = args as unknown[];
+        return typeof length !== 'number' || length <= 6;
+      }),
+    ).toBe(true);
+  });
+
+  test('encodes large text chunks containing short lines in independently bounded pieces', () => {
+    const decoder = new LineDecoder({ maxLineBytes: 4 });
+    const encode = vi.spyOn(bytes, 'encodeUTF8');
+
+    expect(decoder.decode('éé\r\n'.repeat(20))).toEqual(Array.from({ length: 20 }, () => 'éé'));
+    expect(encode.mock.calls.length).toBeGreaterThan(1);
+    expect(encode.mock.calls.every(([chunk]) => new TextEncoder().encode(chunk).length <= 6)).toBe(true);
+  });
+
+  test('preserves CRLF continuations across internally segmented oversized chunks', () => {
+    const decoder = new LineDecoder({ maxLineBytes: 1 });
+
+    expect(decoder.decode('a\r\na\r\na\r\n')).toEqual(['a', 'a', 'a']);
+    expect(decoder.flush()).toEqual([]);
+  });
+
+  test('reads the NDJSON-specific environment limit and lets explicit limits override it', () => {
+    process.env['OPENAI_MAX_NDJSON_LINE_BYTES'] = '3';
+
+    expect(() => new LineDecoder().decode('four')).toThrow(/line.*3.*bytes/iu);
+    expect(new LineDecoder({ maxLineBytes: 4 }).decode('four\n')).toEqual(['four']);
+  });
+
+  test('rejects invalid explicit line limits', () => {
+    for (const maxLineBytes of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() => new LineDecoder({ maxLineBytes })).toThrow(RangeError);
+    }
+  });
+
+  test('uses a conservative 8 MiB default when no override is configured', () => {
+    delete process.env['OPENAI_MAX_NDJSON_LINE_BYTES'];
+    const oversized = new Uint8Array(8 * 1024 * 1024 + 1).fill(0x61);
+    const copies = vi.spyOn(Uint8Array.prototype, 'set');
+
+    expect(() => new LineDecoder().decode(oversized)).toThrow(/line.*8388608.*bytes/iu);
+    expect(copies).not.toHaveBeenCalled();
+  });
+});
+
+describe('newline-delimited stream cleanup after a line exceeds its limit', () => {
+  test.each([
+    {
+      description: 'one oversized chunk',
+      chunks: [new Uint8Array(17).fill(0x61)],
+    },
+    {
+      description: 'many tiny chunks',
+      chunks: Array.from({ length: 17 }, () => Uint8Array.of(0x61)),
+    },
+  ])('cancels and aborts the upstream reader for $description', async ({ chunks }) => {
+    process.env['OPENAI_MAX_NDJSON_LINE_BYTES'] = '16';
+    const pending = [...chunks];
+    const reader = {
+      read: vi.fn(async () => {
+        const value = pending.shift();
+        return value ? { done: false, value } : { done: true };
+      }),
+      cancel: vi.fn().mockResolvedValue(null),
+      releaseLock: vi.fn(),
+    };
+    const controller = new AbortController();
+    const stream = Stream.fromReadableStream({ getReader: () => reader } as any, controller);
+
+    await expect(stream[Symbol.asyncIterator]().next()).rejects.toThrow(/line.*16.*bytes/iu);
+    expect(reader.cancel).toHaveBeenCalledTimes(1);
+    expect(reader.releaseLock).toHaveBeenCalledTimes(1);
+    expect(controller.signal.aborted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Security findings

- `csf_68ab32fb052e825f536dfd7a`: unbounded active server-sent event framing buffer.
- `csf_ebb44bf3e8b19efdf555d9cc`: unbounded active NDJSON line buffer.

## Changes

- Cap SSE frames and NDJSON lines independently at **8 MiB by default**, configurable through `OPENAI_MAX_SSE_EVENT_BYTES` and `OPENAI_MAX_NDJSON_LINE_BYTES`.
- Reject oversized input before UTF-8 encoding, backing-buffer allocation, resize, compaction, or copy; abort and cancel upstream readers immediately.
- Preserve valid packed frames, large chunks containing many short lines, exact-boundary input, fragmented CRLF, Unicode/surrogate pairs, and existing public streaming behavior.
- Preserve merged named-SSE error handling (#2409) and malformed-event diagnostic privacy (#2403).
- Limit changes to handwritten streaming/decoder sources and focused regression tests; generated/upstream-owned logging code is intentionally excluded.

## Verification

- **173 focused tests passed** across SSE limits, NDJSON limits, named-error events, malformed-event privacy, existing streaming behavior, logging, and provider coverage.
- **3,469 handwritten tests passed across 115 files**, excluding two existing environment-dependent infrastructure suites.
- Strict source TypeScript check passed:
  `./node_modules/.bin/tsc --ignoreConfig --pretty false --noEmit --target es2020 --module commonjs --moduleResolution bundler --esModuleInterop --skipLibCheck --strict --types node,jest src/core/streaming.ts src/internal/decoders/line.ts`
- Repository-configured Oxlint, Oxfmt, generated-file checks, and `git diff --check` passed for the owned changes.

**Rollout:** Streams exceeding the new 8 MiB per-event/per-line default now fail closed; deployments that legitimately require larger records can raise the corresponding independent environment limit.