### PR TITLE
fix(security): secure Next.js Edge streaming example requests

### DIFF
--- a/examples/chat-completions/stream-to-client-next.ts
+++ b/examples/chat-completions/stream-to-client-next.ts
@@ -1,38 +1,138 @@
 import OpenAI from 'openai';
-import type { NextApiRequest, NextApiResponse } from 'next';
 
-// This file demonstrates how to stream from a Next.JS server as
-// a new-line separated JSON-encoded stream. This file cannot be run
-// without Next.JS scaffolding.
-
-export const runtime = 'edge';
-
+// This file demonstrates how to stream from a Next.JS Edge handler as a
+// newline-separated JSON stream. It requires Next.JS scaffolding.
+//
+// Configure a dedicated application secret with at least 32 characters:
+//
+//   OPENAI_EXAMPLE_AUTH_TOKEN=your-dedicated-long-application-secret
+//
+// Browser callers must also configure an explicit trusted origin:
+//
+//   OPENAI_EXAMPLE_ALLOWED_ORIGIN=https://your-application.example
+//
 // This endpoint can be called with:
 //
-//   curl 127.0.0.1:3000 -N -X POST -H 'Content-Type: text/plain' \
+//   curl 127.0.0.1:3000 -N -X POST \
+//     -H "Authorization: Bearer $OPENAI_EXAMPLE_AUTH_TOKEN" \
+//     -H 'Content-Type: text/plain' \
 //     --data 'Can you explain why dogs are better than cats?'
 //
 // Or consumed with fetch:
 //
-//   fetch('http://localhost:3000', {
+//   fetch('https://your-application.example', {
 //     method: 'POST',
+//     headers: { Authorization: 'Bearer ' + applicationAuthToken },
 //     body: 'Tell me why dogs are better than cats',
 //   }).then(async res => {
 //     const runner = ChatCompletionStreamingRunner.fromReadableStream(res)
 //   })
 //
+// Never expose your OpenAI API key to a browser. The separate example token is
+// verified before creating an OpenAI client or reading an untrusted request.
+//
 // See examples/chat-completions/stream-to-client-browser.ts for a more complete example.
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const openai = new OpenAI();
 
+export const runtime = 'edge';
+
+const maximumPromptBytes = 64 * 1024;
+
+function hasValidBearerToken(request: Request, expected: string): boolean {
+  const authorization = request.headers.get('authorization');
+  if (!authorization?.startsWith('Bearer ')) {
+    return false;
+  }
+
+  const encoder = new TextEncoder();
+  const expectedBytes = encoder.encode(expected);
+  const actualBytes = encoder.encode(authorization.slice('Bearer '.length));
+  const lengthDifference = expectedBytes.length - actualBytes.length;
+  let difference = lengthDifference * lengthDifference;
+
+  for (let index = 0; index < expectedBytes.length; index += 1) {
+    const byteDifference = (expectedBytes[index] ?? 0) - (actualBytes[index] ?? 0);
+    difference += byteDifference * byteDifference;
+  }
+
+  return difference === 0;
+}
+
+function validateRequest(request: Request): Response | null {
+  if (request.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405, headers: { Allow: 'POST' } });
+  }
+
+  const fetchSite = request.headers.get('sec-fetch-site');
+  if (fetchSite && !['same-origin', 'same-site', 'none'].includes(fetchSite)) {
+    return new Response('Cross-origin requests are not allowed', { status: 403 });
+  }
+
+  const origin = request.headers.get('origin');
+  if (origin !== null && origin !== process.env['OPENAI_EXAMPLE_ALLOWED_ORIGIN']) {
+    return new Response('Cross-origin requests are not allowed', { status: 403 });
+  }
+
+  const expectedToken = process.env['OPENAI_EXAMPLE_AUTH_TOKEN'];
+  if (!expectedToken || expectedToken.length < 32) {
+    return new Response('Example authorization is not configured', { status: 503 });
+  }
+
+  if (!hasValidBearerToken(request, expectedToken)) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
+  const contentLength = request.headers.get('content-length');
+  if (contentLength !== null) {
+    const length = Number(contentLength);
+    if (!/^\d+$/u.test(contentLength) || !Number.isSafeInteger(length)) {
+      return new Response('Invalid Content-Length', { status: 400 });
+    }
+    if (length > maximumPromptBytes) {
+      return new Response('Request body exceeds 64 KiB', { status: 413 });
+    }
+  }
+
+  return null;
+}
+
+async function readBoundedPrompt(request: Request): Promise<string | Response> {
+  if (!request.body) {
+    return '';
+  }
+
+  const decoder = new TextDecoder();
+  let byteLength = 0;
+  let prompt = '';
+
+  for await (const chunk of request.body) {
+    byteLength += chunk.byteLength;
+    if (byteLength > maximumPromptBytes) {
+      return new Response('Request body exceeds 64 KiB', { status: 413 });
+    }
+
+    prompt += decoder.decode(chunk, { stream: true });
+  }
+
+  return prompt + decoder.decode();
+}
+
+export default async function handler(request: Request): Promise<Response> {
+  const rejection = validateRequest(request);
+  if (rejection) {
+    return rejection;
+  }
+
+  const prompt = await readBoundedPrompt(request);
+  if (prompt instanceof Response) {
+    return prompt;
+  }
+
+  const openai = new OpenAI();
   const stream = openai.chat.completions.stream({
     model: 'gpt-3.5-turbo',
     stream: true,
-    // @ts-ignore
-    messages: [{ role: 'user', content: await req.text() }],
+    messages: [{ role: 'user', content: prompt }],
   });
 
-  return res.send(stream.toReadableStream());
-  // @ts-ignore -- Or, for the app router:
   return new Response(stream.toReadableStream());
 }

--- a/examples/chat-completions/stream-to-client-next.ts
+++ b/examples/chat-completions/stream-to-client-next.ts
@@ -3,37 +3,33 @@ import OpenAI from 'openai';
 // This file demonstrates how to stream from a Next.JS Edge handler as a
 // newline-separated JSON stream. It requires Next.JS scaffolding.
 //
-// Configure a dedicated application secret with at least 32 characters:
+// Configure a dedicated, server-only application secret with at least 32 characters:
 //
 //   OPENAI_EXAMPLE_AUTH_TOKEN=your-dedicated-long-application-secret
 //
-// Browser callers must also configure an explicit trusted origin:
+// Trusted server-side proxies that forward browser Origin headers must configure
+// an explicit trusted origin:
 //
 //   OPENAI_EXAMPLE_ALLOWED_ORIGIN=https://your-application.example
 //
-// This endpoint can be called with:
+// A trusted server-side process or command-line client can call this endpoint:
 //
 //   curl 127.0.0.1:3000 -N -X POST \
 //     -H "Authorization: Bearer $OPENAI_EXAMPLE_AUTH_TOKEN" \
 //     -H 'Content-Type: text/plain' \
 //     --data 'Can you explain why dogs are better than cats?'
 //
-// Or consumed with fetch:
-//
-//   fetch('https://your-application.example', {
-//     method: 'POST',
-//     headers: { Authorization: 'Bearer ' + applicationAuthToken },
-//     body: 'Tell me why dogs are better than cats',
-//   }).then(async res => {
-//     const runner = ChatCompletionStreamingRunner.fromReadableStream(res)
-//   })
-//
-// Never expose your OpenAI API key to a browser. The separate example token is
-// verified before creating an OpenAI client or reading an untrusted request.
+// Never expose your OpenAI API key or the dedicated bearer secret to a browser,
+// browser JavaScript, or browser developer tools. Browser clients must instead
+// use a separate session-authenticated server endpoint; only that trusted
+// server-side endpoint may attach the bearer secret. The secret is verified
+// before creating an OpenAI client or reading an untrusted request.
 //
 // See examples/chat-completions/stream-to-client-browser.ts for a more complete example.
 
-export const runtime = 'edge';
+export const config = {
+  runtime: 'edge',
+};
 
 const maximumPromptBytes = 64 * 1024;
 

--- a/tests/lib/next-streaming-example-security.test.ts
+++ b/tests/lib/next-streaming-example-security.test.ts
@@ -1,6 +1,7 @@
+import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-import handler from '../../examples/chat-completions/stream-to-client-next';
+import handler, * as nextEdgeExample from '../../examples/chat-completions/stream-to-client-next';
 
 const openai = vi.hoisted(() => {
   const toReadableStream = vi.fn(
@@ -94,6 +95,21 @@ afterEach(() => {
 });
 
 describe('Next Edge streaming example request boundaries', () => {
+  test('registers the default Pages Router handler with its Edge runtime configuration', () => {
+    expect(nextEdgeExample.config).toEqual({ runtime: 'edge' });
+    expect(nextEdgeExample).not.toHaveProperty('runtime');
+  });
+
+  test('keeps the dedicated bearer secret out of browser-facing documentation', () => {
+    const exampleSource = readFileSync('examples/chat-completions/stream-to-client-next.ts', 'utf-8');
+
+    expect(exampleSource).not.toContain('applicationAuthToken');
+    expect(exampleSource).not.toMatch(/fetch\([^]*Authorization:/u);
+    expect(exampleSource).toContain('session-authenticated server');
+    expect(exampleSource).toContain('server-side');
+    expect(exampleSource).toContain('$OPENAI_EXAMPLE_AUTH_TOKEN');
+  });
+
   test.each(['GET', 'HEAD', 'PUT', 'DELETE'])(
     'rejects %s before constructing a billed client',
     async (method) => {

--- a/tests/lib/next-streaming-example-security.test.ts
+++ b/tests/lib/next-streaming-example-security.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import handler from '../../examples/chat-completions/stream-to-client-next';
+
+const openai = vi.hoisted(() => {
+  const toReadableStream = vi.fn(
+    () =>
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"content":"safe"}\n'));
+          controller.close();
+        },
+      }),
+  );
+
+  const createStream = vi.fn(() => ({ toReadableStream }));
+  class MockOpenAI {
+    readonly chat = { completions: { stream: createStream } };
+  }
+
+  const constructor = vi.fn(MockOpenAI);
+
+  return { constructor, createStream, toReadableStream };
+});
+
+vi.mock('openai', () => ({ default: openai.constructor }));
+
+const token = '0123456789abcdef0123456789abcdef';
+const trustedOrigin = 'https://sdk.example.com';
+const maximumPromptBytes = 64 * 1024;
+
+interface RequestOptions {
+  method?: string;
+  token?: string | null;
+  origin?: string;
+  fetchSite?: string;
+  body?: string | ReadableStream<Uint8Array>;
+  headers?: RequestInit['headers'];
+  url?: string;
+}
+
+function request(options: RequestOptions = {}): Request {
+  const method = options.method ?? 'POST';
+  const headers = new Headers(options.headers);
+
+  if (options.token !== null) {
+    headers.set('authorization', `Bearer ${options.token ?? token}`);
+  }
+  if (options.origin !== undefined) {
+    headers.set('origin', options.origin);
+  }
+  if (options.fetchSite !== undefined) {
+    headers.set('sec-fetch-site', options.fetchSite);
+  }
+
+  const init: RequestInit = { method, headers };
+  if (method !== 'GET' && method !== 'HEAD') {
+    init.body = options.body ?? 'Tell me why dogs are better than cats';
+    if (init.body instanceof ReadableStream) {
+      Object.assign(init, { duplex: 'half' });
+    }
+  }
+
+  return new Request(options.url ?? `${trustedOrigin}/api/chat`, init);
+}
+
+function invoke(input: Request): Promise<Response> {
+  type EdgeHandler = (
+    request: Request,
+    response: { send: (stream: ReadableStream<Uint8Array>) => Response },
+  ) => Promise<Response>;
+
+  return (handler as unknown as EdgeHandler)(input, {
+    send: (stream) => new Response(stream),
+  });
+}
+
+async function expectRejected(input: Request, status: number): Promise<Response> {
+  const response = await invoke(input);
+  expect(response.status).toBe(status);
+  expect(openai.constructor).not.toHaveBeenCalled();
+  expect(openai.createStream).not.toHaveBeenCalled();
+  return response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv('OPENAI_EXAMPLE_AUTH_TOKEN', token);
+  vi.stubEnv('OPENAI_EXAMPLE_ALLOWED_ORIGIN', trustedOrigin);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('Next Edge streaming example request boundaries', () => {
+  test.each(['GET', 'HEAD', 'PUT', 'DELETE'])(
+    'rejects %s before constructing a billed client',
+    async (method) => {
+      const response = await expectRejected(request({ method }), 405);
+      expect(response.headers.get('allow')).toBe('POST');
+    },
+  );
+
+  test('fails closed when its dedicated authorization secret is missing', async () => {
+    Reflect.deleteProperty(process.env, 'OPENAI_EXAMPLE_AUTH_TOKEN');
+    await expectRejected(request(), 503);
+  });
+
+  test.each(['', 'too-short', token.slice(0, 31)])(
+    'fails closed when its configured authorization secret is too short',
+    async (configuredToken) => {
+      vi.stubEnv('OPENAI_EXAMPLE_AUTH_TOKEN', configuredToken);
+      await expectRejected(request({ token: configuredToken }), 503);
+    },
+  );
+
+  test('rejects requests that omit the dedicated bearer token', async () => {
+    await expectRejected(request({ token: null }), 401);
+  });
+
+  test.each([
+    token.slice(0, -1),
+    `${token}x`,
+    `${token.slice(0, -1)}x`,
+    'incorrect-example-authorization-secret',
+  ])('rejects an invalid bearer credential', async (providedToken) => {
+    await expectRejected(request({ token: providedToken }), 401);
+  });
+
+  test('rejects non-bearer authorization schemes', async () => {
+    await expectRejected(
+      request({ token: null, headers: { authorization: 'Basic not-a-bearer-token' } }),
+      401,
+    );
+  });
+
+  test('rejects cross-site browser metadata even with a valid bearer token', async () => {
+    await expectRejected(request({ fetchSite: 'cross-site' }), 403);
+  });
+
+  test('rejects an untrusted browser origin even with a valid bearer token', async () => {
+    await expectRejected(request({ origin: 'https://attacker.example.com' }), 403);
+  });
+
+  test('rejects attacker-controlled Host and request URL as origin authorities', async () => {
+    await expectRejected(
+      request({
+        origin: 'https://attacker.example.com',
+        headers: { host: 'attacker.example.com' },
+        url: 'https://attacker.example.com/api/chat',
+      }),
+      403,
+    );
+  });
+
+  test('fails closed for browser origins without an explicit trusted-origin configuration', async () => {
+    Reflect.deleteProperty(process.env, 'OPENAI_EXAMPLE_ALLOWED_ORIGIN');
+    await expectRejected(request({ origin: trustedOrigin }), 403);
+  });
+
+  test('rejects an oversized advertised body before reading it or constructing a client', async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(1));
+        controller.close();
+      },
+    });
+    const getReader = vi.spyOn(body, 'getReader');
+
+    await expectRejected(
+      request({
+        body,
+        headers: { 'content-length': String(maximumPromptBytes + 1) },
+      }),
+      413,
+    );
+
+    expect(getReader).not.toHaveBeenCalled();
+  });
+
+  test('rejects an invalid advertised body length before constructing a client', async () => {
+    await expectRejected(request({ headers: { 'content-length': 'not-a-number' } }), 400);
+  });
+
+  test('bounds the actual streamed body and cancels it before constructing a client', async () => {
+    const cancel = vi.fn();
+    let produced = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        produced += 1;
+        controller.enqueue(new Uint8Array(maximumPromptBytes / 2));
+        if (produced === 4) {
+          controller.close();
+        }
+      },
+      cancel,
+    });
+
+    await expectRejected(request({ body, headers: { 'content-length': '1' } }), 413);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  test('counts UTF-8 bytes rather than UTF-16 characters when enforcing the body limit', async () => {
+    await expectRejected(request({ body: `${'🐕'.repeat(maximumPromptBytes / 4)}x` }), 413);
+  });
+
+  test('accepts an authenticated command-line request with no browser-origin headers', async () => {
+    const response = await invoke(request());
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('{"content":"safe"}\n');
+    expect(openai.constructor).toHaveBeenCalledOnce();
+    expect(openai.createStream).toHaveBeenCalledWith({
+      model: 'gpt-3.5-turbo',
+      stream: true,
+      messages: [{ role: 'user', content: 'Tell me why dogs are better than cats' }],
+    });
+  });
+
+  test('accepts an authenticated browser request from the configured trusted origin', async () => {
+    const response = await invoke(request({ origin: trustedOrigin, fetchSite: 'same-origin' }));
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('{"content":"safe"}\n');
+    expect(openai.constructor).toHaveBeenCalledOnce();
+  });
+
+  test('preserves an authenticated body at exactly the 64 KiB UTF-8 boundary', async () => {
+    const body = '🐕'.repeat(maximumPromptBytes / 4);
+    const response = await invoke(request({ body }));
+
+    expect(response.status).toBe(200);
+    expect(openai.createStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [{ role: 'user', content: body }],
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Require a dedicated, minimum-32-character `OPENAI_EXAMPLE_AUTH_TOKEN` and perform a fixed-work, Edge-compatible bearer-token comparison before creating the billable OpenAI client.
- Reject non-POST requests, cross-site Fetch Metadata, and browser origins outside the explicitly configured `OPENAI_EXAMPLE_ALLOWED_ORIGIN`; never trust attacker-controlled Host or request URL values as the origin authority.
- Bound both advertised and actual streamed prompt bodies to 64 KiB, cancel oversized Web streams, preserve authorized UTF-8 streaming, and document secure configuration in the example.

## Regression proof

The unchanged public Next.js Edge example produced **22 failing security regressions** while **3 authorized-stream compatibility controls passed**. The hardened implementation passes **all 25 real-handler cases**, including missing/short secrets, tokenless GET/POST, invalid bearer credentials, hostile origins/Host, oversized Content-Length, streamed-body cancellation, and the exact UTF-8 size boundary.

## Validation

- Full handwritten suite: **3,913 passed** across 125 files.
- Generated API suite: **559 passed**.
- Full repository formatting/lint and strict TypeScript checks.
- Distribution build and published-source TypeScript 4.9/current checks.
- `publint dist` and packed CommonJS/ESM/source-map verification on Node.js 22.22.0.
- Independent security cross-review; exactly two handwritten paths and no overlap with any open pull request.
