### PR TITLE
refactor: move webhook signature checks into an SDK-owned helper

### DIFF
--- a/src/lib/webhook-signature.ts
+++ b/src/lib/webhook-signature.ts
@@ -1,0 +1,60 @@
+import { InvalidWebhookSignatureError } from '../error';
+import { fromBase64 } from '../internal/utils/base64';
+import { encodeUTF8 } from '../internal/utils/bytes';
+
+/**
+ * Checks the timestamp and HMAC signatures after the resource has validated its
+ * crypto capabilities, secret, and required headers.
+ *
+ * @internal
+ */
+export async function verifyWebhookSignature(
+  payload: string,
+  signatureHeader: string,
+  timestamp: string,
+  webhookId: string,
+  secret: string,
+  tolerance: number,
+): Promise<void> {
+  // oxlint-disable-next-line unicorn/prefer-number-coercion -- Preserve numeric-prefix parsing while signing the original timestamp text.
+  const timestampSeconds = Number.parseInt(timestamp, 10);
+  if (Number.isNaN(timestampSeconds)) {
+    throw new InvalidWebhookSignatureError('Invalid webhook timestamp format');
+  }
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (nowSeconds - timestampSeconds > tolerance) {
+    throw new InvalidWebhookSignatureError('Webhook timestamp is too old');
+  }
+  if (timestampSeconds > nowSeconds + tolerance) {
+    throw new InvalidWebhookSignatureError('Webhook timestamp is too new');
+  }
+
+  // Multiple signatures are space-separated; accept the first matching value.
+  const signatures = signatureHeader
+    .split(' ')
+    .map((part) => (part.startsWith('v1,') ? part.slice(3) : part));
+  const decodedSecret = Uint8Array.from(
+    secret.startsWith('whsec_') ? fromBase64(secret.slice('whsec_'.length)) : encodeUTF8(secret),
+  );
+  const signedPayload = webhookId ? `${webhookId}.${timestamp}.${payload}` : `${timestamp}.${payload}`;
+  const signedPayloadBytes = Uint8Array.from(encodeUTF8(signedPayload));
+  const key = await crypto.subtle.importKey('raw', decodedSecret, { name: 'HMAC', hash: 'SHA-256' }, false, [
+    'verify',
+  ]);
+
+  for (const signature of signatures) {
+    try {
+      const signatureBytes = Uint8Array.from(fromBase64(signature));
+      // oxlint-disable-next-line no-await-in-loop -- Check signatures in order and stop at the first match.
+      const isValid = await crypto.subtle.verify('HMAC', key, signatureBytes, signedPayloadBytes);
+      if (isValid) {
+        return;
+      }
+    } catch {
+      // Invalid base64 or signature format does not prevent trying the next value.
+    }
+  }
+
+  throw new InvalidWebhookSignatureError('The given webhook signature does not match the expected signature');
+}

--- a/src/resources/webhooks/webhooks.ts
+++ b/src/resources/webhooks/webhooks.ts
@@ -1,10 +1,8 @@
 // File generated from our OpenAPI spec by Castiron. See CONTRIBUTING.md for details.
 
-import { InvalidWebhookSignatureError } from '../../error';
 import { APIResource } from '../../core/resource';
 import { buildHeaders, HeadersLike } from '../../internal/headers';
-import { fromBase64 } from '../../internal/utils/base64';
-import { encodeUTF8 } from '../../internal/utils/bytes';
+import { verifyWebhookSignature } from '../../lib/webhook-signature';
 
 export class Webhooks extends APIResource {
   /**
@@ -52,65 +50,7 @@ export class Webhooks extends APIResource {
     const timestamp = this.#getRequiredHeader(headersObj, 'webhook-timestamp');
     const webhookId = this.#getRequiredHeader(headersObj, 'webhook-id');
 
-    // Validate timestamp to prevent replay attacks
-    const timestampSeconds = parseInt(timestamp, 10);
-    if (isNaN(timestampSeconds)) {
-      throw new InvalidWebhookSignatureError('Invalid webhook timestamp format');
-    }
-
-    const nowSeconds = Math.floor(Date.now() / 1000);
-
-    if (nowSeconds - timestampSeconds > tolerance) {
-      throw new InvalidWebhookSignatureError('Webhook timestamp is too old');
-    }
-
-    if (timestampSeconds > nowSeconds + tolerance) {
-      throw new InvalidWebhookSignatureError('Webhook timestamp is too new');
-    }
-
-    // Extract signatures from v1,<base64> format
-    // The signature header can have multiple values, separated by spaces.
-    // Each value is in the format v1,<base64>. We should accept if any match.
-    const signatures = signatureHeader
-      .split(' ')
-      .map((part) => (part.startsWith('v1,') ? part.substring(3) : part));
-
-    // Decode the secret if it starts with whsec_
-    const decodedSecret = Uint8Array.from(
-      secret.startsWith('whsec_') ? fromBase64(secret.slice('whsec_'.length)) : encodeUTF8(secret),
-    );
-
-    // Create the signed payload: {webhook_id}.{timestamp}.{payload}
-    const signedPayload = webhookId ? `${webhookId}.${timestamp}.${payload}` : `${timestamp}.${payload}`;
-    const signedPayloadBytes = Uint8Array.from(encodeUTF8(signedPayload));
-
-    // Import the secret as a cryptographic key for HMAC
-    const key = await crypto.subtle.importKey(
-      'raw',
-      decodedSecret,
-      { name: 'HMAC', hash: 'SHA-256' },
-      false,
-      ['verify'],
-    );
-
-    // Check if any signature matches using timing-safe WebCrypto verify
-    for (const signature of signatures) {
-      try {
-        const signatureBytes = Uint8Array.from(fromBase64(signature));
-        const isValid = await crypto.subtle.verify('HMAC', key, signatureBytes, signedPayloadBytes);
-
-        if (isValid) {
-          return; // Valid signature found
-        }
-      } catch {
-        // Invalid base64 or signature format, continue to next signature
-        continue;
-      }
-    }
-
-    throw new InvalidWebhookSignatureError(
-      'The given webhook signature does not match the expected signature',
-    );
+    return await verifyWebhookSignature(payload, signatureHeader, timestamp, webhookId, secret, tolerance);
   }
 
   #validateSecret(secret: string | null | undefined): asserts secret is string {

--- a/tests/lib/webhook-signature.test.ts
+++ b/tests/lib/webhook-signature.test.ts
@@ -1,0 +1,191 @@
+import { createHmac } from 'node:crypto';
+import { vi } from 'vitest';
+import OpenAI, { InvalidWebhookSignatureError } from 'openai';
+
+const now = 1_700_000_000;
+
+interface FixtureOptions {
+  payload?: string;
+  timestamp?: string;
+  webhookID?: string;
+  secret?: string;
+  prefix?: boolean;
+}
+
+function createFixture({
+  payload = '{"id":"evt_test","type":"response.completed","data":{"id":"resp_test"}}',
+  timestamp = String(now),
+  webhookID = 'wh_test',
+  secret = 'synthetic-webhook-secret',
+  prefix = true,
+}: FixtureOptions = {}) {
+  const key = secret.startsWith('whsec_') ? Buffer.from(secret.slice('whsec_'.length), 'base64') : secret;
+  const signedPayload = webhookID ? `${webhookID}.${timestamp}.${payload}` : `${timestamp}.${payload}`;
+  const signature = createHmac('sha256', key).update(signedPayload).digest('base64');
+  const headers = new Headers({
+    'webhook-signature': prefix ? `v1,${signature}` : signature,
+    'webhook-timestamp': timestamp,
+    'webhook-id': webhookID,
+  });
+  return { payload, headers, secret, signedPayload };
+}
+
+function createClient() {
+  return new OpenAI({ apiKey: 'test-key' });
+}
+
+beforeEach(() => {
+  vi.spyOn(Date, 'now').mockReturnValue(now * 1000);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('webhook signature compatibility', () => {
+  test.each([
+    { name: 'old boundary', offset: -300, tolerance: undefined, error: undefined },
+    { name: 'new boundary', offset: 300, tolerance: undefined, error: undefined },
+    { name: 'past old boundary', offset: -301, tolerance: undefined, error: 'too old' },
+    { name: 'past new boundary', offset: 301, tolerance: undefined, error: 'too new' },
+    { name: 'zero tolerance', offset: 0, tolerance: 0, error: undefined },
+    { name: 'zero tolerance past', offset: -1, tolerance: 0, error: 'too old' },
+    { name: 'zero tolerance future', offset: 1, tolerance: 0, error: 'too new' },
+    { name: 'negative tolerance', offset: 0, tolerance: -1, error: 'too old' },
+    { name: 'NaN tolerance', offset: -100_000, tolerance: Number.NaN, error: undefined },
+    { name: 'infinite tolerance', offset: 100_000, tolerance: Infinity, error: undefined },
+    { name: 'JavaScript null tolerance', offset: 0, tolerance: null, error: undefined },
+    { name: 'JavaScript null tolerance past', offset: -1, tolerance: null, error: 'too old' },
+  ])('preserves the $name behavior', async ({ offset, tolerance, error }) => {
+    const { payload, headers, secret } = createFixture({ timestamp: String(now + offset) });
+    const result = createClient().webhooks.verifySignature(
+      payload,
+      headers,
+      secret,
+      tolerance as number | undefined,
+    );
+
+    if (error) {
+      await expect(result).rejects.toBeInstanceOf(InvalidWebhookSignatureError);
+      await expect(result).rejects.toThrow(`Webhook timestamp is ${error}`);
+    } else {
+      await expect(result).resolves.toBeUndefined();
+    }
+  });
+
+  test.each([`${now}.75`, `${now}suffix`, `+${now}`])(
+    'parses the numeric timestamp prefix but signs the original header: %s',
+    async (timestamp) => {
+      const { payload, headers, secret } = createFixture({ timestamp });
+      await expect(
+        createClient().webhooks.verifySignature(payload, headers, secret),
+      ).resolves.toBeUndefined();
+    },
+  );
+
+  test('preserves signing without an empty webhook ID prefix', async () => {
+    const { payload, headers, secret } = createFixture({ webhookID: '' });
+    await expect(createClient().webhooks.verifySignature(payload, headers, secret)).resolves.toBeUndefined();
+  });
+
+  test.each([
+    { name: 'raw secret and bare signature', secret: 'x', prefix: false },
+    { name: 'prefixed secret and signature', secret: 'whsec_eA==', prefix: true },
+  ])('preserves the existing $name format', async ({ secret, prefix }) => {
+    const { payload, headers } = createFixture({ secret, prefix });
+    await expect(createClient().webhooks.verifySignature(payload, headers, secret)).resolves.toBeUndefined();
+  });
+
+  test('propagates key-import errors unchanged', async () => {
+    const { payload, headers, secret } = createFixture();
+    const error = new Error('synthetic key-import failure');
+    vi.spyOn(crypto.subtle, 'importKey').mockRejectedValue(error);
+    const verify = vi.spyOn(crypto.subtle, 'verify');
+
+    await expect(createClient().webhooks.verifySignature(payload, headers, secret)).rejects.toBe(error);
+    expect(verify).not.toHaveBeenCalled();
+  });
+
+  test('tries signatures sequentially, reuses key and payload, and stops after a match', async () => {
+    const { payload, headers, secret, signedPayload } = createFixture();
+    headers.set('webhook-signature', 'v1,AA== v1,AQ== v1,Ag==');
+    const verify = vi
+      .spyOn(crypto.subtle, 'verify')
+      .mockRejectedValueOnce(new Error('synthetic verification failure'))
+      .mockResolvedValueOnce(true);
+    const logError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(createClient().webhooks.verifySignature(payload, headers, secret)).resolves.toBeUndefined();
+    expect(verify).toHaveBeenCalledTimes(2);
+    const [first, second] = verify.mock.calls;
+    expect(first?.[0]).toBe('HMAC');
+    expect(first?.[2]).toEqual(Uint8Array.of(0));
+    expect(second?.[2]).toEqual(Uint8Array.of(1));
+    expect(first?.[1]).toBe(second?.[1]);
+    expect(first?.[3]).toBe(second?.[3]);
+    expect(second?.[3]).toEqual(new TextEncoder().encode(signedPayload));
+    expect(logError).not.toHaveBeenCalled();
+  });
+
+  test('returns the typed mismatch error after every verification attempt fails', async () => {
+    const { payload, headers, secret } = createFixture();
+    headers.set('webhook-signature', 'v1,AA== v1,AQ==');
+    const verify = vi
+      .spyOn(crypto.subtle, 'verify')
+      .mockRejectedValue(new Error('synthetic verification failure'));
+    const result = createClient().webhooks.verifySignature(payload, headers, secret);
+
+    await expect(result).rejects.toBeInstanceOf(InvalidWebhookSignatureError);
+    await expect(result).rejects.toThrow('The given webhook signature does not match the expected signature');
+    expect(verify).toHaveBeenCalledTimes(2);
+  });
+
+  test('preserves capability, secret, header, and timestamp validation order', async () => {
+    const client = createClient();
+    const cryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
+    Object.defineProperty(globalThis, 'crypto', { configurable: true, value: undefined });
+    try {
+      await expect(client.webhooks.verifySignature('{}', {}, null)).rejects.toThrow(
+        'Webhook signature verification is only supported when the `crypto` global is defined',
+      );
+    } finally {
+      if (cryptoDescriptor) {
+        Object.defineProperty(globalThis, 'crypto', cryptoDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, 'crypto');
+      }
+    }
+
+    await expect(client.webhooks.verifySignature('{}', {}, null)).rejects.toThrow('The webhook secret must');
+    await expect(client.webhooks.verifySignature('{}', {}, 'synthetic-secret')).rejects.toThrow(
+      'Missing required header: webhook-signature',
+    );
+
+    const { payload, headers } = createFixture();
+    headers.set('webhook-timestamp', 'invalid');
+    const importKey = vi.spyOn(crypto.subtle, 'importKey');
+    await expect(client.webhooks.verifySignature(payload, headers, 'whsec_%%%')).rejects.toThrow(
+      'Invalid webhook timestamp format',
+    );
+    expect(importKey).not.toHaveBeenCalled();
+  });
+
+  test('unwrap still calls the resource override before parsing the payload', async () => {
+    const client = new OpenAI({ apiKey: 'test-key', webhookSecret: 'configured-secret' });
+    const headers = new Headers();
+    const error = new Error('synthetic override failure');
+    const verify = vi.spyOn(client.webhooks, 'verifySignature').mockRejectedValue(error);
+
+    await expect(client.webhooks.unwrap('{', headers)).rejects.toBe(error);
+    expect(verify).toHaveBeenCalledWith('{', headers, 'configured-secret', 300);
+    verify.mockResolvedValue();
+    await expect(client.webhooks.unwrap('{', headers)).rejects.toBeInstanceOf(SyntaxError);
+  });
+
+  test('retains the resource private-brand check for borrowed methods', async () => {
+    const { payload, headers, secret } = createFixture();
+    const verify = createClient().webhooks.verifySignature;
+
+    await expect(Reflect.apply(verify, {}, [payload, headers, secret])).rejects.toBeInstanceOf(TypeError);
+  });
+});


### PR DESCRIPTION
Move the existing timestamp and HMAC verification algorithm into an SDK-owned helper. Keep the resource's public signatures/defaults, crypto capability check, secret/header validation, private nominal brand, and `unwrap` dispatch through the overridable `verifySignature` method unchanged. Preserve portable decoding, original signed timestamp text, tolerance boundaries/coercions, signature-attempt ordering, key/payload reuse, and existing errors.

The hash-verified public custom-code report keeps **32 mixed files** while reducing total custom-patch lines **1,830 → 1,770**. The webhook resource falls **+130/−2 → +70/−2**; the other **31 customizations are unchanged**. No schema, compiler, API-reference, dependency, or generation-metadata changes.

All **24 new public-entrypoint characterization cases** pass against both the refreshed public-main implementation and this extraction. Together with the existing portable and generated webhook suites, **45 focused cases and 12 snapshots** pass. The narrow lint exceptions retain decimal-prefix timestamp parsing and sequential signature verification; replacing either with the suggested generic alternative would change covered behavior.

Validation on current public main: frozen pnpm 11.5.1 install; canonical formatting and full lint; TypeScript 6; build; TypeScript 4.9 published-source check; **all 621 existing declaration files byte-identical**, including the webhook private-brand declaration; **5,364 handwritten tests**, **556 generated tests** and 12 snapshots (one test skipped); packed CJS/ESM and source checks on Node **22.0.0**; publint (only its existing vendored-export warning).

Focused compatibility and security review is requested for this behavior-preserving extraction.

- [x] I understand that this repository is auto-generated and my pull request may not be merged.

Tracked as `custom-code-burndown`.
