### PR TITLE
feat(auth): add caller-attested X.509 transport capability

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
     "@smithy/hash-node": ">=4.3.0 <5",
     "@smithy/signature-v4": ">=5.4.0 <6",
+    "undici": ">=7 <9",
     "ws": "^8.18.0",
     "zod": "^3.25 || ^4.0"
   },
@@ -104,6 +105,9 @@
       "optional": true
     },
     "@smithy/signature-v4": {
+      "optional": true
+    },
+    "undici": {
       "optional": true
     },
     "ws": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
     "@smithy/hash-node": ">=4.3.0 <5",
     "@smithy/signature-v4": ">=5.4.0 <6",
-    "undici": ">=7 <9",
+    "undici": ">=5 <9",
     "ws": "^8.18.0",
     "zod": "^3.25 || ^4.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2978,7 +2978,7 @@ packages:
       '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
       '@smithy/hash-node': '>=4.3.0 <5'
       '@smithy/signature-v4': '>=5.4.0 <6'
-      undici: '>=7 <9'
+      undici: '>=5 <9'
       ws: ^8.18.0
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,7 +137,7 @@ importers:
         version: 16.3.0(@babel/core@7.29.7)(@types/node@26.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openai:
         specifier: file:..
-        version: file:(@aws-sdk/credential-provider-node@3.972.78)(@smithy/hash-node@4.4.16)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3)
+        version: file:(@aws-sdk/credential-provider-node@3.972.78)(@smithy/hash-node@4.4.16)(@smithy/signature-v4@5.6.12)(undici@8.9.0)(ws@8.21.1)(zod@4.4.3)
       undici:
         specifier: ^8.9.0
         version: 8.9.0
@@ -2978,6 +2978,7 @@ packages:
       '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
       '@smithy/hash-node': '>=4.3.0 <5'
       '@smithy/signature-v4': '>=5.4.0 <6'
+      undici: '>=7 <9'
       ws: ^8.18.0
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:
@@ -2986,6 +2987,8 @@ packages:
       '@smithy/hash-node':
         optional: true
       '@smithy/signature-v4':
+        optional: true
+      undici:
         optional: true
       ws:
         optional: true
@@ -6734,11 +6737,12 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openai@file:(@aws-sdk/credential-provider-node@3.972.78)(@smithy/hash-node@4.4.16)(@smithy/signature-v4@5.6.12)(ws@8.21.1)(zod@4.4.3):
+  openai@file:(@aws-sdk/credential-provider-node@3.972.78)(@smithy/hash-node@4.4.16)(@smithy/signature-v4@5.6.12)(undici@8.9.0)(ws@8.21.1)(zod@4.4.3):
     optionalDependencies:
       '@aws-sdk/credential-provider-node': 3.972.78
       '@smithy/hash-node': 4.4.16
       '@smithy/signature-v4': 5.6.12
+      undici: 8.9.0
       ws: 8.21.1
       zod: 4.4.3
 

--- a/scripts/test-packed-package.ts
+++ b/scripts/test-packed-package.ts
@@ -216,7 +216,21 @@ const packedPackagePath = require('node:path');
       tarball,
     ]);
 
-    for (const undiciVersion of ['5.1.1', '5.2.0', '6.29.0', '7.0.0']) {
+    const unsupportedDispatcher =
+      'assert.throws(direct, /Undici 5\\.2\\.0 or later/u); assert.throws(httpConnect, /Undici 5\\.2\\.0 or later/u); assert.throws(httpsConnect, /Undici 5\\.2\\.0 or later/u);';
+    const unsupportedProxy =
+      'assert.doesNotThrow(direct); assert.throws(httpConnect, /CONNECT.*Undici 5\\.5\\.1 or later/u); assert.throws(httpsConnect, /CONNECT.*Undici 5\\.5\\.1 or later/u);';
+    const supportedTransports =
+      'assert.doesNotThrow(direct); assert.doesNotThrow(httpConnect); assert.doesNotThrow(httpsConnect);';
+
+    for (const [undiciVersion, forwardsProxyRequests, transportAssertions] of [
+      ['5.1.1', false, unsupportedDispatcher],
+      ['5.2.0', true, unsupportedProxy],
+      ['5.5.0', true, unsupportedProxy],
+      ['5.5.1', false, supportedTransports],
+      ['6.29.0', false, supportedTransports],
+      ['7.0.0', false, supportedTransports],
+    ] as const) {
       const undiciFixture = path.join(temporaryDirectory, `undici-${undiciVersion}`);
       const consumer = path.join(temporaryDirectory, `legacy-undici-${undiciVersion}`);
       fs.mkdirSync(undiciFixture);
@@ -230,7 +244,24 @@ const packedPackagePath = require('node:path');
         [
           `const undici = require(${JSON.stringify(path.join(root, 'node_modules/undici'))});`,
           'exports.Agent = undici.Agent;',
-          'exports.ProxyAgent = undici.ProxyAgent;',
+          forwardsProxyRequests
+            ? [
+                'exports.ProxyAgent = class ForwardingProxyAgent extends undici.ProxyAgent {',
+                '  #proxyOrigin;',
+                '  constructor(options) {',
+                '    super(options);',
+                '    this.#proxyOrigin = new URL(options.uri).origin;',
+                '  }',
+                '  dispatch(options, handler) {',
+                '    return super.dispatch({',
+                '      ...options,',
+                '      origin: this.#proxyOrigin,',
+                '      path: options.origin + options.path,',
+                '    }, handler);',
+                '  }',
+                '};',
+              ].join('\n')
+            : 'exports.ProxyAgent = undici.ProxyAgent;',
           'exports.Request = undici.Request;',
           undiciVersion === '5.1.1'
             ? [
@@ -285,11 +316,11 @@ const packedPackagePath = require('node:path');
       for (const [inputType, imports] of [
         [
           'commonjs',
-          "const assert = require('node:assert/strict'); const { Agent } = require('undici'); const { createX509Transport } = require('openai/auth/x509-transport');",
+          "const assert = require('node:assert/strict'); const { Agent, ProxyAgent } = require('undici'); const { createX509Transport } = require('openai/auth/x509-transport');",
         ],
         [
           'module',
-          "import assert from 'node:assert/strict'; import { Agent } from 'undici'; import { createX509Transport } from 'openai/auth/x509-transport';",
+          "import assert from 'node:assert/strict'; import { Agent, ProxyAgent } from 'undici'; import { createX509Transport } from 'openai/auth/x509-transport';",
         ],
       ]) {
         run(
@@ -297,7 +328,17 @@ const packedPackagePath = require('node:path');
           [
             `--input-type=${inputType}`,
             '-e',
-            `${imports} const dispatcher = new Agent(); const create = () => createX509Transport({ runtime: 'node', dispatcher, certificateIdentity: 'static', proxy: 'direct' }); ${undiciVersion === '5.1.1' ? 'assert.throws(create, /Undici 5\\.2\\.0 or later/u)' : 'assert.doesNotThrow(create)'}; dispatcher.close();`,
+            [
+              imports,
+              'const dispatcher = new Agent();',
+              "const proxyDispatcher = new ProxyAgent({ uri: 'http://127.0.0.1:1' });",
+              "const secureProxyDispatcher = new ProxyAgent({ uri: 'https://127.0.0.1:1' });",
+              "const direct = () => createX509Transport({ runtime: 'node', dispatcher, certificateIdentity: 'static', proxy: 'direct' });",
+              "const httpConnect = () => createX509Transport({ runtime: 'node', dispatcher: proxyDispatcher, certificateIdentity: 'static', proxy: 'http-connect' });",
+              "const httpsConnect = () => createX509Transport({ runtime: 'node', dispatcher: secureProxyDispatcher, certificateIdentity: 'static', proxy: 'https-connect' });",
+              transportAssertions,
+              'dispatcher.close(); proxyDispatcher.close(); secureProxyDispatcher.close();',
+            ].join(' '),
           ],
           { cwd: consumer },
         );

--- a/scripts/test-packed-package.ts
+++ b/scripts/test-packed-package.ts
@@ -216,10 +216,9 @@ const packedPackagePath = require('node:path');
       tarball,
     ]);
 
-    for (const undiciMajor of [5, 6, 7]) {
-      const undiciFixture = path.join(temporaryDirectory, `undici-${undiciMajor}`);
-      const consumer = path.join(temporaryDirectory, `legacy-undici-${undiciMajor}`);
-      const undiciVersion = undiciMajor === 7 ? '7.0.0' : `${undiciMajor}.29.0`;
+    for (const undiciVersion of ['5.1.1', '5.2.0', '6.29.0', '7.0.0']) {
+      const undiciFixture = path.join(temporaryDirectory, `undici-${undiciVersion}`);
+      const consumer = path.join(temporaryDirectory, `legacy-undici-${undiciVersion}`);
       fs.mkdirSync(undiciFixture);
       fs.mkdirSync(consumer);
       fs.writeFileSync(
@@ -233,7 +232,15 @@ const packedPackagePath = require('node:path');
           'exports.Agent = undici.Agent;',
           'exports.ProxyAgent = undici.ProxyAgent;',
           'exports.Request = undici.Request;',
-          'exports.fetch = undici.fetch;',
+          undiciVersion === '5.1.1'
+            ? [
+                'exports.fetch = async function fetch(resource) {',
+                '  const options = Object.create(arguments[1] ?? null);',
+                "  Object.defineProperty(options, 'dispatcher', { value: undici.getGlobalDispatcher() });",
+                '  return undici.fetch(resource, options);',
+                '};',
+              ].join('\n')
+            : 'exports.fetch = undici.fetch;',
         ].join('\n'),
       );
       const packedUndici = run(
@@ -244,10 +251,10 @@ const packedPackagePath = require('node:path');
         .trim()
         .split(/\r?\n/)
         .pop();
-      assert(packedUndici, `npm pack did not report the Undici ${undiciMajor} fixture`);
+      assert(packedUndici, `npm pack did not report the Undici ${undiciVersion} fixture`);
       fs.writeFileSync(
         path.join(consumer, 'package.json'),
-        JSON.stringify({ name: `legacy-undici-${undiciMajor}-consumer`, private: true }),
+        JSON.stringify({ name: `legacy-undici-${undiciVersion}-consumer`, private: true }),
       );
       const installation = childProcess.spawnSync(
         'npm',
@@ -267,12 +274,12 @@ const packedPackagePath = require('node:path');
       assert.equal(
         installation.status,
         0,
-        `An existing Undici ${undiciMajor} consumer could not install the SDK: ${installation.stderr}`,
+        `An existing Undici ${undiciVersion} consumer could not install the SDK: ${installation.stderr}`,
       );
       assert.doesNotMatch(
         installation.stderr,
         /ERESOLVE/u,
-        `An existing Undici ${undiciMajor} consumer encountered an optional-peer conflict`,
+        `An existing Undici ${undiciVersion} consumer encountered an optional-peer conflict`,
       );
       run(process.execPath, ['-e', "require('openai')"], { cwd: consumer });
       for (const [inputType, imports] of [
@@ -290,7 +297,7 @@ const packedPackagePath = require('node:path');
           [
             `--input-type=${inputType}`,
             '-e',
-            `${imports} const dispatcher = new Agent(); assert.doesNotThrow(() => createX509Transport({ runtime: 'node', dispatcher, certificateIdentity: 'static', proxy: 'direct' })); dispatcher.close();`,
+            `${imports} const dispatcher = new Agent(); const create = () => createX509Transport({ runtime: 'node', dispatcher, certificateIdentity: 'static', proxy: 'direct' }); ${undiciVersion === '5.1.1' ? 'assert.throws(create, /Undici 5\\.2\\.0 or later/u)' : 'assert.doesNotThrow(create)'}; dispatcher.close();`,
           ],
           { cwd: consumer },
         );

--- a/scripts/test-packed-package.ts
+++ b/scripts/test-packed-package.ts
@@ -216,14 +216,15 @@ const packedPackagePath = require('node:path');
       tarball,
     ]);
 
-    for (const undiciMajor of [5, 6]) {
+    for (const undiciMajor of [5, 6, 7]) {
       const undiciFixture = path.join(temporaryDirectory, `undici-${undiciMajor}`);
       const consumer = path.join(temporaryDirectory, `legacy-undici-${undiciMajor}`);
+      const undiciVersion = undiciMajor === 7 ? '7.0.0' : `${undiciMajor}.29.0`;
       fs.mkdirSync(undiciFixture);
       fs.mkdirSync(consumer);
       fs.writeFileSync(
         path.join(undiciFixture, 'package.json'),
-        JSON.stringify({ name: 'undici', version: `${undiciMajor}.29.0`, main: 'index.js' }),
+        JSON.stringify({ name: 'undici', version: undiciVersion, main: 'index.js' }),
       );
       fs.writeFileSync(
         path.join(undiciFixture, 'index.js'),
@@ -231,6 +232,7 @@ const packedPackagePath = require('node:path');
           `const undici = require(${JSON.stringify(path.join(root, 'node_modules/undici'))});`,
           'exports.Agent = undici.Agent;',
           'exports.ProxyAgent = undici.ProxyAgent;',
+          'exports.Request = undici.Request;',
           'exports.fetch = undici.fetch;',
         ].join('\n'),
       );
@@ -288,7 +290,7 @@ const packedPackagePath = require('node:path');
           [
             `--input-type=${inputType}`,
             '-e',
-            `${imports} const dispatcher = new Agent(); assert.throws(() => createX509Transport({ runtime: 'node', dispatcher, certificateIdentity: 'static', proxy: 'direct' }), /Undici 7 or 8/u); dispatcher.close();`,
+            `${imports} const dispatcher = new Agent(); assert.doesNotThrow(() => createX509Transport({ runtime: 'node', dispatcher, certificateIdentity: 'static', proxy: 'direct' })); dispatcher.close();`,
           ],
           { cwd: consumer },
         );

--- a/scripts/test-packed-package.ts
+++ b/scripts/test-packed-package.ts
@@ -16,6 +16,8 @@ const packedPackagePath = require('node:path');
     engines?: {
       node?: string;
     };
+    peerDependencies?: Record<string, string>;
+    peerDependenciesMeta?: Record<string, { optional?: boolean }>;
   }
 
   interface RunOptions {
@@ -73,6 +75,8 @@ const packedPackagePath = require('node:path');
     source === 'helpers/zod.ts' ||
     source === 'helpers/audio.ts' ||
     source === 'providers/bedrock/aws.ts' ||
+    source === 'auth/x509-transport.ts' ||
+    source === 'internal/auth/x509-transport-capability.ts' ||
     source === 'auth/index.ts' ||
     source === 'auth/subject-token-providers.ts';
 
@@ -328,6 +332,28 @@ const packedPackagePath = require('node:path');
       sourcePackage.engines,
       'Packed package engine metadata differs from package.json',
     );
+    assert.equal(installedPackage.peerDependencies?.['undici'], '>=7 <9');
+    assert.equal(installedPackage.peerDependenciesMeta?.['undici']?.optional, true);
+    const optionalUndici = path.join(temporaryDirectory, 'node_modules/undici');
+    assert(!fs.existsSync(optionalUndici), 'Undici must remain optional for ordinary SDK consumers');
+    fs.symlinkSync(path.join(root, 'node_modules/undici'), optionalUndici, 'dir');
+
+    for (const [inputType, consumer] of [
+      [
+        'commonjs',
+        "const { Agent } = require('undici'); const { createX509Transport } = require('openai/auth/x509-transport');",
+      ],
+      [
+        'module',
+        "import { Agent } from 'undici'; import { createX509Transport } from 'openai/auth/x509-transport';",
+      ],
+    ]) {
+      run(process.execPath, [
+        `--input-type=${inputType}`,
+        '-e',
+        `${consumer} const dispatcher = new Agent(); const transport = createX509Transport({ runtime: 'node', dispatcher, certificateIdentity: 'static', proxy: 'direct' }); if (!Object.isFrozen(transport)) throw new Error('X.509 transport capability is not frozen'); dispatcher.close();`,
+      ]);
+    }
 
     console.log(
       `Packed npm artifact passed CommonJS, ESM, and ${browserSafeSources.length}/${mappedSources.size} source checks across ${sourceMaps.length} source maps on ${process.version}.`,

--- a/scripts/test-packed-package.ts
+++ b/scripts/test-packed-package.ts
@@ -216,6 +216,85 @@ const packedPackagePath = require('node:path');
       tarball,
     ]);
 
+    for (const undiciMajor of [5, 6]) {
+      const undiciFixture = path.join(temporaryDirectory, `undici-${undiciMajor}`);
+      const consumer = path.join(temporaryDirectory, `legacy-undici-${undiciMajor}`);
+      fs.mkdirSync(undiciFixture);
+      fs.mkdirSync(consumer);
+      fs.writeFileSync(
+        path.join(undiciFixture, 'package.json'),
+        JSON.stringify({ name: 'undici', version: `${undiciMajor}.29.0`, main: 'index.js' }),
+      );
+      fs.writeFileSync(
+        path.join(undiciFixture, 'index.js'),
+        [
+          `const undici = require(${JSON.stringify(path.join(root, 'node_modules/undici'))});`,
+          'exports.Agent = undici.Agent;',
+          'exports.ProxyAgent = undici.ProxyAgent;',
+          'exports.fetch = undici.fetch;',
+        ].join('\n'),
+      );
+      const packedUndici = run(
+        'npm',
+        ['pack', '--silent', '--cache', npmCache, '--pack-destination', temporaryDirectory],
+        { cwd: undiciFixture },
+      )
+        .trim()
+        .split(/\r?\n/)
+        .pop();
+      assert(packedUndici, `npm pack did not report the Undici ${undiciMajor} fixture`);
+      fs.writeFileSync(
+        path.join(consumer, 'package.json'),
+        JSON.stringify({ name: `legacy-undici-${undiciMajor}-consumer`, private: true }),
+      );
+      const installation = childProcess.spawnSync(
+        'npm',
+        [
+          'install',
+          '--offline',
+          '--ignore-scripts',
+          '--no-audit',
+          '--no-fund',
+          '--cache',
+          npmCache,
+          tarball,
+          path.join(temporaryDirectory, packedUndici),
+        ],
+        { cwd: consumer, encoding: 'utf-8' },
+      );
+      assert.equal(
+        installation.status,
+        0,
+        `An existing Undici ${undiciMajor} consumer could not install the SDK: ${installation.stderr}`,
+      );
+      assert.doesNotMatch(
+        installation.stderr,
+        /ERESOLVE/u,
+        `An existing Undici ${undiciMajor} consumer encountered an optional-peer conflict`,
+      );
+      run(process.execPath, ['-e', "require('openai')"], { cwd: consumer });
+      for (const [inputType, imports] of [
+        [
+          'commonjs',
+          "const assert = require('node:assert/strict'); const { Agent } = require('undici'); const { createX509Transport } = require('openai/auth/x509-transport');",
+        ],
+        [
+          'module',
+          "import assert from 'node:assert/strict'; import { Agent } from 'undici'; import { createX509Transport } from 'openai/auth/x509-transport';",
+        ],
+      ]) {
+        run(
+          process.execPath,
+          [
+            `--input-type=${inputType}`,
+            '-e',
+            `${imports} const dispatcher = new Agent(); assert.throws(() => createX509Transport({ runtime: 'node', dispatcher, certificateIdentity: 'static', proxy: 'direct' }), /Undici 7 or 8/u); dispatcher.close();`,
+          ],
+          { cwd: consumer },
+        );
+      }
+    }
+
     const installedPackageRoot = path.join(temporaryDirectory, 'node_modules/openai');
     const installedSourceRoot = path.join(installedPackageRoot, 'src');
     const installedSourceConfig = path.join(installedSourceRoot, 'tsconfig.json');
@@ -332,7 +411,7 @@ const packedPackagePath = require('node:path');
       sourcePackage.engines,
       'Packed package engine metadata differs from package.json',
     );
-    assert.equal(installedPackage.peerDependencies?.['undici'], '>=7 <9');
+    assert.equal(installedPackage.peerDependencies?.['undici'], '>=5 <9');
     assert.equal(installedPackage.peerDependenciesMeta?.['undici']?.optional, true);
     const optionalUndici = path.join(temporaryDirectory, 'node_modules/undici');
     assert(!fs.existsSync(optionalUndici), 'Undici must remain optional for ordinary SDK consumers');

--- a/src/auth/x509-transport.ts
+++ b/src/auth/x509-transport.ts
@@ -1,0 +1,6 @@
+export { createX509Transport } from '../internal/auth/x509-transport-capability';
+export type {
+  X509ProxyMode,
+  X509Transport,
+  X509TransportOptions,
+} from '../internal/auth/x509-transport-capability';

--- a/src/internal/auth/x509-transport-capability.ts
+++ b/src/internal/auth/x509-transport-capability.ts
@@ -1,5 +1,5 @@
 import { types } from 'node:util';
-import undici, { Agent, ProxyAgent, fetch } from 'undici';
+import { Agent, ProxyAgent, Request, fetch } from 'undici';
 
 declare const x509TransportBrand: unique symbol;
 
@@ -106,18 +106,13 @@ function attestedDispatcher(options: X509TransportOptions): Agent | ProxyAgent {
 export function createX509Transport(options: X509TransportOptions): X509Transport {
   assertNodeRuntime();
 
-  // Undici introduced this public export in v7; v5 and v6 do not provide it.
-  if (!Object.getOwnPropertyDescriptor(undici, 'cacheStores')) {
-    throw new Error('X.509 transport requires Undici 7 or 8.');
-  }
-
   if (!options || typeof options !== 'object' || types.isProxy(options)) {
     throw new Error('X.509 transport configuration must be a non-proxy object.');
   }
 
-  for (const name of Object.keys(options)) {
-    if (!allowedOptionNames.has(name)) {
-      throw new Error(`Unsupported X.509 transport option: \`${name}\`.`);
+  for (const name of Reflect.ownKeys(options)) {
+    if (typeof name !== 'string' || !allowedOptionNames.has(name)) {
+      throw new Error(`Unsupported X.509 transport option: \`${String(name)}\`.`);
     }
   }
 
@@ -156,11 +151,8 @@ export async function sendX509Request(
     throw new Error('X.509 transport does not allow a per-request dispatcher override.');
   }
 
-  const requestOptions: NonNullable<Parameters<typeof fetch>[1]> = Object.create(options);
-  Object.defineProperties(requestOptions, {
-    dispatcher: { value: dispatcher, enumerable: true },
-    redirect: { value: 'manual', enumerable: true },
-  });
-  const response = await fetch(normalizedTarget, requestOptions);
+  const requestOptions: Omit<RequestInit, 'dispatcher'> = options;
+  const request = new Request(normalizedTarget, requestOptions);
+  const response = await fetch(request, { dispatcher, redirect: 'manual' });
   return response;
 }

--- a/src/internal/auth/x509-transport-capability.ts
+++ b/src/internal/auth/x509-transport-capability.ts
@@ -1,0 +1,155 @@
+import { types } from 'node:util';
+import { Agent, ProxyAgent, fetch } from 'undici';
+
+declare const x509TransportBrand: unique symbol;
+
+/** Explicitly supported, application-owned Undici proxy configurations. */
+export type X509ProxyMode = 'direct' | 'http-connect' | 'https-connect';
+
+/** An opaque, immutable X.509 transport identity created by {@link createX509Transport}. */
+export interface X509Transport {
+  /** Prevents ordinary objects from being accepted as X.509 transport capabilities. */
+  readonly [x509TransportBrand]: true;
+}
+
+/** Application attestation for one caller-owned static-certificate Undici transport. */
+export interface X509TransportOptions {
+  /** X.509 transport currently supports genuine Node.js runtimes only. */
+  runtime: 'node';
+
+  /** Caller-owned Undici Agent or ProxyAgent; the SDK never closes or inspects it. */
+  dispatcher: Agent | ProxyAgent;
+
+  /** Attests that the dispatcher uses one static workload-certificate identity. */
+  certificateIdentity: 'static';
+
+  /** Attests that proxy TLS and CONNECT credentials are independently configured. */
+  proxy: X509ProxyMode;
+}
+
+const allowedOptionNames = new Set(['runtime', 'dispatcher', 'certificateIdentity', 'proxy']);
+
+class NodeX509Transport implements X509Transport {
+  declare readonly [x509TransportBrand]: true;
+
+  readonly #dispatcher: Agent | ProxyAgent;
+
+  constructor(dispatcher: Agent | ProxyAgent) {
+    this.#dispatcher = dispatcher;
+    Object.freeze(this);
+  }
+
+  static dispatcher(value: object): Agent | ProxyAgent | undefined {
+    return #dispatcher in value ? value.#dispatcher : undefined;
+  }
+}
+
+function dataOption(options: X509TransportOptions, name: keyof X509TransportOptions): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(options, name);
+  if (!descriptor || !('value' in descriptor)) {
+    throw new Error(`X.509 transport option \`${name}\` must be an own plain data property.`);
+  }
+  return descriptor.value;
+}
+
+function assertNodeRuntime(): void {
+  if (
+    typeof process === 'undefined' ||
+    process.release.name !== 'node' ||
+    'bun' in process.versions ||
+    'Bun' in globalThis ||
+    'Deno' in globalThis
+  ) {
+    throw new Error('X.509 transport requires a genuine Node.js runtime.');
+  }
+}
+
+function attestedDispatcher(options: X509TransportOptions): Agent | ProxyAgent {
+  const dispatcher = dataOption(options, 'dispatcher');
+  if (!dispatcher || typeof dispatcher !== 'object') {
+    throw new Error('X.509 transport requires a caller-owned Undici Agent or ProxyAgent.');
+  }
+  if (types.isProxy(dispatcher)) {
+    throw new Error('X.509 transport does not accept a dispatcher proxy.');
+  }
+
+  const isDirect = dispatcher instanceof Agent;
+  const isConnect = dispatcher instanceof ProxyAgent;
+  if (!isDirect && !isConnect) {
+    throw new Error('X.509 transport requires a caller-owned Undici Agent or ProxyAgent.');
+  }
+
+  const proxy = dataOption(options, 'proxy');
+  if (proxy !== 'direct' && proxy !== 'http-connect' && proxy !== 'https-connect') {
+    throw new Error('X.509 transport requires an explicitly supported proxy mode.');
+  }
+  if ((proxy === 'direct') !== isDirect) {
+    throw new Error('An X.509 CONNECT proxy requires an Undici ProxyAgent.');
+  }
+
+  return dispatcher;
+}
+
+/**
+ * Creates a frozen, opaque capability for one caller-owned Undici transport.
+ *
+ * `certificateIdentity: 'static'` is an application attestation: the SDK does
+ * not inspect certificates, private dispatcher internals, callbacks, or TLS
+ * options and cannot cryptographically prove certificate selection. Configure
+ * one static identity without custom dispatcher factories. For HTTPS CONNECT,
+ * independently configure `proxyTls` and `requestTls` so workload credentials
+ * never reach the proxy. Rotation requires creating a fresh dispatcher and
+ * capability; the application remains responsible for draining the old one.
+ *
+ * This Node-only preview entrypoint requires the optional `undici` peer.
+ */
+export function createX509Transport(options: X509TransportOptions): X509Transport {
+  assertNodeRuntime();
+
+  if (!options || typeof options !== 'object' || types.isProxy(options)) {
+    throw new Error('X.509 transport configuration must be a non-proxy object.');
+  }
+
+  for (const name of Object.keys(options)) {
+    if (!allowedOptionNames.has(name)) {
+      throw new Error(`Unsupported X.509 transport option: \`${name}\`.`);
+    }
+  }
+
+  if (dataOption(options, 'runtime') !== 'node') {
+    throw new Error('X.509 transport requires an explicitly attested Node.js runtime.');
+  }
+
+  if (dataOption(options, 'certificateIdentity') !== 'static') {
+    throw new Error('X.509 transport requires an explicitly attested static client certificate.');
+  }
+
+  return new NodeX509Transport(attestedDispatcher(options));
+}
+
+/** Dispatches through the opaque attested transport without accepting replacement dispatchers. */
+export async function sendX509Request(
+  transport: X509Transport,
+  target: URL,
+  options: RequestInit,
+): Promise<Response> {
+  if (!transport || typeof transport !== 'object' || types.isProxy(transport)) {
+    throw new Error('Invalid X.509 transport capability.');
+  }
+
+  const dispatcher = NodeX509Transport.dispatcher(transport);
+  if (!dispatcher) {
+    throw new Error('Invalid X.509 transport capability.');
+  }
+
+  if (target.protocol !== 'https:') {
+    throw new Error('X.509 transport requires an HTTPS destination.');
+  }
+
+  if (Object.getOwnPropertyDescriptor(options, 'dispatcher')) {
+    throw new Error('X.509 transport does not allow a per-request dispatcher override.');
+  }
+
+  const response = await fetch(target, { ...options, dispatcher, redirect: 'manual' });
+  return response;
+}

--- a/src/internal/auth/x509-transport-capability.ts
+++ b/src/internal/auth/x509-transport-capability.ts
@@ -1,5 +1,5 @@
 import { types } from 'node:util';
-import { Agent, ProxyAgent, fetch } from 'undici';
+import undici, { Agent, ProxyAgent, fetch } from 'undici';
 
 declare const x509TransportBrand: unique symbol;
 
@@ -105,6 +105,11 @@ function attestedDispatcher(options: X509TransportOptions): Agent | ProxyAgent {
  */
 export function createX509Transport(options: X509TransportOptions): X509Transport {
   assertNodeRuntime();
+
+  // Undici introduced this public export in v7; v5 and v6 do not provide it.
+  if (!Object.getOwnPropertyDescriptor(undici, 'cacheStores')) {
+    throw new Error('X.509 transport requires Undici 7 or 8.');
+  }
 
   if (!options || typeof options !== 'object' || types.isProxy(options)) {
     throw new Error('X.509 transport configuration must be a non-proxy object.');

--- a/src/internal/auth/x509-transport-capability.ts
+++ b/src/internal/auth/x509-transport-capability.ts
@@ -108,6 +108,26 @@ function assertRequestDispatcherSupport(dispatcher: Agent | ProxyAgent): void {
   }
 }
 
+function assertConnectProxySupport(): void {
+  const targetOrigin = 'https://127.0.0.1:65535';
+  let routedOrigin: string | undefined;
+  const probe = new ProxyAgent({
+    uri: 'http://127.0.0.1:1',
+    factory(origin) {
+      routedOrigin = String(origin);
+      throw new Error('X.509 CONNECT capability probe');
+    },
+  });
+
+  // The throwing factory reveals the actual routing decision before any socket opens.
+  const request = fetch(targetOrigin, { dispatcher: probe });
+  void Promise.allSettled([request, probe.close()]);
+
+  if (routedOrigin !== targetOrigin) {
+    throw new Error('X.509 CONNECT proxy requires Undici 5.5.1 or later with target TLS tunneling.');
+  }
+}
+
 /**
  * Creates a frozen, opaque capability for one caller-owned Undici transport.
  *
@@ -120,7 +140,8 @@ function assertRequestDispatcherSupport(dispatcher: Agent | ProxyAgent): void {
  * capability; the application remains responsible for draining the old one.
  *
  * This Node-only preview entrypoint requires the optional `undici` peer at
- * version 5.2.0 or later; ordinary SDK clients retain broader compatibility.
+ * version 5.2.0 or later. CONNECT proxy modes require version 5.5.1 or
+ * later; ordinary SDK clients retain broader compatibility.
  */
 export function createX509Transport(options: X509TransportOptions): X509Transport {
   assertNodeRuntime();
@@ -145,6 +166,9 @@ export function createX509Transport(options: X509TransportOptions): X509Transpor
 
   const dispatcher = attestedDispatcher(options);
   assertRequestDispatcherSupport(dispatcher);
+  if (dispatcher instanceof ProxyAgent) {
+    assertConnectProxySupport();
+  }
   return new NodeX509Transport(dispatcher);
 }
 

--- a/src/internal/auth/x509-transport-capability.ts
+++ b/src/internal/auth/x509-transport-capability.ts
@@ -142,7 +142,8 @@ export async function sendX509Request(
     throw new Error('Invalid X.509 transport capability.');
   }
 
-  if (target.protocol !== 'https:') {
+  const normalizedTarget = new URL(target.href);
+  if (normalizedTarget.protocol !== 'https:') {
     throw new Error('X.509 transport requires an HTTPS destination.');
   }
 
@@ -150,6 +151,11 @@ export async function sendX509Request(
     throw new Error('X.509 transport does not allow a per-request dispatcher override.');
   }
 
-  const response = await fetch(target, { ...options, dispatcher, redirect: 'manual' });
+  const requestOptions: NonNullable<Parameters<typeof fetch>[1]> = Object.create(options);
+  Object.defineProperties(requestOptions, {
+    dispatcher: { value: dispatcher, enumerable: true },
+    redirect: { value: 'manual', enumerable: true },
+  });
+  const response = await fetch(normalizedTarget, requestOptions);
   return response;
 }

--- a/src/internal/auth/x509-transport-capability.ts
+++ b/src/internal/auth/x509-transport-capability.ts
@@ -90,6 +90,24 @@ function attestedDispatcher(options: X509TransportOptions): Agent | ProxyAgent {
   return dispatcher;
 }
 
+function assertRequestDispatcherSupport(dispatcher: Agent | ProxyAgent): void {
+  let observesRequestDispatcher = false;
+
+  // about:blank never reaches the network; the getter checks the actual fetch contract.
+  void Promise.allSettled([
+    fetch('about:blank', {
+      get dispatcher() {
+        observesRequestDispatcher = true;
+        return dispatcher;
+      },
+    }),
+  ]);
+
+  if (!observesRequestDispatcher) {
+    throw new Error('X.509 transport requires Undici 5.2.0 or later with per-request dispatcher support.');
+  }
+}
+
 /**
  * Creates a frozen, opaque capability for one caller-owned Undici transport.
  *
@@ -101,7 +119,8 @@ function attestedDispatcher(options: X509TransportOptions): Agent | ProxyAgent {
  * never reach the proxy. Rotation requires creating a fresh dispatcher and
  * capability; the application remains responsible for draining the old one.
  *
- * This Node-only preview entrypoint requires the optional `undici` peer.
+ * This Node-only preview entrypoint requires the optional `undici` peer at
+ * version 5.2.0 or later; ordinary SDK clients retain broader compatibility.
  */
 export function createX509Transport(options: X509TransportOptions): X509Transport {
   assertNodeRuntime();
@@ -124,7 +143,9 @@ export function createX509Transport(options: X509TransportOptions): X509Transpor
     throw new Error('X.509 transport requires an explicitly attested static client certificate.');
   }
 
-  return new NodeX509Transport(attestedDispatcher(options));
+  const dispatcher = attestedDispatcher(options);
+  assertRequestDispatcherSupport(dispatcher);
+  return new NodeX509Transport(dispatcher);
 }
 
 /** Dispatches through the opaque attested transport without accepting replacement dispatchers. */

--- a/tests/auth/x509-transport.test.ts
+++ b/tests/auth/x509-transport.test.ts
@@ -431,6 +431,78 @@ describe('explicit X.509 transport capability', () => {
     }
   });
 
+  test('rejects non-tunneling CONNECT proxies before they receive workload credentials', async () => {
+    const lab = createX509TestLab();
+    let leakedAuthorization: string | undefined;
+    let leakedBody = '';
+    const target = createMutualTLSServer(lab, (_request, response) => {
+      response.writeHead(200);
+      response.end();
+    });
+    const proxy = createConnectProxy(lab, false);
+    proxy.server.on('request', (request, response) => {
+      leakedAuthorization = request.headers.authorization;
+      request.setEncoding('utf-8');
+      request.on('data', (chunk: string) => {
+        leakedBody += chunk;
+      });
+      request.once('end', () => {
+        response.writeHead(200);
+        response.end();
+      });
+    });
+    let dispatcher: ProxyAgent | undefined;
+
+    try {
+      const [targetURL, proxyURL] = await Promise.all([listenLoopback(target), listenLoopback(proxy, false)]);
+      dispatcher = new ProxyAgent({
+        uri: proxyURL.href,
+        auth: 'cHJveHktY3JlZGVudGlhbA==',
+        requestTls: {
+          ca: lab.certificateAuthority,
+          cert: lab.firstClient.certificate,
+          key: lab.firstClient.privateKey,
+          servername: 'localhost',
+        },
+      });
+
+      let capability: X509Transport;
+      try {
+        capability = createX509Transport({
+          runtime: 'node',
+          dispatcher,
+          certificateIdentity: 'static',
+          proxy: 'http-connect',
+        });
+      } catch (error) {
+        expect(error).toEqual(
+          expect.objectContaining({ message: expect.stringMatching(/CONNECT.*Undici 5\.5\.1 or later/u) }),
+        );
+        expect(proxy.requests).toEqual([]);
+        expect(leakedAuthorization).toBeUndefined();
+        expect(leakedBody).toBe('');
+        return;
+      }
+
+      const response = await sendX509Request(capability, targetURL, {
+        method: 'POST',
+        headers: { authorization: 'Bearer synthetic-workload-secret' },
+        body: 'synthetic-workload-body',
+      });
+      await response.body?.cancel();
+
+      expect(response.status).toBe(200);
+      expect(leakedAuthorization).toBeUndefined();
+      expect(leakedBody).toBe('');
+      expect(proxy.requests).toHaveLength(1);
+      expect(proxy.requests[0]?.authorization).toBeUndefined();
+      expect(proxy.requests[0]?.proxyAuthorization).toBe('Basic cHJveHktY3JlZGVudGlhbA==');
+      expect(target.requests[0]?.authorization).toBe('Bearer synthetic-workload-secret');
+    } finally {
+      await Promise.all([dispatcher?.close(), closeObservedServers(target, proxy)]);
+    }
+  });
+
   test('keeps HTTPS CONNECT proxy and workload identities separate on the wire', async () => {
     const lab = createX509TestLab();
     const target = createMutualTLSServer(lab, (_request, response) => {
@@ -444,7 +516,7 @@ describe('explicit X.509 transport capability', () => {
       const [targetURL, proxyURL] = await Promise.all([listenLoopback(target), listenLoopback(proxy)]);
       dispatcher = new ProxyAgent({
         uri: proxyURL.href,
-        token: 'Basic cHJveHktY3JlZGVudGlhbA==',
+        auth: 'cHJveHktY3JlZGVudGlhbA==',
         requestTls: {
           ca: lab.certificateAuthority,
           cert: lab.firstClient.certificate,

--- a/tests/auth/x509-transport.test.ts
+++ b/tests/auth/x509-transport.test.ts
@@ -1,7 +1,7 @@
 import { X509Certificate } from 'node:crypto';
 import { once } from 'node:events';
 import { createServer } from 'node:http';
-import { Agent, ProxyAgent } from 'undici';
+import { Agent, ProxyAgent, fetch } from 'undici';
 import { vi } from 'vitest';
 
 import { createX509Transport } from 'openai/auth/x509-transport';
@@ -26,6 +26,32 @@ function directOptions(dispatcher: Agent): X509TransportOptions {
 }
 
 describe('explicit X.509 transport capability', () => {
+  test('rejects Undici without per-request dispatcher support before creating a capability', async () => {
+    const dispatcher = new Agent();
+    const dispatch = vi.spyOn(dispatcher, 'dispatch');
+    let observesRequestDispatcher = false;
+
+    try {
+      await Promise.allSettled([
+        fetch('about:blank', {
+          get dispatcher() {
+            observesRequestDispatcher = true;
+            return dispatcher;
+          },
+        }),
+      ]);
+
+      if (observesRequestDispatcher) {
+        expect(() => createX509Transport(directOptions(dispatcher))).not.toThrow();
+      } else {
+        expect(() => createX509Transport(directOptions(dispatcher))).toThrow(/Undici 5\.2\.0 or later/u);
+      }
+      expect(dispatch).not.toHaveBeenCalled();
+    } finally {
+      await dispatcher.close();
+    }
+  });
+
   test('creates an opaque, frozen capability with a distinct rotation generation', async () => {
     const dispatcher = new Agent();
     const rotatedDispatcher = new Agent();

--- a/tests/auth/x509-transport.test.ts
+++ b/tests/auth/x509-transport.test.ts
@@ -1,0 +1,293 @@
+import { X509Certificate } from 'node:crypto';
+import { Agent, ProxyAgent } from 'undici';
+import { vi } from 'vitest';
+
+import { createX509Transport } from 'openai/auth/x509-transport';
+import type { X509Transport, X509TransportOptions } from 'openai/auth/x509-transport';
+import { sendX509Request } from 'openai/internal/auth/x509-transport-capability';
+
+import {
+  closeObservedServers,
+  createConnectProxy,
+  createMutualTLSServer,
+  createX509TestLab,
+  listenLoopback,
+} from '../utils/x509-test-lab';
+
+function directOptions(dispatcher: Agent): X509TransportOptions {
+  return {
+    runtime: 'node',
+    dispatcher,
+    certificateIdentity: 'static',
+    proxy: 'direct',
+  };
+}
+
+describe('explicit X.509 transport capability', () => {
+  test('creates an opaque, frozen capability with a distinct rotation generation', async () => {
+    const dispatcher = new Agent();
+    const rotatedDispatcher = new Agent();
+
+    try {
+      const first = createX509Transport(directOptions(dispatcher));
+      const rotated = createX509Transport(directOptions(rotatedDispatcher));
+
+      expect(Object.isFrozen(first)).toBe(true);
+      expect(Reflect.ownKeys(first)).toEqual([]);
+      expect(rotated).not.toBe(first);
+    } finally {
+      await Promise.all([dispatcher.close(), rotatedDispatcher.close()]);
+    }
+  });
+
+  test.each([
+    ['browser', 'browser'],
+    ['Bun', 'bun'],
+    ['Deno', 'deno'],
+  ])('rejects an explicitly attested %s runtime', (_label, runtime) => {
+    const dispatcher = new Agent();
+
+    try {
+      expect(() =>
+        createX509Transport({ ...directOptions(dispatcher), runtime } as X509TransportOptions),
+      ).toThrow(/Node\.js/iu);
+    } finally {
+      void dispatcher.close();
+    }
+  });
+
+  test.each(['Bun', 'Deno'])('rejects a Node-compatibility shim for %s', (runtime) => {
+    const dispatcher = new Agent();
+    vi.stubGlobal(runtime, {});
+
+    try {
+      expect(() => createX509Transport(directOptions(dispatcher))).toThrow(/Node\.js/iu);
+    } finally {
+      vi.unstubAllGlobals();
+      void dispatcher.close();
+    }
+  });
+
+  test('rejects absent static-certificate attestation', () => {
+    const dispatcher = new Agent();
+    const options = directOptions(dispatcher);
+    Object.defineProperty(options, 'certificateIdentity', { value: 'dynamic' });
+
+    try {
+      expect(() => createX509Transport(options)).toThrow(/static.*certificate/iu);
+    } finally {
+      void dispatcher.close();
+    }
+  });
+
+  test('rejects opaque custom dispatchers without touching their methods', () => {
+    const dispatch = vi.fn();
+    const dispatcher = { dispatch } as unknown as Agent;
+
+    expect(() => createX509Transport(directOptions(dispatcher))).toThrow(/Undici Agent or ProxyAgent/u);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  test('rejects dispatcher proxies without evaluating traps', async () => {
+    const dispatcher = new Agent();
+    const trap = vi.fn(() => {
+      throw new Error('dispatcher trap executed');
+    });
+    const opaqueDispatcher = new Proxy(dispatcher, { get: trap, getPrototypeOf: trap });
+
+    try {
+      expect(() => createX509Transport(directOptions(opaqueDispatcher))).toThrow(/proxy/iu);
+      expect(trap).not.toHaveBeenCalled();
+    } finally {
+      await dispatcher.close();
+    }
+  });
+
+  test('rejects configuration proxies without evaluating traps', async () => {
+    const dispatcher = new Agent();
+    const trap = vi.fn(() => {
+      throw new Error('configuration trap executed');
+    });
+    const options = new Proxy(directOptions(dispatcher), { get: trap, ownKeys: trap });
+
+    try {
+      expect(() => createX509Transport(options)).toThrow(/proxy/iu);
+      expect(trap).not.toHaveBeenCalled();
+    } finally {
+      await dispatcher.close();
+    }
+  });
+
+  test('rejects executable configuration getters without invoking them', async () => {
+    const dispatcher = new Agent();
+    const getter = vi.fn(() => dispatcher);
+    const options = {
+      ...directOptions(dispatcher),
+      get dispatcher() {
+        return getter();
+      },
+    };
+
+    try {
+      expect(() => createX509Transport(options)).toThrow(/plain data/iu);
+      expect(getter).not.toHaveBeenCalled();
+    } finally {
+      await dispatcher.close();
+    }
+  });
+
+  test.each(['fetch', 'factory', 'tls', 'certificate', 'privateKey'])(
+    'rejects unsupported %s input',
+    async (key) => {
+      const dispatcher = new Agent();
+
+      try {
+        expect(() => createX509Transport({ ...directOptions(dispatcher), [key]: () => {} })).toThrow(
+          /unsupported.*option/iu,
+        );
+      } finally {
+        await dispatcher.close();
+      }
+    },
+  );
+
+  test('rejects an Agent attested as a CONNECT proxy', async () => {
+    const dispatcher = new Agent();
+
+    try {
+      expect(() => createX509Transport({ ...directOptions(dispatcher), proxy: 'http-connect' })).toThrow(
+        /proxy.*ProxyAgent/iu,
+      );
+    } finally {
+      await dispatcher.close();
+    }
+  });
+
+  test('rejects forged capability objects before dispatch', async () => {
+    await expect(
+      sendX509Request({} as X509Transport, new URL('https://example.invalid'), {}),
+    ).rejects.toThrow(/invalid.*transport/iu);
+  });
+
+  test('rejects plaintext destinations before dispatch', async () => {
+    const dispatcher = new Agent();
+
+    try {
+      const capability = createX509Transport(directOptions(dispatcher));
+      await expect(sendX509Request(capability, new URL('http://example.invalid'), {})).rejects.toThrow(
+        /HTTPS/iu,
+      );
+    } finally {
+      await dispatcher.close();
+    }
+  });
+
+  test('rejects per-request dispatcher overrides before dispatch', async () => {
+    const dispatcher = new Agent();
+    const override = new Agent();
+
+    try {
+      const capability = createX509Transport(directOptions(dispatcher));
+      const options: RequestInit = {};
+      Object.defineProperty(options, 'dispatcher', { value: override, enumerable: true });
+      await expect(sendX509Request(capability, new URL('https://example.invalid'), options)).rejects.toThrow(
+        /dispatcher.*override/iu,
+      );
+    } finally {
+      await Promise.all([dispatcher.close(), override.close()]);
+    }
+  });
+
+  test('snapshots the attested dispatcher and uses its static certificate on a real TLS request', async () => {
+    const lab = createX509TestLab();
+    const server = createMutualTLSServer(lab, (_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end('{}');
+    });
+    const dispatcher = new Agent({
+      connect: {
+        ca: lab.certificateAuthority,
+        cert: lab.firstClient.certificate,
+        key: lab.firstClient.privateKey,
+        servername: 'localhost',
+      },
+      maxCachedSessions: 0,
+    });
+    const replacement = new Agent({
+      connect: {
+        ca: lab.certificateAuthority,
+        cert: lab.secondClient.certificate,
+        key: lab.secondClient.privateKey,
+        servername: 'localhost',
+      },
+      maxCachedSessions: 0,
+    });
+
+    try {
+      const options = directOptions(dispatcher);
+      const capability = createX509Transport(options);
+      options.dispatcher = replacement;
+      options.proxy = 'http-connect';
+      const response = await sendX509Request(capability, await listenLoopback(server), {});
+      await response.body?.cancel();
+
+      expect(response.status).toBe(200);
+      expect(server.requests[0]?.certificateFingerprint).toBe(
+        new X509Certificate(lab.firstClient.certificate).fingerprint256,
+      );
+    } finally {
+      await Promise.all([dispatcher.close(), replacement.close(), closeObservedServers(server)]);
+    }
+  });
+
+  test('keeps HTTPS CONNECT proxy and workload identities separate on the wire', async () => {
+    const lab = createX509TestLab();
+    const target = createMutualTLSServer(lab, (_request, response) => {
+      response.writeHead(200);
+      response.end();
+    });
+    const proxy = createConnectProxy(lab, true);
+    let dispatcher: ProxyAgent | undefined;
+
+    try {
+      const [targetURL, proxyURL] = await Promise.all([listenLoopback(target), listenLoopback(proxy)]);
+      dispatcher = new ProxyAgent({
+        uri: proxyURL.href,
+        token: 'Basic cHJveHktY3JlZGVudGlhbA==',
+        requestTls: {
+          ca: lab.certificateAuthority,
+          cert: lab.firstClient.certificate,
+          key: lab.firstClient.privateKey,
+          servername: 'localhost',
+        },
+        proxyTls: {
+          ca: lab.proxyCertificateAuthority,
+          cert: lab.proxyClient.certificate,
+          key: lab.proxyClient.privateKey,
+          servername: 'localhost',
+        },
+      });
+      const capability = createX509Transport({
+        runtime: 'node',
+        dispatcher,
+        certificateIdentity: 'static',
+        proxy: 'https-connect',
+      });
+
+      const response = await sendX509Request(capability, targetURL, {});
+      await response.body?.cancel();
+
+      expect(response.status).toBe(200);
+      expect(proxy.requests[0]?.certificateFingerprint).toBe(
+        new X509Certificate(lab.proxyClient.certificate).fingerprint256,
+      );
+      expect(proxy.requests[0]?.proxyAuthorization).toBe('Basic cHJveHktY3JlZGVudGlhbA==');
+      expect(target.requests[0]?.certificateFingerprint).toBe(
+        new X509Certificate(lab.firstClient.certificate).fingerprint256,
+      );
+      expect(target.requests[0]?.proxyAuthorization).toBeUndefined();
+    } finally {
+      await Promise.all([dispatcher?.close(), closeObservedServers(target, proxy)]);
+    }
+  });
+});

--- a/tests/auth/x509-transport.test.ts
+++ b/tests/auth/x509-transport.test.ts
@@ -153,6 +153,30 @@ describe('explicit X.509 transport capability', () => {
     },
   );
 
+  test.each(['factory', 'tls', 'privateKey'])('rejects non-enumerable unsupported %s input', async (key) => {
+    const dispatcher = new Agent();
+    const options = directOptions(dispatcher);
+    Object.defineProperty(options, key, { value: 'hidden transport option' });
+
+    try {
+      expect(() => createX509Transport(options)).toThrow(/unsupported.*option/iu);
+    } finally {
+      await dispatcher.close();
+    }
+  });
+
+  test('rejects unsupported symbol-keyed transport options', async () => {
+    const dispatcher = new Agent();
+    const options = directOptions(dispatcher);
+    Object.defineProperty(options, Symbol('privateKey'), { value: 'hidden transport option' });
+
+    try {
+      expect(() => createX509Transport(options)).toThrow(/unsupported.*option/iu);
+    } finally {
+      await dispatcher.close();
+    }
+  });
+
   test('rejects an Agent attested as a CONNECT proxy', async () => {
     const dispatcher = new Agent();
 
@@ -317,6 +341,65 @@ describe('explicit X.509 transport capability', () => {
       expect(observedMethod).toBe('POST');
       expect(observedAuthorization).toBe('Bearer synthetic-secret');
       expect(observedBody).toBe('inherited-request-body');
+    } finally {
+      await Promise.all([dispatcher.close(), closeObservedServers(server)]);
+    }
+  });
+
+  test('preserves the original receiver for inherited private-field RequestInit accessors', async () => {
+    const lab = createX509TestLab();
+    let observedMethod: string | undefined;
+    let observedAuthorization: string | undefined;
+    let observedBody = '';
+    const server = createMutualTLSServer(lab, (request, response) => {
+      observedMethod = request.method;
+      observedAuthorization = request.headers.authorization;
+      request.setEncoding('utf-8');
+      request.on('data', (chunk: string) => {
+        observedBody += chunk;
+      });
+      request.once('end', () => {
+        response.writeHead(200);
+        response.end();
+      });
+    });
+    const dispatcher = new Agent({
+      connect: {
+        ca: lab.certificateAuthority,
+        cert: lab.firstClient.certificate,
+        key: lab.firstClient.privateKey,
+        servername: 'localhost',
+      },
+      maxCachedSessions: 0,
+    });
+
+    class PrivateRequestOptions {
+      readonly #method = 'POST';
+      readonly #headers = { authorization: 'Bearer synthetic-secret' };
+      readonly #body = 'private-request-body';
+
+      get method(): string {
+        return this.#method;
+      }
+
+      get headers(): Record<string, string> {
+        return this.#headers;
+      }
+
+      get body(): string {
+        return this.#body;
+      }
+    }
+
+    try {
+      const options: RequestInit = new PrivateRequestOptions();
+      const capability = createX509Transport(directOptions(dispatcher));
+      const response = await sendX509Request(capability, await listenLoopback(server), options);
+      await response.body?.cancel();
+
+      expect(observedMethod).toBe('POST');
+      expect(observedAuthorization).toBe('Bearer synthetic-secret');
+      expect(observedBody).toBe('private-request-body');
     } finally {
       await Promise.all([dispatcher.close(), closeObservedServers(server)]);
     }

--- a/tests/auth/x509-transport.test.ts
+++ b/tests/auth/x509-transport.test.ts
@@ -1,4 +1,6 @@
 import { X509Certificate } from 'node:crypto';
+import { once } from 'node:events';
+import { createServer } from 'node:http';
 import { Agent, ProxyAgent } from 'undici';
 import { vi } from 'vitest';
 
@@ -182,6 +184,40 @@ describe('explicit X.509 transport capability', () => {
     }
   });
 
+  test('rejects a URL that misreports HTTPS without leaking credentials to a plaintext server', async () => {
+    const dispatcher = new Agent();
+    let leakedAuthorization: string | undefined;
+    const attacker = createServer((request, response) => {
+      leakedAuthorization = request.headers.authorization;
+      response.writeHead(200);
+      response.end();
+    });
+    const listening = once(attacker, 'listening');
+    attacker.listen(0, '127.0.0.1');
+    await listening;
+
+    try {
+      const address = attacker.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Expected a loopback TCP server address');
+      }
+
+      const target = new URL(`http://127.0.0.1:${address.port}`);
+      Object.defineProperty(target, 'protocol', { get: () => 'https:' });
+      const capability = createX509Transport(directOptions(dispatcher));
+
+      await expect(
+        sendX509Request(capability, target, { headers: { authorization: 'Bearer synthetic-secret' } }),
+      ).rejects.toThrow(/HTTPS/iu);
+      expect(leakedAuthorization).toBeUndefined();
+    } finally {
+      attacker.closeAllConnections();
+      const closed = once(attacker, 'close');
+      attacker.close();
+      await Promise.all([dispatcher.close(), closed]);
+    }
+  });
+
   test('rejects per-request dispatcher overrides before dispatch', async () => {
     const dispatcher = new Agent();
     const override = new Agent();
@@ -237,6 +273,52 @@ describe('explicit X.509 transport capability', () => {
       );
     } finally {
       await Promise.all([dispatcher.close(), replacement.close(), closeObservedServers(server)]);
+    }
+  });
+
+  test('preserves inherited request method, headers, and body at native dispatch', async () => {
+    const lab = createX509TestLab();
+    let observedMethod: string | undefined;
+    let observedAuthorization: string | undefined;
+    let observedBody = '';
+    const server = createMutualTLSServer(lab, (request, response) => {
+      observedMethod = request.method;
+      observedAuthorization = request.headers.authorization;
+      request.setEncoding('utf-8');
+      request.on('data', (chunk: string) => {
+        observedBody += chunk;
+      });
+      request.once('end', () => {
+        response.writeHead(200);
+        response.end();
+      });
+    });
+    const dispatcher = new Agent({
+      connect: {
+        ca: lab.certificateAuthority,
+        cert: lab.firstClient.certificate,
+        key: lab.firstClient.privateKey,
+        servername: 'localhost',
+      },
+      maxCachedSessions: 0,
+    });
+
+    try {
+      const inherited = {
+        method: 'POST',
+        headers: { authorization: 'Bearer synthetic-secret' },
+        body: 'inherited-request-body',
+      };
+      const options: RequestInit = Object.create(inherited);
+      const capability = createX509Transport(directOptions(dispatcher));
+      const response = await sendX509Request(capability, await listenLoopback(server), options);
+      await response.body?.cancel();
+
+      expect(observedMethod).toBe('POST');
+      expect(observedAuthorization).toBe('Bearer synthetic-secret');
+      expect(observedBody).toBe('inherited-request-body');
+    } finally {
+      await Promise.all([dispatcher.close(), closeObservedServers(server)]);
     }
   });
 


### PR DESCRIPTION
## Summary
- Add an isolated, preview `openai/auth/x509-transport` entrypoint for one explicitly caller-attested Node.js Undici `Agent` or `ProxyAgent`.
- Freeze and privately brand each opaque transport generation; snapshot its dispatcher; reject unsupported runtimes, executable getters, JavaScript proxies, unknown options, plaintext targets, and per-request dispatcher replacement without examining Undici private state.
- Keep Undici optional for ordinary SDK consumers and verify installed-package CommonJS/ESM behavior with the optional peer both absent and present.
- Exercise genuine direct mTLS and independently authenticated HTTPS CONNECT, including distinct proxy/workload certificate authorities, certificate fingerprints, proxy credential isolation, and post-construction option mutation.

This is **PR 2 of 5**, following #2417. Certificate stability, safe proxy TLS separation, and fresh-dispatcher rotation are application attestations—not claims that transport identity cryptographically proves certificate selection. OAuth exchange, OpenAI client integration, credential caching, and lifecycle policy remain explicitly out of scope.

## Verification
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `node --experimental-strip-types scripts/test-packed-package.ts` — CommonJS, ESM, TypeScript 4.9/current, browser-safe source navigation, and optional Undici absent/present
- Node 22.15.1, 22.22.0, 24.16.0, and 26.2.0: all 30 focused X.509 and real-wire conformance tests pass
- `env NODE_USE_ENV_PROXY=0 CI=1 ./scripts/test --testNamePattern='^(?!.*(?:pre-opened readable original inode|original held inode)).*$'` — **4,064 handwritten tests passed; two pre-existing Linux-only inode cases skipped on macOS; 559 generated tests and 12 snapshots passed**
- Exact-head Codex Security diff scan `a3ac2b08-df37-44b8-9ba1-e105c884df5e` — complete changed-source coverage, **zero findings**