### PR TITLE
fix(security): authenticate Cloudflare tests and restrict streaming proxies

### DIFF
--- a/ecosystem-tests/cloudflare-worker/src/uploadWebApiTestCases.ts
+++ b/ecosystem-tests/cloudflare-worker/src/uploadWebApiTestCases.ts
@@ -117,18 +117,30 @@ export function uploadWebApiTestCases({
 		// @ts-expect-error we don't type support for `string` to avoid a footgun with passing the file path
 		const file = await toFile(fineTune, 'finetune.jsonl');
 		const result = await client.files.create({ file, purpose: 'fine-tune' });
-		expectEqual(result.filename, 'finetune.jsonl');
+		try {
+			expectEqual(result.filename, 'finetune.jsonl');
+		} finally {
+			await client.files.delete(result.id);
+		}
 	});
 	it('toFile handles Blob', async () => {
 		const result = await client.files.create({ file: await toFile(new Blob([fineTune]), 'finetune.jsonl'), purpose: 'fine-tune' });
-		expectEqual(result.filename, 'finetune.jsonl');
+		try {
+			expectEqual(result.filename, 'finetune.jsonl');
+		} finally {
+			await client.files.delete(result.id);
+		}
 	});
 	it('toFile handles Uint8Array', async () => {
 		const result = await client.files.create({
 			file: await toFile(new TextEncoder().encode(fineTune), 'finetune.jsonl'),
 			purpose: 'fine-tune',
 		});
-		expectEqual(result.filename, 'finetune.jsonl');
+		try {
+			expectEqual(result.filename, 'finetune.jsonl');
+		} finally {
+			await client.files.delete(result.id);
+		}
 	});
 	it('toFile handles ArrayBuffer', async () => {
 		const result = await client.files.create({
@@ -136,13 +148,21 @@ export function uploadWebApiTestCases({
 			file: await toFile(new TextEncoder().encode(fineTune).buffer, 'finetune.jsonl'),
 			purpose: 'fine-tune',
 		});
-		expectEqual(result.filename, 'finetune.jsonl');
+		try {
+			expectEqual(result.filename, 'finetune.jsonl');
+		} finally {
+			await client.files.delete(result.id);
+		}
 	});
 	it('toFile handles DataView', async () => {
 		const result = await client.files.create({
 			file: await toFile(new DataView(new TextEncoder().encode(fineTune).buffer), 'finetune.jsonl'),
 			purpose: 'fine-tune',
 		});
-		expectEqual(result.filename, 'finetune.jsonl');
+		try {
+			expectEqual(result.filename, 'finetune.jsonl');
+		} finally {
+			await client.files.delete(result.id);
+		}
 	});
 }

--- a/ecosystem-tests/cloudflare-worker/src/worker.ts
+++ b/ecosystem-tests/cloudflare-worker/src/worker.ts
@@ -31,6 +31,54 @@ export interface Env {
 
 type Test = { description: string; handler: () => Promise<void> };
 
+const MAX_SIGNATURE_AGE_MS = 60_000;
+const MAX_USED_NONCES = 1024;
+const usedNonces = new Map<string, number>();
+let activeTestRun = false;
+
+async function authenticateTestRequest(request: Request, apiKey: string): Promise<string | undefined> {
+	const authorization = request.headers.get('authorization');
+	const timestampHeader = request.headers.get('x-worker-timestamp');
+	const nonce = request.headers.get('x-worker-nonce');
+
+	if (
+		!apiKey ||
+		!authorization ||
+		!/^HMAC-SHA256 [a-f0-9]{64}$/u.test(authorization) ||
+		!timestampHeader ||
+		!/^\d{13}$/u.test(timestampHeader) ||
+		!nonce ||
+		!/^[a-f0-9]{32}$/u.test(nonce)
+	) {
+		return undefined;
+	}
+
+	const timestamp = Number(timestampHeader);
+	if (Math.abs(Date.now() - timestamp) > MAX_SIGNATURE_AGE_MS) {
+		return undefined;
+	}
+
+	const digest = authorization.slice('HMAC-SHA256 '.length);
+	const signature = new Uint8Array(digest.length / 2);
+	for (let index = 0; index < signature.length; index += 1) {
+		signature[index] = Number.parseInt(digest.slice(index * 2, index * 2 + 2), 16);
+	}
+
+	const encoder = new TextEncoder();
+	const key = await crypto.subtle.importKey(
+		'raw',
+		encoder.encode(apiKey),
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		['verify'],
+	);
+	const url = new URL(request.url);
+	const message = encoder.encode(`${request.method}\n${url.pathname}\n${timestampHeader}\n${nonce}`);
+	const valid = await crypto.subtle.verify('HMAC', key, signature, message);
+
+	return valid ? nonce : undefined;
+}
+
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
 		const url = new URL(request.url);
@@ -38,6 +86,29 @@ export default {
 		if (url.pathname === '/') {return new Response();}
 		// then the test code requests /test
 		if (url.pathname !== '/test') {return new Response(null, { status: 404 });}
+		if (request.method !== 'POST') {
+			return new Response('Method Not Allowed', { status: 405, headers: { allow: 'POST' } });
+		}
+
+		let nonce: string | undefined;
+		try {
+			nonce = await authenticateTestRequest(request, env.OPENAI_API_KEY);
+		} catch {
+			return new Response('Unauthorized', { status: 401 });
+		}
+		if (!nonce) {return new Response('Unauthorized', { status: 401 });}
+
+		const now = Date.now();
+		for (const [usedNonce, timestamp] of usedNonces) {
+			if (now - timestamp > MAX_SIGNATURE_AGE_MS) {usedNonces.delete(usedNonce);}
+		}
+		if (usedNonces.has(nonce)) {return new Response('Conflict', { status: 409 });}
+		if (activeTestRun || usedNonces.size >= MAX_USED_NONCES) {
+			return new Response('Too Many Requests', { status: 429, headers: { 'retry-after': '1' } });
+		}
+
+		usedNonces.set(nonce, Number(request.headers.get('x-worker-timestamp')));
+		activeTestRun = true;
 		try {
 			console.error('importing openai');
 			const { default: OpenAI } = await import('openai');
@@ -94,6 +165,8 @@ export default {
 		} catch (error) {
 			console.error(error instanceof Error ? error.stack : String(error));
 			return new Response('Internal Server Error', { status: 500 });
+		} finally {
+			activeTestRun = false;
 		}
 	},
 };

--- a/ecosystem-tests/cloudflare-worker/tests/error-response.test.js
+++ b/ecosystem-tests/cloudflare-worker/tests/error-response.test.js
@@ -1,5 +1,29 @@
+import { createHmac, randomBytes } from 'node:crypto';
 import { jest } from '@jest/globals';
+import { uploadWebApiTestCases } from '../src/uploadWebApiTestCases.ts';
 import worker from '../src/worker.ts';
+
+const uploadModule = '../src/uploadWebApiTestCases.js';
+const uploadModuleFactory = () => ({ uploadWebApiTestCases });
+jest.mock(uploadModule, uploadModuleFactory, { virtual: true });
+jest.unstable_mockModule(uploadModule, uploadModuleFactory, { virtual: true });
+
+function authenticatedRequest(apiKey) {
+	const timestamp = String(Date.now());
+	const nonce = randomBytes(16).toString('hex');
+	const signature = createHmac('sha256', apiKey)
+		.update(`POST\n/test\n${timestamp}\n${nonce}`)
+		.digest('hex');
+
+	return new Request('http://localhost:8787/test', {
+		method: 'POST',
+		headers: {
+			authorization: `HMAC-SHA256 ${signature}`,
+			'x-worker-timestamp': timestamp,
+			'x-worker-nonce': nonce,
+		},
+	});
+}
 
 it('keeps the health check response available', async () => {
 	const response = await worker.fetch(new Request('http://localhost:8787/'), { OPENAI_API_KEY: '' }, {});
@@ -12,18 +36,30 @@ it('does not expose stack traces from unexpected errors', async () => {
 	const apiKey = process.env.OPENAI_API_KEY;
 	const adminKey = process.env.OPENAI_ADMIN_KEY;
 	const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+	const fetch = jest.spyOn(globalThis, 'fetch');
+	let apiKeyReads = 0;
+	const env = {
+		get OPENAI_API_KEY() {
+			if (apiKeyReads === 0) {
+				apiKeyReads += 1;
+				return 'test-key';
+			}
+			throw new Error('sensitive stack trace');
+		},
+	};
 	delete process.env.OPENAI_API_KEY;
 	delete process.env.OPENAI_ADMIN_KEY;
 
 	try {
 		const response = await worker.fetch(
-			new Request('http://localhost:8787/test'),
-			{ OPENAI_API_KEY: '' },
+			authenticatedRequest('test-key'),
+			env,
 			{},
 		);
 
 		expect(response.status).toBe(500);
 		expect(await response.text()).toBe('Internal Server Error');
+		expect(fetch).not.toHaveBeenCalled();
 	} finally {
 		if (apiKey === undefined) {
 			delete process.env.OPENAI_API_KEY;
@@ -35,6 +71,7 @@ it('does not expose stack traces from unexpected errors', async () => {
 		} else {
 			process.env.OPENAI_ADMIN_KEY = adminKey;
 		}
+		fetch.mockRestore();
 		consoleError.mockRestore();
 	}
 });
@@ -45,13 +82,14 @@ it('does not expose stack traces from failed test handlers', async () => {
 
 	try {
 		const response = await worker.fetch(
-			new Request('http://localhost:8787/test'),
+			authenticatedRequest('test-key'),
 			{ OPENAI_API_KEY: 'test-key' },
 			{},
 		);
 
 		expect(response.status).toBe(500);
 		expect(await response.text()).toBe('Internal Server Error');
+		expect(fetch).toHaveBeenCalled();
 	} finally {
 		fetch.mockRestore();
 		consoleError.mockRestore();

--- a/ecosystem-tests/cloudflare-worker/tests/streaming-example-security.test.js
+++ b/ecosystem-tests/cloudflare-worker/tests/streaming-example-security.test.js
@@ -5,6 +5,15 @@ import ts from 'typescript';
 
 const examples = ['stream-to-client-express.ts', 'stream-to-client-raw.ts'];
 const strongToken = '0123456789abcdef0123456789abcdef';
+const certificatePath = 'synthetic-certificate.pem';
+const privateKeyPath = 'synthetic-private-key.pem';
+const tlsEnvironment = {
+	OPENAI_EXAMPLE_HOST: '0.0.0.0',
+	OPENAI_EXAMPLE_ALLOW_REMOTE: 'true',
+	OPENAI_EXAMPLE_AUTH_TOKEN: strongToken,
+	OPENAI_EXAMPLE_TLS_CERT_FILE: certificatePath,
+	OPENAI_EXAMPLE_TLS_KEY_FILE: privateKeyPath,
+};
 
 async function* completionStream() {
 	yield { choices: [{ delta: { content: 'mock completion' } }] };
@@ -13,12 +22,16 @@ async function* completionStream() {
 async function loadExample(filename, environment = {}) {
 	const middleware = [];
 	const listenCalls = [];
+	const httpListenCalls = [];
+	const tlsServers = [];
 	const runtime = {
 		apiCalls: 0,
 		bodyParserCalls: 0,
 		clientsCreated: 0,
+		httpListenCalls,
 		listenCalls,
 		middleware,
+		tlsServers,
 		routeHandler: undefined,
 	};
 
@@ -33,6 +46,7 @@ async function loadExample(filename, environment = {}) {
 		},
 		listen(...args) {
 			listenCalls.push(args);
+			httpListenCalls.push(args);
 			return app;
 		},
 	};
@@ -85,6 +99,37 @@ async function loadExample(filename, environment = {}) {
 		['openai', { default: OpenAI }],
 		['express', { default: express }],
 		['node:crypto', { timingSafeEqual }],
+		[
+			'node:fs',
+			{
+				readFileSync(candidate) {
+					if (candidate === certificatePath) {
+						return Buffer.from('synthetic TLS certificate');
+					}
+					if (candidate === privateKeyPath) {
+						return Buffer.from('synthetic TLS private key');
+					}
+					throw new Error('Missing TLS fixture');
+				},
+			},
+		],
+		[
+			'node:https',
+			{
+				createServer(options, listener) {
+					const server = {
+						options,
+						listener,
+						listen(...args) {
+							listenCalls.push(args);
+							return server;
+						},
+					};
+					tlsServers.push(server);
+					return server;
+				},
+			},
+		],
 	]);
 
 	await sourceModule.link((specifier) => {
@@ -176,6 +221,8 @@ describe.each(examples)('%s streaming proxy security', (filename) => {
 		expect(runtime.error).toBeUndefined();
 		expect(runtime.listenCalls).toHaveLength(1);
 		expect(runtime.listenCalls[0][1]).toBe('127.0.0.1');
+		expect(runtime.httpListenCalls).toHaveLength(1);
+		expect(runtime.tlsServers).toHaveLength(0);
 
 		const response = await requestExample(runtime);
 		expect(response.statusCode).toBe(200);
@@ -187,7 +234,9 @@ describe.each(examples)('%s streaming proxy security', (filename) => {
 		const runtime = await loadExample(filename, { OPENAI_EXAMPLE_HOST: host });
 
 		expect(runtime.error).toBeUndefined();
-		expect(runtime.listenCalls[0][1]).toBe(host);
+		expect(runtime.listenCalls[0][1]).toBe(host === 'localhost' ? '127.0.0.1' : host);
+		expect(runtime.httpListenCalls).toHaveLength(1);
+		expect(runtime.tlsServers).toHaveLength(0);
 		const response = await requestExample(runtime);
 		expect(response.statusCode).toBe(200);
 	});
@@ -204,6 +253,28 @@ describe.each(examples)('%s streaming proxy security', (filename) => {
 			},
 		],
 		[
+			'missing TLS certificate',
+			{
+				OPENAI_EXAMPLE_HOST: '0.0.0.0',
+				OPENAI_EXAMPLE_ALLOW_REMOTE: 'true',
+				OPENAI_EXAMPLE_AUTH_TOKEN: strongToken,
+				OPENAI_EXAMPLE_TLS_KEY_FILE: privateKeyPath,
+			},
+		],
+		[
+			'missing TLS private key',
+			{
+				OPENAI_EXAMPLE_HOST: '0.0.0.0',
+				OPENAI_EXAMPLE_ALLOW_REMOTE: 'true',
+				OPENAI_EXAMPLE_AUTH_TOKEN: strongToken,
+				OPENAI_EXAMPLE_TLS_CERT_FILE: certificatePath,
+			},
+		],
+		[
+			'unreadable TLS certificate',
+			{ ...tlsEnvironment, OPENAI_EXAMPLE_TLS_CERT_FILE: 'missing-certificate.pem' },
+		],
+		[
 			'unrecognized loopback-looking host',
 			{ OPENAI_EXAMPLE_HOST: '127.0.0.2', OPENAI_EXAMPLE_AUTH_TOKEN: strongToken },
 		],
@@ -216,14 +287,12 @@ describe.each(examples)('%s streaming proxy security', (filename) => {
 	});
 
 	it('rejects missing and incorrect remote bearer tokens before parsing request bodies', async () => {
-		const runtime = await loadExample(filename, {
-			OPENAI_EXAMPLE_HOST: '0.0.0.0',
-			OPENAI_EXAMPLE_ALLOW_REMOTE: 'true',
-			OPENAI_EXAMPLE_AUTH_TOKEN: strongToken,
-		});
+		const runtime = await loadExample(filename, tlsEnvironment);
 
 		expect(runtime.error).toBeUndefined();
 		expect(runtime.listenCalls[0][1]).toBe('0.0.0.0');
+		expect(runtime.httpListenCalls).toHaveLength(0);
+		expect(runtime.tlsServers).toHaveLength(1);
 
 		const responses = await Promise.all(
 			[undefined, `Bearer ${strongToken.slice(0, -1)}x`].map((authorization) => requestExample(runtime, authorization)),
@@ -238,11 +307,13 @@ describe.each(examples)('%s streaming proxy security', (filename) => {
 	});
 
 	it('accepts the configured remote bearer token and preserves streaming', async () => {
-		const runtime = await loadExample(filename, {
-			OPENAI_EXAMPLE_HOST: '0.0.0.0',
-			OPENAI_EXAMPLE_ALLOW_REMOTE: 'true',
-			OPENAI_EXAMPLE_AUTH_TOKEN: strongToken,
-		});
+		const runtime = await loadExample(filename, tlsEnvironment);
+
+		expect(runtime.error).toBeUndefined();
+		expect(runtime.httpListenCalls).toHaveLength(0);
+		expect(runtime.tlsServers).toHaveLength(1);
+		expect(runtime.tlsServers[0].options.cert).toEqual(Buffer.from('synthetic TLS certificate'));
+		expect(runtime.tlsServers[0].options.key).toEqual(Buffer.from('synthetic TLS private key'));
 
 		const response = await requestExample(runtime, `Bearer ${strongToken}`);
 
@@ -250,5 +321,16 @@ describe.each(examples)('%s streaming proxy security', (filename) => {
 		expect(response.body).toBe('mock completion');
 		expect(runtime.bodyParserCalls).toBe(1);
 		expect(runtime.apiCalls).toBe(1);
+	});
+
+	it('keeps documented and browser clients on the bound numeric IPv4 loopback address', async () => {
+		const sourceURL = new URL(`../../../examples/chat-completions/${filename}`, import.meta.url);
+		const browserURL = new URL('../../../examples/chat-completions/stream-to-client-browser.ts', import.meta.url);
+		const [source, browser] = await Promise.all([readFile(sourceURL, 'utf-8'), readFile(browserURL, 'utf-8')]);
+
+		expect(source).toContain("fetch('http://127.0.0.1:3000'");
+		expect(browser).toContain("fetch('http://127.0.0.1:3000'");
+		expect(source).not.toContain("fetch('http://localhost:3000'");
+		expect(browser).not.toContain("fetch('http://localhost:3000'");
 	});
 });

--- a/ecosystem-tests/cloudflare-worker/tests/streaming-example-security.test.js
+++ b/ecosystem-tests/cloudflare-worker/tests/streaming-example-security.test.js
@@ -1,0 +1,254 @@
+import { timingSafeEqual } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { createContext, SourceTextModule, SyntheticModule } from 'node:vm';
+import ts from 'typescript';
+
+const examples = ['stream-to-client-express.ts', 'stream-to-client-raw.ts'];
+const strongToken = '0123456789abcdef0123456789abcdef';
+
+async function* completionStream() {
+	yield { choices: [{ delta: { content: 'mock completion' } }] };
+}
+
+async function loadExample(filename, environment = {}) {
+	const middleware = [];
+	const listenCalls = [];
+	const runtime = {
+		apiCalls: 0,
+		bodyParserCalls: 0,
+		clientsCreated: 0,
+		listenCalls,
+		middleware,
+		routeHandler: undefined,
+	};
+
+	const app = {
+		use(handler) {
+			middleware.push(handler);
+			return app;
+		},
+		post(_path, handler) {
+			runtime.routeHandler = handler;
+			return app;
+		},
+		listen(...args) {
+			listenCalls.push(args);
+			return app;
+		},
+	};
+
+	const express = Object.assign(() => app, {
+		text: () => (_request, _response, next) => {
+			runtime.bodyParserCalls += 1;
+			return next();
+		},
+	});
+
+	class OpenAI {
+		constructor() {
+			runtime.clientsCreated += 1;
+		}
+
+		chat = {
+			completions: {
+				stream: () => {
+					runtime.apiCalls += 1;
+					return {
+						async *toReadableStream() {
+							yield 'mock completion';
+						},
+					};
+				},
+				create: () => {
+					runtime.apiCalls += 1;
+					return completionStream();
+				},
+			},
+		};
+	}
+
+	const context = createContext({
+		Buffer,
+		console: { error() {}, log() {} },
+		process: { env: environment },
+	});
+	const sourceURL = new URL(`../../../examples/chat-completions/${filename}`, import.meta.url);
+	const source = ts.transpileModule(await readFile(sourceURL, 'utf-8'), {
+		compilerOptions: {
+			module: ts.ModuleKind.ES2022,
+			target: ts.ScriptTarget.ES2022,
+		},
+		fileName: filename,
+	}).outputText;
+	const sourceModule = new SourceTextModule(source, { context, identifier: sourceURL.href });
+	const mockModules = new Map([
+		['openai', { default: OpenAI }],
+		['express', { default: express }],
+		['node:crypto', { timingSafeEqual }],
+	]);
+
+	await sourceModule.link((specifier) => {
+		const exports = mockModules.get(specifier);
+
+		if (!exports) {
+			throw new Error(`Unexpected example import: ${specifier}`);
+		}
+
+		return new SyntheticModule(
+			Object.keys(exports),
+			function initializeMockModule() {
+				for (const [name, value] of Object.entries(exports)) {
+					this.setExport(name, value);
+				}
+			},
+			{ context },
+		);
+	});
+
+	try {
+		await sourceModule.evaluate();
+	} catch (error) {
+		runtime.error = error;
+	}
+
+	return runtime;
+}
+
+async function requestExample(runtime, authorization) {
+	const request = {
+		body: 'hello',
+		get(name) {
+			return name.toLowerCase() === 'authorization' ? authorization : undefined;
+		},
+	};
+	const response = {
+		body: '',
+		headers: {},
+		statusCode: 200,
+		ended: false,
+		status(code) {
+			this.statusCode = code;
+			return this;
+		},
+		set(name, value) {
+			this.headers[name.toLowerCase()] = value;
+			return this;
+		},
+		header(name, value) {
+			return this.set(name, value);
+		},
+		send(body) {
+			this.body = body;
+			this.ended = true;
+			return this;
+		},
+		write(chunk) {
+			this.body += chunk;
+			return true;
+		},
+		end() {
+			this.ended = true;
+			return this;
+		},
+	};
+
+	let index = 0;
+	let routePromise;
+	const dispatch = () => {
+		if (index < runtime.middleware.length) {
+			const currentMiddleware = runtime.middleware[index];
+			index += 1;
+			return currentMiddleware(request, response, dispatch);
+		}
+		routePromise = runtime.routeHandler(request, response);
+		return routePromise;
+	};
+
+	await dispatch();
+	await routePromise;
+	return response;
+}
+
+describe.each(examples)('%s streaming proxy security', (filename) => {
+	it('binds to IPv4 loopback by default and preserves local streaming', async () => {
+		const runtime = await loadExample(filename);
+
+		expect(runtime.error).toBeUndefined();
+		expect(runtime.listenCalls).toHaveLength(1);
+		expect(runtime.listenCalls[0][1]).toBe('127.0.0.1');
+
+		const response = await requestExample(runtime);
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toBe('mock completion');
+		expect(runtime.apiCalls).toBe(1);
+	});
+
+	it.each(['::1', 'localhost'])('permits the explicit loopback host %s without authentication', async (host) => {
+		const runtime = await loadExample(filename, { OPENAI_EXAMPLE_HOST: host });
+
+		expect(runtime.error).toBeUndefined();
+		expect(runtime.listenCalls[0][1]).toBe(host);
+		const response = await requestExample(runtime);
+		expect(response.statusCode).toBe(200);
+	});
+
+	it.each([
+		['missing remote opt-in', { OPENAI_EXAMPLE_HOST: '0.0.0.0', OPENAI_EXAMPLE_AUTH_TOKEN: strongToken }],
+		['missing authentication token', { OPENAI_EXAMPLE_HOST: '0.0.0.0', OPENAI_EXAMPLE_ALLOW_REMOTE: 'true' }],
+		[
+			'weak authentication token',
+			{
+				OPENAI_EXAMPLE_HOST: '0.0.0.0',
+				OPENAI_EXAMPLE_ALLOW_REMOTE: 'true',
+				OPENAI_EXAMPLE_AUTH_TOKEN: 'short-secret',
+			},
+		],
+		[
+			'unrecognized loopback-looking host',
+			{ OPENAI_EXAMPLE_HOST: '127.0.0.2', OPENAI_EXAMPLE_AUTH_TOKEN: strongToken },
+		],
+	])('rejects %s before creating an OpenAI client', async (_description, environment) => {
+		const runtime = await loadExample(filename, environment);
+
+		expect(runtime.error).toBeDefined();
+		expect(runtime.clientsCreated).toBe(0);
+		expect(runtime.listenCalls).toHaveLength(0);
+	});
+
+	it('rejects missing and incorrect remote bearer tokens before parsing request bodies', async () => {
+		const runtime = await loadExample(filename, {
+			OPENAI_EXAMPLE_HOST: '0.0.0.0',
+			OPENAI_EXAMPLE_ALLOW_REMOTE: 'true',
+			OPENAI_EXAMPLE_AUTH_TOKEN: strongToken,
+		});
+
+		expect(runtime.error).toBeUndefined();
+		expect(runtime.listenCalls[0][1]).toBe('0.0.0.0');
+
+		const responses = await Promise.all(
+			[undefined, `Bearer ${strongToken.slice(0, -1)}x`].map((authorization) => requestExample(runtime, authorization)),
+		);
+		for (const response of responses) {
+			expect(response.statusCode).toBe(401);
+			expect(response.headers['www-authenticate']).toBe('Bearer');
+		}
+
+		expect(runtime.bodyParserCalls).toBe(0);
+		expect(runtime.apiCalls).toBe(0);
+	});
+
+	it('accepts the configured remote bearer token and preserves streaming', async () => {
+		const runtime = await loadExample(filename, {
+			OPENAI_EXAMPLE_HOST: '0.0.0.0',
+			OPENAI_EXAMPLE_ALLOW_REMOTE: 'true',
+			OPENAI_EXAMPLE_AUTH_TOKEN: strongToken,
+		});
+
+		const response = await requestExample(runtime, `Bearer ${strongToken}`);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toBe('mock completion');
+		expect(runtime.bodyParserCalls).toBe(1);
+		expect(runtime.apiCalls).toBe(1);
+	});
+});

--- a/ecosystem-tests/cloudflare-worker/tests/streaming-example-security.test.js
+++ b/ecosystem-tests/cloudflare-worker/tests/streaming-example-security.test.js
@@ -159,11 +159,12 @@ async function loadExample(filename, environment = {}) {
 	return runtime;
 }
 
-async function requestExample(runtime, authorization) {
+async function requestExample(runtime, authorization, headers = {}) {
 	const request = {
 		body: 'hello',
 		get(name) {
-			return name.toLowerCase() === 'authorization' ? authorization : undefined;
+			const normalizedName = name.toLowerCase();
+			return normalizedName === 'authorization' ? authorization : headers[normalizedName];
 		},
 	};
 	const response = {
@@ -227,6 +228,49 @@ describe.each(examples)('%s streaming proxy security', (filename) => {
 		const response = await requestExample(runtime);
 		expect(response.statusCode).toBe(200);
 		expect(response.body).toBe('mock completion');
+		expect(runtime.apiCalls).toBe(1);
+	});
+
+	it.each([
+		['a foreign browser origin', { origin: 'https://attacker.example' }],
+		['a different loopback port', { origin: 'http://127.0.0.1:4000' }],
+		['an opaque browser origin', { origin: 'null' }],
+		['cross-site Fetch Metadata without an Origin', { 'sec-fetch-site': 'cross-site' }],
+		[
+			'cross-site Fetch Metadata despite a matching Origin',
+			{ origin: 'http://127.0.0.1:3000', 'sec-fetch-site': 'cross-site' },
+		],
+	])('rejects %s before parsing a loopback request body', async (_description, headers) => {
+		const runtime = await loadExample(filename);
+		const response = await requestExample(runtime, undefined, headers);
+
+		expect(response.statusCode).toBe(403);
+		expect(runtime.bodyParserCalls).toBe(0);
+		expect(runtime.apiCalls).toBe(0);
+	});
+
+	it.each([
+		['a tokenless local CLI request', {}],
+		['a same-origin browser request', { origin: 'http://127.0.0.1:3000' }],
+		[
+			'a same-origin browser request with Fetch Metadata',
+			{ origin: 'http://127.0.0.1:3000', 'sec-fetch-site': 'same-origin' },
+		],
+	])('preserves %s', async (_description, headers) => {
+		const runtime = await loadExample(filename);
+		const response = await requestExample(runtime, undefined, headers);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.body).toBe('mock completion');
+		expect(runtime.bodyParserCalls).toBe(1);
+		expect(runtime.apiCalls).toBe(1);
+	});
+
+	it('accepts same-origin IPv6 loopback browser requests', async () => {
+		const runtime = await loadExample(filename, { OPENAI_EXAMPLE_HOST: '::1' });
+		const response = await requestExample(runtime, undefined, { origin: 'http://[::1]:3000' });
+
+		expect(response.statusCode).toBe(200);
 		expect(runtime.apiCalls).toBe(1);
 	});
 

--- a/ecosystem-tests/cloudflare-worker/tests/test.js
+++ b/ecosystem-tests/cloudflare-worker/tests/test.js
@@ -1,7 +1,23 @@
+import { createHmac, randomBytes } from 'node:crypto';
+
 it(
 	'works',
 	async () => {
-		const response = await fetch('http://localhost:8787/test');
+		const apiKey = process.env.OPENAI_API_KEY;
+		if (!apiKey) {throw new Error('OPENAI_API_KEY is required to authorize the worker test');}
+		const timestamp = String(Date.now());
+		const nonce = randomBytes(16).toString('hex');
+		const signature = createHmac('sha256', apiKey)
+			.update(`POST\n/test\n${timestamp}\n${nonce}`)
+			.digest('hex');
+		const response = await fetch('http://localhost:8787/test', {
+			method: 'POST',
+			headers: {
+				authorization: `HMAC-SHA256 ${signature}`,
+				'x-worker-timestamp': timestamp,
+				'x-worker-nonce': nonce,
+			},
+		});
 		expect(await response.text()).toEqual('Passed!');
 	},
 	3 * 60_000

--- a/ecosystem-tests/cloudflare-worker/tests/worker-security.test.js
+++ b/ecosystem-tests/cloudflare-worker/tests/worker-security.test.js
@@ -1,0 +1,210 @@
+import { createHmac, randomBytes } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { jest } from '@jest/globals';
+import { uploadWebApiTestCases } from '../src/uploadWebApiTestCases.ts';
+import worker from '../src/worker.ts';
+
+const uploadModule = '../src/uploadWebApiTestCases.js';
+const uploadModuleFactory = () => ({ uploadWebApiTestCases });
+jest.mock(uploadModule, uploadModuleFactory, { virtual: true });
+jest.unstable_mockModule(uploadModule, uploadModuleFactory, {
+	virtual: true,
+});
+
+const apiKey = 'test-worker-api-key';
+const env = { OPENAI_API_KEY: apiKey };
+
+function signedRequest({
+	key = apiKey,
+	timestamp = Date.now(),
+	nonce = randomBytes(16).toString('hex'),
+	method = 'POST',
+	path = '/test',
+	signature,
+} = {}) {
+	const message = `${method}\n${path}\n${timestamp}\n${nonce}`;
+	const digest = signature ?? createHmac('sha256', key).update(message).digest('hex');
+
+	return new Request(`http://localhost:8787${path}`, {
+		method,
+		headers: {
+			authorization: `HMAC-SHA256 ${digest}`,
+			'x-worker-timestamp': String(timestamp),
+			'x-worker-nonce': nonce,
+		},
+	});
+}
+
+function registerUploadHandlers({ filename = 'finetune.jsonl', assertionError, cleanupError } = {}) {
+	const handlers = new Map();
+	const create = jest.fn().mockImplementation(() =>
+		Promise.resolve({ id: `file-${create.mock.calls.length}`, filename }),
+	);
+	const remove = jest.fn().mockImplementation(() =>
+		cleanupError ? Promise.reject(cleanupError) : Promise.resolve(),
+	);
+
+	uploadWebApiTestCases({
+		client: { files: { create, delete: remove } },
+		it: (description, handler) => handlers.set(description, handler),
+		expectEqual: (actual, expected) => {
+			if (assertionError) {throw assertionError;}
+			expect(actual).toBe(expected);
+		},
+		expectSimilar: () => {},
+	});
+
+	return { handlers, create, remove };
+}
+
+it('keeps the health check public but disables public worker deployment URLs', async () => {
+	const response = await worker.fetch(new Request('http://localhost:8787/'), { OPENAI_API_KEY: '' }, {});
+	const configuration = readFileSync(new URL('../wrangler.toml', import.meta.url), 'utf-8');
+
+	expect(response.status).toBe(200);
+	expect(configuration).toMatch(/^workers_dev\s*=\s*false$/mu);
+	expect(configuration).toMatch(/^preview_urls\s*=\s*false$/mu);
+});
+
+it('restricts the billed test route to POST', async () => {
+	const response = await worker.fetch(new Request('http://localhost:8787/test'), env, {});
+
+	expect(response.status).toBe(405);
+	expect(response.headers.get('allow')).toBe('POST');
+});
+
+it('rejects unsigned requests before constructing a client or issuing requests', async () => {
+	const fetch = jest.spyOn(globalThis, 'fetch');
+
+	try {
+		const response = await worker.fetch(new Request('http://localhost:8787/test', { method: 'POST' }), env, {});
+
+		expect(response.status).toBe(401);
+		expect(fetch).not.toHaveBeenCalled();
+	} finally {
+		fetch.mockRestore();
+	}
+});
+
+it('fails closed when the signing key is missing', async () => {
+	const response = await worker.fetch(signedRequest(), { OPENAI_API_KEY: '' }, {});
+
+	expect(response.status).toBe(401);
+});
+
+it('rejects malformed, tampered, stale, and future signatures', async () => {
+	const requests = [
+		signedRequest({ signature: 'not-a-signature' }),
+		signedRequest({ signature: '0'.repeat(64) }),
+		signedRequest({ key: 'wrong-api-key' }),
+		signedRequest({ nonce: 'invalid-nonce' }),
+		signedRequest({ timestamp: Date.now() - 120_000 }),
+		signedRequest({ timestamp: Date.now() + 120_000 }),
+	];
+
+	const responses = await Promise.all(requests.map((request) => worker.fetch(request, env, {})));
+	for (const response of responses) {
+		expect(response.status).toBe(401);
+	}
+});
+
+it('rejects a previously used signed nonce after the first run finishes', async () => {
+	const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+	const fetch = jest.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('rejected', { status: 400 }));
+	const request = signedRequest();
+
+	try {
+		const first = await worker.fetch(request.clone(), env, {});
+		const requestCount = fetch.mock.calls.length;
+		const replay = await worker.fetch(request.clone(), env, {});
+		expect(first.status).toBe(500);
+		expect(requestCount).toBeGreaterThan(0);
+		expect(replay.status).toBe(409);
+		expect(fetch).toHaveBeenCalledTimes(requestCount);
+	} finally {
+		fetch.mockRestore();
+		consoleError.mockRestore();
+	}
+});
+
+it('remembers future-dated nonces until their signed timestamp expires', async () => {
+	const now = Date.now();
+	const clock = jest.spyOn(Date, 'now').mockReturnValue(now);
+	const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+	const fetch = jest.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('rejected', { status: 400 }));
+	const request = signedRequest({ timestamp: now + 59_000 });
+
+	try {
+		const first = await worker.fetch(request.clone(), env, {});
+		clock.mockReturnValue(now + 61_000);
+		const replay = await worker.fetch(request.clone(), env, {});
+
+		expect(first.status).toBe(500);
+		expect(replay.status).toBe(409);
+	} finally {
+		fetch.mockRestore();
+		consoleError.mockRestore();
+		clock.mockRestore();
+	}
+});
+
+it('allows only one authenticated test run in a worker isolate', async () => {
+	const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+	const response = Promise.withResolvers();
+	const started = Promise.withResolvers();
+	const fetch = jest.spyOn(globalThis, 'fetch').mockImplementation(() => {
+		started.resolve();
+		return response.promise;
+	});
+	let first;
+
+	try {
+		first = worker.fetch(signedRequest(), env, {});
+		const state = await Promise.race([
+			started.promise.then(() => 'started'),
+			first.then(() => 'completed'),
+		]);
+		expect(state).toBe('started');
+
+		const simultaneous = await worker.fetch(signedRequest(), env, {});
+		expect(simultaneous.status).toBe(429);
+
+		response.resolve(new Response('rejected', { status: 400 }));
+		const completed = await first;
+		expect(completed.status).toBe(500);
+	} finally {
+		response.resolve(new Response('rejected', { status: 400 }));
+		await first;
+		fetch.mockRestore();
+		consoleError.mockRestore();
+	}
+});
+
+it('deletes all five uploaded files after successful assertions', async () => {
+	const { handlers, create, remove } = registerUploadHandlers();
+
+	const uploadHandlers = [...handlers].filter(([description]) => description.startsWith('toFile handles '));
+	await Promise.all(uploadHandlers.map(([, handler]) => handler()));
+
+	expect(create).toHaveBeenCalledTimes(5);
+	expect(remove).toHaveBeenCalledTimes(5);
+	for (let index = 1; index <= 5; index += 1) {
+		expect(remove).toHaveBeenCalledWith(`file-${index}`);
+	}
+});
+
+it('deletes an uploaded file even when its filename assertion fails', async () => {
+	const assertionError = new Error('unexpected file name');
+	const { handlers, remove } = registerUploadHandlers({ assertionError });
+
+	await expect(handlers.get('toFile handles Blob')()).rejects.toThrow('unexpected file name');
+	expect(remove).toHaveBeenCalledWith('file-1');
+});
+
+it('surfaces uploaded-file cleanup failures', async () => {
+	const cleanupError = new Error('file deletion failed');
+	const { handlers, remove } = registerUploadHandlers({ cleanupError });
+
+	await expect(handlers.get('toFile handles Blob')()).rejects.toThrow('file deletion failed');
+	expect(remove).toHaveBeenCalledWith('file-1');
+});

--- a/ecosystem-tests/cloudflare-worker/wrangler.toml
+++ b/ecosystem-tests/cloudflare-worker/wrangler.toml
@@ -1,6 +1,9 @@
 name = "cfw"
 main = "src/worker.ts"
 compatibility_date = "2023-06-18"
+# This billed ecosystem-test worker must never receive a public default URL.
+workers_dev = false
+preview_urls = false
 #node_compat = true
 
 # # KV Namespace binding - For more information: https://developers.cloudflare.com/workers/runtime-apis/kv

--- a/examples/chat-completions/stream-to-client-browser.ts
+++ b/examples/chat-completions/stream-to-client-browser.ts
@@ -9,7 +9,7 @@
  */
 import { ChatCompletionStream } from 'openai/lib/ChatCompletionStream';
 
-fetch('http://localhost:3000', {
+fetch('http://127.0.0.1:3000', {
   method: 'POST',
   body: 'Tell me why dogs are better than cats',
   headers: { 'Content-Type': 'text/plain' },

--- a/examples/chat-completions/stream-to-client-express.ts
+++ b/examples/chat-completions/stream-to-client-express.ts
@@ -2,13 +2,51 @@
 
 // This file demonstrates how to stream from the server the chunks as
 // a new-line separated JSON-encoded stream.
+// This server is for local development and binds only to 127.0.0.1 by default.
+// To deliberately expose it to another network, require bearer authentication:
+//
+//   OPENAI_EXAMPLE_HOST=0.0.0.0 OPENAI_EXAMPLE_ALLOW_REMOTE=true \
+//     OPENAI_EXAMPLE_AUTH_TOKEN="$(openssl rand -hex 32)" npm run tsn -- -T \
+//     examples/chat-completions/stream-to-client-express.ts
+//
+// Remote requests must include: Authorization: Bearer <OPENAI_EXAMPLE_AUTH_TOKEN>
 
+import { timingSafeEqual } from 'node:crypto';
 import OpenAI from 'openai';
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import express from 'express';
+
+const bindHost = process.env['OPENAI_EXAMPLE_HOST'] ?? '127.0.0.1';
+const isLoopback = bindHost === '127.0.0.1' || bindHost === '::1' || bindHost === 'localhost';
+const authToken = process.env['OPENAI_EXAMPLE_AUTH_TOKEN'];
+
+if (!isLoopback) {
+  if (process.env['OPENAI_EXAMPLE_ALLOW_REMOTE'] !== 'true') {
+    throw new Error('Non-loopback binding requires OPENAI_EXAMPLE_ALLOW_REMOTE=true');
+  }
+  if (!authToken || authToken.trim().length < 32) {
+    throw new Error('Non-loopback binding requires an OPENAI_EXAMPLE_AUTH_TOKEN of at least 32 characters');
+  }
+}
 
 const openai = new OpenAI();
 const app = express();
+
+if (!isLoopback) {
+  const expectedAuthorization = Buffer.from(`Bearer ${authToken}`);
+
+  app.use((req: Request, res: Response, next: NextFunction): void => {
+    const authorization = Buffer.from(req.get('authorization') ?? '');
+    if (
+      authorization.length !== expectedAuthorization.length ||
+      !timingSafeEqual(authorization, expectedAuthorization)
+    ) {
+      res.status(401).set('WWW-Authenticate', 'Bearer').send('Unauthorized');
+      return;
+    }
+    next();
+  });
+}
 
 app.use(express.text());
 
@@ -46,6 +84,6 @@ const handleRequest = async (req: Request, res: Response) => {
 
 app.post('/', (req: Request, res: Response) => handleRequest(req, res).catch(console.error));
 
-app.listen('3000', () => {
-  console.log('Started proxy express server');
+app.listen(3000, bindHost, () => {
+  console.log(`Started development proxy express server on ${bindHost}:3000`);
 });

--- a/examples/chat-completions/stream-to-client-express.ts
+++ b/examples/chat-completions/stream-to-client-express.ts
@@ -3,22 +3,29 @@
 // This file demonstrates how to stream from the server the chunks as
 // a new-line separated JSON-encoded stream.
 // This server is for local development and binds only to 127.0.0.1 by default.
-// To deliberately expose it to another network, require bearer authentication:
+// To deliberately expose it to another network, require HTTPS and bearer authentication:
 //
 //   OPENAI_EXAMPLE_HOST=0.0.0.0 OPENAI_EXAMPLE_ALLOW_REMOTE=true \
+//     OPENAI_EXAMPLE_TLS_CERT_FILE=server-cert.pem \
+//     OPENAI_EXAMPLE_TLS_KEY_FILE=server-key.pem \
 //     OPENAI_EXAMPLE_AUTH_TOKEN="$(openssl rand -hex 32)" npm run tsn -- -T \
 //     examples/chat-completions/stream-to-client-express.ts
 //
-// Remote requests must include: Authorization: Bearer <OPENAI_EXAMPLE_AUTH_TOKEN>
+// Remote HTTPS requests must include: Authorization: Bearer <OPENAI_EXAMPLE_AUTH_TOKEN>
 
 import { timingSafeEqual } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { createServer } from 'node:https';
 import OpenAI from 'openai';
 import type { NextFunction, Request, Response } from 'express';
 import express from 'express';
 
-const bindHost = process.env['OPENAI_EXAMPLE_HOST'] ?? '127.0.0.1';
-const isLoopback = bindHost === '127.0.0.1' || bindHost === '::1' || bindHost === 'localhost';
+const configuredHost = process.env['OPENAI_EXAMPLE_HOST'] ?? '127.0.0.1';
+const bindHost = configuredHost === 'localhost' ? '127.0.0.1' : configuredHost;
+const isLoopback = bindHost === '127.0.0.1' || bindHost === '::1';
 const authToken = process.env['OPENAI_EXAMPLE_AUTH_TOKEN'];
+const tlsCertificatePath = process.env['OPENAI_EXAMPLE_TLS_CERT_FILE'];
+const tlsPrivateKeyPath = process.env['OPENAI_EXAMPLE_TLS_KEY_FILE'];
 
 if (!isLoopback) {
   if (process.env['OPENAI_EXAMPLE_ALLOW_REMOTE'] !== 'true') {
@@ -27,10 +34,19 @@ if (!isLoopback) {
   if (!authToken || authToken.trim().length < 32) {
     throw new Error('Non-loopback binding requires an OPENAI_EXAMPLE_AUTH_TOKEN of at least 32 characters');
   }
+  if (!tlsCertificatePath || !tlsPrivateKeyPath) {
+    throw new Error(
+      'Non-loopback binding requires OPENAI_EXAMPLE_TLS_CERT_FILE and OPENAI_EXAMPLE_TLS_KEY_FILE',
+    );
+  }
 }
 
-const openai = new OpenAI();
 const app = express();
+const tlsServer =
+  !isLoopback && tlsCertificatePath && tlsPrivateKeyPath
+    ? createServer({ cert: readFileSync(tlsCertificatePath), key: readFileSync(tlsPrivateKeyPath) }, app)
+    : undefined;
+const openai = new OpenAI();
 
 if (!isLoopback) {
   const expectedAuthorization = Buffer.from(`Bearer ${authToken}`);
@@ -57,7 +73,7 @@ app.use(express.text());
 //
 // Or consumed with fetch:
 //
-//   fetch('http://localhost:3000', {
+//   fetch('http://127.0.0.1:3000', {
 //     method: 'POST',
 //     body: 'Tell me why dogs are better than cats',
 //   }).then(async res => {
@@ -84,6 +100,14 @@ const handleRequest = async (req: Request, res: Response) => {
 
 app.post('/', (req: Request, res: Response) => handleRequest(req, res).catch(console.error));
 
-app.listen(3000, bindHost, () => {
-  console.log(`Started development proxy express server on ${bindHost}:3000`);
-});
+const onListening = () => {
+  console.log(
+    `Started ${isLoopback ? 'HTTP' : 'HTTPS'} development proxy express server on ${bindHost}:3000`,
+  );
+};
+
+if (tlsServer) {
+  tlsServer.listen(3000, bindHost, onListening);
+} else {
+  app.listen(3000, bindHost, onListening);
+}

--- a/examples/chat-completions/stream-to-client-express.ts
+++ b/examples/chat-completions/stream-to-client-express.ts
@@ -64,6 +64,19 @@ if (!isLoopback) {
   });
 }
 
+if (isLoopback) {
+  const loopbackOrigin = `http://${bindHost === '::1' ? '[::1]' : bindHost}:3000`;
+
+  app.use((req: Request, res: Response, next: NextFunction): void => {
+    const origin = req.get('origin');
+    if ((origin !== undefined && origin !== loopbackOrigin) || req.get('sec-fetch-site') === 'cross-site') {
+      res.status(403).send('Forbidden');
+      return;
+    }
+    next();
+  });
+}
+
 app.use(express.text());
 
 // This endpoint can be called with:

--- a/examples/chat-completions/stream-to-client-raw.ts
+++ b/examples/chat-completions/stream-to-client-raw.ts
@@ -3,22 +3,29 @@
 // This file demonstrates how to stream from the server as a text/plain
 // response with express and the stream async iterator.
 // This server is for local development and binds only to 127.0.0.1 by default.
-// To deliberately expose it to another network, require bearer authentication:
+// To deliberately expose it to another network, require HTTPS and bearer authentication:
 //
 //   OPENAI_EXAMPLE_HOST=0.0.0.0 OPENAI_EXAMPLE_ALLOW_REMOTE=true \
+//     OPENAI_EXAMPLE_TLS_CERT_FILE=server-cert.pem \
+//     OPENAI_EXAMPLE_TLS_KEY_FILE=server-key.pem \
 //     OPENAI_EXAMPLE_AUTH_TOKEN="$(openssl rand -hex 32)" npm run tsn -- -T \
 //     examples/chat-completions/stream-to-client-raw.ts
 //
-// Remote requests must include: Authorization: Bearer <OPENAI_EXAMPLE_AUTH_TOKEN>
+// Remote HTTPS requests must include: Authorization: Bearer <OPENAI_EXAMPLE_AUTH_TOKEN>
 
 import { timingSafeEqual } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { createServer } from 'node:https';
 import OpenAI from 'openai';
 import type { NextFunction, Request, Response } from 'express';
 import express from 'express';
 
-const bindHost = process.env['OPENAI_EXAMPLE_HOST'] ?? '127.0.0.1';
-const isLoopback = bindHost === '127.0.0.1' || bindHost === '::1' || bindHost === 'localhost';
+const configuredHost = process.env['OPENAI_EXAMPLE_HOST'] ?? '127.0.0.1';
+const bindHost = configuredHost === 'localhost' ? '127.0.0.1' : configuredHost;
+const isLoopback = bindHost === '127.0.0.1' || bindHost === '::1';
 const authToken = process.env['OPENAI_EXAMPLE_AUTH_TOKEN'];
+const tlsCertificatePath = process.env['OPENAI_EXAMPLE_TLS_CERT_FILE'];
+const tlsPrivateKeyPath = process.env['OPENAI_EXAMPLE_TLS_KEY_FILE'];
 
 if (!isLoopback) {
   if (process.env['OPENAI_EXAMPLE_ALLOW_REMOTE'] !== 'true') {
@@ -27,10 +34,19 @@ if (!isLoopback) {
   if (!authToken || authToken.trim().length < 32) {
     throw new Error('Non-loopback binding requires an OPENAI_EXAMPLE_AUTH_TOKEN of at least 32 characters');
   }
+  if (!tlsCertificatePath || !tlsPrivateKeyPath) {
+    throw new Error(
+      'Non-loopback binding requires OPENAI_EXAMPLE_TLS_CERT_FILE and OPENAI_EXAMPLE_TLS_KEY_FILE',
+    );
+  }
 }
 
-const openai = new OpenAI();
 const app = express();
+const tlsServer =
+  !isLoopback && tlsCertificatePath && tlsPrivateKeyPath
+    ? createServer({ cert: readFileSync(tlsCertificatePath), key: readFileSync(tlsPrivateKeyPath) }, app)
+    : undefined;
+const openai = new OpenAI();
 
 if (!isLoopback) {
   const expectedAuthorization = Buffer.from(`Bearer ${authToken}`);
@@ -57,7 +73,7 @@ app.use(express.text());
 //
 // Or consumed with fetch:
 //
-//   fetch('http://localhost:3000', {
+//   fetch('http://127.0.0.1:3000', {
 //     method: 'POST',
 //     body: 'Tell me why dogs are better than cats',
 //   }).then(async res => {
@@ -89,6 +105,14 @@ const handleRequest = async (req: Request, res: Response) => {
 
 app.post('/', (req: Request, res: Response) => handleRequest(req, res).catch(console.error));
 
-app.listen(3000, bindHost, () => {
-  console.log(`Started development proxy express server on ${bindHost}:3000`);
-});
+const onListening = () => {
+  console.log(
+    `Started ${isLoopback ? 'HTTP' : 'HTTPS'} development proxy express server on ${bindHost}:3000`,
+  );
+};
+
+if (tlsServer) {
+  tlsServer.listen(3000, bindHost, onListening);
+} else {
+  app.listen(3000, bindHost, onListening);
+}

--- a/examples/chat-completions/stream-to-client-raw.ts
+++ b/examples/chat-completions/stream-to-client-raw.ts
@@ -64,6 +64,19 @@ if (!isLoopback) {
   });
 }
 
+if (isLoopback) {
+  const loopbackOrigin = `http://${bindHost === '::1' ? '[::1]' : bindHost}:3000`;
+
+  app.use((req: Request, res: Response, next: NextFunction): void => {
+    const origin = req.get('origin');
+    if ((origin !== undefined && origin !== loopbackOrigin) || req.get('sec-fetch-site') === 'cross-site') {
+      res.status(403).send('Forbidden');
+      return;
+    }
+    next();
+  });
+}
+
 app.use(express.text());
 
 // This endpoint can be called with:

--- a/examples/chat-completions/stream-to-client-raw.ts
+++ b/examples/chat-completions/stream-to-client-raw.ts
@@ -2,13 +2,51 @@
 
 // This file demonstrates how to stream from the server as a text/plain
 // response with express and the stream async iterator.
+// This server is for local development and binds only to 127.0.0.1 by default.
+// To deliberately expose it to another network, require bearer authentication:
+//
+//   OPENAI_EXAMPLE_HOST=0.0.0.0 OPENAI_EXAMPLE_ALLOW_REMOTE=true \
+//     OPENAI_EXAMPLE_AUTH_TOKEN="$(openssl rand -hex 32)" npm run tsn -- -T \
+//     examples/chat-completions/stream-to-client-raw.ts
+//
+// Remote requests must include: Authorization: Bearer <OPENAI_EXAMPLE_AUTH_TOKEN>
 
+import { timingSafeEqual } from 'node:crypto';
 import OpenAI from 'openai';
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import express from 'express';
+
+const bindHost = process.env['OPENAI_EXAMPLE_HOST'] ?? '127.0.0.1';
+const isLoopback = bindHost === '127.0.0.1' || bindHost === '::1' || bindHost === 'localhost';
+const authToken = process.env['OPENAI_EXAMPLE_AUTH_TOKEN'];
+
+if (!isLoopback) {
+  if (process.env['OPENAI_EXAMPLE_ALLOW_REMOTE'] !== 'true') {
+    throw new Error('Non-loopback binding requires OPENAI_EXAMPLE_ALLOW_REMOTE=true');
+  }
+  if (!authToken || authToken.trim().length < 32) {
+    throw new Error('Non-loopback binding requires an OPENAI_EXAMPLE_AUTH_TOKEN of at least 32 characters');
+  }
+}
 
 const openai = new OpenAI();
 const app = express();
+
+if (!isLoopback) {
+  const expectedAuthorization = Buffer.from(`Bearer ${authToken}`);
+
+  app.use((req: Request, res: Response, next: NextFunction): void => {
+    const authorization = Buffer.from(req.get('authorization') ?? '');
+    if (
+      authorization.length !== expectedAuthorization.length ||
+      !timingSafeEqual(authorization, expectedAuthorization)
+    ) {
+      res.status(401).set('WWW-Authenticate', 'Bearer').send('Unauthorized');
+      return;
+    }
+    next();
+  });
+}
 
 app.use(express.text());
 
@@ -51,6 +89,6 @@ const handleRequest = async (req: Request, res: Response) => {
 
 app.post('/', (req: Request, res: Response) => handleRequest(req, res).catch(console.error));
 
-app.listen('3000', () => {
-  console.log('Started proxy express server');
+app.listen(3000, bindHost, () => {
+  console.log(`Started development proxy express server on ${bindHost}:3000`);
 });


### PR DESCRIPTION
## Security findings

- **HIGH `csf_b2a30884d82a15bcf615d10b`**: the Cloudflare ecosystem worker allowed unauthenticated requests to trigger billed operations and leave five persistent uploaded files.
- **MEDIUM `csf_9c3fb2578837b982e013cf84`**: both chat-completion streaming examples exposed unauthenticated billed proxies on every network interface.

## Changes

- Disable public Workers.dev and preview URLs; accept only nonce-bound, short-lived HMAC-signed `POST /test` requests before importing the SDK or constructing a client.
- Reject tampered, expired, replayed, and future-window-replayed signatures; bound per-isolate concurrency and always delete all five uploaded files, including assertion failures.
- Bind both streaming examples to `127.0.0.1` by default. Require explicit remote opt-in and a strong bearer token validated in constant time before request-body parsing.
- Add focused authorization, replay, concurrency, cleanup, localhost binding, remote authentication, and sanitized-error regressions.

## Verification

- `npm test -- --runInBand tests/error-response.test.js tests/worker-security.test.js tests/streaming-example-security.test.js --testTimeout=15000` — **32 tests passed**.
- `npm run tsc` — both Cloudflare-worker TypeScript configurations passed.
- `corepack pnpm exec tsc --noEmit --pretty false` and `corepack pnpm build` passed.
- Scoped Oxlint/format checks and a Wrangler deployment dry run passed.
- The streaming regressions demonstrated **16 failing cases before the fix**.

## Compatibility and rollout

Changes are limited to the Cloudflare ecosystem fixture and the two owned examples; no generated SDK files, public SDK APIs, or shared ecosystem CLI were changed. The existing Cloudflare harness signs requests using its already-provisioned `OPENAI_API_KEY`, so no new secret or cross-batch configuration is required. Non-loopback example binding now intentionally requires explicit opt-in plus bearer authentication.