### PR TITLE
refactor: move vector store batch uploads into an SDK-owned helper

### DIFF
--- a/src/lib/vector-store-upload.ts
+++ b/src/lib/vector-store-upload.ts
@@ -1,0 +1,52 @@
+import type { OpenAI } from '../client';
+import type { RequestOptions } from '../internal/request-options';
+import type { FileBatches, VectorStoreFileBatch } from '../resources/vector-stores/file-batches';
+import type { Uploadable } from '../uploads';
+import { allSettledWithThrow } from './Util';
+
+type UploadOptions = RequestOptions & { pollIntervalMs?: number; maxConcurrency?: number };
+
+/**
+ * Uploads files with a shared iterator, then creates and polls the batch. Every
+ * worker settles before upload failures are propagated.
+ *
+ * @internal
+ */
+export async function uploadAndPollVectorStoreFileBatch(
+  resource: Pick<FileBatches, 'createAndPoll'>,
+  client: Pick<OpenAI, 'files'>,
+  vectorStoreId: string,
+  files: Uploadable[],
+  fileIds: string[],
+  options?: UploadOptions,
+): Promise<VectorStoreFileBatch> {
+  if (files === null || files === undefined || files.length === 0) {
+    throw new Error(
+      "No `files` provided to process. If you've already uploaded files you should use `.createAndPoll()` instead",
+    );
+  }
+
+  const configuredConcurrency = options?.maxConcurrency ?? 5;
+  const concurrencyLimit = Math.min(configuredConcurrency, files.length);
+  const fileIterator = files.values();
+  const allFileIds = [...fileIds];
+
+  // This code is based on this design. The libraries don't accommodate our environment limits.
+  // https://stackoverflow.com/questions/40639432/what-is-the-best-way-to-limit-concurrency-when-using-es6s-promise-all
+  async function processFiles(iterator: IterableIterator<Uploadable>) {
+    for (const item of iterator) {
+      // oxlint-disable-next-line no-await-in-loop -- Each worker uploads one file at a time.
+      const fileObj = await client.files.create({ file: item, purpose: 'assistants' }, options);
+      allFileIds.push(fileObj.id);
+    }
+  }
+
+  // oxlint-disable-next-line unicorn/no-new-array -- Preserve native RangeError for negative, NaN, or fractional limits.
+  const workers = new Array<Promise<void>>(concurrencyLimit);
+  for (let index = 0; index < workers.length; index += 1) {
+    workers[index] = processFiles(fileIterator);
+  }
+  await allSettledWithThrow(workers);
+
+  return await resource.createAndPoll(vectorStoreId, { file_ids: allFileIds }, options);
+}

--- a/src/lib/vector-store-upload.ts
+++ b/src/lib/vector-store-upload.ts
@@ -41,8 +41,9 @@ export async function uploadAndPollVectorStoreFileBatch(
     }
   }
 
-  // oxlint-disable-next-line unicorn/no-new-array -- Preserve native RangeError for negative, NaN, or fractional limits.
-  const workers = new Array<Promise<void>>(concurrencyLimit);
+  // Assigning length preserves native validation of invalid concurrency values.
+  const workers: Promise<void>[] = [];
+  workers.length = concurrencyLimit;
   for (let index = 0; index < workers.length; index += 1) {
     workers[index] = processFiles(fileIterator);
   }

--- a/src/resources/vector-stores/file-batches.ts
+++ b/src/resources/vector-stores/file-batches.ts
@@ -9,8 +9,8 @@ import { CursorPage, type CursorPageParams, PagePromise } from '../../core/pagin
 import { buildHeaders } from '../../internal/headers';
 import { RequestOptions } from '../../internal/request-options';
 import { type Uploadable } from '../../uploads';
-import { allSettledWithThrow } from '../../lib/Util';
 import { pollVectorStoreFileBatch } from '../../lib/vector-store-polling';
+import { uploadAndPollVectorStoreFileBatch } from '../../lib/vector-store-upload';
 import { path } from '../../internal/utils/path';
 
 export class FileBatches extends APIResource {
@@ -120,41 +120,12 @@ export class FileBatches extends APIResource {
     { files, fileIds = [] }: { files: Uploadable[]; fileIds?: string[] },
     options?: RequestOptions & { pollIntervalMs?: number; maxConcurrency?: number },
   ): Promise<VectorStoreFileBatch> {
-    if (files == null || files.length == 0) {
-      throw new Error(
-        `No \`files\` provided to process. If you've already uploaded files you should use \`.createAndPoll()\` instead`,
-      );
-    }
-
-    const configuredConcurrency = options?.maxConcurrency ?? 5;
-
-    // We cap the number of workers at the number of files (so we don't start any unnecessary workers)
-    const concurrencyLimit = Math.min(configuredConcurrency, files.length);
-
-    const client = this._client;
-    const fileIterator = files.values();
-    const allFileIds: string[] = [...fileIds];
-
-    // This code is based on this design. The libraries don't accommodate our environment limits.
-    // https://stackoverflow.com/questions/40639432/what-is-the-best-way-to-limit-concurrency-when-using-es6s-promise-all
-    async function processFiles(iterator: IterableIterator<Uploadable>) {
-      for (let item of iterator) {
-        const fileObj = await client.files.create({ file: item, purpose: 'assistants' }, options);
-        allFileIds.push(fileObj.id);
-      }
-    }
-
-    // Start workers to process results
-    const workers = Array(concurrencyLimit).fill(fileIterator).map(processFiles);
-
-    // Wait for all processing to complete.
-    await allSettledWithThrow(workers);
-
-    return await this.createAndPoll(
+    return await uploadAndPollVectorStoreFileBatch(
+      this,
+      this._client,
       vectorStoreId,
-      {
-        file_ids: allFileIds,
-      },
+      files,
+      fileIds,
       options,
     );
   }

--- a/tests/lib/vector-store-upload.test.ts
+++ b/tests/lib/vector-store-upload.test.ts
@@ -108,20 +108,20 @@ describe('vector-store batch upload orchestration', () => {
     expect(fileIds).toEqual(['existing']);
   });
 
-  test.each([-1, Number.NaN, 1.5])(
+  test.each([-1, Number.NaN, 1.5, Number.NEGATIVE_INFINITY])(
     'preserves the invalid array-length error for concurrency %s',
     async (limit) => {
       const client = createClient();
       const upload = vi.spyOn(client.files, 'create');
       const createAndPoll = vi.spyOn(client.vectorStores.fileBatches, 'createAndPoll');
 
-      await expect(
-        client.vectorStores.fileBatches.uploadAndPoll(
-          'vs_123',
-          { files: createFiles(3) },
-          { maxConcurrency: limit },
-        ),
-      ).rejects.toBeInstanceOf(RangeError);
+      const result = client.vectorStores.fileBatches.uploadAndPoll(
+        'vs_123',
+        { files: createFiles(3) },
+        { maxConcurrency: limit },
+      );
+      await expect(result).rejects.toBeInstanceOf(RangeError);
+      await expect(result).rejects.toThrow('Invalid array length');
       expect(upload).not.toHaveBeenCalled();
       expect(createAndPoll).not.toHaveBeenCalled();
     },

--- a/tests/lib/vector-store-upload.test.ts
+++ b/tests/lib/vector-store-upload.test.ts
@@ -1,0 +1,241 @@
+import { vi } from 'vitest';
+
+import OpenAI from 'openai';
+import type { Uploadable } from 'openai/uploads';
+import type { VectorStoreFileBatch } from 'openai/resources/vector-stores/file-batches';
+
+interface UploadedFile {
+  id: string;
+}
+type UploadPromise = ReturnType<OpenAI['files']['create']>;
+
+function deferred<T>() {
+  let resolveValue!: (value: T) => void;
+  let rejectValue!: (reason: unknown) => void;
+  // oxlint-disable-next-line promise/avoid-new -- Tests control the order in which concurrent uploads settle.
+  const promise = new Promise<T>((resolve, reject) => {
+    resolveValue = resolve;
+    rejectValue = reject;
+  });
+  return { promise, resolve: resolveValue, reject: rejectValue };
+}
+
+function createClient() {
+  return new OpenAI({ apiKey: 'test-key', baseURL: 'https://example.com/v1/' });
+}
+
+function createFiles(count: number) {
+  return Array.from({ length: count }, (_, index) => new File([String(index)], `${index}.txt`));
+}
+
+function createControlledUpload(name: string) {
+  return { file: new File([name], `${name}.txt`), ...deferred<UploadedFile>() };
+}
+
+function mockControlledUploads(client: OpenAI, uploads: ReturnType<typeof createControlledUpload>[]) {
+  const pending = new Map<Uploadable, (typeof uploads)[number]>(
+    uploads.map((upload) => [upload.file, upload]),
+  );
+  return vi.spyOn(client.files, 'create').mockImplementation(({ file }) => {
+    const upload = pending.get(file);
+    if (!upload) {
+      throw new Error('Unexpected upload');
+    }
+    return upload.promise as UploadPromise;
+  });
+}
+
+const completed = { id: 'batch_123', status: 'completed' } as VectorStoreFileBatch;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('vector-store batch upload orchestration', () => {
+  test.each([
+    { name: 'default', maxConcurrency: undefined, expected: 5 },
+    { name: 'null default', maxConcurrency: null, expected: 5 },
+    { name: 'configured', maxConcurrency: 2, expected: 2 },
+    { name: 'file-count cap', maxConcurrency: Infinity, expected: 6 },
+  ])('preserves the $name worker limit', async ({ maxConcurrency, expected }) => {
+    const client = createClient();
+    const files = createFiles(6);
+    const gate = deferred<boolean>();
+    let active = 0;
+    let peak = 0;
+    let nextID = 0;
+    const upload = vi.spyOn(client.files, 'create').mockImplementation(() => {
+      active += 1;
+      peak = Math.max(peak, active);
+      nextID += 1;
+      const id = `file_${nextID}`;
+      return gate.promise.then(() => {
+        active -= 1;
+        return { id };
+      }) as UploadPromise;
+    });
+    const createAndPoll = vi
+      .spyOn(client.vectorStores.fileBatches, 'createAndPoll')
+      .mockResolvedValue(completed);
+    const options = maxConcurrency === undefined ? undefined : { maxConcurrency: maxConcurrency as number };
+
+    const result = client.vectorStores.fileBatches.uploadAndPoll('vs_123', { files }, options);
+    expect(upload).toHaveBeenCalledTimes(expected);
+    expect(createAndPoll).not.toHaveBeenCalled();
+    gate.resolve(true);
+
+    await expect(result).resolves.toBe(completed);
+    expect(upload).toHaveBeenCalledTimes(files.length);
+    expect(peak).toBe(expected);
+    expect(active).toBe(0);
+  });
+
+  test('preserves zero concurrency and copies existing identifiers', async () => {
+    const client = createClient();
+    const upload = vi.spyOn(client.files, 'create');
+    const createAndPoll = vi
+      .spyOn(client.vectorStores.fileBatches, 'createAndPoll')
+      .mockResolvedValue(completed);
+    const fileIds = ['existing'];
+    const options = { maxConcurrency: 0 };
+
+    await expect(
+      client.vectorStores.fileBatches.uploadAndPoll('vs_123', { files: createFiles(1), fileIds }, options),
+    ).resolves.toBe(completed);
+    expect(upload).not.toHaveBeenCalled();
+    expect(createAndPoll).toHaveBeenCalledWith('vs_123', { file_ids: ['existing'] }, options);
+    expect(createAndPoll.mock.calls[0]?.[1].file_ids).not.toBe(fileIds);
+    expect(fileIds).toEqual(['existing']);
+  });
+
+  test.each([-1, Number.NaN, 1.5])(
+    'preserves the invalid array-length error for concurrency %s',
+    async (limit) => {
+      const client = createClient();
+      const upload = vi.spyOn(client.files, 'create');
+      const createAndPoll = vi.spyOn(client.vectorStores.fileBatches, 'createAndPoll');
+
+      await expect(
+        client.vectorStores.fileBatches.uploadAndPoll(
+          'vs_123',
+          { files: createFiles(3) },
+          { maxConcurrency: limit },
+        ),
+      ).rejects.toBeInstanceOf(RangeError);
+      expect(upload).not.toHaveBeenCalled();
+      expect(createAndPoll).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([undefined, null, []])('rejects missing uploads even with existing IDs: %s', async (files) => {
+    const client = createClient();
+    const upload = vi.spyOn(client.files, 'create');
+    const createAndPoll = vi.spyOn(client.vectorStores.fileBatches, 'createAndPoll');
+
+    await expect(
+      client.vectorStores.fileBatches.uploadAndPoll('vs_123', {
+        files: files as unknown as Uploadable[],
+        fileIds: ['existing'],
+      }),
+    ).rejects.toThrow(
+      "No `files` provided to process. If you've already uploaded files you should use `.createAndPoll()` instead",
+    );
+    expect(upload).not.toHaveBeenCalled();
+    expect(createAndPoll).not.toHaveBeenCalled();
+  });
+
+  test('keeps completion-order IDs and forwards the original files and options', async () => {
+    const client = createClient();
+    const first = createControlledUpload('first');
+    const second = createControlledUpload('second');
+    const third = createControlledUpload('third');
+    const uploads = [first, second, third];
+    const files = uploads.map(({ file }) => file);
+    const upload = mockControlledUploads(client, uploads);
+    const createAndPoll = vi
+      .spyOn(client.vectorStores.fileBatches, 'createAndPoll')
+      .mockResolvedValue(completed);
+    const fileIds = ['existing'];
+    const options = { maxConcurrency: 2, pollIntervalMs: 7, headers: { 'X-Test': 'yes' } };
+
+    const result = client.vectorStores.fileBatches.uploadAndPoll('vs_123', { files, fileIds }, options);
+    fileIds.push('added-later');
+    expect(upload).toHaveBeenCalledTimes(2);
+    second.resolve({ id: 'second' });
+    await Promise.resolve();
+    expect(upload).toHaveBeenCalledTimes(3);
+    third.resolve({ id: 'third' });
+    await Promise.resolve();
+    first.resolve({ id: 'first' });
+
+    await expect(result).resolves.toBe(completed);
+    expect(createAndPoll).toHaveBeenCalledWith(
+      'vs_123',
+      { file_ids: ['existing', 'second', 'third', 'first'] },
+      options,
+    );
+    expect(fileIds).toEqual(['existing', 'added-later']);
+    for (const [index, [body, uploadOptions]] of upload.mock.calls.entries()) {
+      expect(body.file).toBe(files[index]);
+      expect(body.purpose).toBe('assistants');
+      expect(uploadOptions).toBe(options);
+    }
+    expect(createAndPoll.mock.calls[0]?.[2]).toBe(options);
+  });
+
+  test('waits for every worker and retains private errors in worker order', async () => {
+    const client = createClient();
+    const first = createControlledUpload('first');
+    const second = createControlledUpload('second');
+    const third = createControlledUpload('third');
+    const fourth = createControlledUpload('fourth');
+    const uploads = [first, second, third, fourth];
+    const files = uploads.map(({ file }) => file);
+    const upload = mockControlledUploads(client, uploads);
+    const createAndPoll = vi.spyOn(client.vectorStores.fileBatches, 'createAndPoll');
+    const logError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const firstWorkerError = new Error('first worker');
+    const secondWorkerError = new Error('second worker');
+    let settled = false;
+    const result = client.vectorStores.fileBatches.uploadAndPoll('vs_123', { files }, { maxConcurrency: 2 });
+    async function getOutcome() {
+      try {
+        return await result;
+      } catch (error) {
+        settled = true;
+        return error;
+      }
+    }
+    const outcome = getOutcome();
+
+    second.reject(secondWorkerError);
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(upload).toHaveBeenCalledTimes(2);
+    first.resolve({ id: 'first' });
+    await Promise.resolve();
+    expect(upload).toHaveBeenCalledTimes(3);
+    third.reject(firstWorkerError);
+
+    const error = await outcome;
+    expect(error).toMatchObject({
+      message: '2 promise(s) failed',
+      rejections: [firstWorkerError, secondWorkerError],
+    });
+    expect(Object.getOwnPropertyDescriptor(error, 'rejections')?.enumerable).toBe(false);
+    expect(upload).toHaveBeenCalledTimes(3);
+    expect(createAndPoll).not.toHaveBeenCalled();
+    expect(logError).not.toHaveBeenCalled();
+  });
+
+  test('propagates the batch creation error unchanged', async () => {
+    const client = createClient();
+    vi.spyOn(client.files, 'create').mockReturnValue(Promise.resolve({ id: 'file_123' }) as UploadPromise);
+    const error = new Error('batch creation failed');
+    vi.spyOn(client.vectorStores.fileBatches, 'createAndPoll').mockRejectedValue(error);
+
+    await expect(
+      client.vectorStores.fileBatches.uploadAndPoll('vs_123', { files: createFiles(1) }),
+    ).rejects.toBe(error);
+  });
+});


### PR DESCRIPTION
Move vector-store batch upload orchestration into an SDK-owned helper while retaining the exact public `uploadAndPoll` signature and defaults. Preserve the shared worker iterator, concurrency limits (including native errors for invalid values), completion-order file IDs, original uploadables and request options, resource overrides, and batch/error identity. The existing all-workers-settle error aggregator is unchanged, including its ordered, non-enumerable rejection causes and quiet logging behavior.

The hash-verified public custom-code report keeps **32 mixed files** while reducing total custom-patch lines **1,961 → 1,932**. The file-batch resource falls **+78/−0 → +49/−0**; the other **31 customizations are unchanged**. No schema, compiler, API-reference, dependency, or generation-metadata changes.

All **14 new public-entrypoint characterization cases** pass against both exact public `main` and this extraction. Together with the existing generated-resource helper and error-privacy suites, **55 focused cases** pass.

Validation: frozen pnpm 11.5.1 install; canonical formatting and full lint; TypeScript 6; build; TypeScript 4.9 published-source check; **all 611 existing declaration files byte-identical**; **5,305 handwritten tests**, **556 generated tests** and 12 snapshots (one test skipped); packed CJS/ESM and source checks on Node **22.0.0**; publint (only its existing vendored-export warning).

- [x] I understand that this repository is auto-generated and my pull request may not be merged.

Tracked as `custom-code-burndown`.
