### PR TITLE
test(auth): establish real-wire X.509 transport conformance

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "typescript": "6.0.3",
     "typescript-4-9": "npm:typescript@4.9.5",
     "ultracite": "7.10.0",
+    "undici": "8.9.0",
     "vitest": "4.1.10",
     "ws": "^8.18.0",
     "yargs": "^18.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       ultracite:
         specifier: 7.10.0
         version: 7.10.0(eslint@10.8.0)(oxfmt@0.62.0)(oxlint@1.76.0)(typescript@6.0.3)
+      undici:
+        specifier: 8.9.0
+        version: 8.9.0
       vitest:
         specifier: 4.1.10
         version: 4.1.10(@types/node@26.2.0)(vite@8.1.5(@types/node@26.2.0)(yaml@2.9.0))

--- a/tests/auth/x509-transport-conformance.test.ts
+++ b/tests/auth/x509-transport-conformance.test.ts
@@ -1,6 +1,7 @@
 import { X509Certificate } from 'node:crypto';
 import { Agent, ProxyAgent, fetch } from 'undici';
 import { expect } from 'vitest';
+import OpenAI from 'openai';
 
 import {
   closeObservedServers,
@@ -28,6 +29,42 @@ function createAgent(certificate: TestCertificate): Agent {
   });
 }
 
+function createSDKClient(
+  issuerURL: URL,
+  apiURL: URL,
+  dispatcher: Agent | ProxyAgent,
+  issuerDispatcher: Agent | ProxyAgent = dispatcher,
+): OpenAI {
+  return new OpenAI({
+    apiKey: null,
+    baseURL: new URL('/v1', apiURL).href,
+    maxRetries: 0,
+    workloadIdentity: {
+      identityProviderId: 'synthetic-identity-provider',
+      serviceAccountId: 'synthetic-service-account',
+      provider: {
+        tokenType: 'jwt',
+        getToken: async () => 'synthetic-subject-token',
+      },
+    },
+    fetch: async (input, init) => {
+      const target = new URL(typeof input === 'string' || input instanceof URL ? input : input.url);
+      if (init?.redirect !== 'manual') {
+        throw new Error('The SDK did not preserve its manual redirect policy');
+      }
+      if (target.href === 'https://auth.openai.com/oauth/token') {
+        // Existing JWT exchange does not inherit client fetchOptions; bridge only its pinned test issuer.
+        return fetch(new URL('/oauth/token', issuerURL), { ...init, dispatcher: issuerDispatcher });
+      }
+      if (!Object.is(init.dispatcher, dispatcher)) {
+        throw new Error('The SDK did not propagate its configured fetchOptions dispatcher');
+      }
+      return fetch(target, { ...init, dispatcher });
+    },
+    fetchOptions: { dispatcher, redirect: 'manual' },
+  });
+}
+
 function createTokenServer(): ObservedServer {
   return createMutualTLSServer(lab, (_request, response) => {
     response.writeHead(200, { 'Content-Type': 'application/json' });
@@ -48,12 +85,8 @@ function createAPIServer(): ObservedServer {
   });
 }
 
-beforeAll(async () => {
-  lab = await createX509TestLab();
-});
-
-afterAll(async () => {
-  await lab?.cleanup();
+beforeAll(() => {
+  lab = createX509TestLab();
 });
 
 describe('real-wire X.509 transport conformance', () => {
@@ -64,22 +97,10 @@ describe('real-wire X.509 transport conformance', () => {
 
     try {
       const [issuerURL, apiURL] = await Promise.all([listenLoopback(issuer), listenLoopback(api)]);
-      const tokenResponse = await fetch(new URL('/oauth/token', issuerURL), {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: '{}',
-        redirect: 'manual',
-        dispatcher,
-      });
-      expect(await tokenResponse.json()).toEqual({ access_token: ACCESS_TOKEN });
+      const client = createSDKClient(issuerURL, apiURL, dispatcher);
 
-      const apiResponse = await fetch(new URL('/v1/models', apiURL), {
-        headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
-        redirect: 'manual',
-        dispatcher,
-      });
-
-      expect(apiResponse.status).toBe(200);
+      const models = await client.models.list();
+      expect(models.data).toEqual([]);
       const fingerprint = new X509Certificate(lab.firstClient.certificate).fingerprint256;
       expect(issuer.requests).toEqual([
         expect.objectContaining({
@@ -112,8 +133,25 @@ describe('real-wire X.509 transport conformance', () => {
 
     try {
       const issuerURL = await listenLoopback(issuer);
+      const client = createSDKClient(issuerURL, issuerURL, dispatcher);
 
-      await expect(fetch(new URL('/oauth/token', issuerURL), { dispatcher })).rejects.toThrow();
+      await expect(client.models.list()).rejects.toThrow();
+      expect(issuer.requests).toEqual([]);
+    } finally {
+      await dispatcher.close();
+      await closeObservedServers(issuer);
+    }
+  });
+
+  test('rejects a proxy-only client certificate at the workload issuer trust boundary', async () => {
+    const issuer = createTokenServer();
+    const dispatcher = createAgent(lab.proxyClient);
+
+    try {
+      const issuerURL = await listenLoopback(issuer);
+      const client = createSDKClient(issuerURL, issuerURL, dispatcher);
+
+      await expect(client.models.list()).rejects.toThrow();
       expect(issuer.requests).toEqual([]);
     } finally {
       await dispatcher.close();
@@ -129,18 +167,10 @@ describe('real-wire X.509 transport conformance', () => {
 
     try {
       const [issuerURL, apiURL] = await Promise.all([listenLoopback(issuer), listenLoopback(api)]);
-      const exchange = await fetch(new URL('/oauth/token', issuerURL), {
-        method: 'POST',
-        dispatcher: firstIdentity,
-      });
-      expect(await exchange.json()).toEqual({ access_token: ACCESS_TOKEN });
+      const client = createSDKClient(issuerURL, apiURL, secondIdentity, firstIdentity);
 
-      const response = await fetch(new URL('/v1/models', apiURL), {
-        headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
-        dispatcher: secondIdentity,
-      });
-
-      expect(response.status).toBe(200);
+      const models = await client.models.list();
+      expect(models.data).toEqual([]);
       expect(issuer.requests[0]?.certificateFingerprint).toBe(
         new X509Certificate(lab.firstClient.certificate).fingerprint256,
       );
@@ -155,6 +185,7 @@ describe('real-wire X.509 transport conformance', () => {
   });
 
   test('refuses an mTLS redirect before the destination receives a certificate or bearer', async () => {
+    const issuer = createTokenServer();
     const destination = createAPIServer();
     let destinationURL: URL;
     const source = createMutualTLSServer(lab, (_request, response) => {
@@ -164,21 +195,20 @@ describe('real-wire X.509 transport conformance', () => {
     const dispatcher = createAgent(lab.firstClient);
 
     try {
-      const endpoints = await Promise.all([listenLoopback(destination), listenLoopback(source)]);
-      [destinationURL] = endpoints;
+      const [issuerURL, redirectDestinationURL, sourceURL] = await Promise.all([
+        listenLoopback(issuer),
+        listenLoopback(destination),
+        listenLoopback(source),
+      ]);
+      destinationURL = redirectDestinationURL;
+      const client = createSDKClient(issuerURL, sourceURL, dispatcher);
 
-      const response = await fetch(new URL('/v1/models', endpoints[1]), {
-        headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
-        redirect: 'manual',
-        dispatcher,
-      });
-
-      expect(response.status).toBe(307);
+      await expect(client.models.list()).rejects.toMatchObject({ status: 307 });
       expect(source.requests).toHaveLength(1);
       expect(destination.requests).toEqual([]);
     } finally {
       await dispatcher.close();
-      await closeObservedServers(source, destination);
+      await closeObservedServers(issuer, source, destination);
     }
   });
 
@@ -212,31 +242,23 @@ describe('real-wire X.509 transport conformance', () => {
             ? {
                 proxyTls: {
                   ca: lab.certificateAuthority,
-                  cert: lab.secondClient.certificate,
-                  key: lab.secondClient.privateKey,
+                  cert: lab.proxyClient.certificate,
+                  key: lab.proxyClient.privateKey,
                   servername: 'localhost',
                 },
               }
             : {}),
         });
 
-        const exchange = await fetch(new URL('/oauth/token', issuerURL), {
-          method: 'POST',
-          dispatcher,
-        });
-        expect(await exchange.json()).toEqual({ access_token: ACCESS_TOKEN });
+        const client = createSDKClient(issuerURL, apiURL, dispatcher);
 
-        const response = await fetch(new URL('/v1/models', apiURL), {
-          headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
-          dispatcher,
-        });
-
-        expect(response.status).toBe(200);
+        const models = await client.models.list();
+        expect(models.data).toEqual([]);
         expect(proxy.requests).toEqual([
           expect.objectContaining({
             authorization: undefined,
             certificateFingerprint: encrypted
-              ? new X509Certificate(lab.secondClient.certificate).fingerprint256
+              ? new X509Certificate(lab.proxyClient.certificate).fingerprint256
               : undefined,
             cookie: undefined,
             path: issuerURL.host,
@@ -245,7 +267,7 @@ describe('real-wire X.509 transport conformance', () => {
           expect.objectContaining({
             authorization: undefined,
             certificateFingerprint: encrypted
-              ? new X509Certificate(lab.secondClient.certificate).fingerprint256
+              ? new X509Certificate(lab.proxyClient.certificate).fingerprint256
               : undefined,
             cookie: undefined,
             path: apiURL.host,

--- a/tests/auth/x509-transport-conformance.test.ts
+++ b/tests/auth/x509-transport-conformance.test.ts
@@ -1,0 +1,262 @@
+import { X509Certificate } from 'node:crypto';
+import { Agent, ProxyAgent, fetch } from 'undici';
+import { expect } from 'vitest';
+
+import {
+  closeObservedServers,
+  createConnectProxy,
+  createMutualTLSServer,
+  createX509TestLab,
+  listenLoopback,
+} from '../utils/x509-test-lab';
+import type { ObservedServer, TestCertificate, X509TestLab } from '../utils/x509-test-lab';
+
+const ACCESS_TOKEN = 'synthetic-workload-access-token';
+const PROXY_AUTHORIZATION = 'Basic c3ludGhldGljLXByb3h5LWNyZWRlbnRpYWw=';
+
+let lab: X509TestLab;
+
+function createAgent(certificate: TestCertificate): Agent {
+  return new Agent({
+    connect: {
+      ca: lab.certificateAuthority,
+      cert: certificate.certificate,
+      key: certificate.privateKey,
+      servername: 'localhost',
+    },
+    maxCachedSessions: 0,
+  });
+}
+
+function createTokenServer(): ObservedServer {
+  return createMutualTLSServer(lab, (_request, response) => {
+    response.writeHead(200, { 'Content-Type': 'application/json' });
+    response.end(JSON.stringify({ access_token: ACCESS_TOKEN }));
+  });
+}
+
+function createAPIServer(): ObservedServer {
+  return createMutualTLSServer(lab, (request, response) => {
+    if (request.headers.authorization !== `Bearer ${ACCESS_TOKEN}`) {
+      response.writeHead(401);
+      response.end();
+      return;
+    }
+
+    response.writeHead(200, { 'Content-Type': 'application/json' });
+    response.end(JSON.stringify({ data: [] }));
+  });
+}
+
+beforeAll(async () => {
+  lab = await createX509TestLab();
+});
+
+afterAll(async () => {
+  await lab?.cleanup();
+});
+
+describe('real-wire X.509 transport conformance', () => {
+  test('observes one client certificate and isolated credentials on the issuer and API TLS handshakes', async () => {
+    const issuer = createTokenServer();
+    const api = createAPIServer();
+    const dispatcher = createAgent(lab.firstClient);
+
+    try {
+      const [issuerURL, apiURL] = await Promise.all([listenLoopback(issuer), listenLoopback(api)]);
+      const tokenResponse = await fetch(new URL('/oauth/token', issuerURL), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+        redirect: 'manual',
+        dispatcher,
+      });
+      expect(await tokenResponse.json()).toEqual({ access_token: ACCESS_TOKEN });
+
+      const apiResponse = await fetch(new URL('/v1/models', apiURL), {
+        headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
+        redirect: 'manual',
+        dispatcher,
+      });
+
+      expect(apiResponse.status).toBe(200);
+      const fingerprint = new X509Certificate(lab.firstClient.certificate).fingerprint256;
+      expect(issuer.requests).toEqual([
+        expect.objectContaining({
+          authority: issuerURL.host,
+          authorization: undefined,
+          certificateFingerprint: fingerprint,
+          cookie: undefined,
+          path: '/oauth/token',
+          proxyAuthorization: undefined,
+        }),
+      ]);
+      expect(api.requests).toEqual([
+        expect.objectContaining({
+          authority: apiURL.host,
+          authorization: `Bearer ${ACCESS_TOKEN}`,
+          certificateFingerprint: fingerprint,
+          path: '/v1/models',
+          proxyAuthorization: undefined,
+        }),
+      ]);
+    } finally {
+      await dispatcher.close();
+      await closeObservedServers(issuer, api);
+    }
+  });
+
+  test('rejects a TLS request without an enrolled client certificate before the application sees it', async () => {
+    const issuer = createTokenServer();
+    const dispatcher = new Agent({ connect: { ca: lab.certificateAuthority, servername: 'localhost' } });
+
+    try {
+      const issuerURL = await listenLoopback(issuer);
+
+      await expect(fetch(new URL('/oauth/token', issuerURL), { dispatcher })).rejects.toThrow();
+      expect(issuer.requests).toEqual([]);
+    } finally {
+      await dispatcher.close();
+      await closeObservedServers(issuer);
+    }
+  });
+
+  test('demonstrates that an ordinary bearer remains transferable between distinct enrolled certificates', async () => {
+    const issuer = createTokenServer();
+    const api = createAPIServer();
+    const firstIdentity = createAgent(lab.firstClient);
+    const secondIdentity = createAgent(lab.secondClient);
+
+    try {
+      const [issuerURL, apiURL] = await Promise.all([listenLoopback(issuer), listenLoopback(api)]);
+      const exchange = await fetch(new URL('/oauth/token', issuerURL), {
+        method: 'POST',
+        dispatcher: firstIdentity,
+      });
+      expect(await exchange.json()).toEqual({ access_token: ACCESS_TOKEN });
+
+      const response = await fetch(new URL('/v1/models', apiURL), {
+        headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
+        dispatcher: secondIdentity,
+      });
+
+      expect(response.status).toBe(200);
+      expect(issuer.requests[0]?.certificateFingerprint).toBe(
+        new X509Certificate(lab.firstClient.certificate).fingerprint256,
+      );
+      expect(api.requests[0]?.certificateFingerprint).toBe(
+        new X509Certificate(lab.secondClient.certificate).fingerprint256,
+      );
+      expect(issuer.requests[0]?.certificateFingerprint).not.toBe(api.requests[0]?.certificateFingerprint);
+    } finally {
+      await Promise.all([firstIdentity.close(), secondIdentity.close()]);
+      await closeObservedServers(issuer, api);
+    }
+  });
+
+  test('refuses an mTLS redirect before the destination receives a certificate or bearer', async () => {
+    const destination = createAPIServer();
+    let destinationURL: URL;
+    const source = createMutualTLSServer(lab, (_request, response) => {
+      response.writeHead(307, { Location: new URL('/capture', destinationURL).href });
+      response.end();
+    });
+    const dispatcher = createAgent(lab.firstClient);
+
+    try {
+      const endpoints = await Promise.all([listenLoopback(destination), listenLoopback(source)]);
+      [destinationURL] = endpoints;
+
+      const response = await fetch(new URL('/v1/models', endpoints[1]), {
+        headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
+        redirect: 'manual',
+        dispatcher,
+      });
+
+      expect(response.status).toBe(307);
+      expect(source.requests).toHaveLength(1);
+      expect(destination.requests).toEqual([]);
+    } finally {
+      await dispatcher.close();
+      await closeObservedServers(source, destination);
+    }
+  });
+
+  test.each([
+    { label: 'HTTP CONNECT', encrypted: false },
+    { label: 'HTTPS CONNECT', encrypted: true },
+  ])(
+    'keeps workload certificates and bearer tokens off the $label proxy handshake',
+    async ({ encrypted }) => {
+      const issuer = createTokenServer();
+      const api = createAPIServer();
+      const proxy = createConnectProxy(lab, encrypted);
+      let dispatcher: ProxyAgent | undefined;
+
+      try {
+        const [issuerURL, apiURL, proxyURL] = await Promise.all([
+          listenLoopback(issuer),
+          listenLoopback(api),
+          listenLoopback(proxy, encrypted),
+        ]);
+        dispatcher = new ProxyAgent({
+          uri: proxyURL.href,
+          token: PROXY_AUTHORIZATION,
+          requestTls: {
+            ca: lab.certificateAuthority,
+            cert: lab.firstClient.certificate,
+            key: lab.firstClient.privateKey,
+            servername: 'localhost',
+          },
+          ...(encrypted ? { proxyTls: { ca: lab.certificateAuthority, servername: 'localhost' } } : {}),
+        });
+
+        const exchange = await fetch(new URL('/oauth/token', issuerURL), {
+          method: 'POST',
+          dispatcher,
+        });
+        expect(await exchange.json()).toEqual({ access_token: ACCESS_TOKEN });
+
+        const response = await fetch(new URL('/v1/models', apiURL), {
+          headers: { Authorization: `Bearer ${ACCESS_TOKEN}` },
+          dispatcher,
+        });
+
+        expect(response.status).toBe(200);
+        expect(proxy.requests).toEqual([
+          expect.objectContaining({
+            authorization: undefined,
+            certificateFingerprint: undefined,
+            cookie: undefined,
+            path: issuerURL.host,
+            proxyAuthorization: PROXY_AUTHORIZATION,
+          }),
+          expect.objectContaining({
+            authorization: undefined,
+            certificateFingerprint: undefined,
+            cookie: undefined,
+            path: apiURL.host,
+            proxyAuthorization: PROXY_AUTHORIZATION,
+          }),
+        ]);
+        expect(issuer.requests).toEqual([
+          expect.objectContaining({
+            authorization: undefined,
+            certificateFingerprint: new X509Certificate(lab.firstClient.certificate).fingerprint256,
+            proxyAuthorization: undefined,
+          }),
+        ]);
+        expect(api.requests).toEqual([
+          expect.objectContaining({
+            authorization: `Bearer ${ACCESS_TOKEN}`,
+            certificateFingerprint: new X509Certificate(lab.firstClient.certificate).fingerprint256,
+            proxyAuthorization: undefined,
+          }),
+        ]);
+      } finally {
+        await dispatcher?.close();
+        await closeObservedServers(issuer, api, proxy);
+      }
+    },
+  );
+});

--- a/tests/auth/x509-transport-conformance.test.ts
+++ b/tests/auth/x509-transport-conformance.test.ts
@@ -29,6 +29,29 @@ function createAgent(certificate: TestCertificate): Agent {
   });
 }
 
+function createProxyAgent(proxyURL: URL, encrypted: boolean): ProxyAgent {
+  return new ProxyAgent({
+    uri: proxyURL.href,
+    token: PROXY_AUTHORIZATION,
+    requestTls: {
+      ca: lab.certificateAuthority,
+      cert: lab.firstClient.certificate,
+      key: lab.firstClient.privateKey,
+      servername: 'localhost',
+    },
+    ...(encrypted
+      ? {
+          proxyTls: {
+            ca: lab.proxyCertificateAuthority,
+            cert: lab.proxyClient.certificate,
+            key: lab.proxyClient.privateKey,
+            servername: 'localhost',
+          },
+        }
+      : {}),
+  });
+}
+
 function createSDKClient(
   issuerURL: URL,
   apiURL: URL,
@@ -159,6 +182,31 @@ describe('real-wire X.509 transport conformance', () => {
     }
   });
 
+  test('rejects a workload-signed HTTPS proxy before disclosing CONNECT credentials', async () => {
+    const issuer = createTokenServer();
+    const api = createAPIServer();
+    const proxy = createConnectProxy(lab, true, lab.server);
+    let dispatcher: ProxyAgent | undefined;
+
+    try {
+      const [issuerURL, apiURL, proxyURL] = await Promise.all([
+        listenLoopback(issuer),
+        listenLoopback(api),
+        listenLoopback(proxy),
+      ]);
+      dispatcher = createProxyAgent(proxyURL, true);
+      const client = createSDKClient(issuerURL, apiURL, dispatcher);
+
+      await expect(client.models.list()).rejects.toThrow();
+      expect(proxy.requests).toEqual([]);
+      expect(issuer.requests).toEqual([]);
+      expect(api.requests).toEqual([]);
+    } finally {
+      await dispatcher?.close();
+      await closeObservedServers(issuer, api, proxy);
+    }
+  });
+
   test('demonstrates that an ordinary bearer remains transferable between distinct enrolled certificates', async () => {
     const issuer = createTokenServer();
     const api = createAPIServer();
@@ -229,26 +277,7 @@ describe('real-wire X.509 transport conformance', () => {
           listenLoopback(api),
           listenLoopback(proxy, encrypted),
         ]);
-        dispatcher = new ProxyAgent({
-          uri: proxyURL.href,
-          token: PROXY_AUTHORIZATION,
-          requestTls: {
-            ca: lab.certificateAuthority,
-            cert: lab.firstClient.certificate,
-            key: lab.firstClient.privateKey,
-            servername: 'localhost',
-          },
-          ...(encrypted
-            ? {
-                proxyTls: {
-                  ca: lab.certificateAuthority,
-                  cert: lab.proxyClient.certificate,
-                  key: lab.proxyClient.privateKey,
-                  servername: 'localhost',
-                },
-              }
-            : {}),
-        });
+        dispatcher = createProxyAgent(proxyURL, encrypted);
 
         const client = createSDKClient(issuerURL, apiURL, dispatcher);
 

--- a/tests/auth/x509-transport-conformance.test.ts
+++ b/tests/auth/x509-transport-conformance.test.ts
@@ -208,7 +208,16 @@ describe('real-wire X.509 transport conformance', () => {
             key: lab.firstClient.privateKey,
             servername: 'localhost',
           },
-          ...(encrypted ? { proxyTls: { ca: lab.certificateAuthority, servername: 'localhost' } } : {}),
+          ...(encrypted
+            ? {
+                proxyTls: {
+                  ca: lab.certificateAuthority,
+                  cert: lab.secondClient.certificate,
+                  key: lab.secondClient.privateKey,
+                  servername: 'localhost',
+                },
+              }
+            : {}),
         });
 
         const exchange = await fetch(new URL('/oauth/token', issuerURL), {
@@ -226,14 +235,18 @@ describe('real-wire X.509 transport conformance', () => {
         expect(proxy.requests).toEqual([
           expect.objectContaining({
             authorization: undefined,
-            certificateFingerprint: undefined,
+            certificateFingerprint: encrypted
+              ? new X509Certificate(lab.secondClient.certificate).fingerprint256
+              : undefined,
             cookie: undefined,
             path: issuerURL.host,
             proxyAuthorization: PROXY_AUTHORIZATION,
           }),
           expect.objectContaining({
             authorization: undefined,
-            certificateFingerprint: undefined,
+            certificateFingerprint: encrypted
+              ? new X509Certificate(lab.secondClient.certificate).fingerprint256
+              : undefined,
             cookie: undefined,
             path: apiURL.host,
             proxyAuthorization: PROXY_AUTHORIZATION,

--- a/tests/utils/x509-test-lab.ts
+++ b/tests/utils/x509-test-lab.ts
@@ -18,6 +18,7 @@ export interface X509TestLab {
   certificateAuthority: Buffer;
   proxyCertificateAuthority: Buffer;
   server: TestCertificate;
+  proxyServer: TestCertificate;
   firstClient: TestCertificate;
   secondClient: TestCertificate;
   proxyClient: TestCertificate;
@@ -158,6 +159,7 @@ export function createX509TestLab(): X509TestLab {
     certificateAuthority: workloadAuthority.certificate,
     proxyCertificateAuthority: proxyAuthority.certificate,
     server: issueCertificate('localhost', 'server', workloadAuthority),
+    proxyServer: issueCertificate('localhost', 'server', proxyAuthority),
     firstClient: issueCertificate('workload-a', 'client', workloadAuthority),
     secondClient: issueCertificate('workload-b', 'client', workloadAuthority),
     proxyClient: issueCertificate('proxy-only', 'client', proxyAuthority),
@@ -198,14 +200,18 @@ export function createMutualTLSServer(
   return { server, requests, connections: new Set() };
 }
 
-export function createConnectProxy(lab: X509TestLab, encrypted: boolean): ObservedServer {
+export function createConnectProxy(
+  lab: X509TestLab,
+  encrypted: boolean,
+  serverCertificate: TestCertificate = lab.proxyServer,
+): ObservedServer {
   const requests: ObservedRequest[] = [];
   const connections = new Set<Duplex>();
   const server = encrypted
     ? createHTTPSServer({
         ca: lab.proxyCertificateAuthority,
-        cert: lab.server.certificate,
-        key: lab.server.privateKey,
+        cert: serverCertificate.certificate,
+        key: serverCertificate.privateKey,
         requestCert: true,
         rejectUnauthorized: true,
       })

--- a/tests/utils/x509-test-lab.ts
+++ b/tests/utils/x509-test-lab.ts
@@ -1,0 +1,253 @@
+import { execFile } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { createServer as createHTTPServer } from 'node:http';
+import type { IncomingMessage, Server as HTTPServer, ServerResponse } from 'node:http';
+import { createServer as createHTTPSServer } from 'node:https';
+import type { Server as HTTPSServer } from 'node:https';
+import { connect } from 'node:net';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type { Duplex } from 'node:stream';
+import type { TLSSocket } from 'node:tls';
+import { promisify } from 'node:util';
+
+const runOpenSSL = promisify(execFile);
+
+export interface TestCertificate {
+  certificate: Buffer;
+  privateKey: Buffer;
+}
+
+export interface X509TestLab {
+  certificateAuthority: Buffer;
+  server: TestCertificate;
+  firstClient: TestCertificate;
+  secondClient: TestCertificate;
+  cleanup: () => Promise<void>;
+}
+
+export interface ObservedRequest {
+  authority: string | undefined;
+  authorization: string | undefined;
+  certificateFingerprint: string | undefined;
+  cookie: string | undefined;
+  path: string | undefined;
+  proxyAuthorization: string | undefined;
+}
+
+export interface ObservedServer {
+  server: HTTPServer | HTTPSServer;
+  requests: ObservedRequest[];
+  connections: Set<Duplex>;
+}
+
+async function issueCertificate(
+  directory: string,
+  name: string,
+  extensions: string[],
+): Promise<TestCertificate> {
+  await runOpenSSL(
+    'openssl',
+    [
+      'req',
+      '-new',
+      '-newkey',
+      'ec',
+      '-pkeyopt',
+      'ec_paramgen_curve:P-256',
+      '-nodes',
+      '-keyout',
+      `${name}.key`,
+      '-out',
+      `${name}.csr`,
+      '-subj',
+      `/CN=${name}`,
+      ...extensions.flatMap((extension) => ['-addext', extension]),
+    ],
+    { cwd: directory, windowsHide: true },
+  );
+  await runOpenSSL(
+    'openssl',
+    [
+      'x509',
+      '-req',
+      '-in',
+      `${name}.csr`,
+      '-CA',
+      'ca.crt',
+      '-CAkey',
+      'ca.key',
+      '-CAcreateserial',
+      '-out',
+      `${name}.crt`,
+      '-days',
+      '1',
+      '-copy_extensions',
+      'copy',
+    ],
+    { cwd: directory, windowsHide: true },
+  );
+
+  const [certificate, privateKey] = await Promise.all([
+    readFile(path.join(directory, `${name}.crt`)),
+    readFile(path.join(directory, `${name}.key`)),
+  ]);
+  return { certificate, privateKey };
+}
+
+export async function createX509TestLab(): Promise<X509TestLab> {
+  const directory = await mkdtemp(path.join(tmpdir(), 'openai-x509-conformance-'));
+
+  try {
+    await runOpenSSL(
+      'openssl',
+      [
+        'req',
+        '-x509',
+        '-newkey',
+        'ec',
+        '-pkeyopt',
+        'ec_paramgen_curve:P-256',
+        '-nodes',
+        '-keyout',
+        'ca.key',
+        '-out',
+        'ca.crt',
+        '-days',
+        '1',
+        '-subj',
+        '/CN=OpenAI SDK ephemeral test certificate authority',
+        '-addext',
+        'basicConstraints=critical,CA:TRUE',
+      ],
+      { cwd: directory, windowsHide: true },
+    );
+
+    const server = await issueCertificate(directory, 'localhost', [
+      'subjectAltName=DNS:localhost,IP:127.0.0.1',
+      'extendedKeyUsage=serverAuth',
+    ]);
+    const firstClient = await issueCertificate(directory, 'workload-a', ['extendedKeyUsage=clientAuth']);
+    const secondClient = await issueCertificate(directory, 'workload-b', ['extendedKeyUsage=clientAuth']);
+
+    return {
+      certificateAuthority: await readFile(path.join(directory, 'ca.crt')),
+      server,
+      firstClient,
+      secondClient,
+      cleanup: async () => {
+        await rm(directory, { recursive: true, force: true });
+      },
+    };
+  } catch (error) {
+    await rm(directory, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function observeRequest(request: IncomingMessage): ObservedRequest {
+  const socket = request.socket as Partial<TLSSocket>;
+  return {
+    authority: request.headers.host,
+    authorization: request.headers.authorization,
+    certificateFingerprint: socket.getPeerCertificate?.().fingerprint256,
+    cookie: request.headers.cookie,
+    path: request.url,
+    proxyAuthorization: request.headers['proxy-authorization'],
+  };
+}
+
+export function createMutualTLSServer(
+  lab: X509TestLab,
+  respond: (request: IncomingMessage, response: ServerResponse) => void,
+): ObservedServer {
+  const requests: ObservedRequest[] = [];
+  const server = createHTTPSServer(
+    {
+      ca: lab.certificateAuthority,
+      cert: lab.server.certificate,
+      key: lab.server.privateKey,
+      requestCert: true,
+      rejectUnauthorized: true,
+    },
+    (request, response) => {
+      requests.push(observeRequest(request));
+      respond(request, response);
+    },
+  );
+
+  return { server, requests, connections: new Set() };
+}
+
+export function createConnectProxy(lab: X509TestLab, encrypted: boolean): ObservedServer {
+  const requests: ObservedRequest[] = [];
+  const connections = new Set<Duplex>();
+  const server = encrypted
+    ? createHTTPSServer({
+        ca: lab.certificateAuthority,
+        cert: lab.server.certificate,
+        key: lab.server.privateKey,
+        requestCert: true,
+        // Observe leaked client certificates while allowing the expected certificate-free proxy handshake.
+        rejectUnauthorized: false,
+      })
+    : createHTTPServer();
+
+  server.on('connect', (request, downstream, head) => {
+    requests.push(observeRequest(request));
+    const target = new URL(`https://${request.url}`);
+    if (target.hostname !== '127.0.0.1') {
+      downstream.destroy();
+      return;
+    }
+
+    const upstream = connect({ host: target.hostname, port: Number(target.port) });
+    connections.add(downstream);
+    connections.add(upstream);
+    downstream.once('close', () => connections.delete(downstream));
+    upstream.once('close', () => connections.delete(upstream));
+    downstream.once('error', () => upstream.destroy());
+    upstream.once('error', () => downstream.destroy());
+    upstream.once('connect', () => {
+      downstream.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+      if (head.length > 0) {
+        upstream.write(head);
+      }
+      downstream.pipe(upstream).pipe(downstream);
+    });
+  });
+
+  return { server, requests, connections };
+}
+
+export async function listenLoopback(observed: ObservedServer, encrypted = true): Promise<URL> {
+  const listening = once(observed.server, 'listening');
+  observed.server.listen(0, '127.0.0.1');
+  await listening;
+
+  const address = observed.server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected a loopback TCP server address');
+  }
+
+  return new URL(`${encrypted ? 'https' : 'http'}://127.0.0.1:${address.port}`);
+}
+
+export async function closeObservedServers(...observedServers: ObservedServer[]): Promise<void> {
+  await Promise.all(
+    observedServers.map(async ({ server, connections }) => {
+      for (const connection of connections) {
+        connection.destroy();
+      }
+      if (!server.listening) {
+        return;
+      }
+
+      const closed = once(server, 'close');
+      server.close();
+      server.closeAllConnections();
+      await closed;
+    }),
+  );
+}

--- a/tests/utils/x509-test-lab.ts
+++ b/tests/utils/x509-test-lab.ts
@@ -189,8 +189,7 @@ export function createConnectProxy(lab: X509TestLab, encrypted: boolean): Observ
         cert: lab.server.certificate,
         key: lab.server.privateKey,
         requestCert: true,
-        // Observe leaked client certificates while allowing the expected certificate-free proxy handshake.
-        rejectUnauthorized: false,
+        rejectUnauthorized: true,
       })
     : createHTTPServer();
 

--- a/tests/utils/x509-test-lab.ts
+++ b/tests/utils/x509-test-lab.ts
@@ -1,18 +1,13 @@
-import { execFile } from 'node:child_process';
+import { generateKeyPairSync, randomBytes, sign } from 'node:crypto';
+import type { KeyObject } from 'node:crypto';
 import { once } from 'node:events';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { createServer as createHTTPServer } from 'node:http';
 import type { IncomingMessage, Server as HTTPServer, ServerResponse } from 'node:http';
 import { createServer as createHTTPSServer } from 'node:https';
 import type { Server as HTTPSServer } from 'node:https';
 import { connect } from 'node:net';
-import { tmpdir } from 'node:os';
-import path from 'node:path';
 import type { Duplex } from 'node:stream';
 import type { TLSSocket } from 'node:tls';
-import { promisify } from 'node:util';
-
-const runOpenSSL = promisify(execFile);
 
 export interface TestCertificate {
   certificate: Buffer;
@@ -21,10 +16,11 @@ export interface TestCertificate {
 
 export interface X509TestLab {
   certificateAuthority: Buffer;
+  proxyCertificateAuthority: Buffer;
   server: TestCertificate;
   firstClient: TestCertificate;
   secondClient: TestCertificate;
-  cleanup: () => Promise<void>;
+  proxyClient: TestCertificate;
 }
 
 export interface ObservedRequest {
@@ -42,108 +38,130 @@ export interface ObservedServer {
   connections: Set<Duplex>;
 }
 
-async function issueCertificate(
-  directory: string,
-  name: string,
-  extensions: string[],
-): Promise<TestCertificate> {
-  await runOpenSSL(
-    'openssl',
-    [
-      'req',
-      '-new',
-      '-newkey',
-      'ec',
-      '-pkeyopt',
-      'ec_paramgen_curve:P-256',
-      '-nodes',
-      '-keyout',
-      `${name}.key`,
-      '-out',
-      `${name}.csr`,
-      '-subj',
-      `/CN=${name}`,
-      ...extensions.flatMap((extension) => ['-addext', extension]),
-    ],
-    { cwd: directory, windowsHide: true },
-  );
-  await runOpenSSL(
-    'openssl',
-    [
-      'x509',
-      '-req',
-      '-in',
-      `${name}.csr`,
-      '-CA',
-      'ca.crt',
-      '-CAkey',
-      'ca.key',
-      '-CAcreateserial',
-      '-out',
-      `${name}.crt`,
-      '-days',
-      '1',
-      '-copy_extensions',
-      'copy',
-    ],
-    { cwd: directory, windowsHide: true },
-  );
-
-  const [certificate, privateKey] = await Promise.all([
-    readFile(path.join(directory, `${name}.crt`)),
-    readFile(path.join(directory, `${name}.key`)),
-  ]);
-  return { certificate, privateKey };
+interface SigningIdentity extends TestCertificate {
+  name: string;
+  signingKey: KeyObject;
 }
 
-export async function createX509TestLab(): Promise<X509TestLab> {
-  const directory = await mkdtemp(path.join(tmpdir(), 'openai-x509-conformance-'));
-
-  try {
-    await runOpenSSL(
-      'openssl',
-      [
-        'req',
-        '-x509',
-        '-newkey',
-        'ec',
-        '-pkeyopt',
-        'ec_paramgen_curve:P-256',
-        '-nodes',
-        '-keyout',
-        'ca.key',
-        '-out',
-        'ca.crt',
-        '-days',
-        '1',
-        '-subj',
-        '/CN=OpenAI SDK ephemeral test certificate authority',
-        '-addext',
-        'basicConstraints=critical,CA:TRUE',
-      ],
-      { cwd: directory, windowsHide: true },
-    );
-
-    const server = await issueCertificate(directory, 'localhost', [
-      'subjectAltName=DNS:localhost,IP:127.0.0.1',
-      'extendedKeyUsage=serverAuth',
-    ]);
-    const firstClient = await issueCertificate(directory, 'workload-a', ['extendedKeyUsage=clientAuth']);
-    const secondClient = await issueCertificate(directory, 'workload-b', ['extendedKeyUsage=clientAuth']);
-
-    return {
-      certificateAuthority: await readFile(path.join(directory, 'ca.crt')),
-      server,
-      firstClient,
-      secondClient,
-      cleanup: async () => {
-        await rm(directory, { recursive: true, force: true });
-      },
-    };
-  } catch (error) {
-    await rm(directory, { recursive: true, force: true });
-    throw error;
+function encodeDER(tag: number, value: Buffer): Buffer {
+  if (value.length < 128) {
+    return Buffer.concat([Buffer.from([tag, value.length]), value]);
   }
+
+  const bytes: number[] = [];
+  for (let remaining = value.length; remaining > 0; remaining = Math.floor(remaining / 256)) {
+    bytes.unshift(remaining % 256);
+  }
+  return Buffer.concat([Buffer.from([tag, 0x80 + bytes.length, ...bytes]), value]);
+}
+
+function sequence(...values: Buffer[]): Buffer {
+  return encodeDER(0x30, Buffer.concat(values));
+}
+
+function objectIdentifier(value: number[]): Buffer {
+  return encodeDER(0x06, Buffer.from(value));
+}
+
+function distinguishedName(name: string): Buffer {
+  const commonName = sequence(objectIdentifier([0x55, 0x04, 0x03]), encodeDER(0x0c, Buffer.from(name)));
+  return sequence(encodeDER(0x31, commonName));
+}
+
+function utcTime(date: Date): Buffer {
+  const timestamp = date.toISOString();
+  const value = `${timestamp.slice(2, 4)}${timestamp.slice(5, 7)}${timestamp.slice(8, 10)}${timestamp.slice(11, 13)}${timestamp.slice(14, 16)}${timestamp.slice(17, 19)}Z`;
+  return encodeDER(0x17, Buffer.from(value));
+}
+
+function extension(identifier: number[], value: Buffer, critical = false): Buffer {
+  return sequence(
+    objectIdentifier(identifier),
+    ...(critical ? [encodeDER(0x01, Buffer.from([0xff]))] : []),
+    encodeDER(0x04, value),
+  );
+}
+
+function issueCertificate(
+  name: string,
+  purpose: 'authority' | 'server' | 'client',
+  issuer?: SigningIdentity,
+): SigningIdentity {
+  const keys = generateKeyPairSync('ec', { namedCurve: 'prime256v1' });
+  const signatureAlgorithm = sequence(objectIdentifier([0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02]));
+  const isAuthority = purpose === 'authority';
+  const extensions = [
+    extension(
+      [0x55, 0x1d, 0x13],
+      sequence(...(isAuthority ? [encodeDER(0x01, Buffer.from([0xff]))] : [])),
+      true,
+    ),
+    extension(
+      [0x55, 0x1d, 0x0f],
+      encodeDER(0x03, Buffer.from(isAuthority ? [0x01, 0x06] : [0x07, 0x80])),
+      true,
+    ),
+  ];
+
+  if (!isAuthority) {
+    const keyPurpose = [0x2b, 0x06, 0x01, 0x05, 0x05, 0x07, 0x03, purpose === 'server' ? 0x01 : 0x02];
+    extensions.push(extension([0x55, 0x1d, 0x25], sequence(objectIdentifier(keyPurpose))));
+  }
+  if (purpose === 'server') {
+    extensions.push(
+      extension(
+        [0x55, 0x1d, 0x11],
+        sequence(encodeDER(0x82, Buffer.from('localhost')), encodeDER(0x87, Buffer.from([127, 0, 0, 1]))),
+      ),
+    );
+  }
+
+  const serial = randomBytes(16);
+  serial[0] = (serial[0] ?? 0) % 128 || 1;
+  const now = Date.now();
+  const certificateBody = sequence(
+    encodeDER(0xa0, encodeDER(0x02, Buffer.from([0x02]))),
+    encodeDER(0x02, serial),
+    signatureAlgorithm,
+    distinguishedName(issuer?.name ?? name),
+    sequence(utcTime(new Date(now - 60_000)), utcTime(new Date(now + 86_400_000))),
+    distinguishedName(name),
+    keys.publicKey.export({ format: 'der', type: 'spki' }),
+    encodeDER(0xa3, sequence(...extensions)),
+  );
+  const signature = sign('sha256', certificateBody, issuer?.signingKey ?? keys.privateKey);
+  const certificateDER = sequence(
+    certificateBody,
+    signatureAlgorithm,
+    encodeDER(0x03, Buffer.concat([Buffer.from([0]), signature])),
+  );
+  const certificateBase64 = certificateDER
+    .toString('base64')
+    .match(/.{1,64}/gu)
+    ?.join('\n');
+
+  return {
+    name,
+    certificate: Buffer.from(
+      `-----BEGIN CERTIFICATE-----\n${certificateBase64}\n-----END CERTIFICATE-----\n`,
+    ),
+    privateKey: Buffer.from(keys.privateKey.export({ format: 'pem', type: 'pkcs8' })),
+    signingKey: keys.privateKey,
+  };
+}
+
+export function createX509TestLab(): X509TestLab {
+  const workloadAuthority = issueCertificate('OpenAI SDK ephemeral workload test authority', 'authority');
+  const proxyAuthority = issueCertificate('OpenAI SDK ephemeral proxy test authority', 'authority');
+
+  return {
+    certificateAuthority: workloadAuthority.certificate,
+    proxyCertificateAuthority: proxyAuthority.certificate,
+    server: issueCertificate('localhost', 'server', workloadAuthority),
+    firstClient: issueCertificate('workload-a', 'client', workloadAuthority),
+    secondClient: issueCertificate('workload-b', 'client', workloadAuthority),
+    proxyClient: issueCertificate('proxy-only', 'client', proxyAuthority),
+  };
 }
 
 function observeRequest(request: IncomingMessage): ObservedRequest {
@@ -185,7 +203,7 @@ export function createConnectProxy(lab: X509TestLab, encrypted: boolean): Observ
   const connections = new Set<Duplex>();
   const server = encrypted
     ? createHTTPSServer({
-        ca: lab.certificateAuthority,
+        ca: lab.proxyCertificateAuthority,
         cert: lab.server.certificate,
         key: lab.server.privateKey,
         requestCert: true,


### PR DESCRIPTION
## Summary

First of five focused X.509 workload-identity changes. This slice changes neither production SDK behavior nor the public API.

- Drive seven real-wire mTLS, replay, redirect, and HTTP/HTTPS CONNECT scenarios through the public OpenAI client and existing workload-identity token exchange.
- Generate ephemeral P-256 X.509 certificates entirely in memory with Node's built-in crypto APIs; no external OpenSSL executable, subprocess, committed fixture, or filesystem private key is required.
- Use independent workload and proxy certificate authorities, a dedicated proxy-only client identity, and a negative test proving proxy credentials cannot authenticate to the workload issuer.
- Verify SDK dispatcher/manual-redirect propagation, distinct issuer/API peer certificates, ordinary bearer transferability, absent-certificate rejection, and strict separation of proxy versus origin credentials.
- Pin the already-present Undici 8.9.0 workspace version as a development-only dependency; published runtime dependencies remain unchanged.

## Follow-on slices

1. Real-wire transport conformance foundation (this PR).
2. Explicit, immutable Node transport capability.
3. Pinned X.509 token exchange and bounded protocol validation.
4. Minimal HTTP client integration and final-dispatch authority guards.
5. Cache, retry, cancellation, documentation, compatibility, and staging hardening.

## Verification

- Node 22.22.0, 24.16.0, and 26.2.0: four authentication suites and 71 passing tests on each version, with `PATH` restricted so no external OpenSSL binary is available.
- Full handwritten suite: 117 files, 3,602 passing tests, and two Linux-only inode tests skipped because macOS lacks Linux `/proc/<pid>/fd`.
- Generated suite: 82 suites, 559 passing tests, one pre-existing skipped test, and 12 passing snapshots.
- `pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm build`, Node policy validation, and TypeScript 4.9 published-source checks.
- Exact immutable-commit Codex Security diff scan `9874b8f2-0fa1-4803-bd0e-ba484bbb09d5`: zero findings across all four changed files.