### PR TITLE
fix: [responses] Avoid quadratic comparisons when accumulating long text

### DIFF
--- a/src/internal/responses/canonical-output-text.ts
+++ b/src/internal/responses/canonical-output-text.ts
@@ -44,9 +44,9 @@ export function ensureCanonicalOutputText(context: ResponseAccumulatorContext, s
     text += outputText;
     outputTextIndex.append(outputText.length);
   }
-  if (snapshot.output_text !== text) {
-    snapshot.output_text = text;
-  }
+  // Comparing independently accumulated strings can scan all preceding text on
+  // every delta. The recount is authoritative, so assign it without comparing.
+  snapshot.output_text = text;
   context.outputTextIndex = outputTextIndex;
   context.canonicalSnapshot = snapshot;
 }

--- a/tests/lib/response-accumulator-output-text-performance.test.ts
+++ b/tests/lib/response-accumulator-output-text-performance.test.ts
@@ -273,6 +273,41 @@ describe('canonical streamed response output text', () => {
     expect(work.count).toBeLessThanOrEqual(count * 8);
   });
 
+  test('recounts long public snapshots without comparing the previous aggregate', () => {
+    const count = 16_000;
+    const delta = 'x'.repeat(64);
+    const snapshot = accumulateResponse(created([message(0, [text('')])]));
+    let aggregate = snapshot.output_text;
+    let recounted = false;
+    let readsBeforeRecount = 0;
+    Object.defineProperty(snapshot, 'output_text', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        if (!recounted) {
+          readsBeforeRecount += 1;
+        }
+        return aggregate;
+      },
+      set(value: string) {
+        aggregate = value;
+        recounted = true;
+      },
+    });
+
+    const event = textFrame('delta', 0, 0, delta);
+    for (let index = 0; index < count; index += 1) {
+      recounted = false;
+      accumulateResponse(event, snapshot);
+    }
+
+    // Comparing two equal, independently accumulated strings can walk the
+    // entire prefix per delta. Count the reads instead of timing the test.
+    expect(readsBeforeRecount).toBe(0);
+    expect(snapshot.output_text).toBe(delta.repeat(count));
+    expect(firstText(snapshot).text).toBe(snapshot.output_text);
+  });
+
   test.each([false, true])('releases the accumulator context when parsing fails: %s', async (fails) => {
     const createContext = vi.spyOn(responseAccumulator, 'createResponseContext');
     const failure = new OpenAIError('response parsing failed');


### PR DESCRIPTION
## Summary

#2354 made direct `accumulateResponse(event, snapshot)` calls recount caller-owned output so that edits between calls cannot leave stale text behind. That correctness guarantee is necessary, but the recount also compared the rebuilt string with the previous aggregate. For a long response, those independently accumulated strings can be equal only after walking the entire prefix again on every delta.

Assign the authoritative recount directly. A local replay of 16,000 64-byte deltas (1.024 MB) dropped from about 1.5 seconds to 14 ms on Node 22 and 24. This preserves the existing public API, snapshot-mutation behavior, and privately owned `ResponseStream` context; it does not introduce a cache or pretend the necessary content-part scan can be eliminated.

Add a deterministic public-entrypoint regression for that long-response shape. It detects reads of the old aggregate before the recount is installed, so the original implementation fails without relying on a wall-clock threshold.
