### PR TITLE
refactor: move file processing wait into an SDK-owned helper

### DIFF
--- a/src/lib/file-processing.ts
+++ b/src/lib/file-processing.ts
@@ -1,0 +1,36 @@
+import { APIConnectionTimeoutError } from '../error';
+import { sleep } from '../internal/utils/sleep';
+import type { FileObject, Files } from '../resources/files';
+
+/**
+ * Waits for file processing through the resource's retrieve method. The timeout
+ * is checked after each subsequent retrieval, preserving the existing behavior
+ * for an initially terminal file and for a terminal response received too late.
+ *
+ * @internal
+ */
+export async function waitForFileProcessing(
+  resource: Pick<Files, 'retrieve'>,
+  id: string,
+  pollInterval: number,
+  maxWait: number,
+): Promise<FileObject> {
+  const terminalStates = new Set(['processed', 'error', 'deleted']);
+  const start = Date.now();
+  let file = await resource.retrieve(id);
+
+  while (!file.status || !terminalStates.has(file.status)) {
+    // oxlint-disable-next-line no-await-in-loop -- Wait before issuing the next processing-status request.
+    await sleep(pollInterval);
+
+    // oxlint-disable-next-line no-await-in-loop -- The timeout and next iteration depend on this response.
+    file = await resource.retrieve(id);
+    if (Date.now() - start > maxWait) {
+      throw new APIConnectionTimeoutError({
+        message: `Giving up on waiting for file ${id} to finish processing after ${maxWait} milliseconds.`,
+      });
+    }
+  }
+
+  return file;
+}

--- a/src/resources/files.ts
+++ b/src/resources/files.ts
@@ -6,9 +6,8 @@ import { CursorPage, type CursorPageParams, PagePromise } from '../core/paginati
 import { type Uploadable } from '../core/uploads';
 import { buildHeaders } from '../internal/headers';
 import { RequestOptions } from '../internal/request-options';
-import { sleep } from '../internal/utils/sleep';
-import { APIConnectionTimeoutError } from '../error';
 import { multipartFormRequestOptions } from '../internal/uploads';
+import { waitForFileProcessing } from '../lib/file-processing';
 import { path } from '../internal/utils/path';
 
 /**
@@ -98,23 +97,7 @@ export class Files extends APIResource {
     id: string,
     { pollInterval = 5000, maxWait = 30 * 60 * 1000 }: { pollInterval?: number; maxWait?: number } = {},
   ): Promise<FileObject> {
-    const TERMINAL_STATES = new Set(['processed', 'error', 'deleted']);
-
-    const start = Date.now();
-    let file = await this.retrieve(id);
-
-    while (!file.status || !TERMINAL_STATES.has(file.status)) {
-      await sleep(pollInterval);
-
-      file = await this.retrieve(id);
-      if (Date.now() - start > maxWait) {
-        throw new APIConnectionTimeoutError({
-          message: `Giving up on waiting for file ${id} to finish processing after ${maxWait} milliseconds.`,
-        });
-      }
-    }
-
-    return file;
+    return await waitForFileProcessing(this, id, pollInterval, maxWait);
   }
 }
 

--- a/tests/lib/file-processing.test.ts
+++ b/tests/lib/file-processing.test.ts
@@ -1,0 +1,128 @@
+import { vi } from 'vitest';
+import OpenAI, { APIConnectionTimeoutError } from 'openai';
+import type { Fetch } from 'openai/internal/builtin-types';
+import { sleep } from 'openai/internal/utils/sleep';
+
+vi.mock('openai/internal/utils/sleep', () => ({
+  sleep: vi.fn(async () => {}),
+}));
+
+const mockedSleep = vi.mocked(sleep);
+
+function fileClient(statuses: (string | undefined)[], onFetch?: () => void) {
+  let index = 0;
+  const fetch = vi.fn<Fetch>(async () => {
+    if (index >= statuses.length) {
+      throw new Error('Unexpected extra file retrieval');
+    }
+    const status = statuses[index];
+    index += 1;
+    onFetch?.();
+    return Response.json({ id: 'file_123', ...(status === undefined ? {} : { status }) });
+  });
+  return { client: new OpenAI({ apiKey: 'test-key', maxRetries: 0, fetch }), fetch };
+}
+
+beforeEach(() => {
+  mockedSleep.mockReset();
+  mockedSleep.mockImplementation(async () => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('file processing compatibility', () => {
+  test.each(['processed', 'error', 'deleted'])(
+    'returns an initially %s file even after maxWait has elapsed',
+    async (status) => {
+      let now = 0;
+      vi.spyOn(Date, 'now').mockImplementation(() => now);
+      const { client, fetch } = fileClient([status], () => {
+        now = 1000;
+      });
+      const retrieve = vi.spyOn(client.files, 'retrieve');
+
+      const file = await client.files.waitForProcessing('file_123', { maxWait: 0 });
+
+      expect(file).toBe(await retrieve.mock.results[0]?.value);
+      expect(file).toMatchObject({ id: 'file_123', status });
+      expect(retrieve).toHaveBeenCalledWith('file_123');
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(mockedSleep).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    { interval: undefined, expected: 5000 },
+    { interval: 0, expected: 0 },
+    { interval: -2, expected: -2 },
+    { interval: Number.NaN, expected: Number.NaN },
+  ])('preserves pollInterval $interval', async ({ interval, expected }) => {
+    const { client, fetch } = fileClient(['uploaded', 'processed']);
+    const options = interval === undefined ? {} : { pollInterval: interval };
+
+    await expect(client.files.waitForProcessing('file_123', options)).resolves.toMatchObject({
+      status: 'processed',
+    });
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(mockedSleep).toHaveBeenCalledTimes(1);
+    expect(mockedSleep).toHaveBeenCalledWith(expected);
+  });
+
+  test('keeps polling missing and unknown statuses', async () => {
+    const { client, fetch } = fileClient([undefined, 'future_status', 'processed']);
+
+    await expect(client.files.waitForProcessing('file_123')).resolves.toMatchObject({ status: 'processed' });
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(mockedSleep.mock.calls).toEqual([[5000], [5000]]);
+  });
+
+  test.each([
+    { maxWait: undefined, elapsed: 1_800_000, fails: false },
+    { maxWait: undefined, elapsed: 1_800_001, fails: true },
+    { maxWait: 0, elapsed: 0, fails: false },
+    { maxWait: 0, elapsed: 1, fails: true },
+    { maxWait: 10, elapsed: 10, fails: false },
+    { maxWait: 10, elapsed: 11, fails: true },
+  ])('checks maxWait $maxWait after retrieval at $elapsed ms', async ({ maxWait, elapsed, fails }) => {
+    let now = 0;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    mockedSleep.mockImplementation(async () => {
+      now = elapsed;
+    });
+    const { client, fetch } = fileClient(['uploaded', 'processed']);
+    const options = { pollInterval: 7, ...(maxWait === undefined ? {} : { maxWait }) };
+    const promise = client.files.waitForProcessing('file_123', options);
+
+    if (fails) {
+      const failure: unknown = await promise.catch((error: unknown) => error);
+      expect(failure).toBeInstanceOf(APIConnectionTimeoutError);
+      expect(failure).toMatchObject({
+        message: `Giving up on waiting for file file_123 to finish processing after ${maxWait ?? 1_800_000} milliseconds.`,
+      });
+    } else {
+      await expect(promise).resolves.toMatchObject({ status: 'processed' });
+    }
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(mockedSleep.mock.calls).toEqual([[7]]);
+  });
+
+  test.each([1, 2])('preserves a failure from retrieval %s', async (failureOn) => {
+    const { client } = fileClient(['uploaded']);
+    const originalRetrieve = client.files.retrieve.bind(client.files);
+    const failure = new Error('synthetic retrieval failure');
+    let count = 0;
+    vi.spyOn(client.files, 'retrieve').mockImplementation((...args) => {
+      count += 1;
+      if (count === failureOn) {
+        throw failure;
+      }
+      return originalRetrieve(...args);
+    });
+
+    await expect(client.files.waitForProcessing('file_123')).rejects.toBe(failure);
+    expect(count).toBe(failureOn);
+    expect(mockedSleep).toHaveBeenCalledTimes(failureOn - 1);
+  });
+});


### PR DESCRIPTION
Move the existing `files.waitForProcessing` loop into an SDK-owned helper, leaving the generated resource method's signature and defaults unchanged. Preserve the terminal states, original return object, polling intervals, timeout boundary and ordering, and retrieval errors. In particular, an initially terminal file still returns without a timeout check, while a later terminal response can still time out. No schema, compiler, API-reference, dependency, or generation-metadata changes.

The hash-verified public custom-code report keeps **32 mixed files** while reducing the file resource's custom patch **+28/−0 → +11/−0**. Total custom-patch lines fall **1,961 → 1,944**; the other **31 customizations are unchanged**.

The 16 new public-entrypoint characterization cases in `tests/lib/file-processing.test.ts` passed against the original implementation before extraction. Together with the existing SDK behavior suite, all **27 focused cases** pass. Coverage includes initially processed/error/deleted files, default/zero/negative/NaN intervals, missing and unknown statuses, default/custom timeout boundaries, timeout-after-retrieval ordering, and error identity.

Validation on the refreshed public-main base: frozen pnpm 11.5.1 install; pinned formatting and full lint; TypeScript 6; build; TypeScript 4.9 published-source check; **all 611 pre-existing declaration files byte-identical**; **5,307 handwritten tests**, **556 generated tests** and 12 snapshots (one test skipped); packed CJS/ESM and source checks on Node **22.0.0**; publint (only its existing vendored-export warning).

- [x] I understand that this repository is auto-generated and my pull request may not be merged.

Tracked as `custom-code-burndown`.
