### PR TITLE
refactor: move embedding encoding into an SDK-owned helper

### DIFF
--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -1,0 +1,61 @@
+import type { OpenAI } from '../client';
+import type { APIPromise } from '../core/api-promise';
+import type { RequestOptions } from '../internal/request-options';
+import { loggerFor, toFloat32Array } from '../internal/utils';
+import type { CreateEmbeddingResponse, Embedding, EmbeddingCreateParams } from '../resources/embeddings';
+
+type Base64EmbeddingResponse = Omit<CreateEmbeddingResponse, 'data'> & {
+  data: (Omit<Embedding, 'embedding'> & { embedding: string })[];
+};
+
+/**
+ * Sends the optimized embeddings request while preserving explicit encodings and
+ * the original APIPromise response accessors.
+ *
+ * @internal
+ */
+export function createEmbedding(
+  client: OpenAI,
+  body: EmbeddingCreateParams,
+  options?: RequestOptions,
+): APIPromise<CreateEmbeddingResponse | Base64EmbeddingResponse> {
+  const hasUserProvidedEncodingFormat = !!body.encoding_format;
+  // No encoding_format specified, defaulting to base64 for performance reasons.
+  // See https://github.com/openai/openai-node/pull/1312.
+  const encodingFormat = hasUserProvidedEncodingFormat ? body.encoding_format : 'base64';
+
+  if (hasUserProvidedEncodingFormat) {
+    loggerFor(client).debug('embeddings/user defined encoding_format:', body.encoding_format);
+  }
+
+  const response: APIPromise<CreateEmbeddingResponse> = client.post('/embeddings', {
+    body: {
+      ...body,
+      encoding_format: encodingFormat,
+    },
+    ...options,
+    __security: { bearerAuth: true },
+  });
+
+  // Explicit encodings return the original response promise unchanged.
+  if (hasUserProvidedEncodingFormat) {
+    return response;
+  }
+
+  // The default request uses base64 on the wire, but returns the API's default
+  // numeric embedding representation to the caller.
+  loggerFor(client).debug('embeddings/decoding base64 embeddings from base64');
+
+  return response._thenUnwrap((data) => {
+    if (data && data.data) {
+      // Preserve skipped holes when a custom response parser returns a sparse array.
+      // oxlint-disable-next-line unicorn/no-array-for-each
+      data.data.forEach((embeddingBase64Obj) => {
+        const embeddingBase64Str = embeddingBase64Obj.embedding as unknown as string;
+        embeddingBase64Obj.embedding = toFloat32Array(embeddingBase64Str);
+      });
+    }
+
+    return data;
+  });
+}

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -48,12 +48,16 @@ export function createEmbedding(
 
   return response._thenUnwrap((data) => {
     if (data && data.data) {
-      // Preserve skipped holes when a custom response parser returns a sparse array.
-      // oxlint-disable-next-line unicorn/no-array-for-each
-      data.data.forEach((embeddingBase64Obj) => {
-        const embeddingBase64Str = embeddingBase64Obj.embedding as unknown as string;
-        embeddingBase64Obj.embedding = toFloat32Array(embeddingBase64Str);
-      });
+      const embeddings = data.data;
+      const { length } = embeddings;
+      // Preserve the original iteration length and skip sparse-array holes.
+      for (let index = 0; index < length; index += 1) {
+        if (index in embeddings) {
+          const embeddingBase64Obj = embeddings[index] as Embedding;
+          const embeddingBase64Str = embeddingBase64Obj.embedding as unknown as string;
+          embeddingBase64Obj.embedding = toFloat32Array(embeddingBase64Str);
+        }
+      }
     }
 
     return data;

--- a/src/resources/embeddings.ts
+++ b/src/resources/embeddings.ts
@@ -3,7 +3,7 @@
 import { APIResource } from '../core/resource';
 import { APIPromise } from '../core/api-promise';
 import { RequestOptions } from '../internal/request-options';
-import { loggerFor, toFloat32Array } from '../internal/utils';
+import { createEmbedding } from '../lib/embeddings';
 
 type Base64EmbeddingResponse = Omit<CreateEmbeddingResponse, 'data'> & {
   data: Array<Omit<Embedding, 'embedding'> & { embedding: string }>;
@@ -34,47 +34,7 @@ export class Embeddings extends APIResource {
     body: EmbeddingCreateParams,
     options?: RequestOptions,
   ): APIPromise<CreateEmbeddingResponse | Base64EmbeddingResponse> {
-    const hasUserProvidedEncodingFormat = !!body.encoding_format;
-    // No encoding_format specified, defaulting to base64 for performance reasons
-    // See https://github.com/openai/openai-node/pull/1312
-    let encoding_format: EmbeddingCreateParams['encoding_format'] = hasUserProvidedEncodingFormat
-      ? body.encoding_format
-      : 'base64';
-
-    if (hasUserProvidedEncodingFormat) {
-      loggerFor(this._client).debug('embeddings/user defined encoding_format:', body.encoding_format);
-    }
-
-    const response: APIPromise<CreateEmbeddingResponse> = this._client.post('/embeddings', {
-      body: {
-        ...body,
-        encoding_format: encoding_format as EmbeddingCreateParams['encoding_format'],
-      },
-      ...options,
-      __security: { bearerAuth: true },
-    });
-
-    // if the user specified an encoding_format, return the response as-is
-    if (hasUserProvidedEncodingFormat) {
-      return response;
-    }
-
-    // in this stage, we are sure the user did not specify an encoding_format
-    // and we defaulted to base64 for performance reasons
-    // we are sure then that the response is base64 encoded, let's decode it
-    // the returned result will be a float32 array since this is OpenAI API's default encoding
-    loggerFor(this._client).debug('embeddings/decoding base64 embeddings from base64');
-
-    return (response as APIPromise<CreateEmbeddingResponse>)._thenUnwrap((response) => {
-      if (response && response.data) {
-        response.data.forEach((embeddingBase64Obj) => {
-          const embeddingBase64Str = embeddingBase64Obj.embedding as unknown as string;
-          embeddingBase64Obj.embedding = toFloat32Array(embeddingBase64Str);
-        });
-      }
-
-      return response;
-    });
+    return createEmbedding(this._client, body, options);
   }
 }
 

--- a/tests/lib/embeddings-request.test.ts
+++ b/tests/lib/embeddings-request.test.ts
@@ -1,0 +1,185 @@
+import { vi } from 'vitest';
+import OpenAI, { BadRequestError } from 'openai';
+import { APIPromise } from 'openai/api-promise';
+import type { Fetch } from 'openai/internal/builtin-types';
+import type { RequestOptions } from 'openai/internal/request-options';
+import type { PromiseOrValue } from 'openai/internal/types';
+
+const vector = [1.25, -2.5];
+const encodedVector = Buffer.from(new Float32Array(vector).buffer).toString('base64');
+const request = { input: 'hello', model: 'text-embedding-3-small' };
+
+class RecordingClient extends OpenAI {
+  readonly requests: {
+    path: string;
+    options: PromiseOrValue<RequestOptions> | undefined;
+    response: APIPromise<unknown>;
+  }[] = [];
+
+  override post<Rsp>(path: string, options?: PromiseOrValue<RequestOptions>): APIPromise<Rsp> {
+    const response = super.post<Rsp>(path, options);
+    this.requests.push({ path, options, response });
+    return response;
+  }
+}
+
+function embeddingResponse(embedding: number[] | string): Response {
+  return Response.json(
+    {
+      object: 'list',
+      data: [{ object: 'embedding', index: 0, embedding }],
+      model: request.model,
+      usage: { prompt_tokens: 1, total_tokens: 1 },
+    },
+    { headers: { 'x-request-id': 'req_embeddings' } },
+  );
+}
+
+describe('embedding request compatibility', () => {
+  test.each([
+    { name: 'omitted', present: false, format: undefined, explicit: false },
+    { name: 'undefined', present: true, format: undefined, explicit: false },
+    { name: 'null from JavaScript', present: true, format: null, explicit: false },
+    { name: 'empty string from JavaScript', present: true, format: '', explicit: false },
+    { name: 'float', present: true, format: 'float', explicit: true },
+    { name: 'base64', present: true, format: 'base64', explicit: true },
+  ])('preserves $name encoding and response accessors', async ({ present, format, explicit }) => {
+    const debug = vi.fn();
+    const fetch = vi.fn<Fetch>(async (_url, init) => {
+      const body = JSON.parse(String(init?.body)) as { encoding_format: string };
+      return embeddingResponse(body.encoding_format === 'base64' ? encodedVector : vector);
+    });
+    const client = new RecordingClient({
+      apiKey: 'test-key',
+      fetch,
+      logLevel: 'debug',
+      logger: { debug, info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+    const body = { ...request };
+    if (present) {
+      Object.assign(body, { encoding_format: format });
+    }
+    const originalBody = { ...body };
+    const promise = client.embeddings.create(body);
+    const [call] = client.requests;
+    const rawPromise = call?.response;
+
+    expect(promise).toBeInstanceOf(APIPromise);
+    expect(promise === rawPromise).toBe(explicit);
+    expect(body).toEqual(originalBody);
+    expect(client.requests).toHaveLength(1);
+    expect(call?.path).toBe('/embeddings');
+    expect(await call?.options).toEqual({
+      body: { ...body, encoding_format: explicit ? format : 'base64' },
+      __security: { bearerAuth: true },
+    });
+
+    const rawResponse = await promise.asResponse();
+    expect(await rawResponse.clone().json()).toMatchObject({
+      data: [{ embedding: format === 'float' ? vector : encodedVector }],
+    });
+    const response = await promise;
+    const dataAndResponse = await promise.withResponse();
+    expect(response.data[0]?.embedding).toEqual(format === 'base64' ? encodedVector : vector);
+    expect(await rawPromise?.asResponse()).toBe(rawResponse);
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+    expect(dataAndResponse.request_id).toBe('req_embeddings');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(debug.mock.calls.filter(([message]) => String(message).startsWith('embeddings/'))).toEqual(
+      explicit
+        ? [['embeddings/user defined encoding_format:', format]]
+        : [['embeddings/decoding base64 embeddings from base64']],
+    );
+  });
+
+  test('preserves request-option precedence without mutating caller objects', async () => {
+    const overrideBody = { ...request, input: 'overridden', encoding_format: 'base64' };
+    const fetch = vi.fn<Fetch>(async (_url, init) => {
+      expect(JSON.parse(String(init?.body))).toEqual(overrideBody);
+      expect(new Headers(init?.headers).get('X-Custom')).toBe('kept');
+      return embeddingResponse(encodedVector);
+    });
+    const client = new RecordingClient({ apiKey: 'test-key', fetch });
+    const body = { ...request, encoding_format: 'float' as const };
+    const headers = { 'X-Custom': 'kept' };
+    const options: RequestOptions = {
+      body: overrideBody,
+      headers,
+      __security: { adminAPIKeyAuth: true },
+    };
+    const originalOptions = { ...options };
+    const promise = client.embeddings.create(body, options);
+
+    const [call] = client.requests;
+    const sentOptions = await call?.options;
+    expect(promise).toBe(call?.response);
+    expect(call?.path).toBe('/embeddings');
+    expect(sentOptions).toEqual({
+      ...options,
+      __security: { bearerAuth: true },
+    });
+    expect(sentOptions?.body).toBe(overrideBody);
+    expect(sentOptions?.headers).toBe(headers);
+    const response = await promise;
+    expect(response.data[0]?.embedding).toBe(encodedVector);
+    expect(body).toEqual({ ...request, encoding_format: 'float' });
+    expect(options).toEqual(originalOptions);
+  });
+
+  test('preserves response identity and sparse entries from custom parsers', async () => {
+    const client = new OpenAI({ apiKey: 'test-key' });
+    const entries: OpenAI.Embedding[] = [];
+    const entry = {
+      object: 'embedding' as const,
+      index: 1,
+      // The existing raw parser types the wire value as numeric before decoding.
+      embedding: encodedVector as unknown as number[],
+    };
+    entries[1] = entry;
+    const data: OpenAI.CreateEmbeddingResponse = {
+      object: 'list',
+      data: entries,
+      model: request.model,
+      usage: { prompt_tokens: 1, total_tokens: 1 },
+    };
+    const rawPromise = new APIPromise(
+      client,
+      Promise.resolve({
+        response: new Response(null),
+        options: { method: 'post', path: '/embeddings' },
+        controller: new AbortController(),
+        requestLogID: 'synthetic',
+        retryOfRequestLogID: undefined,
+        startTime: 0,
+      }),
+      () => data,
+    );
+    vi.spyOn(client, 'post').mockReturnValue(rawPromise);
+
+    const result = await client.embeddings.create(request);
+    expect(result).toBe(data);
+    expect(result.data).toBe(entries);
+    expect(result.data[1]).toBe(entry);
+    expect(0 in result.data).toBe(false);
+    expect(entry.embedding).toEqual(vector);
+  });
+
+  test('preserves the API error object through the decoding wrapper', async () => {
+    const client = new RecordingClient({
+      apiKey: 'test-key',
+      maxRetries: 0,
+      fetch: async () => Response.json({ error: { message: 'synthetic failure' } }, { status: 400 }),
+    });
+    const promise = client.embeddings.create(request);
+    const [raw, wrapped] = await Promise.allSettled([client.requests[0]?.response, promise]);
+
+    expect(raw.status).toBe('rejected');
+    expect(wrapped.status).toBe('rejected');
+    if (raw.status === 'rejected' && wrapped.status === 'rejected') {
+      expect(wrapped.reason).toBe(raw.reason);
+      expect(wrapped.reason).toBeInstanceOf(BadRequestError);
+      expect(wrapped.reason.message).toContain('synthetic failure');
+    }
+  });
+});

--- a/tests/lib/embeddings-request.test.ts
+++ b/tests/lib/embeddings-request.test.ts
@@ -35,6 +35,22 @@ function embeddingResponse(embedding: number[] | string): Response {
   );
 }
 
+function mockEmbeddingParser(client: OpenAI, data: OpenAI.CreateEmbeddingResponse): void {
+  const rawPromise = new APIPromise(
+    client,
+    Promise.resolve({
+      response: new Response(null),
+      options: { method: 'post', path: '/embeddings' },
+      controller: new AbortController(),
+      requestLogID: 'synthetic',
+      retryOfRequestLogID: undefined,
+      startTime: 0,
+    }),
+    () => data,
+  );
+  vi.spyOn(client, 'post').mockReturnValue(rawPromise);
+}
+
 describe('embedding request compatibility', () => {
   test.each([
     { name: 'omitted', present: false, format: undefined, explicit: false },
@@ -143,19 +159,7 @@ describe('embedding request compatibility', () => {
       model: request.model,
       usage: { prompt_tokens: 1, total_tokens: 1 },
     };
-    const rawPromise = new APIPromise(
-      client,
-      Promise.resolve({
-        response: new Response(null),
-        options: { method: 'post', path: '/embeddings' },
-        controller: new AbortController(),
-        requestLogID: 'synthetic',
-        retryOfRequestLogID: undefined,
-        startTime: 0,
-      }),
-      () => data,
-    );
-    vi.spyOn(client, 'post').mockReturnValue(rawPromise);
+    mockEmbeddingParser(client, data);
 
     const result = await client.embeddings.create(request);
     expect(result).toBe(data);
@@ -163,6 +167,41 @@ describe('embedding request compatibility', () => {
     expect(result.data[1]).toBe(entry);
     expect(0 in result.data).toBe(false);
     expect(entry.embedding).toEqual(vector);
+  });
+
+  test('keeps the original iteration length when a custom parser mutates the array', async () => {
+    const client = new OpenAI({ apiKey: 'test-key' });
+    const entries: OpenAI.Embedding[] = [];
+    const appended: OpenAI.Embedding = {
+      object: 'embedding',
+      index: 1,
+      embedding: encodedVector as unknown as number[],
+    };
+    let value = encodedVector as unknown as number[];
+    entries.push({
+      object: 'embedding',
+      index: 0,
+      get embedding() {
+        entries.push(appended);
+        return value;
+      },
+      set embedding(decoded: number[]) {
+        value = decoded;
+      },
+    });
+    const data: OpenAI.CreateEmbeddingResponse = {
+      object: 'list',
+      data: entries,
+      model: request.model,
+      usage: { prompt_tokens: 1, total_tokens: 1 },
+    };
+    mockEmbeddingParser(client, data);
+
+    await expect(client.embeddings.create(request)).resolves.toBe(data);
+    expect(value).toEqual(vector);
+    expect(entries).toHaveLength(2);
+    expect(entries[1]).toBe(appended);
+    expect(appended.embedding).toBe(encodedVector);
   });
 
   test('preserves the API error object through the decoding wrapper', async () => {


### PR DESCRIPTION
Move the existing embedding encoding optimization into an SDK-owned helper, leaving a thin typed delegate in the generated resource. Keep the request-discriminated overloads from #1554, explicit-format pass-through, default base64 decoding, request-option precedence, logging, response identity/accessors, and exceptions unchanged. No schema, compiler, API-reference, dependency, or generation-metadata changes.

The public custom-code report keeps **34 mixed files** while reducing the embedding resource’s custom patch from **+55/−2 to +15/−2**. Total custom-patch lines fall **2,121 → 2,081**; the other **33 customizations are unchanged**. This is independent of the test-ownership cleanup in #2435.

`tests/lib/embeddings-request.test.ts` adds:

- `preserves $name encoding and response accessors`: omitted, explicit `undefined`, JavaScript `null`/empty string, `float`, and `base64`; checks the wire encoding, logs, APIPromise pass-through, raw/parsed response accessors, and request ID.
- `preserves request-option precedence without mutating caller objects`.
- `preserves response identity and sparse entries from custom parsers`.
- `preserves the API error object through the decoding wrapper`.

All nine characterization cases pass against both the original public implementation and this refactor. The existing four embedding type tests and generated embedding tests remain unchanged.

Validation: frozen pnpm 11.5.1 install; pinned formatting and full lint; TypeScript 6; build; TypeScript 4.9 published-source check; **all 609 pre-existing declaration files byte-identical**; **5,276 handwritten tests**, **559 generated tests** and 12 snapshots (one test skipped); packed CJS/ESM and source checks on Node **22.0.0**; publint (only its existing vendored-export warning).

Tracked as `custom-code-burndown`.
