### PR TITLE
fix(security): authenticate Vercel ecosystem APIs and clean up uploaded files

### DIFF
--- a/ecosystem-tests/vercel-edge/package.json
+++ b/ecosystem-tests/vercel-edge/package.json
@@ -10,8 +10,8 @@
     "edge-runtime": "edge-runtime",
     "vercel": "vercel",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "test:ci:dev": "start-server-and-test dev http://localhost:3000 test",
-    "test:ci": "start-server-and-test start http://localhost:3000 test"
+    "test:ci:dev": "VERCEL_EDGE_TEST_TOKEN=$(node -e \"process.stdout.write(require('node:crypto').randomBytes(32).toString('hex'))\") start-server-and-test dev http://localhost:3000 test",
+    "test:ci": "VERCEL_EDGE_TEST_TOKEN=$(node -e \"process.stdout.write(require('node:crypto').randomBytes(32).toString('hex'))\") start-server-and-test start http://localhost:3000 test"
   },
   "dependencies": {
     "@ai-sdk/react": "4.0.20",

--- a/ecosystem-tests/vercel-edge/src/middleware.ts
+++ b/ecosystem-tests/vercel-edge/src/middleware.ts
@@ -1,0 +1,42 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const minimumTokenLength = 32;
+const maximumRequestBodyBytes = 64 * 1024;
+
+function matchesAuthorization(actual: string, expected: string): boolean {
+  let difference = Math.abs(actual.length - expected.length);
+
+  for (let index = 0; index < expected.length; index += 1) {
+    difference += Number(actual[index] !== expected[index]);
+  }
+
+  return difference === 0;
+}
+
+export function middleware(request: NextRequest): NextResponse {
+  const token = process.env.VERCEL_EDGE_TEST_TOKEN;
+  const authorization = request.headers.get('authorization') ?? '';
+
+  if (
+    !token ||
+    token.length < minimumTokenLength ||
+    !matchesAuthorization(authorization, `Bearer ${token}`)
+  ) {
+    return new NextResponse('Unauthorized', {
+      status: 401,
+      headers: { 'www-authenticate': 'Bearer' },
+    });
+  }
+
+  const contentLength = request.headers.get('content-length');
+  if (contentLength && Number(contentLength) > maximumRequestBodyBytes) {
+    return new NextResponse('Payload Too Large', { status: 413 });
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: '/api/:path*',
+};

--- a/ecosystem-tests/vercel-edge/src/pages/ai-streaming.tsx
+++ b/ecosystem-tests/vercel-edge/src/pages/ai-streaming.tsx
@@ -7,13 +7,14 @@ const transport = new DefaultChatTransport({ api: '/api/vercel-ai-streaming' });
 
 export default function Chat() {
   const [input, setInput] = useState('');
+  const [accessToken, setAccessToken] = useState('');
   const { messages, sendMessage } = useChat({ transport });
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!input.trim()) {return;}
+    if (!input.trim() || !accessToken.trim()) {return;}
 
-    void sendMessage({ text: input });
+    void sendMessage({ text: input }, { headers: { authorization: `Bearer ${accessToken.trim()}` } });
     setInput('');
   };
 
@@ -30,6 +31,15 @@ export default function Chat() {
       ))}
 
       <form onSubmit={handleSubmit}>
+        <label>
+          Test access token
+          <input
+            autoComplete="off"
+            onChange={(event) => setAccessToken(event.target.value)}
+            type="password"
+            value={accessToken}
+          />
+        </label>
         <label>
           Say something...
           <input

--- a/ecosystem-tests/vercel-edge/src/pages/api/response.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/response.ts
@@ -18,6 +18,7 @@ export default async function handler(request: NextRequest) {
   const result = await openai.completions.create({
     prompt: 'Reply with exactly this text and nothing else: This is a test',
     model: 'gpt-3.5-turbo-instruct',
+    max_tokens: 128,
   });
   return NextResponse.json(result);
 }

--- a/ecosystem-tests/vercel-edge/src/pages/api/streaming.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/streaming.ts
@@ -20,6 +20,7 @@ export default async function handler(request: NextRequest) {
   const stream = await openai.completions.create({
     prompt: 'Reply with exactly this text and nothing else: This is a test',
     model: 'gpt-3.5-turbo-instruct',
+    max_tokens: 128,
     stream: true,
   });
 

--- a/ecosystem-tests/vercel-edge/src/pages/api/vercel-ai-streaming.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/vercel-ai-streaming.ts
@@ -11,15 +11,26 @@ export const config = {
   ],
 };
 
-export default async function handler(request: NextRequest) {
-  const openai = new OpenAI();
+const maximumMessages = 32;
+const maximumMessageCharacters = 16_384;
 
+export default async function handler(request: NextRequest) {
   const { messages }: { messages: UIMessage[] } = await request.json();
+
+  if (!Array.isArray(messages)) {
+    return new Response('Invalid messages', { status: 400 });
+  }
+  if (messages.length > maximumMessages) {
+    return new Response('Too many messages', { status: 413 });
+  }
+
+  let totalCharacters = 0;
   const openAIMessages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = messages.map((message) => {
     const content = message.parts
       .filter((part) => part.type === 'text')
       .map((part) => part.text)
       .join('');
+    totalCharacters += content.length;
 
     switch (message.role) {
       case 'system': {
@@ -37,8 +48,14 @@ export default async function handler(request: NextRequest) {
     }
   });
 
+  if (totalCharacters > maximumMessageCharacters) {
+    return new Response('Messages are too large', { status: 413 });
+  }
+
+  const openai = new OpenAI();
   const completion = await openai.chat.completions.create({
     model: 'gpt-3.5-turbo',
+    max_tokens: 128,
     stream: true,
     messages: openAIMessages,
   });

--- a/ecosystem-tests/vercel-edge/src/pages/api/vercel-ai-streaming.ts
+++ b/ecosystem-tests/vercel-edge/src/pages/api/vercel-ai-streaming.ts
@@ -13,9 +13,54 @@ export const config = {
 
 const maximumMessages = 32;
 const maximumMessageCharacters = 16_384;
+const maximumRequestBodyBytes = 64 * 1024;
+
+async function cancelOversizedRequest(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<void> {
+  try {
+    await reader.cancel();
+  } catch {
+    // Cleanup failures must not mask the original payload-size rejection.
+  }
+}
+
+async function readRequestBody(request: NextRequest): Promise<string | null> {
+  const reader = request.body?.getReader();
+  if (!reader) {
+    return '';
+  }
+
+  const body = new Uint8Array(maximumRequestBodyBytes);
+  let length = 0;
+
+  try {
+    while (true) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- A bounded stream must consume chunks sequentially.
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value.byteLength > maximumRequestBodyBytes - length) {
+        void cancelOversizedRequest(reader);
+        return null;
+      }
+
+      body.set(value, length);
+      length += value.byteLength;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return new TextDecoder().decode(body.subarray(0, length));
+}
 
 export default async function handler(request: NextRequest) {
-  const { messages }: { messages: UIMessage[] } = await request.json();
+  const body = await readRequestBody(request);
+  if (body === null) {
+    return new Response('Payload Too Large', { status: 413 });
+  }
+
+  const { messages }: { messages: UIMessage[] } = JSON.parse(body);
 
   if (!Array.isArray(messages)) {
     return new Response('Invalid messages', { status: 400 });

--- a/ecosystem-tests/vercel-edge/src/uploadWebApiTestCases.ts
+++ b/ecosystem-tests/vercel-edge/src/uploadWebApiTestCases.ts
@@ -143,32 +143,40 @@ export function uploadWebApiTestCases({
 
   const fineTune = `{"prompt": "<prompt text>", "completion": "<ideal generated text>"}`;
 
+  async function expectAndDeleteUploadedFile(file: { filename: string; id: string }) {
+    try {
+      expectEqual(file.filename, 'finetune.jsonl');
+    } finally {
+      await client.files.delete(file.id);
+    }
+  }
+
   it('toFile handles string', async () => {
     // @ts-ignore this only doesn't error in vercel build...
     const file = await toFile(fineTune, 'finetune.jsonl');
     const result = await client.files.create({ file, purpose: 'fine-tune' });
-    expectEqual(result.filename, 'finetune.jsonl');
+    await expectAndDeleteUploadedFile(result);
   });
   it('toFile handles Blob', async () => {
     const result = await client.files.create({
       file: await toFile(new Blob([fineTune]), 'finetune.jsonl'),
       purpose: 'fine-tune',
     });
-    expectEqual(result.filename, 'finetune.jsonl');
+    await expectAndDeleteUploadedFile(result);
   });
   it('toFile handles Uint8Array', async () => {
     const result = await client.files.create({
       file: await toFile(new TextEncoder().encode(fineTune), 'finetune.jsonl'),
       purpose: 'fine-tune',
     });
-    expectEqual(result.filename, 'finetune.jsonl');
+    await expectAndDeleteUploadedFile(result);
   });
   it('toFile handles ArrayBuffer', async () => {
     const result = await client.files.create({
       file: await toFile(new TextEncoder().encode(fineTune).buffer, 'finetune.jsonl'),
       purpose: 'fine-tune',
     });
-    expectEqual(result.filename, 'finetune.jsonl');
+    await expectAndDeleteUploadedFile(result);
   });
   if (runtime !== 'edge') {
     // this fails in edge for some reason
@@ -177,7 +185,7 @@ export function uploadWebApiTestCases({
         file: await toFile(new DataView(new TextEncoder().encode(fineTune).buffer), 'finetune.jsonl'),
         purpose: 'fine-tune',
       });
-      expectEqual(result.filename, 'finetune.jsonl');
+      await expectAndDeleteUploadedFile(result);
     });
   }
 }

--- a/ecosystem-tests/vercel-edge/tests/middleware.test.ts
+++ b/ecosystem-tests/vercel-edge/tests/middleware.test.ts
@@ -101,3 +101,17 @@ it('checks authorization before inspecting an oversized body', () => {
 
   expect(middleware(request).status).toBe(401);
 });
+
+it('rejects unauthenticated streaming requests before consuming their bodies', () => {
+  const request = new NextRequest('https://example.com/api/vercel-ai-streaming', {
+    method: 'POST',
+    body: new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new Uint8Array(65_537));
+      },
+    }),
+  });
+
+  expect(middleware(request).status).toBe(401);
+  expect(request.bodyUsed).toBe(false);
+});

--- a/ecosystem-tests/vercel-edge/tests/middleware.test.ts
+++ b/ecosystem-tests/vercel-edge/tests/middleware.test.ts
@@ -1,0 +1,103 @@
+import { NextRequest } from 'next/server';
+import { config, middleware } from '../src/middleware';
+
+const token = 'test-token-with-at-least-thirty-two-characters';
+const originalToken = process.env.VERCEL_EDGE_TEST_TOKEN;
+const protectedRoutes = [
+  '/api/query-params',
+  '/api/vercel-ai-streaming',
+  '/api/response',
+  '/api/streaming',
+  '/api/transcribe',
+  '/api/edge-test',
+  '/api/node-test',
+];
+
+beforeEach(() => {
+  process.env.VERCEL_EDGE_TEST_TOKEN = token;
+});
+
+afterAll(() => {
+  if (originalToken === undefined) {
+    delete process.env.VERCEL_EDGE_TEST_TOKEN;
+  } else {
+    process.env.VERCEL_EDGE_TEST_TOKEN = originalToken;
+  }
+});
+
+it('applies the authentication boundary to every API route', () => {
+  expect(config.matcher).toBe('/api/:path*');
+});
+
+it.each(protectedRoutes)('rejects an unauthenticated request to %s', (path) => {
+  const response = middleware(new NextRequest(`https://example.com${path}`));
+
+  expect(response.status).toBe(401);
+  expect(response.headers.get('www-authenticate')).toBe('Bearer');
+});
+
+it.each(['', 'Bearer wrong-token', `Basic ${token}`, token, `Bearer ${token} extra`])(
+  'rejects the invalid authorization header %p',
+  (authorization) => {
+    const request = new NextRequest('https://example.com/api/query-params', {
+      headers: { authorization },
+    });
+
+    expect(middleware(request).status).toBe(401);
+  },
+);
+
+it('fails closed when its separate access token is not configured', () => {
+  delete process.env.VERCEL_EDGE_TEST_TOKEN;
+  const request = new NextRequest('https://example.com/api/query-params', {
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+  expect(middleware(request).status).toBe(401);
+});
+
+it('rejects an insecure access token configuration', () => {
+  process.env.VERCEL_EDGE_TEST_TOKEN = 'too-short';
+  const request = new NextRequest('https://example.com/api/query-params', {
+    headers: { authorization: 'Bearer too-short' },
+  });
+
+  expect(middleware(request).status).toBe(401);
+});
+
+it('does not treat proxy or middleware headers as authorization', () => {
+  const request = new NextRequest('https://example.com/api/query-params', {
+    headers: {
+      'x-forwarded-host': 'localhost',
+      'x-middleware-subrequest': 'src/middleware:src/middleware:src/middleware',
+    },
+  });
+
+  expect(middleware(request).status).toBe(401);
+});
+
+it('forwards requests carrying the configured bearer token', () => {
+  const request = new NextRequest('https://example.com/api/query-params', {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  const response = middleware(request);
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get('x-middleware-next')).toBe('1');
+});
+
+it('rejects an authenticated request with an oversized declared body', () => {
+  const request = new NextRequest('https://example.com/api/vercel-ai-streaming', {
+    headers: { authorization: `Bearer ${token}`, 'content-length': '65537' },
+  });
+
+  expect(middleware(request).status).toBe(413);
+});
+
+it('checks authorization before inspecting an oversized body', () => {
+  const request = new NextRequest('https://example.com/api/vercel-ai-streaming', {
+    headers: { 'content-length': '65537' },
+  });
+
+  expect(middleware(request).status).toBe(401);
+});

--- a/ecosystem-tests/vercel-edge/tests/streaming-input-limits.test.ts
+++ b/ecosystem-tests/vercel-edge/tests/streaming-input-limits.test.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server';
+import { createUIMessageStream, createUIMessageStreamResponse } from 'ai';
 import handler from '../src/pages/api/vercel-ai-streaming';
 
 jest.mock('ai', () => ({
@@ -8,6 +9,12 @@ jest.mock('ai', () => ({
 
 const apiKey = process.env.OPENAI_API_KEY;
 const adminKey = process.env.OPENAI_ADMIN_KEY;
+const maximumRequestBodyBytes = 64 * 1024;
+const streamingBodyHeaderCases: { name: string; headers: Record<string, string> }[] = [
+  { name: 'a missing Content-Length', headers: {} },
+  { name: 'a spoofed smaller Content-Length', headers: { 'content-length': '8' } },
+  { name: 'chunked transfer encoding', headers: { 'transfer-encoding': 'chunked' } },
+];
 
 beforeEach(() => {
   delete process.env.OPENAI_API_KEY;
@@ -34,6 +41,111 @@ function requestWithMessages(messages: unknown): NextRequest {
     headers: { 'content-type': 'application/json' },
   });
 }
+
+function requestWithBodyChunks(
+  chunks: string[],
+  headers: Record<string, string> = {},
+  cancel = jest.fn(),
+): { request: NextRequest; cancel: jest.Mock } {
+  let index = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      const chunk = chunks[index];
+      if (chunk === undefined) {
+        controller.close();
+        return;
+      }
+
+      index += 1;
+      controller.enqueue(new TextEncoder().encode(chunk));
+    },
+    cancel,
+  });
+
+  return {
+    request: new NextRequest('https://example.com/api/vercel-ai-streaming', {
+      method: 'POST',
+      body,
+      headers: { 'content-type': 'application/json', ...headers },
+    }),
+    cancel,
+  };
+}
+
+it.each(streamingBodyHeaderCases)('rejects an oversized streamed body with $name', async ({ headers }) => {
+  const body = JSON.stringify({ messages: null, padding: 'a'.repeat(maximumRequestBodyBytes) });
+  const { request, cancel } = requestWithBodyChunks(
+    [body.slice(0, maximumRequestBodyBytes / 2), body.slice(maximumRequestBodyBytes / 2), ' '],
+    headers,
+  );
+
+  const response = await handler(request);
+
+  expect(response.status).toBe(413);
+  expect(await response.text()).toBe('Payload Too Large');
+  expect(cancel).toHaveBeenCalledTimes(1);
+  expect(request.body?.locked).toBe(false);
+});
+
+it('does not let stream cancellation failures mask the oversized-body response', async () => {
+  const cancel = jest.fn().mockRejectedValue(new Error('stream cancellation failed'));
+  const body = JSON.stringify({ messages: null, padding: 'a'.repeat(maximumRequestBodyBytes) });
+  const { request } = requestWithBodyChunks([body, ' '], {}, cancel);
+
+  const response = await handler(request);
+
+  expect(response.status).toBe(413);
+  expect(cancel).toHaveBeenCalledTimes(1);
+  expect(request.body?.locked).toBe(false);
+});
+
+it('enforces UTF-8 byte size instead of JavaScript character count', async () => {
+  const body = JSON.stringify({ messages: null, padding: '🙂'.repeat(maximumRequestBodyBytes / 4) });
+  const { request, cancel } = requestWithBodyChunks([body, ' '], { 'content-length': '8' });
+
+  const response = await handler(request);
+
+  expect(body.length).toBeLessThan(maximumRequestBodyBytes);
+  expect(response.status).toBe(413);
+  expect(cancel).toHaveBeenCalledTimes(1);
+});
+
+it('accepts a streamed body exactly at the 64 KiB boundary', async () => {
+  const prefix = '{"messages":null,"padding":"';
+  const suffix = '"}';
+  const body = prefix + 'a'.repeat(maximumRequestBodyBytes - prefix.length - suffix.length) + suffix;
+  const { request, cancel } = requestWithBodyChunks([body.slice(0, 17), body.slice(17)]);
+
+  const response = await handler(request);
+
+  expect(response.status).toBe(400);
+  expect(await response.text()).toBe('Invalid messages');
+  expect(cancel).not.toHaveBeenCalled();
+  expect(request.body?.locked).toBe(false);
+});
+
+it('preserves valid message streaming after consuming the body once', async () => {
+  process.env.OPENAI_API_KEY = 'safe-synthetic-key';
+  const expected = new Response('stream response');
+  const fetch = jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response('data: [DONE]\n\n', {
+      headers: { 'content-type': 'text/event-stream' },
+    }),
+  );
+  jest.mocked(createUIMessageStream).mockReturnValue(new ReadableStream());
+  jest.mocked(createUIMessageStreamResponse).mockReturnValue(expected);
+  const request = requestWithMessages([
+    { id: 'message', role: 'user', parts: [{ type: 'text', text: 'safe message' }] },
+  ]);
+
+  try {
+    expect(await handler(request)).toBe(expected);
+    expect(request.bodyUsed).toBe(true);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  } finally {
+    fetch.mockRestore();
+  }
+});
 
 it('rejects invalid messages before initializing an OpenAI client', async () => {
   const response = await handler(requestWithMessages(null));

--- a/ecosystem-tests/vercel-edge/tests/streaming-input-limits.test.ts
+++ b/ecosystem-tests/vercel-edge/tests/streaming-input-limits.test.ts
@@ -1,0 +1,63 @@
+import { NextRequest } from 'next/server';
+import handler from '../src/pages/api/vercel-ai-streaming';
+
+jest.mock('ai', () => ({
+  createUIMessageStream: jest.fn(),
+  createUIMessageStreamResponse: jest.fn(),
+}));
+
+const apiKey = process.env.OPENAI_API_KEY;
+const adminKey = process.env.OPENAI_ADMIN_KEY;
+
+beforeEach(() => {
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.OPENAI_ADMIN_KEY;
+});
+
+afterAll(() => {
+  if (apiKey === undefined) {
+    delete process.env.OPENAI_API_KEY;
+  } else {
+    process.env.OPENAI_API_KEY = apiKey;
+  }
+  if (adminKey === undefined) {
+    delete process.env.OPENAI_ADMIN_KEY;
+  } else {
+    process.env.OPENAI_ADMIN_KEY = adminKey;
+  }
+});
+
+function requestWithMessages(messages: unknown): NextRequest {
+  return new NextRequest('https://example.com/api/vercel-ai-streaming', {
+    method: 'POST',
+    body: JSON.stringify({ messages }),
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+it('rejects invalid messages before initializing an OpenAI client', async () => {
+  const response = await handler(requestWithMessages(null));
+
+  expect(response.status).toBe(400);
+  expect(await response.text()).toBe('Invalid messages');
+});
+
+it('rejects too many messages before initializing an OpenAI client', async () => {
+  const message = { id: 'message', role: 'user', parts: [{ type: 'text', text: 'test' }] };
+  const response = await handler(requestWithMessages(Array.from({ length: 33 }, () => message)));
+
+  expect(response.status).toBe(413);
+  expect(await response.text()).toBe('Too many messages');
+});
+
+it('rejects oversized text before initializing an OpenAI client', async () => {
+  const message = {
+    id: 'message',
+    role: 'user',
+    parts: [{ type: 'text', text: 'a'.repeat(16_385) }],
+  };
+  const response = await handler(requestWithMessages([message]));
+
+  expect(response.status).toBe(413);
+  expect(await response.text()).toBe('Messages are too large');
+});

--- a/ecosystem-tests/vercel-edge/tests/test-file-cleanup.test.ts
+++ b/ecosystem-tests/vercel-edge/tests/test-file-cleanup.test.ts
@@ -1,0 +1,80 @@
+import type OpenAI from 'openai';
+import { uploadWebApiTestCases } from '../src/uploadWebApiTestCases';
+
+const uploadCases = [
+  ['node', 'toFile handles string'],
+  ['node', 'toFile handles Blob'],
+  ['node', 'toFile handles Uint8Array'],
+  ['node', 'toFile handles ArrayBuffer'],
+  ['node', 'toFile handles DataView'],
+  ['edge', 'toFile handles string'],
+  ['edge', 'toFile handles Blob'],
+  ['edge', 'toFile handles Uint8Array'],
+  ['edge', 'toFile handles ArrayBuffer'],
+] as const;
+
+function registerUploadTests(
+  runtime: 'node' | 'edge',
+  {
+    create = jest.fn().mockResolvedValue({ filename: 'finetune.jsonl', id: 'file-test' }),
+    deleteFile = jest.fn().mockResolvedValue({ deleted: true }),
+    expectEqual = jest.fn(),
+  }: { create?: jest.Mock; deleteFile?: jest.Mock; expectEqual?: jest.Mock } = {},
+) {
+  const tests = new Map<string, () => Promise<void>>();
+
+  uploadWebApiTestCases({
+    client: { files: { create, delete: deleteFile } } as unknown as OpenAI,
+    it: (description, handler) => tests.set(description, handler),
+    expectEqual,
+    expectSimilar: jest.fn(),
+    runtime,
+  });
+
+  return { create, deleteFile, expectEqual, tests };
+}
+
+describe('uploaded test file cleanup', () => {
+  it.each(uploadCases)('deletes the uploaded file after a successful %s %s test', async (runtime, description) => {
+    const { create, deleteFile, expectEqual, tests } = registerUploadTests(runtime);
+
+    await expect(tests.get(description)?.()).resolves.toBeUndefined();
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(expectEqual).toHaveBeenCalledWith('finetune.jsonl', 'finetune.jsonl');
+    expect(deleteFile).toHaveBeenCalledWith('file-test');
+  });
+
+  it.each(uploadCases)('deletes the uploaded file after a failed %s %s assertion', async (runtime, description) => {
+    const assertionError = new Error('filename assertion failed');
+    const expectEqual = jest.fn(() => {
+      throw assertionError;
+    });
+    const { deleteFile, tests } = registerUploadTests(runtime, { expectEqual });
+
+    await expect(tests.get(description)?.()).rejects.toBe(assertionError);
+
+    expect(deleteFile).toHaveBeenCalledWith('file-test');
+  });
+
+  it.each(uploadCases)('does not delete a file after a failed %s %s upload', async (runtime, description) => {
+    const uploadError = new Error('upload failed');
+    const create = jest.fn().mockRejectedValue(uploadError);
+    const { deleteFile, expectEqual, tests } = registerUploadTests(runtime, { create });
+
+    await expect(tests.get(description)?.()).rejects.toBe(uploadError);
+
+    expect(expectEqual).not.toHaveBeenCalled();
+    expect(deleteFile).not.toHaveBeenCalled();
+  });
+
+  it.each(['node', 'edge'] as const)('surfaces failed %s file cleanup', async (runtime) => {
+    const cleanupError = new Error('cleanup failed');
+    const deleteFile = jest.fn().mockRejectedValue(cleanupError);
+    const { tests } = registerUploadTests(runtime, { deleteFile });
+
+    await expect(tests.get('toFile handles string')?.()).rejects.toBe(cleanupError);
+
+    expect(deleteFile).toHaveBeenCalledWith('file-test');
+  });
+});

--- a/ecosystem-tests/vercel-edge/tests/test.ts
+++ b/ecosystem-tests/vercel-edge/tests/test.ts
@@ -1,10 +1,32 @@
 const baseUrl = process.env.TEST_BASE_URL || 'http://localhost:3000';
+const token = process.env.VERCEL_EDGE_TEST_TOKEN;
+
+if (!token) {
+  throw new Error('VERCEL_EDGE_TEST_TOKEN must be configured for live ecosystem tests');
+}
+
+const headers = { authorization: `Bearer ${token}` };
+
 console.log(baseUrl);
+
+it.each([
+  'query-params',
+  'vercel-ai-streaming',
+  'response',
+  'streaming',
+  'transcribe',
+  'edge-test',
+  'node-test',
+])('rejects unauthenticated access to /api/%s', async (route) => {
+  const response = await fetch(`${baseUrl}/api/${route}`);
+
+  expect(response.status).toBe(401);
+});
 
 it(
   'node runtime',
   async () => {
-    const response = await fetch(`${baseUrl}/api/node-test`);
+    const response = await fetch(`${baseUrl}/api/node-test`, { headers });
     expect(await response.text()).toEqual('Passed!');
   },
   3 * 60_000,
@@ -13,7 +35,7 @@ it(
 it(
   'edge runtime',
   async () => {
-    const response = await fetch(`${baseUrl}/api/edge-test`);
+    const response = await fetch(`${baseUrl}/api/edge-test`, { headers });
     expect(await response.text()).toEqual('Passed!');
   },
   3 * 60_000,


### PR DESCRIPTION
## Security findings

- HIGH `csf_60ad55d472f1de23a525c274`: unauthenticated assistant listing exposes account data.
- MEDIUM `csf_97c0b7e3dc03a6c21566a620`: anonymous completion and streaming routes proxy paid model requests.
- MEDIUM `csf_c2b9fc853edab3a40da1eb0f`: anonymous transcription requests consume paid capacity.
- MEDIUM `csf_3d634c846334bb5128ffb403` and `csf_e2bb95e5859e20ee92db380c`: public Edge/Node test routes incur charges and leave uploaded files behind.

## Changes

- Require a separate, fail-closed bearer token for every `/api/*` route before OpenAI client initialization; reject oversized requests and bound chat inputs/model output.
- Generate cryptographically random credentials for existing CI smoke runs and allow browser users to enter the token without exposing it in public build configuration.
- Delete every uploaded ecosystem-test file in `finally`, including assertion-failure paths, across both Edge and Node runtimes.
- Add focused authentication, request-boundary, and file-cleanup regressions; restrict every change to `ecosystem-tests/vercel-edge/**`.

## Verification

- Five focused Jest suites: **55 passing tests**; **20 cleanup regressions failed before the fix**.
- Ecosystem TypeScript check: `node_modules/.bin/tsc --noEmit --incremental false`.
- Production application build: `npm run build`.
- Full repository lint with pinned Oxfmt 0.62.0: `./scripts/lint`.
- Real development/production HTTP checks: seven anonymous routes and spoofed middleware headers return `401`; oversized authorized input returns `413`; authorized requests reach the existing handler; the public homepage remains `200`. No paid upstream requests were made.

## Rollout

Deployments must configure a private `VERCEL_EDGE_TEST_TOKEN` containing at least 32 characters; without it, API routes remain safely disabled. Existing ecosystem CI generates a fresh token automatically. Public SDK APIs and generated/upstream-owned files are unchanged.