### PR TITLE
refactor: move vector store polling into an SDK-owned helper

### DIFF
--- a/src/lib/vector-store-polling.ts
+++ b/src/lib/vector-store-polling.ts
@@ -1,0 +1,88 @@
+import type { APIPromise } from '../core/api-promise';
+import { buildHeaders } from '../internal/headers';
+import type { NullableHeaders } from '../internal/headers';
+import type { RequestOptions } from '../internal/request-options';
+import { sleep } from '../internal/utils/sleep';
+import type { FileBatches, VectorStoreFileBatch } from '../resources/vector-stores/file-batches';
+import type { Files, VectorStoreFile } from '../resources/vector-stores/files';
+
+type PollOptions = RequestOptions & { pollIntervalMs?: number };
+
+async function poll<T extends { status: string }>(
+  retrieve: (headers: NullableHeaders) => APIPromise<T>,
+  terminalStatuses: readonly T['status'][],
+  options?: PollOptions,
+): Promise<T> {
+  const headers = buildHeaders([
+    options?.headers,
+    {
+      'X-Stainless-Poll-Helper': 'true',
+      'X-Stainless-Custom-Poll-Interval': options?.pollIntervalMs?.toString() ?? undefined,
+    },
+  ]);
+
+  while (true) {
+    // oxlint-disable-next-line no-await-in-loop -- Each poll depends on the previous response.
+    const { data, response } = await retrieve(headers).withResponse();
+    const { status } = data;
+
+    if (status === 'in_progress') {
+      let sleepInterval = 5000;
+
+      if (options?.pollIntervalMs) {
+        sleepInterval = options.pollIntervalMs;
+      } else {
+        const headerInterval = response.headers.get('openai-poll-after-ms');
+        if (headerInterval) {
+          // oxlint-disable-next-line radix -- Preserve the existing decimal and hexadecimal header parsing.
+          const headerIntervalMs = Number.parseInt(headerInterval);
+          if (!Number.isNaN(headerIntervalMs)) {
+            sleepInterval = headerIntervalMs;
+          }
+        }
+      }
+      // oxlint-disable-next-line no-await-in-loop -- Wait before issuing the next poll request.
+      await sleep(sleepInterval);
+    } else if (terminalStatuses.includes(status)) {
+      return data;
+    }
+  }
+}
+
+/**
+ * Polls an attached file through the resource's retrieve method. Failed files are
+ * returned to the caller, and cancelled files retain their existing retry behavior.
+ *
+ * @internal
+ */
+export function pollVectorStoreFile(
+  resource: Pick<Files, 'retrieve'>,
+  vectorStoreID: string,
+  fileID: string,
+  options?: PollOptions,
+): Promise<VectorStoreFile> {
+  return poll(
+    (headers) => resource.retrieve(fileID, { vector_store_id: vectorStoreID }, { ...options, headers }),
+    ['failed', 'completed'],
+    options,
+  );
+}
+
+/**
+ * Polls a file batch through the resource's retrieve method until it completes,
+ * fails, or is cancelled. Retrieval errors are propagated unchanged.
+ *
+ * @internal
+ */
+export function pollVectorStoreFileBatch(
+  resource: Pick<FileBatches, 'retrieve'>,
+  vectorStoreID: string,
+  batchID: string,
+  options?: PollOptions,
+): Promise<VectorStoreFileBatch> {
+  return poll(
+    (headers) => resource.retrieve(batchID, { vector_store_id: vectorStoreID }, { ...options, headers }),
+    ['failed', 'cancelled', 'completed'],
+    options,
+  );
+}

--- a/src/resources/vector-stores/file-batches.ts
+++ b/src/resources/vector-stores/file-batches.ts
@@ -8,9 +8,9 @@ import { APIPromise } from '../../core/api-promise';
 import { CursorPage, type CursorPageParams, PagePromise } from '../../core/pagination';
 import { buildHeaders } from '../../internal/headers';
 import { RequestOptions } from '../../internal/request-options';
-import { sleep } from '../../internal/utils/sleep';
 import { type Uploadable } from '../../uploads';
 import { allSettledWithThrow } from '../../lib/Util';
+import { pollVectorStoreFileBatch } from '../../lib/vector-store-polling';
 import { path } from '../../internal/utils/path';
 
 export class FileBatches extends APIResource {
@@ -107,47 +107,7 @@ export class FileBatches extends APIResource {
     batchID: string,
     options?: RequestOptions & { pollIntervalMs?: number },
   ): Promise<VectorStoreFileBatch> {
-    const headers = buildHeaders([
-      options?.headers,
-      {
-        'X-Stainless-Poll-Helper': 'true',
-        'X-Stainless-Custom-Poll-Interval': options?.pollIntervalMs?.toString() ?? undefined,
-      },
-    ]);
-
-    while (true) {
-      const { data: batch, response } = await this.retrieve(
-        batchID,
-        { vector_store_id: vectorStoreID },
-        {
-          ...options,
-          headers,
-        },
-      ).withResponse();
-
-      switch (batch.status) {
-        case 'in_progress':
-          let sleepInterval = 5000;
-
-          if (options?.pollIntervalMs) {
-            sleepInterval = options.pollIntervalMs;
-          } else {
-            const headerInterval = response.headers.get('openai-poll-after-ms');
-            if (headerInterval) {
-              const headerIntervalMs = parseInt(headerInterval);
-              if (!isNaN(headerIntervalMs)) {
-                sleepInterval = headerIntervalMs;
-              }
-            }
-          }
-          await sleep(sleepInterval);
-          break;
-        case 'failed':
-        case 'cancelled':
-        case 'completed':
-          return batch;
-      }
-    }
+    return await pollVectorStoreFileBatch(this, vectorStoreID, batchID, options);
   }
 
   /**

--- a/src/resources/vector-stores/files.ts
+++ b/src/resources/vector-stores/files.ts
@@ -3,11 +3,11 @@
 import { APIResource } from '../../core/resource';
 import * as VectorStoresAPI from './vector-stores';
 import { APIPromise } from '../../core/api-promise';
-import { CursorPage, type CursorPageParams, PagePromise, Page } from '../../core/pagination';
+import { CursorPage, type CursorPageParams, Page, PagePromise } from '../../core/pagination';
 import { buildHeaders } from '../../internal/headers';
 import { RequestOptions } from '../../internal/request-options';
-import { sleep } from '../../internal/utils';
 import { Uploadable } from '../../uploads';
+import { pollVectorStoreFile } from '../../lib/vector-store-polling';
 import { path } from '../../internal/utils/path';
 
 export class Files extends APIResource {
@@ -115,47 +115,7 @@ export class Files extends APIResource {
     fileID: string,
     options?: RequestOptions & { pollIntervalMs?: number },
   ): Promise<VectorStoreFile> {
-    const headers = buildHeaders([
-      options?.headers,
-      {
-        'X-Stainless-Poll-Helper': 'true',
-        'X-Stainless-Custom-Poll-Interval': options?.pollIntervalMs?.toString() ?? undefined,
-      },
-    ]);
-
-    while (true) {
-      const fileResponse = await this.retrieve(
-        fileID,
-        {
-          vector_store_id: vectorStoreID,
-        },
-        { ...options, headers },
-      ).withResponse();
-
-      const file = fileResponse.data;
-
-      switch (file.status) {
-        case 'in_progress':
-          let sleepInterval = 5000;
-
-          if (options?.pollIntervalMs) {
-            sleepInterval = options.pollIntervalMs;
-          } else {
-            const headerInterval = fileResponse.response.headers.get('openai-poll-after-ms');
-            if (headerInterval) {
-              const headerIntervalMs = parseInt(headerInterval);
-              if (!isNaN(headerIntervalMs)) {
-                sleepInterval = headerIntervalMs;
-              }
-            }
-          }
-          await sleep(sleepInterval);
-          break;
-        case 'failed':
-        case 'completed':
-          return file;
-      }
-    }
+    return await pollVectorStoreFile(this, vectorStoreID, fileID, options);
   }
   /**
    * Upload a file to the `files` API and then attach it to the given vector store.

--- a/tests/lib/vector-store-polling.test.ts
+++ b/tests/lib/vector-store-polling.test.ts
@@ -1,0 +1,116 @@
+import { vi } from 'vitest';
+import OpenAI from 'openai';
+import type { Fetch } from 'openai/internal/builtin-types';
+import { sleep } from 'openai/internal/utils/sleep';
+import type { RequestOptions } from 'openai/internal/request-options';
+
+vi.mock('openai/internal/utils/sleep', () => ({
+  sleep: vi.fn(async () => {}),
+}));
+
+const mockedSleep = vi.mocked(sleep);
+
+beforeEach(() => {
+  mockedSleep.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe.each([
+  { name: 'file', id: 'file_123', segment: 'files' },
+  { name: 'batch', id: 'batch_123', segment: 'file_batches' },
+] as const)('vector store $name polling compatibility', ({ name, id, segment }) => {
+  test.each([
+    { label: 'zero explicit interval', interval: 0, header: '17', expected: 17 },
+    { label: 'negative explicit interval', interval: -2, header: '17', expected: -2 },
+    { label: 'NaN explicit interval', interval: Number.NaN, header: '0x10', expected: 16 },
+    { label: 'numeric header prefix', interval: undefined, header: '12ms', expected: 12 },
+    { label: 'zero server interval', interval: undefined, header: '0', expected: 0 },
+    { label: 'empty server interval', interval: undefined, header: '', expected: 5000 },
+  ])('preserves $label and helper-header precedence', async ({ interval, header, expected }) => {
+    const requests: { url: string; headers: Headers }[] = [];
+    const fetch = vi.fn<Fetch>(async (url, init) => {
+      requests.push({ url: String(url), headers: new Headers(init?.headers) });
+      return Response.json(
+        { id, status: requests.length === 1 ? 'in_progress' : 'completed' },
+        { headers: { 'openai-poll-after-ms': header } },
+      );
+    });
+    const client = new OpenAI({ apiKey: 'test-key', baseURL: 'https://example.com/v1/', fetch });
+    const resource = name === 'file' ? client.vectorStores.files : client.vectorStores.fileBatches;
+    const headers = {
+      'X-Test': 'kept',
+      'X-Stainless-Poll-Helper': 'caller',
+      'X-Stainless-Custom-Poll-Interval': 'caller',
+    };
+    const options: RequestOptions & { pollIntervalMs?: number } = { headers };
+    if (interval !== undefined) {
+      options.pollIntervalMs = interval;
+    }
+    const originalOptions = { ...options, headers: { ...headers } };
+
+    await expect(resource.poll('vs_123', id, options)).resolves.toMatchObject({ id, status: 'completed' });
+    expect(mockedSleep).toHaveBeenCalledTimes(1);
+    expect(mockedSleep).toHaveBeenCalledWith(expected);
+    expect(requests).toHaveLength(2);
+    for (const request of requests) {
+      expect(request.url).toBe(`https://example.com/v1/vector_stores/vs_123/${segment}/${id}`);
+      expect(request.headers.get('X-Test')).toBe('kept');
+      expect(request.headers.get('OpenAI-Beta')).toBe('assistants=v2');
+      expect(request.headers.get('X-Stainless-Poll-Helper')).toBe('true');
+      expect(request.headers.get('X-Stainless-Custom-Poll-Interval')).toBe(
+        interval === undefined ? 'caller' : String(interval),
+      );
+    }
+    expect(options).toEqual(originalOptions);
+  });
+
+  test('retries an unknown status without adding a delay', async () => {
+    let count = 0;
+    const client = new OpenAI({
+      apiKey: 'test-key',
+      fetch: async () => {
+        count += 1;
+        return Response.json({ id, status: count === 1 ? 'future_status' : 'completed' });
+      },
+    });
+    const resource = name === 'file' ? client.vectorStores.files : client.vectorStores.fileBatches;
+
+    await expect(resource.poll('vs_123', id)).resolves.toMatchObject({ id, status: 'completed' });
+    expect(count).toBe(2);
+    expect(mockedSleep).not.toHaveBeenCalled();
+  });
+
+  test('preserves the distinct cancelled status behavior', async () => {
+    let count = 0;
+    const client = new OpenAI({
+      apiKey: 'test-key',
+      fetch: async () => {
+        count += 1;
+        return Response.json({ id, status: count === 1 ? 'cancelled' : 'completed' });
+      },
+    });
+    const resource = name === 'file' ? client.vectorStores.files : client.vectorStores.fileBatches;
+
+    await expect(resource.poll('vs_123', id)).resolves.toMatchObject({
+      id,
+      status: name === 'file' ? 'completed' : 'cancelled',
+    });
+    expect(count).toBe(name === 'file' ? 2 : 1);
+    expect(mockedSleep).not.toHaveBeenCalled();
+  });
+
+  test('preserves retrieval failures without wrapping them', async () => {
+    const client = new OpenAI({ apiKey: 'test-key' });
+    const resource = name === 'file' ? client.vectorStores.files : client.vectorStores.fileBatches;
+    const failure = new Error('synthetic retrieval failure');
+    vi.spyOn(resource, 'retrieve').mockImplementation(() => {
+      throw failure;
+    });
+
+    await expect(resource.poll('vs_123', id)).rejects.toBe(failure);
+    expect(mockedSleep).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Move the existing vector-store file and file-batch polling loops into one SDK-owned helper, leaving the public resource methods as thin typed delegates. Preserve the existing terminal-status sets (including their different cancellation behavior), interval defaults and parsing, request-option/header precedence, resource overrides, and errors. Upload concurrency and create/upload helpers are unchanged. No schema, compiler, API-reference, dependency, or generation-metadata changes.

The hash-verified public custom-code report keeps **34 mixed files** while reducing total custom-patch lines **2,121 → 2,039**. File batches fall **+118/−0 → +78/−0** and files **+89/−1 → +48/−0**; the other **32 customizations are unchanged**. This PR is independent of #2435 and #2436.

The 18 new public-entrypoint characterization cases in `tests/lib/vector-store-polling.test.ts` pass against both unmodified public-main source and this refactor. They cover zero/negative/NaN intervals, decimal/hexadecimal/zero/empty server headers, caller-header precedence, unknown and cancelled statuses, and unchanged retrieval errors. Together with the existing generated-resource helper suite, all **55 focused cases** pass.

Validation: frozen pnpm 11.5.1 install; pinned formatting and full lint; TypeScript 6; build; TypeScript 4.9 published-source check; **609 existing declaration files unchanged except equivalent generated import ordering in two files**; **5,285 handwritten tests**, **559 generated tests** and 12 snapshots (one test skipped); packed CJS/ESM and source checks on Node **22.0.0**; publint (only its existing vendored-export warning).

- [x] I understand that this repository is auto-generated and my pull request may not be merged.

Tracked as `custom-code-burndown`.
