### PR TITLE
test: move custom resource regressions into handwritten suites

### DIFF
--- a/tests/api-resources/embeddings.test.ts
+++ b/tests/api-resources/embeddings.test.ts
@@ -1,9 +1,6 @@
 // File generated from our OpenAPI spec by Castiron. See CONTRIBUTING.md for details.
 
 import OpenAI from 'openai';
-import { mockFetch } from '../utils/mock-fetch';
-import fs from 'fs/promises';
-import Path from 'path';
 
 const client = new OpenAI({
   apiKey: 'My API Key',
@@ -35,73 +32,4 @@ describe('resource embeddings', () => {
       user: 'user-1234',
     });
   });
-
-  test('create: encoding_format=default should create float32 embeddings', async () => {
-    const client = makeClient();
-    const response = await client.embeddings.create({
-      input: 'The quick brown fox jumped over the lazy dog',
-      model: 'text-embedding-3-small',
-    });
-
-    expect(Array.isArray(response.data?.[0]?.embedding)).toBe(true);
-    expect(response.data?.[0]?.embedding[0]).toBe(-0.09928705543279648);
-  });
-
-  test('create: encoding_format=float should create float32 embeddings', async () => {
-    const client = makeClient();
-    const response = await client.embeddings.create({
-      input: 'The quick brown fox jumped over the lazy dog',
-      model: 'text-embedding-3-small',
-      encoding_format: 'float',
-    });
-
-    expect(Array.isArray(response.data?.[0]?.embedding)).toBe(true);
-    expect(response.data?.[0]?.embedding[0]).toBe(-0.099287055);
-  });
-
-  test('create: encoding_format=base64 should return base64 embeddings', async () => {
-    const client = makeClient();
-    const response = await client.embeddings.create({
-      input: 'The quick brown fox jumped over the lazy dog',
-      model: 'text-embedding-3-small',
-      encoding_format: 'base64',
-    });
-
-    expect(typeof response.data?.[0]?.embedding).toBe('string');
-  });
 });
-
-function makeClient(): OpenAI {
-  const { fetch, handleRequest } = mockFetch();
-
-  handleRequest(async (_, init) => {
-    const format = (JSON.parse(init!.body as string) as OpenAI.EmbeddingCreateParams).encoding_format;
-    return new Response(
-      await fs.readFile(
-        Path.join(
-          __dirname,
-
-          // these responses were taken from the live API with:
-          //
-          // model: 'text-embedding-3-large',
-          // input: 'h',
-          // dimensions: 256,
-
-          format === 'base64' ? 'embeddings-base64-response.json' : 'embeddings-float-response.json',
-        ),
-      ),
-      {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      },
-    );
-  });
-
-  return new OpenAI({
-    fetch,
-    apiKey: 'My API Key',
-    baseURL: process.env['TEST_API_BASE_URL'] ?? 'http://127.0.0.1:4010',
-  });
-}

--- a/tests/api-resources/responses/responses.test.ts
+++ b/tests/api-resources/responses/responses.test.ts
@@ -18,9 +18,6 @@ describe('resource responses', () => {
     const dataAndResponse = await responsePromise.withResponse();
     expect(dataAndResponse.data).toBe(response);
     expect(dataAndResponse.response).toBe(rawResponse);
-
-    expect(response).toHaveProperty('output_text');
-    expect(typeof response.output_text).toBe('string');
   });
 
   test('retrieve', async () => {
@@ -32,9 +29,6 @@ describe('resource responses', () => {
     const dataAndResponse = await responsePromise.withResponse();
     expect(dataAndResponse.data).toBe(response);
     expect(dataAndResponse.response).toBe(rawResponse);
-
-    expect(response).toHaveProperty('output_text');
-    expect(typeof response.output_text).toBe('string');
   });
 
   test('retrieve: request options and params are passed correctly', async () => {

--- a/tests/lib/embeddings.test.ts
+++ b/tests/lib/embeddings.test.ts
@@ -1,5 +1,7 @@
 import OpenAI from 'openai';
 
+import base64EmbeddingFixture from '../api-resources/embeddings-base64-response.json';
+import floatEmbeddingFixture from '../api-resources/embeddings-float-response.json';
 import { compareType, expectType } from '../utils/typing';
 
 const vector = [1.25, -2.5];
@@ -27,6 +29,55 @@ function createClient(): OpenAI {
     },
   });
 }
+
+function makeFixtureClient(): OpenAI {
+  return new OpenAI({
+    apiKey: 'My API Key',
+    baseURL: process.env['TEST_API_BASE_URL'] ?? 'http://127.0.0.1:4010',
+    fetch: async (_, init) => {
+      const format = (JSON.parse(String(init?.body)) as OpenAI.EmbeddingCreateParams).encoding_format;
+      // These existing responses were taken from the live API with:
+      // model: 'text-embedding-3-large', input: 'h', dimensions: 256.
+      return Response.json(format === 'base64' ? base64EmbeddingFixture : floatEmbeddingFixture);
+    },
+  });
+}
+
+describe('resource embeddings', () => {
+  test('create: encoding_format=default should create float32 embeddings', async () => {
+    const client = makeFixtureClient();
+    const response = await client.embeddings.create({
+      input: 'The quick brown fox jumped over the lazy dog',
+      model: 'text-embedding-3-small',
+    });
+
+    expect(Array.isArray(response.data?.[0]?.embedding)).toBe(true);
+    expect(response.data?.[0]?.embedding[0]).toBe(-0.09928705543279648);
+  });
+
+  test('create: encoding_format=float should create float32 embeddings', async () => {
+    const client = makeFixtureClient();
+    const response = await client.embeddings.create({
+      input: 'The quick brown fox jumped over the lazy dog',
+      model: 'text-embedding-3-small',
+      encoding_format: 'float',
+    });
+
+    expect(Array.isArray(response.data?.[0]?.embedding)).toBe(true);
+    expect(response.data?.[0]?.embedding[0]).toBe(-0.099287055);
+  });
+
+  test('create: encoding_format=base64 should return base64 embeddings', async () => {
+    const client = makeFixtureClient();
+    const response = await client.embeddings.create({
+      input: 'The quick brown fox jumped over the lazy dog',
+      model: 'text-embedding-3-small',
+      encoding_format: 'base64',
+    });
+
+    expect(typeof response.data?.[0]?.embedding).toBe('string');
+  });
+});
 
 describe('embedding response types', () => {
   test('preserves numeric embedding types for default and float requests', async () => {

--- a/tests/lib/responses-output-text.test.ts
+++ b/tests/lib/responses-output-text.test.ts
@@ -1,0 +1,24 @@
+import OpenAI from 'openai';
+
+describe('resource responses output_text', () => {
+  const responseID = 'resp_677efb5139a88190b512bc3fef8e535d';
+
+  test.each(['create', 'retrieve'] as const)('%s', async (method) => {
+    const client = new OpenAI({
+      apiKey: 'My API Key',
+      fetch: async () => Response.json({ id: responseID, object: 'response', output: [] }),
+    });
+    const responsePromise =
+      method === 'create' ? client.responses.create({}) : client.responses.retrieve(responseID);
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+
+    expect(response).toHaveProperty('output_text');
+    expect(typeof response.output_text).toBe('string');
+  });
+});


### PR DESCRIPTION
Move handwritten SDK behavior checks out of generated API-resource tests so regeneration no longer has to preserve those patches. Both generated files now match the verified public generated snapshot exactly. No production source, public declarations, dependencies, API-reference artifacts, or generation metadata changes.

Replacement coverage:

- `tests/lib/embeddings.test.ts` retains `resource embeddings` → `create: encoding_format=default should create float32 embeddings`, `create: encoding_format=float should create float32 embeddings`, and `create: encoding_format=base64 should return base64 embeddings`. It uses the same existing response fixtures and preserves the array/string and exact numeric assertions. The existing four embedding-type regressions remain.
- `tests/lib/responses-output-text.test.ts` → `resource responses output_text` → `create` and `retrieve` preserve the `output_text` presence/type assertions and the raw-response, parsed-data, and `withResponse()` identity checks. These run against a deterministic local fetch response.

The public custom-code report verifies **34 → 32 mixed files**, **2,121 → 2,043 custom-patch lines** (additions plus deletions), and all other **32 customizations unchanged**.

Validation: pinned pnpm 11.5.1 install with frozen lockfile; Oxfmt 0.62.0; full lint; TypeScript 6 check; build; published-source TypeScript 4.9 check; 5,272 handwritten tests; 556 generated tests and 12 snapshots (one test skipped); packed-package CJS/ESM and published-type checks on the exact Node 22.0.0 floor. Generated tests used pinned Steady 0.22.1 on a separate local port.

Tracked as `custom-code-burndown`.
