### PR TITLE
fix(security): harden Realtime WebSocket origins, worker guards, and Azure credentials

### DIFF
--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -122,7 +122,7 @@ const rt = await OpenAIRealtimeWS.create(client, {
 });
 ```
 
-The callback receives the client and validated connection target and returns the final `wss:` URL. Exactly one of `model`, `callID`, or transcription `intent` is still required, but the SDK does not add routing parameters such as `model` to the returned URL. Use only a trusted endpoint because connection credentials are sent to it. For native Azure WebSocket connections, the required authentication query parameter is still added before connecting and redacted from the exposed URL afterward.
+The callback receives the client and validated connection target and returns the final `wss:` URL. Exactly one of `model`, `callID`, or transcription `intent` is still required, but the SDK does not add routing parameters such as `model` to the returned URL. Use only a trusted endpoint because connection credentials are sent to it. Native Azure WebSocket connections send API keys and bearer tokens as handshake request headers, never in the socket URL. Browsers cannot set WebSocket handshake headers, so browser-based Azure clients must use a server-side authentication proxy; server applications can use either `OpenAIRealtimeWebSocket.azure()` on a header-capable runtime or `OpenAIRealtimeWS.azure()`.
 
 A full example can be found in [`examples/realtime/websocket.ts`](../examples/realtime/websocket.ts).
 

--- a/src/beta/realtime/websocket.ts
+++ b/src/beta/realtime/websocket.ts
@@ -21,6 +21,7 @@ type _WebSocket = typeof globalThis extends {
   : any;
 
 type RuntimeScope = typeof globalThis & {
+  process?: { versions?: { node?: string } };
   WorkerGlobalScope?: typeof Object;
   WorkerNavigator?: typeof Object;
   Deno?: { version?: { deno?: string } };

--- a/src/beta/realtime/websocket.ts
+++ b/src/beta/realtime/websocket.ts
@@ -20,14 +20,124 @@ type _WebSocket = typeof globalThis extends {
     InstanceType<ws>
   : any;
 
-/** Removes Azure credential query values from the publicly exposed connection URL. */
-function redactAzureCredentials(url: URL): void {
-  const hasAuthorization = url.searchParams.has('Authorization');
-  if (url.searchParams.has('api-key') || !hasAuthorization) {
+type RuntimeScope = typeof globalThis & {
+  WorkerGlobalScope?: typeof Object;
+  WorkerNavigator?: typeof Object;
+  Deno?: { version?: { deno?: string } };
+  Bun?: { version?: string };
+  EdgeRuntime?: unknown;
+  WebSocketPair?: unknown;
+};
+
+/** Identifies browser pages and workers without blocking trusted server runtimes. */
+function isRunningInBrowserOrBrowserWorker(): boolean {
+  if (isRunningInBrowser()) {
+    return true;
+  }
+
+  const scope = globalThis as RuntimeScope;
+  return (
+    typeof scope.WorkerGlobalScope === 'function' &&
+    scope instanceof scope.WorkerGlobalScope &&
+    typeof scope.WorkerNavigator === 'function' &&
+    scope.navigator instanceof scope.WorkerNavigator &&
+    typeof scope.navigator?.userAgent === 'string' &&
+    scope.navigator.userAgent !== 'Cloudflare-Workers' &&
+    scope.process?.versions?.node === undefined &&
+    scope.Deno === undefined &&
+    scope.Bun === undefined &&
+    scope.EdgeRuntime === undefined &&
+    scope.WebSocketPair === undefined
+  );
+}
+
+/** Reports whether the runtime supports request headers in native WebSocket options. */
+function supportsWebSocketRequestHeaders(): boolean {
+  const scope = globalThis as RuntimeScope;
+  if (
+    isRunningInBrowserOrBrowserWorker() ||
+    scope.EdgeRuntime !== undefined ||
+    scope.WebSocketPair !== undefined ||
+    scope.navigator?.userAgent === 'Cloudflare-Workers'
+  ) {
+    return false;
+  }
+
+  if (scope.Deno !== undefined) {
+    const [major, minor] = (scope.Deno.version?.deno ?? '').split('.').map(Number);
+    return major !== undefined && minor !== undefined && (major > 2 || (major === 2 && minor >= 5));
+  }
+
+  if (typeof scope.Bun?.version === 'string') {
+    return true;
+  }
+
+  return (
+    Object.prototype.toString.call(scope.process) === '[object process]' &&
+    typeof scope.process?.versions?.node === 'string'
+  );
+}
+
+/** Removes Azure credentials while preserving the existing public URL redaction contract. */
+function redactAzureCredentials(url: URL, isBearerToken: boolean): void {
+  let hasApiKey = !isBearerToken;
+  let hasAuthorization = isBearerToken;
+  const parameterNames = [...url.searchParams.keys()];
+
+  for (const name of parameterNames) {
+    if (name.toLowerCase() === 'api-key') {
+      hasApiKey = true;
+      url.searchParams.delete(name);
+    } else if (name.toLowerCase() === 'authorization') {
+      hasAuthorization = true;
+      url.searchParams.delete(name);
+    }
+  }
+
+  if (hasApiKey) {
     url.searchParams.set('api-key', '<REDACTED>');
   }
   if (hasAuthorization) {
     url.searchParams.set('Authorization', '<REDACTED>');
+  }
+}
+
+/** Opens an Azure native socket with header authentication and a credential-free URL. */
+function createAzureWebSocket(
+  url: URL,
+  apiKey: string | null,
+  isBearerToken: boolean,
+  protocols: string[],
+): _WebSocket {
+  if (!supportsWebSocketRequestHeaders()) {
+    throw new OpenAIError(
+      'Azure OpenAI Realtime credentials require a WebSocket transport that supports request headers; use openai/realtime/ws or a server-side authentication proxy.',
+    );
+  }
+  if (!apiKey) {
+    throw new Error('Azure OpenAI Realtime requires an API key');
+  }
+
+  redactAzureCredentials(url, isBearerToken);
+  const socketURL = new URL(url);
+  socketURL.searchParams.delete('api-key');
+  socketURL.searchParams.delete('Authorization');
+  const headers = isBearerToken ? { Authorization: `Bearer ${apiKey}` } : { 'api-key': apiKey };
+
+  // @ts-ignore
+  return new WebSocket(socketURL.toString(), { protocols, headers });
+}
+
+/** Prevents credentials from being attached outside the configured secure origin. */
+function assertTrustedRealtimeURL(client: Pick<OpenAI, 'apiKey' | 'baseURL'>, url: URL): void {
+  if (url.protocol !== 'wss:') {
+    throw new OpenAIError('Realtime WebSocket URLs must use the wss: protocol.');
+  }
+
+  const configuredURL = new URL(client.baseURL);
+  configuredURL.protocol = 'wss:';
+  if (url.origin !== configuredURL.origin) {
+    throw new OpenAIError('Realtime WebSocket URL origin must match the configured client origin.');
   }
 }
 
@@ -39,13 +149,6 @@ function redactAzureCredentials(url: URL): void {
  * listener before using the connection. Use the stable Realtime helper for
  * Azure sideband calls.
  */
-function resolveRealtimeURL(
-  client: Pick<OpenAI, 'apiKey' | 'baseURL'>,
-  props: RealtimeConnectionConfig & { __url?: URL | undefined },
-): URL {
-  return props.__url ?? buildRealtimeURL(client, props);
-}
-
 export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
   /** Secure beta Realtime WebSocket URL; Azure authentication query parameters are redacted. */
   url: URL;
@@ -77,9 +180,6 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
       onURL?: (url: URL) => void;
       /** Indicates the token was resolved by the factory just before connecting. @internal */
       __resolvedApiKey?: boolean;
-
-      /** Final URL validated before an asynchronous credential provider ran. @internal */
-      __url?: URL;
     },
     client?: Pick<OpenAI, 'apiKey' | 'baseURL'>,
   ) {
@@ -89,7 +189,7 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
       props.dangerouslyAllowBrowser ??
       (client as any)?._options?.dangerouslyAllowBrowser ??
       (client?.apiKey?.startsWith('ek_') ? true : null);
-    if (!dangerouslyAllowBrowser && isRunningInBrowser()) {
+    if (!dangerouslyAllowBrowser && isRunningInBrowserOrBrowserWorker()) {
       throw new OpenAIError(
         "It looks like you're running in a browser-like environment.\n\nThis is disabled by default, as it risks exposing your secret API credentials to attackers.\n\nYou can avoid this error by creating an ephemeral session token:\nhttps://platform.openai.com/docs/api-reference/realtime-sessions\n",
       );
@@ -106,16 +206,21 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
       );
     }
 
-    this.url = resolveRealtimeURL(client, props);
+    this.url = buildRealtimeURL(client, props);
     props.onURL?.(this.url);
+    assertTrustedRealtimeURL(client, this.url);
     assertBedrockWebSocketOrigin(client, this.url);
 
-    // @ts-ignore
-    this.socket = new WebSocket(this.url.toString(), [
+    const azure = isAzure(client);
+    const protocols = [
       'realtime',
-      ...(isAzure(client) ? [] : [`openai-insecure-api-key.${client.apiKey}`]),
+      ...(azure ? [] : [`openai-insecure-api-key.${client.apiKey}`]),
       'openai-beta.realtime-v1',
-    ]);
+    ];
+
+    this.socket = azure
+      ? createAzureWebSocket(this.url, client.apiKey, props.__resolvedApiKey === true, protocols)
+      : new WebSocket(this.url.toString(), protocols);
 
     this.socket.addEventListener('message', (websocketEvent: MessageEvent) => {
       const event = (() => {
@@ -154,10 +259,6 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     this.socket.addEventListener('error', (event: any) => {
       this._onError(null, event.message, null);
     });
-
-    if (isAzure(client)) {
-      redactAzureCredentials(this.url);
-    }
   }
 
   /**
@@ -176,17 +277,20 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     },
   ): Promise<OpenAIRealtimeWebSocket> {
     const url = buildRealtimeURL(client, props);
+    assertTrustedRealtimeURL(client, url);
     assertBedrockWebSocketOrigin(client, url);
     const resolvedApiKey = await client._callApiKey();
-    return new OpenAIRealtimeWebSocket({ ...props, __resolvedApiKey: resolvedApiKey, __url: url }, client);
+    assertTrustedRealtimeURL(client, url);
+    assertBedrockWebSocketOrigin(client, url);
+    return new OpenAIRealtimeWebSocket({ ...props, __resolvedApiKey: resolvedApiKey }, client);
   }
 
   /**
    * Opens a native beta Azure OpenAI Realtime session for a model deployment.
    *
-   * Azure credentials are redacted from the exposed `url` property immediately
-   * after connection setup. Use the stable Realtime helper to attach to an
-   * existing Azure call.
+   * Azure credentials are sent in WebSocket handshake headers and never appear
+   * in the native socket URL. Browser WebSockets cannot set these headers;
+   * use a server-side authentication proxy or the Node.js `ws` transport.
    *
    * @param client Azure OpenAI client that supplies the endpoint and credential.
    * @param options Optional deployment override and browser-safety settings.
@@ -207,14 +311,6 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     if (!apiKey) {
       throw new Error('Azure OpenAI Realtime requires an API key');
     }
-    const azureApiKey = apiKey;
-    function onURL(url: URL) {
-      if (isApiKeyProvider) {
-        url.searchParams.set('Authorization', `Bearer ${azureApiKey}`);
-      } else {
-        url.searchParams.set('api-key', azureApiKey);
-      }
-    }
     const deploymentName = options.deploymentName ?? client.deploymentName;
     if (!deploymentName) {
       throw new Error('No deployment name provided');
@@ -223,7 +319,6 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     return new OpenAIRealtimeWebSocket(
       {
         model: deploymentName,
-        onURL,
         ...(dangerouslyAllowBrowser === undefined ? {} : { dangerouslyAllowBrowser }),
         __resolvedApiKey: isApiKeyProvider,
       },

--- a/src/beta/realtime/ws.ts
+++ b/src/beta/realtime/ws.ts
@@ -14,11 +14,16 @@ import type { RealtimeConnectionConfig } from './internal-base';
  * Register an SDK `error` listener and wait for `socket`'s `open` event before
  * sending client events. Use the stable Realtime helper for Azure sideband calls.
  */
-function resolveRealtimeURL(
-  client: Pick<OpenAI, 'apiKey' | 'baseURL'>,
-  props: RealtimeConnectionConfig & { __url?: URL | undefined },
-): URL {
-  return props.__url ?? buildRealtimeURL(client, props);
+function assertTrustedRealtimeURL(client: Pick<OpenAI, 'apiKey' | 'baseURL'>, url: URL): void {
+  if (url.protocol !== 'wss:') {
+    throw new Error('Realtime WebSocket URLs must use the wss: protocol.');
+  }
+
+  const configuredURL = new URL(client.baseURL);
+  configuredURL.protocol = 'wss:';
+  if (url.origin !== configuredURL.origin) {
+    throw new Error('Realtime WebSocket URL origin must match the configured client origin.');
+  }
 }
 
 export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
@@ -45,9 +50,6 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
 
       /** Indicates that a function-based credential was resolved by an async factory. @internal */
       __resolvedApiKey?: boolean;
-
-      /** Final URL validated before an asynchronous credential provider ran. @internal */
-      __url?: URL;
     },
     client?: Pick<OpenAI, 'apiKey' | 'baseURL'>,
   ) {
@@ -62,7 +64,8 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
         ].join('\n'),
       );
     }
-    this.url = resolveRealtimeURL(client, props);
+    this.url = buildRealtimeURL(client, props);
+    assertTrustedRealtimeURL(client, this.url);
     assertBedrockWebSocketOrigin(client, this.url);
     const headers = {
       ...props.options?.headers,
@@ -133,9 +136,12 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
     },
   ): Promise<OpenAIRealtimeWS> {
     const url = buildRealtimeURL(client, props);
+    assertTrustedRealtimeURL(client, url);
     assertBedrockWebSocketOrigin(client, url);
     const resolvedApiKey = await client._callApiKey();
-    return new OpenAIRealtimeWS({ ...props, __resolvedApiKey: resolvedApiKey, __url: url }, client);
+    assertTrustedRealtimeURL(client, url);
+    assertBedrockWebSocketOrigin(client, url);
+    return new OpenAIRealtimeWS({ ...props, __resolvedApiKey: resolvedApiKey }, client);
   }
 
   /**

--- a/src/realtime/websocket.ts
+++ b/src/realtime/websocket.ts
@@ -26,6 +26,7 @@ type _WebSocket = typeof globalThis extends {
   : any;
 
 type RuntimeScope = typeof globalThis & {
+  process?: { versions?: { node?: string } };
   WorkerGlobalScope?: typeof Object;
   WorkerNavigator?: typeof Object;
   Deno?: { version?: { deno?: string } };

--- a/src/realtime/websocket.ts
+++ b/src/realtime/websocket.ts
@@ -25,15 +25,112 @@ type _WebSocket = typeof globalThis extends {
     InstanceType<ws>
   : any;
 
-/** Removes Azure credential query values from the publicly exposed connection URL. */
-function redactAzureCredentials(url: URL): void {
-  const hasAuthorization = url.searchParams.has('Authorization');
-  if (url.searchParams.has('api-key') || !hasAuthorization) {
+type RuntimeScope = typeof globalThis & {
+  WorkerGlobalScope?: typeof Object;
+  WorkerNavigator?: typeof Object;
+  Deno?: { version?: { deno?: string } };
+  Bun?: { version?: string };
+  EdgeRuntime?: unknown;
+  WebSocketPair?: unknown;
+};
+
+/** Identifies browser pages and workers without blocking trusted server runtimes. */
+function isRunningInBrowserOrBrowserWorker(): boolean {
+  if (isRunningInBrowser()) {
+    return true;
+  }
+
+  const scope = globalThis as RuntimeScope;
+  return (
+    typeof scope.WorkerGlobalScope === 'function' &&
+    scope instanceof scope.WorkerGlobalScope &&
+    typeof scope.WorkerNavigator === 'function' &&
+    scope.navigator instanceof scope.WorkerNavigator &&
+    typeof scope.navigator?.userAgent === 'string' &&
+    scope.navigator.userAgent !== 'Cloudflare-Workers' &&
+    scope.process?.versions?.node === undefined &&
+    scope.Deno === undefined &&
+    scope.Bun === undefined &&
+    scope.EdgeRuntime === undefined &&
+    scope.WebSocketPair === undefined
+  );
+}
+
+/** Reports whether the runtime supports request headers in native WebSocket options. */
+function supportsWebSocketRequestHeaders(): boolean {
+  const scope = globalThis as RuntimeScope;
+  if (
+    isRunningInBrowserOrBrowserWorker() ||
+    scope.EdgeRuntime !== undefined ||
+    scope.WebSocketPair !== undefined ||
+    scope.navigator?.userAgent === 'Cloudflare-Workers'
+  ) {
+    return false;
+  }
+
+  if (scope.Deno !== undefined) {
+    const [major, minor] = (scope.Deno.version?.deno ?? '').split('.').map(Number);
+    return major !== undefined && minor !== undefined && (major > 2 || (major === 2 && minor >= 5));
+  }
+
+  if (typeof scope.Bun?.version === 'string') {
+    return true;
+  }
+
+  return (
+    Object.prototype.toString.call(scope.process) === '[object process]' &&
+    typeof scope.process?.versions?.node === 'string'
+  );
+}
+
+/** Removes Azure credentials while preserving the existing public URL redaction contract. */
+function redactAzureCredentials(url: URL, isBearerToken: boolean): void {
+  let hasApiKey = !isBearerToken;
+  let hasAuthorization = isBearerToken;
+  const parameterNames = [...url.searchParams.keys()];
+
+  for (const name of parameterNames) {
+    if (name.toLowerCase() === 'api-key') {
+      hasApiKey = true;
+      url.searchParams.delete(name);
+    } else if (name.toLowerCase() === 'authorization') {
+      hasAuthorization = true;
+      url.searchParams.delete(name);
+    }
+  }
+
+  if (hasApiKey) {
     url.searchParams.set('api-key', '<REDACTED>');
   }
   if (hasAuthorization) {
     url.searchParams.set('Authorization', '<REDACTED>');
   }
+}
+
+/** Opens an Azure native socket with header authentication and a credential-free URL. */
+function createAzureWebSocket(
+  url: URL,
+  apiKey: string | null,
+  isBearerToken: boolean,
+  protocols: string[],
+): _WebSocket {
+  if (!supportsWebSocketRequestHeaders()) {
+    throw new OpenAIError(
+      'Azure OpenAI Realtime credentials require a WebSocket transport that supports request headers; use openai/realtime/ws or a server-side authentication proxy.',
+    );
+  }
+  if (!apiKey) {
+    throw new Error('Azure OpenAI Realtime requires an API key');
+  }
+
+  redactAzureCredentials(url, isBearerToken);
+  const socketURL = new URL(url);
+  socketURL.searchParams.delete('api-key');
+  socketURL.searchParams.delete('Authorization');
+  const headers = isBearerToken ? { Authorization: `Bearer ${apiKey}` } : { 'api-key': apiKey };
+
+  // @ts-ignore
+  return new WebSocket(socketURL.toString(), { protocols, headers });
 }
 
 /**
@@ -85,7 +182,7 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
       props.dangerouslyAllowBrowser ??
       (client as any)?._options?.dangerouslyAllowBrowser ??
       (client?.apiKey?.startsWith('ek_') ? true : null);
-    if (!dangerouslyAllowBrowser && isRunningInBrowser()) {
+    if (!dangerouslyAllowBrowser && isRunningInBrowserOrBrowserWorker()) {
       throw new OpenAIError(
         "It looks like you're running in a browser-like environment.\n\nThis is disabled by default, as it risks exposing your secret API credentials to attackers.\n\nYou can avoid this error by creating an ephemeral session token:\nhttps://platform.openai.com/docs/api-reference/realtime-sessions\n",
       );
@@ -104,13 +201,17 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
 
     this.url = buildRealtimeURL(client, props);
     props.onURL?.(this.url);
+    if (this.url.protocol !== 'wss:') {
+      throw new OpenAIError('Realtime WebSocket URLs must use the wss: protocol.');
+    }
     assertBedrockWebSocketOrigin(client, this.url);
 
-    // @ts-ignore
-    this.socket = new WebSocket(this.url.toString(), [
-      'realtime',
-      ...(isAzure(client) ? [] : [`openai-insecure-api-key.${client.apiKey}`]),
-    ]);
+    const azure = isAzure(client);
+    const protocols = ['realtime', ...(azure ? [] : [`openai-insecure-api-key.${client.apiKey}`])];
+
+    this.socket = azure
+      ? createAzureWebSocket(this.url, client.apiKey, props.__resolvedApiKey === true, protocols)
+      : new WebSocket(this.url.toString(), protocols);
 
     this.socket.addEventListener('message', (websocketEvent: MessageEvent) => {
       const event = (() => {
@@ -149,10 +250,6 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     this.socket.addEventListener('error', (event: any) => {
       this._onError(null, event.message, null);
     });
-
-    if (isAzure(client)) {
-      redactAzureCredentials(this.url);
-    }
   }
 
   /**
@@ -186,8 +283,9 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
   /**
    * Opens a native Azure deployment or transcription session, or an existing sideband call.
    *
-   * Azure credentials are included only in the initial connection URL and are
-   * redacted from the exposed `url` property immediately after connection setup.
+   * Azure credentials are sent in WebSocket handshake headers and never appear
+   * in the native socket URL. Browser WebSockets cannot set these headers;
+   * use a server-side authentication proxy or the Node.js `ws` transport.
    *
    * @param client Azure OpenAI client that supplies the endpoint and credential.
    * @param options Deployment, transcription intent, or call ID, plus browser-safety settings.
@@ -206,19 +304,10 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     if (!apiKey) {
       throw new Error('Azure OpenAI Realtime requires an API key');
     }
-    const azureApiKey = apiKey;
-    function onURL(url: URL) {
-      if (isApiKeyProvider) {
-        url.searchParams.set('Authorization', `Bearer ${azureApiKey}`);
-      } else {
-        url.searchParams.set('api-key', azureApiKey);
-      }
-    }
     const { dangerouslyAllowBrowser } = options;
     return new OpenAIRealtimeWebSocket(
       {
         ...connection,
-        onURL,
         ...(dangerouslyAllowBrowser === undefined ? {} : { dangerouslyAllowBrowser }),
         __resolvedApiKey: isApiKeyProvider,
       },

--- a/tests/realtime-transport-security.test.ts
+++ b/tests/realtime-transport-security.test.ts
@@ -293,6 +293,27 @@ describe.each(nativeRealtimeSurfaces)('$name native Azure credential security', 
     expect(realtime.url.toString()).not.toContain(fixture.credential);
   });
 
+  test.each(['22.0.0', '22.23.2', '24.0.0', '26.0.0'])(
+    'preserves authenticated native WebSocket headers on supported Node.js %s',
+    (version) => {
+      const nodeProcess = Object.create(process);
+      Object.defineProperty(nodeProcess, 'versions', { value: { node: version } });
+
+      withBrowserWorker(
+        'DedicatedWorkerGlobalScope',
+        () => {
+          const realtime = new Realtime({ model: 'chat' }, createAzureClient());
+
+          expect(realtime.socket).toBe(lastNativeSocket());
+          expect(lastNativeSocket().options).toMatchObject({
+            headers: { 'api-key': 'azure-api-key-secret' },
+          });
+        },
+        { runtime: { process: nodeProcess } },
+      );
+    },
+  );
+
   test.each([false, true])(
     'refuses unsafe browser header fallback for token provider %s',
     async (tokenProvider) => {

--- a/tests/realtime-transport-security.test.ts
+++ b/tests/realtime-transport-security.test.ts
@@ -1,0 +1,360 @@
+import { vi } from 'vitest';
+import type { Mock } from 'vitest';
+
+import OpenAI, { AzureOpenAI, OpenAIError } from 'openai';
+import { OpenAIRealtimeWebSocket as StableNativeRealtime } from 'openai/realtime/websocket';
+import { OpenAIRealtimeWebSocket as BetaNativeRealtime } from 'openai/beta/realtime/websocket';
+import { OpenAIRealtimeWS as BetaNodeRealtime } from 'openai/beta/realtime/ws';
+import * as WS from 'ws';
+
+type NativeSocketOptions =
+  | string[]
+  | {
+      protocols: string[];
+      headers: Record<string, string>;
+    };
+
+class CapturingNativeSocket {
+  static instances: CapturingNativeSocket[] = [];
+
+  readonly url: string;
+  readonly options: NativeSocketOptions;
+  readonly addEventListener = vi.fn();
+  readonly send = vi.fn();
+  readonly close = vi.fn();
+
+  constructor(url: string, options: NativeSocketOptions) {
+    this.url = url;
+    this.options = options;
+    CapturingNativeSocket.instances.push(this);
+  }
+}
+
+function createNodeSocket(url: URL, options: WS.ClientOptions) {
+  return { url, options, on: vi.fn(), send: vi.fn(), close: vi.fn() };
+}
+
+vi.mock('ws', () => ({
+  WebSocket: vi.fn(createNodeSocket),
+}));
+
+const nodeSocketConstructor = WS.WebSocket as unknown as Mock;
+const nativeRealtimeSurfaces = [
+  { name: 'stable', Realtime: StableNativeRealtime, beta: false },
+  { name: 'beta', Realtime: BetaNativeRealtime, beta: true },
+] as const;
+
+function createClient(apiKey = 'permanent-secret', dangerouslyAllowBrowser?: boolean): OpenAI {
+  return new OpenAI({
+    apiKey,
+    baseURL: 'https://trusted.example.com/v1/',
+    ...(dangerouslyAllowBrowser === undefined ? {} : { dangerouslyAllowBrowser }),
+  });
+}
+
+function createAzureClient(tokenProvider = false, dangerouslyAllowBrowser?: boolean): AzureOpenAI {
+  return new AzureOpenAI({
+    apiVersion: '2024-10-01-preview',
+    baseURL: 'https://azure.example.com/openai/',
+    deployment: 'chat',
+    ...(tokenProvider
+      ? { azureADTokenProvider: async () => 'azure-bearer-secret' }
+      : { apiKey: 'azure-api-key-secret' }),
+    ...(dangerouslyAllowBrowser === undefined ? {} : { dangerouslyAllowBrowser }),
+  });
+}
+
+function lastNativeSocket(): CapturingNativeSocket {
+  const [socket] = CapturingNativeSocket.instances.slice(-1);
+  if (!socket) {
+    throw new Error('Expected a native WebSocket instance');
+  }
+  return socket;
+}
+
+function withBrowserWorker<T>(
+  workerType: 'DedicatedWorkerGlobalScope' | 'SharedWorkerGlobalScope' | 'ServiceWorkerGlobalScope',
+  run: () => T,
+  options: { runtime?: Record<string, unknown>; userAgent?: string } = {},
+): T {
+  const navigator = { userAgent: options.userAgent ?? 'Mozilla/5.0' };
+  const browserWorkerGlobalScope = Object.defineProperty(() => null, Symbol.hasInstance, {
+    value: (value: unknown) => value === globalThis,
+  });
+  const browserWorkerNavigator = Object.defineProperty(() => null, Symbol.hasInstance, {
+    value: (value: unknown) => value === navigator,
+  });
+
+  const globals: Record<string, unknown> = {
+    WorkerGlobalScope: browserWorkerGlobalScope,
+    WorkerNavigator: browserWorkerNavigator,
+    [workerType]: browserWorkerGlobalScope,
+    navigator,
+    window: undefined,
+    process: undefined,
+    Deno: undefined,
+    Bun: undefined,
+    EdgeRuntime: undefined,
+    WebSocketPair: undefined,
+    ...options.runtime,
+  };
+  const descriptors = new Map<string, PropertyDescriptor | undefined>();
+
+  try {
+    for (const [name, value] of Object.entries(globals)) {
+      descriptors.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+      if (value === undefined) {
+        Reflect.deleteProperty(globalThis, name);
+      } else {
+        Object.defineProperty(globalThis, name, { configurable: true, value });
+      }
+    }
+
+    return run();
+  } finally {
+    for (const [name, descriptor] of descriptors) {
+      if (descriptor) {
+        Object.defineProperty(globalThis, name, descriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, name);
+      }
+    }
+  }
+}
+
+beforeEach(() => {
+  CapturingNativeSocket.instances = [];
+  nodeSocketConstructor.mockClear();
+  vi.stubGlobal('WebSocket', CapturingNativeSocket);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe.each(nativeRealtimeSurfaces)('$name native realtime browser-worker security', ({ Realtime }) => {
+  test.each(['DedicatedWorkerGlobalScope', 'SharedWorkerGlobalScope', 'ServiceWorkerGlobalScope'] as const)(
+    'rejects permanent credentials in a %s before opening a socket',
+    (workerType) => {
+      const client = createClient();
+
+      withBrowserWorker(workerType, () => {
+        expect(() => new Realtime({ model: 'gpt-realtime' }, client)).toThrow(OpenAIError);
+        expect(CapturingNativeSocket.instances).toHaveLength(0);
+      });
+    },
+  );
+
+  test.each([
+    { setting: 'an ephemeral key', key: 'ek_temporary', clientOptIn: undefined, connectionOptIn: undefined },
+    { setting: 'connection opt-in', key: 'permanent-secret', clientOptIn: undefined, connectionOptIn: true },
+    { setting: 'client opt-in', key: 'permanent-secret', clientOptIn: true, connectionOptIn: undefined },
+  ])('preserves $setting inside a browser worker', ({ key, clientOptIn, connectionOptIn }) => {
+    const client = createClient(key, clientOptIn);
+
+    withBrowserWorker('DedicatedWorkerGlobalScope', () => {
+      const realtime = new Realtime(
+        {
+          model: 'gpt-realtime',
+          ...(connectionOptIn === undefined ? {} : { dangerouslyAllowBrowser: true }),
+        },
+        client,
+      );
+
+      expect(realtime.socket).toBe(lastNativeSocket());
+    });
+  });
+
+  test.each([
+    { runtime: 'Cloudflare Workers', options: { userAgent: 'Cloudflare-Workers' } },
+    { runtime: 'Node.js', options: { runtime: { process } } },
+    { runtime: 'Deno', options: { runtime: { Deno: {} } } },
+    { runtime: 'Bun', options: { runtime: { Bun: {} } } },
+    { runtime: 'Edge Runtime', options: { runtime: { EdgeRuntime: 'edge' } } },
+    { runtime: 'WebSocketPair runtimes', options: { runtime: { WebSocketPair: Object } } },
+  ])('does not mistake $runtime for an untrusted browser worker', ({ options }) => {
+    const client = createClient();
+
+    withBrowserWorker(
+      'DedicatedWorkerGlobalScope',
+      () => {
+        expect(new Realtime({ model: 'gpt-realtime' }, client).socket).toBe(lastNativeSocket());
+      },
+      options,
+    );
+  });
+});
+
+describe('beta realtime WebSocket destination security', () => {
+  test.each([
+    { name: 'native', Realtime: BetaNativeRealtime },
+    { name: 'Node', Realtime: BetaNodeRealtime },
+  ])('$name ignores the previously exposed destination override', ({ Realtime }) => {
+    const client = createClient();
+
+    for (const destination of [
+      'ws://trusted.example.com/v1/realtime',
+      'wss://attacker.example.com/collect',
+      'wss://trusted.example.com:444/collect',
+    ]) {
+      const realtime = new Realtime(
+        { model: 'gpt-realtime', __url: new URL(destination) } as { model: string },
+        client,
+      );
+
+      expect(realtime.url.toString()).toBe('wss://trusted.example.com/v1/realtime?model=gpt-realtime');
+    }
+  });
+
+  test.each([
+    { name: 'native', Realtime: BetaNativeRealtime },
+    { name: 'Node', Realtime: BetaNodeRealtime },
+  ])('$name validates the connection target even when an override is injected', ({ Realtime }) => {
+    expect(
+      () =>
+        new Realtime(
+          { __url: new URL('wss://trusted.example.com/v1/realtime') } as unknown as { model: string },
+          createClient(),
+        ),
+    ).toThrow(/exactly one/iu);
+
+    expect(CapturingNativeSocket.instances).toHaveLength(0);
+    expect(nodeSocketConstructor).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    { mutation: 'insecure protocol', mutate: (url: URL) => (url.protocol = 'ws:') },
+    { mutation: 'untrusted host', mutate: (url: URL) => (url.hostname = 'attacker.example.com') },
+    { mutation: 'untrusted port', mutate: (url: URL) => (url.port = '444') },
+  ])('rejects an $mutation introduced by the URL hook', ({ mutate }) => {
+    expect(() => new BetaNativeRealtime({ model: 'gpt-realtime', onURL: mutate }, createClient())).toThrow(
+      /wss|origin/iu,
+    );
+
+    expect(CapturingNativeSocket.instances).toHaveLength(0);
+  });
+
+  test.each([
+    { name: 'native', Realtime: BetaNativeRealtime },
+    { name: 'Node', Realtime: BetaNodeRealtime },
+  ])('$name rejects an origin changed while resolving an asynchronous credential', async ({ Realtime }) => {
+    const client: OpenAI = new OpenAI({
+      baseURL: 'https://trusted.example.com/v1/',
+      apiKey: async () => {
+        client.baseURL = 'https://attacker.example.com/v1/';
+        return 'rotating-secret';
+      },
+    });
+
+    await expect(Realtime.create(client, { model: 'gpt-realtime' })).rejects.toThrow(/origin/iu);
+    expect(CapturingNativeSocket.instances).toHaveLength(0);
+    expect(nodeSocketConstructor).not.toHaveBeenCalled();
+  });
+});
+
+test('stable native realtime rejects an insecure protocol introduced by its URL hook', () => {
+  expect(
+    () =>
+      new StableNativeRealtime(
+        { model: 'gpt-realtime', onURL: (url) => (url.protocol = 'ws:') },
+        createClient(),
+      ),
+  ).toThrow(/wss/iu);
+
+  expect(CapturingNativeSocket.instances).toHaveLength(0);
+});
+
+describe.each(nativeRealtimeSurfaces)('$name native Azure credential security', ({ Realtime, beta }) => {
+  test.each([
+    {
+      authentication: 'an API key',
+      tokenProvider: false,
+      credential: 'azure-api-key-secret',
+      headers: { 'api-key': 'azure-api-key-secret' },
+    },
+    {
+      authentication: 'an Entra bearer token',
+      tokenProvider: true,
+      credential: 'azure-bearer-secret',
+      headers: { Authorization: 'Bearer azure-bearer-secret' },
+    },
+  ])('sends $authentication in handshake headers without exposing it in the socket URL', async (fixture) => {
+    const realtime = await Realtime.azure(createAzureClient(fixture.tokenProvider));
+    const socket = lastNativeSocket();
+
+    expect(socket.options).toEqual({
+      protocols: ['realtime', ...(beta ? ['openai-beta.realtime-v1'] : [])],
+      headers: fixture.headers,
+    });
+    expect(socket.url).not.toContain(fixture.credential);
+    expect(new URL(socket.url).searchParams.has('api-key')).toBe(false);
+    expect(new URL(socket.url).searchParams.has('Authorization')).toBe(false);
+    expect(realtime.url.toString()).not.toContain(fixture.credential);
+  });
+
+  test.each([false, true])(
+    'refuses unsafe browser header fallback for token provider %s',
+    async (tokenProvider) => {
+      const client = createAzureClient(tokenProvider, true);
+      vi.stubGlobal('window', { document: {} });
+      vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0' });
+
+      await expect(Realtime.azure(client, { dangerouslyAllowBrowser: true })).rejects.toThrow(
+        /request headers|authentication proxy/iu,
+      );
+
+      expect(CapturingNativeSocket.instances).toHaveLength(0);
+    },
+  );
+
+  test.each([
+    { runtime: 'Cloudflare Workers', options: { userAgent: 'Cloudflare-Workers' }, supported: false },
+    { runtime: 'Deno 2.4', options: { runtime: { Deno: { version: { deno: '2.4.9' } } } }, supported: false },
+    { runtime: 'Deno 2.5', options: { runtime: { Deno: { version: { deno: '2.5.0' } } } }, supported: true },
+    { runtime: 'Deno 3', options: { runtime: { Deno: { version: { deno: '3.0.0' } } } }, supported: true },
+    { runtime: 'Bun', options: { runtime: { Bun: { version: '1.1.0' } } }, supported: true },
+    { runtime: 'Edge Runtime', options: { runtime: { EdgeRuntime: 'edge' } }, supported: false },
+  ])('uses header authentication only when $runtime supports it', ({ options, supported }) => {
+    const client = createAzureClient();
+
+    withBrowserWorker(
+      'DedicatedWorkerGlobalScope',
+      () => {
+        if (supported) {
+          const realtime = new Realtime({ model: 'chat' }, client);
+          expect(realtime.socket).toBe(lastNativeSocket());
+          expect(lastNativeSocket().options).toMatchObject({
+            headers: { 'api-key': 'azure-api-key-secret' },
+          });
+        } else {
+          expect(() => new Realtime({ model: 'chat' }, client)).toThrow(
+            /request headers|authentication proxy/iu,
+          );
+          expect(CapturingNativeSocket.instances).toHaveLength(0);
+        }
+      },
+      options,
+    );
+  });
+});
+
+test('strips pre-existing Azure credential query parameters before opening a native socket', async () => {
+  const client = createAzureClient();
+
+  const realtime = await StableNativeRealtime.azure(client, {
+    buildRealtimeURL: () =>
+      new URL(
+        'wss://azure.example.com/custom/realtime?routing=private&api-key=old-secret&Authorization=Bearer+old-token',
+      ),
+  });
+  const socketURL = new URL(lastNativeSocket().url);
+
+  expect(socketURL.searchParams.get('routing')).toBe('private');
+  expect(socketURL.searchParams.has('api-key')).toBe(false);
+  expect(socketURL.searchParams.has('Authorization')).toBe(false);
+  expect(lastNativeSocket().url).not.toContain('old-secret');
+  expect(lastNativeSocket().url).not.toContain('old-token');
+  expect(realtime.url.toString()).not.toContain('old-secret');
+  expect(realtime.url.toString()).not.toContain('old-token');
+});

--- a/tests/realtime-websocket.test.ts
+++ b/tests/realtime-websocket.test.ts
@@ -42,10 +42,12 @@ class FakeBrowserSocket {
   readonly close = vi.fn();
   readonly url: string;
   readonly protocols: string[];
+  readonly headers: Record<string, string>;
 
-  constructor(url: string, protocols: string[]) {
+  constructor(url: string, options: string[] | { protocols: string[]; headers: Record<string, string> }) {
     this.url = url;
-    this.protocols = protocols;
+    this.protocols = Array.isArray(options) ? options : options.protocols;
+    this.headers = Array.isArray(options) ? {} : options.headers;
     FakeBrowserSocket.instances.push(this);
   }
 
@@ -263,11 +265,12 @@ describe.each([
     expect(errors).toHaveBeenCalledTimes(2);
   });
 
-  test('places Azure API keys in the URL and redacts them after opening', async () => {
+  test('sends Azure API keys in request headers and redacts the exposed URL', async () => {
     const realtime = await Realtime.azure(createAzureClient({ deployment: 'chat' }));
     const connectionURL = new URL(lastBrowserSocket().url);
 
-    expect(lastBrowserSocket().url).toContain('api-key=azure-key');
+    expect(lastBrowserSocket().headers).toEqual({ 'api-key': 'azure-key' });
+    expect(connectionURL.searchParams.has('api-key')).toBe(false);
     expect(lastBrowserSocket().protocols).not.toContain('openai-insecure-api-key.azure-key');
     expect(realtime.url.searchParams.get('api-key')).toBe('<REDACTED>');
     expect(connectionURL.pathname).toBe(beta ? '/openai/realtime' : '/openai/v1/realtime');
@@ -275,11 +278,12 @@ describe.each([
     expect(connectionURL.searchParams.has('api-version')).toBe(beta);
   });
 
-  test('places rotating Azure credentials in Authorization and redacts them', async () => {
+  test('sends rotating Azure credentials in Authorization headers and redacts the exposed URL', async () => {
     const realtime = await Realtime.azure(createAzureClient({ deployment: 'chat', tokenProvider: true }));
     const connectionURL = new URL(lastBrowserSocket().url);
 
-    expect(connectionURL.searchParams.get('Authorization')).toBe('Bearer azure-token');
+    expect(lastBrowserSocket().headers).toEqual({ Authorization: 'Bearer azure-token' });
+    expect(connectionURL.searchParams.has('Authorization')).toBe(false);
     expect(realtime.url.searchParams.get('Authorization')).toBe('<REDACTED>');
     expect(connectionURL.pathname).toBe(beta ? '/openai/realtime' : '/openai/v1/realtime');
     expect(connectionURL.searchParams.get(beta ? 'deployment' : 'model')).toBe('chat');
@@ -287,7 +291,7 @@ describe.each([
   });
 
   test.each(azureCredentialCases)(
-    'redacts both Azure query credentials when the URL already contains another credential with $authentication',
+    'strips and redacts existing Azure query credentials when authenticating with $authentication',
     async ({ tokenProvider, queryParameter, credential }) => {
       const existingParameter = queryParameter === 'api-key' ? 'Authorization' : 'api-key';
       const existingCredential = tokenProvider ? 'existing-gateway-key' : 'existing-gateway-token';
@@ -305,8 +309,9 @@ describe.each([
           });
       const connectionURL = new URL(lastBrowserSocket().url);
 
-      expect(connectionURL.searchParams.get(existingParameter)).toBe(existingCredential);
-      expect(connectionURL.searchParams.get(queryParameter)).toBe(credential);
+      expect(connectionURL.searchParams.has(existingParameter)).toBe(false);
+      expect(connectionURL.searchParams.has(queryParameter)).toBe(false);
+      expect(lastBrowserSocket().headers).toEqual({ [queryParameter]: credential });
       expect(realtime.url.searchParams.get('Authorization')).toBe('<REDACTED>');
       expect(realtime.url.searchParams.get('api-key')).toBe('<REDACTED>');
       expect(realtime.url.toString()).not.toContain(existingCredential);
@@ -326,7 +331,8 @@ describe.each([
       const realtime = await Realtime.azure(client, { dangerouslyAllowBrowser: false });
 
       expect(realtime.socket).toBe(lastBrowserSocket());
-      expect(new URL(lastBrowserSocket().url).searchParams.get(queryParameter)).toBe(credential);
+      expect(lastBrowserSocket().headers).toEqual({ [queryParameter]: credential });
+      expect(new URL(lastBrowserSocket().url).searchParams.has(queryParameter)).toBe(false);
     },
   );
 
@@ -340,42 +346,37 @@ describe.each([
       vi.unstubAllGlobals();
     });
 
-    describe.each(azureCredentialCases)(
-      'with $authentication',
-      ({ tokenProvider, queryParameter, credential }) => {
-        test('rejects an explicit browser denial before opening a WebSocket', async () => {
+    describe.each(azureCredentialCases)('with $authentication', ({ tokenProvider }) => {
+      test('rejects an explicit browser denial before opening a WebSocket', async () => {
+        const client = createAzureClient({
+          deployment: 'chat',
+          tokenProvider,
+          dangerouslyAllowBrowser: true,
+        });
+
+        await expect(Realtime.azure(client, { dangerouslyAllowBrowser: false })).rejects.toThrow(OpenAIError);
+        expect(FakeBrowserSocket.instances).toHaveLength(0);
+      });
+
+      test.each([
+        { setting: 'explicitly enabled', dangerouslyAllowBrowser: true },
+        { setting: 'inherited from the client', dangerouslyAllowBrowser: undefined },
+      ])(
+        'rejects a browser WebSocket when browser access is $setting',
+        async ({ dangerouslyAllowBrowser }) => {
           const client = createAzureClient({
             deployment: 'chat',
             tokenProvider,
             dangerouslyAllowBrowser: true,
           });
 
-          await expect(Realtime.azure(client, { dangerouslyAllowBrowser: false })).rejects.toThrow(
-            OpenAIError,
-          );
+          await expect(
+            Realtime.azure(client, dangerouslyAllowBrowser === undefined ? {} : { dangerouslyAllowBrowser }),
+          ).rejects.toThrow(/request headers|authentication proxy/iu);
           expect(FakeBrowserSocket.instances).toHaveLength(0);
-        });
-
-        test.each([
-          { setting: 'explicitly enabled', dangerouslyAllowBrowser: true },
-          { setting: 'inherited from the client', dangerouslyAllowBrowser: undefined },
-        ])('opens a WebSocket when browser access is $setting', async ({ dangerouslyAllowBrowser }) => {
-          const client = createAzureClient({
-            deployment: 'chat',
-            tokenProvider,
-            dangerouslyAllowBrowser: true,
-          });
-
-          const realtime = await Realtime.azure(
-            client,
-            dangerouslyAllowBrowser === undefined ? {} : { dangerouslyAllowBrowser },
-          );
-
-          expect(realtime.socket).toBe(lastBrowserSocket());
-          expect(new URL(lastBrowserSocket().url).searchParams.get(queryParameter)).toBe(credential);
-        });
-      },
-    );
+        },
+      );
+    });
   });
 
   test('rejects Azure connections without a deployment', async () => {
@@ -423,7 +424,8 @@ describe('stable browser realtime transcription', () => {
       expect(connectionURL.searchParams.get('intent')).toBe('transcription');
       expect(connectionURL.searchParams.has('api-version')).toBe(false);
       expect(connectionURL.searchParams.has('deployment')).toBe(false);
-      expect(connectionURL.searchParams.get('api-key')).toBe('azure-key');
+      expect(connectionURL.searchParams.has('api-key')).toBe(false);
+      expect(lastBrowserSocket().headers).toEqual({ 'api-key': 'azure-key' });
       expect(lastBrowserSocket().protocols).toEqual(['realtime']);
       expect(realtime.url.searchParams.get('api-key')).toBe('<REDACTED>');
     },
@@ -439,7 +441,8 @@ describe('stable browser realtime transcription', () => {
     expect(connectionURL.searchParams.get('intent')).toBe('transcription');
     expect(connectionURL.searchParams.has('api-version')).toBe(false);
     expect(connectionURL.searchParams.has('deployment')).toBe(false);
-    expect(connectionURL.searchParams.get('Authorization')).toBe('Bearer azure-token');
+    expect(connectionURL.searchParams.has('Authorization')).toBe(false);
+    expect(lastBrowserSocket().headers).toEqual({ Authorization: 'Bearer azure-token' });
     expect(lastBrowserSocket().protocols).toEqual(['realtime']);
     expect(realtime.url.searchParams.get('Authorization')).toBe('<REDACTED>');
   });
@@ -748,7 +751,8 @@ describe('stable browser realtime custom URL builder', () => {
     );
     expect(connectionURL.pathname).toBe('/azure/custom');
     expect(connectionURL.searchParams.get('existing')).toBe('value');
-    expect(connectionURL.searchParams.get('api-key')).toBe('azure-key');
+    expect(connectionURL.searchParams.has('api-key')).toBe(false);
+    expect(lastBrowserSocket().headers).toEqual({ 'api-key': 'azure-key' });
     expect(connectionURL.searchParams.has('model')).toBe(false);
     expect(connectionURL.searchParams.has('deployment')).toBe(false);
     expect(lastBrowserSocket().protocols).toEqual(['realtime']);
@@ -767,7 +771,8 @@ describe('stable browser realtime custom URL builder', () => {
     const connectionURL = new URL(lastBrowserSocket().url);
 
     expect(connectionURL.searchParams.get('existing')).toBe('value');
-    expect(connectionURL.searchParams.get('Authorization')).toBe('Bearer azure-token');
+    expect(connectionURL.searchParams.has('Authorization')).toBe(false);
+    expect(lastBrowserSocket().headers).toEqual({ Authorization: 'Bearer azure-token' });
     expect(connectionURL.searchParams.has('model')).toBe(false);
     expect(realtime.url.searchParams.get('Authorization')).toBe('<REDACTED>');
     expect(customURL.toString()).toBe('wss://sap.example.com/azure/custom?existing=value');
@@ -801,8 +806,9 @@ describe('stable browser realtime custom URL builder', () => {
 
       expect(connectionURL.pathname).toBe('/azure/custom');
       expect(connectionURL.searchParams.get('routing')).toBe('value');
-      expect(connectionURL.searchParams.get(existingParameter)).toBe('existing');
-      expect(connectionURL.searchParams.get(authenticationParameter)).toBe(authenticationValue);
+      expect(connectionURL.searchParams.has(existingParameter)).toBe(false);
+      expect(connectionURL.searchParams.has(authenticationParameter)).toBe(false);
+      expect(lastBrowserSocket().headers).toEqual({ [authenticationParameter]: authenticationValue });
       expect(realtime.url.searchParams.get('routing')).toBe('value');
       expect(realtime.url.searchParams.get('Authorization')).toBe('<REDACTED>');
       expect(realtime.url.searchParams.get('api-key')).toBe('<REDACTED>');


### PR DESCRIPTION
## Summary

- **HIGH `csf_9fa6cc6334a3ca41d6b376ee`:** Remove the beta Realtime constructor's public `__url` override, validate the final `wss:` destination against the configured client origin, and revalidate origin after asynchronous credential resolution.
- **MEDIUM `csf_62853a37575e349189b743e9`:** Reject permanent credentials in Dedicated, Shared, and Service Worker runtimes across stable and beta native transports while preserving explicit non-Azure opt-ins, ephemeral keys, and trusted server-runtime exceptions.
- **MEDIUM `csf_ec0dd77f3df5485e700b70b3`:** Send Azure API keys and Entra bearer tokens in native WebSocket handshake headers instead of URLs; strip preexisting credential query parameters and retain the existing redacted public-URL contract.
- Preserve stable cross-origin custom URL builders, existing malformed-frame protections, and the concurrent privacy improvements in #2408. No generated/upstream-owned files or `internal-base.ts` files are changed.

## Verification

- Regression-first: **22 new security cases failed on untouched main**, followed by **55 focused security regressions passing**.
- **415 targeted Realtime, Bedrock, redirect, malformed-frame, and platform tests passed on Node 26 and Node 22.0.0**.
- **346 tests passed on a conflict-free synthetic merge with #2408**, including its malformed-frame privacy suite.
- `pnpm lint`, `pnpm exec tsc --noEmit`, and `pnpm build` all pass, including CJS/ESM package smoke checks.
- A broader handwritten sweep passed **3,587 tests**; two unrelated existing Cloudflare inode-fixture tests cannot access `/proc/<parent>/fd` in this sandbox (`ENOENT`).

## Compatibility

Azure native authentication remains available on Node >=22, Bun, and Deno >=2.5 without adding the optional `ws` dependency. Browser-native Azure sockets cannot safely send handshake headers and now fail closed with guidance to use a server-side authentication proxy or `openai/realtime/ws`; ordinary browser/worker ephemeral credentials and explicit opt-ins remain supported.