### PR TITLE
fix: publish Castiron checks for external-fork pull requests

### DIFF
--- a/.github/workflows/castiron-custom-code-comment.yml
+++ b/.github/workflows/castiron-custom-code-comment.yml
@@ -137,21 +137,37 @@ jobs:
           script: |
             const event = context.payload.workflow_run;
             const {data: run} = await github.rest.actions.getWorkflowRun({...context.repo, run_id: event.id});
+            const upstream = `${context.repo.owner}/${context.repo.repo}`;
             if (run.head_sha !== event.head_sha || run.run_attempt !== event.run_attempt ||
                 run.status !== 'completed' || run.path.split('@', 1)[0] !== '.github/workflows/castiron-custom-code.yml' ||
-                run.repository.full_name !== `${context.repo.owner}/${context.repo.repo}`) return;
+                run.repository.full_name !== upstream) return;
             const head = run.head_sha;
             if (!/^[0-9a-f]{40}$/.test(head)) throw new Error('Invalid candidate SHA');
             const {data: main} = await github.rest.git.getRef({...context.repo, ref: 'heads/main'});
             const base = main.object.sha;
             if (run.event === 'pull_request') {
+              const source = run.head_repository;
+              const identity = typeof source?.full_name === 'string' &&
+                /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(source.full_name);
+              if (!identity || identity.slice(1).some(part => part === '.' || part === '..') ||
+                  (source.name !== undefined && source.name !== identity[2]) ||
+                  (source.owner != null &&
+                    (typeof source.owner !== 'object' || source.owner.login !== identity[1])) ||
+                  !Array.isArray(run.pull_requests)) return;
               const pulls = run.pull_requests.length ? run.pull_requests : await github.paginate(
-                github.rest.repos.listPullRequestsAssociatedWithCommit, {...context.repo, commit_sha: head});
-              const current = [];
+                github.rest.repos.listPullRequestsAssociatedWithCommit,
+                {owner: identity[1], repo: identity[2], commit_sha: head});
+              const numbers = new Set();
               for (const pull of pulls) {
-                const {data: pr} = await github.rest.pulls.get({...context.repo, pull_number: pull.number});
-                if (pr.state === 'open' && pr.head.sha === head && pr.base.sha === base &&
-                    pr.base.ref === 'main' && pr.base.repo.full_name === `${context.repo.owner}/${context.repo.repo}`) current.push(pr);
+                if (!Number.isSafeInteger(pull?.number) || pull.number <= 0) return;
+                numbers.add(pull.number);
+              }
+              const current = [];
+              for (const number of numbers) {
+                const {data: pr} = await github.rest.pulls.get({...context.repo, pull_number: number});
+                if (pr.number === number && pr.state === 'open' && pr.head.sha === head && pr.base.sha === base &&
+                    pr.head.repo?.full_name === source.full_name && pr.base.ref === 'main' &&
+                    pr.base.repo.full_name === upstream) current.push(pr);
               }
               if (current.length !== 1) return;
             } else if (run.event !== 'merge_group' || !run.head_branch.startsWith('gh-readonly-queue/main/')) {
@@ -220,18 +236,43 @@ jobs:
         with:
           script: |
             const marker = '<!-- castiron:custom-code-report:v1 -->';
-            const run = context.payload.workflow_run;
-            if (run.event !== 'pull_request' || run.path !== '.github/workflows/castiron-custom-code.yml') return;
-            const pulls = run.pull_requests?.length ? run.pull_requests : await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {...context.repo, commit_sha: run.head_sha});
+            const event = context.payload.workflow_run;
+            const {data: run} = await github.rest.actions.getWorkflowRun({...context.repo, run_id: event.id});
+            const upstream = `${context.repo.owner}/${context.repo.repo}`;
+            if (run.event !== 'pull_request' || run.head_sha !== event.head_sha ||
+                run.run_attempt !== event.run_attempt || run.status !== 'completed' ||
+                run.path.split('@', 1)[0] !== '.github/workflows/castiron-custom-code.yml' ||
+                run.repository.full_name !== upstream || !/^[0-9a-f]{40}$/.test(run.head_sha)) return;
+            const source = run.head_repository;
+            const identity = typeof source?.full_name === 'string' &&
+              /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(source.full_name);
+            if (!identity || identity.slice(1).some(part => part === '.' || part === '..') ||
+                (source.name !== undefined && source.name !== identity[2]) ||
+                (source.owner != null &&
+                  (typeof source.owner !== 'object' || source.owner.login !== identity[1])) ||
+                !Array.isArray(run.pull_requests)) return;
+            const pulls = run.pull_requests.length ? run.pull_requests : await github.paginate(
+              github.rest.repos.listPullRequestsAssociatedWithCommit,
+              {owner: identity[1], repo: identity[2], commit_sha: run.head_sha});
+            const numbers = new Set();
             for (const pull of pulls) {
-              const {data: current} = await github.rest.pulls.get({...context.repo, pull_number: pull.number});
-              if (current.state !== 'open' || current.head.sha !== run.head_sha) continue;
-              const comments = await github.paginate(github.rest.issues.listComments, {...context.repo, issue_number: pull.number});
-              const previous = comments.find(c => c.user?.type === 'Bot' && c.user?.login === 'github-actions[bot]' && c.body?.startsWith(marker));
-              const prior = previous?.body?.match(/<!-- castiron:run:v1:(\d+):(\d+) -->/);
-              if (prior && (Number(prior[1]) > run.id || (Number(prior[1]) === run.id && Number(prior[2]) > run.run_attempt))) continue;
-              const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${run.id}`;
-              const body = `${marker}\n\n## Castiron custom code\n\n⚠️ Report unavailable for \`${run.head_sha.slice(0, 12)}\`.\n\nThe report setup or validation failed. [Inspect the workflow run](${url}).\n\n<!-- castiron:run:v1:${run.id}:${run.run_attempt} -->`;
-              if (previous) await github.rest.issues.updateComment({...context.repo, comment_id: previous.id, body});
-              else await github.rest.issues.createComment({...context.repo, issue_number: pull.number, body});
+              if (!Number.isSafeInteger(pull?.number) || pull.number <= 0) return;
+              numbers.add(pull.number);
             }
+            const current = [];
+            for (const number of numbers) {
+              const {data: pr} = await github.rest.pulls.get({...context.repo, pull_number: number});
+              if (pr.number === number && pr.state === 'open' && pr.head.sha === run.head_sha &&
+                  pr.head.repo?.full_name === source.full_name && pr.base.ref === 'main' &&
+                  pr.base.repo.full_name === upstream) current.push({number, pr});
+            }
+            if (current.length !== 1) return;
+            const number = current[0].number;
+            const comments = await github.paginate(github.rest.issues.listComments, {...context.repo, issue_number: number});
+            const previous = comments.find(c => c.user?.type === 'Bot' && c.user?.login === 'github-actions[bot]' && c.body?.startsWith(marker));
+            const prior = previous?.body?.match(/<!-- castiron:run:v1:(\d+):(\d+) -->/);
+            if (prior && (Number(prior[1]) > run.id || (Number(prior[1]) === run.id && Number(prior[2]) > run.run_attempt))) return;
+            const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${run.id}`;
+            const body = `${marker}\n\n## Castiron custom code\n\n⚠️ Report unavailable for \`${run.head_sha.slice(0, 12)}\`.\n\nThe report setup or validation failed. [Inspect the workflow run](${url}).\n\n<!-- castiron:run:v1:${run.id}:${run.run_attempt} -->`;
+            if (previous) await github.rest.issues.updateComment({...context.repo, comment_id: previous.id, body});
+            else await github.rest.issues.createComment({...context.repo, issue_number: number, body});

--- a/.github/workflows/castiron-custom-code.yml
+++ b/.github/workflows/castiron-custom-code.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  REPORTER_SHA256: b971c18701081ff47e7a5f935fd1fe9cd5f58b3d8f570a4daede62c5611e3fc9
+  REPORTER_SHA256: ac8f5df5306250b8594cc8c85274a86744df8bd5d48538bf9f909b193cfa4a09
 
 jobs:
   queue-signal:

--- a/scripts/castiron/custom_code_budget.py
+++ b/scripts/castiron/custom_code_budget.py
@@ -300,23 +300,7 @@ def github_evaluate(
         raise ValueError("unexpected or superseded source workflow run")
     head = report.require_sha(run["head_sha"])
     if run["event"] == "pull_request":
-        associated = run["pull_requests"] or report.api(
-            "GET", f"{root}/commits/{head}/pulls?per_page=100"
-        )
-        current: list[int] = []
-        for number in sorted({int(pr["number"]) for pr in associated}):
-            if number <= 0:
-                raise ValueError("invalid associated PR number")
-            pull = report.api("GET", f"{root}/pulls/{number}")
-            if (
-                pull["state"] == "open"
-                and pull["head"]["sha"] == head
-                and pull["base"]["repo"]["full_name"] == repository
-                and pull["base"]["ref"] == branch
-                and pull["base"]["sha"] == main
-            ):
-                current.append(number)
-        if len(current) != 1:
+        if report.associated_pull_request(repository, run, base_ref=branch, base_sha=main) is None:
             raise ValueError("source run must identify exactly one current PR targeting main")
     elif run["event"] == "merge_group":
         if not run["head_branch"].startswith(f"gh-readonly-queue/{branch}/"):

--- a/scripts/castiron/custom_code_report.py
+++ b/scripts/castiron/custom_code_report.py
@@ -766,6 +766,77 @@ def api(method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
     return json.loads(result.stdout)
 
 
+def associated_pull_request(
+    repository: str,
+    run: dict[str, Any],
+    *,
+    base_ref: str = "main",
+    base_sha: str | None = None,
+) -> dict[str, Any] | None:
+    """Resolve one current upstream PR without trusting fork-side associations."""
+    if not REPOSITORY.fullmatch(repository) or any(
+        part in {".", ".."} for part in repository.split("/")
+    ):
+        raise ReportError("invalid associated repository")
+    upstream = run.get("repository")
+    source = run.get("head_repository")
+    source_name = source.get("full_name") if isinstance(source, dict) else None
+    if (
+        not isinstance(upstream, dict)
+        or upstream.get("full_name") != repository
+        or not isinstance(source_name, str)
+        or not REPOSITORY.fullmatch(source_name)
+        or any(part in {".", ".."} for part in source_name.split("/"))
+    ):
+        raise ReportError("workflow run has invalid source repository")
+    owner, name = source_name.split("/", 1)
+    if "name" in source and source["name"] != name:
+        raise ReportError("workflow run has invalid source repository")
+    source_owner = source.get("owner")
+    if source_owner is not None and (
+        not isinstance(source_owner, dict) or source_owner.get("login") != owner
+    ):
+        raise ReportError("workflow run has invalid source repository")
+
+    head = require_sha(run["head_sha"])
+    if base_sha is not None:
+        require_sha(base_sha)
+    associated = run.get("pull_requests")
+    if not isinstance(associated, list):
+        raise ReportError("invalid associated pull request")
+    if not associated:
+        associated = api("GET", f"repos/{source_name}/commits/{head}/pulls?per_page=100")
+    if not isinstance(associated, list):
+        raise ReportError("invalid associated pull request")
+    numbers: set[int] = set()
+    for candidate in associated:
+        number = candidate.get("number") if isinstance(candidate, dict) else None
+        if type(number) is not int or number <= 0:
+            raise ReportError("invalid associated pull request")
+        numbers.add(number)
+
+    current: list[dict[str, Any]] = []
+    for number in sorted(numbers):
+        pull = api("GET", f"repos/{repository}/pulls/{number}")
+        if not isinstance(pull, dict) or type(pull.get("number")) is not int:
+            raise ReportError("invalid associated pull request")
+        if pull["number"] != number:
+            raise ReportError("invalid associated pull request")
+        if (
+            pull["state"] == "open"
+            and pull["head"]["sha"] == head
+            and pull["head"]["repo"]["full_name"] == source_name
+            and pull["base"]["repo"]["full_name"] == repository
+            and pull["base"]["ref"] == base_ref
+            and (base_sha is None or pull["base"]["sha"] == base_sha)
+        ):
+            require_sha(pull["base"]["sha"])
+            current.append(pull)
+    if len(current) > 1:
+        raise ReportError("workflow run has multiple current pull requests")
+    return current[0] if current else None
+
+
 def publish_comment(
     report: dict[str, Any],
     repository: str,
@@ -793,14 +864,11 @@ def publish_comment(
         or run["head_sha"] != report["head_sha"]
     ):
         raise ReportError("workflow run does not match report PR/head")
-    associated = run["pull_requests"]
-    if not associated:
-        # GitHub can omit the PR association on workflow runs from forks.
-        associated = api("GET", f"{root}/commits/{require_sha(run['head_sha'])}/pulls?per_page=100")
-    if not any(pr["number"] == number for pr in associated):
-        raise ReportError("workflow run does not match report PR/head")
     if run["run_attempt"] != run_attempt:
         return "Skipped stale report"
+    current = associated_pull_request(repository, run, base_sha=report["target_base_sha"])
+    if current is None or current["number"] != number:
+        raise ReportError("workflow run does not match report PR/head")
     artifact_run_id = artifact_run_id or run_id
     artifact_run_attempt = artifact_run_attempt or run_attempt
     body = render_report(
@@ -833,6 +901,9 @@ def publish_comment(
     if (
         pull["state"] != "open"
         or pull["head"]["sha"] != report["head_sha"]
+        or pull["head"]["repo"]["full_name"] != current["head"]["repo"]["full_name"]
+        or pull["base"]["repo"]["full_name"] != repository
+        or pull["base"]["ref"] != "main"
         or pull["base"]["sha"] != report["target_base_sha"]
     ):
         return "Skipped stale report"
@@ -890,23 +961,10 @@ def trusted_report(repo: Path, repository: str, run_id: int, run_attempt: int, o
     if run["run_attempt"] != run_attempt:
         return
     head = require_sha(run["head_sha"])
-    associated = run["pull_requests"] or api("GET", f"{root}/commits/{head}/pulls?per_page=100")
-    current: list[tuple[int, str]] = []
-    for number in sorted({int(pr["number"]) for pr in associated}):
-        if number <= 0:
-            raise ReportError("invalid associated pull request")
-        pull = api("GET", f"{root}/pulls/{number}")
-        if (
-            pull["state"] == "open"
-            and pull["head"]["sha"] == head
-            and pull["base"]["repo"]["full_name"] == repository
-        ):
-            current.append((number, require_sha(pull["base"]["sha"])))
-    if not current:
+    pull = associated_pull_request(repository, run)
+    if pull is None:
         return
-    if len(current) != 1:
-        raise ReportError("workflow run has multiple current pull requests")
-    number, base = current[0]
+    number, base = pull["number"], require_sha(pull["base"]["sha"])
     public = not api("GET", root)["private"]
     # This must be a new, bare repository: no PR worktree, hooks, configuration,
     # submodules, or Python imports can affect the trusted reporter.

--- a/scripts/castiron/test_custom_code_budget.py
+++ b/scripts/castiron/test_custom_code_budget.py
@@ -22,6 +22,11 @@ def source_run(head: str, event: str = "pull_request") -> dict[str, Any]:
         "head_sha": head,
         "head_branch": "gh-readonly-queue/main/pr-7-example" if event == "merge_group" else "sdk",
         "repository": {"full_name": "openai/example"},
+        "head_repository": {
+            "full_name": "openai/example",
+            "name": "example",
+            "owner": {"login": "openai"},
+        },
         "path": ".github/workflows/castiron-custom-code.yml",
         "status": "completed",
         "run_attempt": 1,
@@ -309,6 +314,9 @@ class StatusPublisherTests(unittest.TestCase):
         base_changed: bool = False,
         no_result: bool = False,
         failed_budget: bool = False,
+        head_repository: str = "openai/example",
+        pull_repository: str | None = None,
+        associations: list[dict[str, Any]] | None = None,
         run_overrides: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         path = (
@@ -319,6 +327,17 @@ class StatusPublisherTests(unittest.TestCase):
         publisher = section.split("          script: |\n", 1)[1]
         script = "\n".join(line[12:] for line in publisher.splitlines())
         base, head = "a" * 40, "b" * 40
+        owner, _, name = head_repository.partition("/")
+        run = {
+            **source_run(head, event_name),
+            "head_repository": {
+                "full_name": head_repository,
+                "name": name,
+                "owner": {"login": owner},
+            },
+            **({"pull_requests": []} if associations is not None else {}),
+            **(run_overrides or {}),
+        }
         payload = {
             "script": script,
             "context": {
@@ -330,10 +349,15 @@ class StatusPublisherTests(unittest.TestCase):
                     "workflow_run": source_run(head, event_name),
                 },
             },
-            "run": {**source_run(head, event_name), **(run_overrides or {})},
+            "run": run,
+            "associations": associations,
+            "association_repository": head_repository,
             "current": {
                 "state": "open",
-                "head": {"sha": "c" * 40 if head_changed else head},
+                "head": {
+                    "sha": "c" * 40 if head_changed else head,
+                    "repo": {"full_name": pull_repository or head_repository},
+                },
                 "base": {
                     "sha": "c" * 40 if base_changed else base,
                     "ref": "main",
@@ -351,12 +375,22 @@ class StatusPublisherTests(unittest.TestCase):
           const fs = require('node:fs');
           const data = JSON.parse(fs.readFileSync(0, 'utf8'));
           const published = [];
-          const github = {rest: {
-            pulls: {get: async () => ({data: data.current})},
-            actions: {getWorkflowRun: async () => ({data: data.run})},
-            git: {getRef: async () => ({data: {object: {sha: data.current.base.sha}}})},
-            repos: {createCommitStatus: async value => published.push(value)},
-          }};
+          const github = {
+            paginate: async (_method, options) => {
+              if (`${options.owner}/${options.repo}` !== data.association_repository)
+                throw new Error('Associated PRs queried from the wrong repository');
+              return data.associations;
+            },
+            rest: {
+              pulls: {get: async options => ({data: {...data.current, number: options.pull_number}})},
+              actions: {getWorkflowRun: async () => ({data: data.run})},
+              git: {getRef: async () => ({data: {object: {sha: data.current.base.sha}}})},
+              repos: {
+                listPullRequestsAssociatedWithCommit: async () => {},
+                createCommitStatus: async value => published.push(value),
+              },
+            },
+          };
           const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
           new AsyncFunction('github','context','process', data.script)(github, data.context, {env:data.env})
             .then(() => process.stdout.write(JSON.stringify(published)))
@@ -379,6 +413,87 @@ class StatusPublisherTests(unittest.TestCase):
                 self.assertTrue(
                     all(r["sha"] == "b" * 40 and r["state"] == "success" for r in results)
                 )
+
+    def test_missing_fork_associations_are_resolved_from_the_source_repository(self) -> None:
+        for source in ("contributor/example", "contributor/renamed-fork"):
+            with self.subTest(source=source):
+                results = self.publish(head_repository=source, associations=[{"number": 3}])
+                self.assertEqual(
+                    [result["context"] for result in results],
+                    ["Castiron / budget-only change", "Castiron / custom-code budget"],
+                )
+                self.assertTrue(all(result["state"] == "success" for result in results))
+
+    def test_missing_same_repository_associations_still_publish(self) -> None:
+        self.assertEqual(len(self.publish(associations=[{"number": 3}])), 2)
+
+    def test_invalid_or_spoofed_source_repositories_cannot_publish(self) -> None:
+        cases: list[tuple[str, dict[str, Any] | None]] = [
+            ("contributor/example/unrelated", None),
+            ("./example", None),
+            ("../example", None),
+            ("contributor/.", None),
+            ("contributor/..", None),
+            (
+                "contributor/example",
+                {
+                    "head_repository": {
+                        "full_name": "contributor/example",
+                        "name": "unrelated",
+                        "owner": {"login": "contributor"},
+                    }
+                },
+            ),
+            (
+                "contributor/example",
+                {
+                    "head_repository": {
+                        "full_name": "contributor/example",
+                        "name": "example",
+                        "owner": {"login": "someone-else"},
+                    }
+                },
+            ),
+            (
+                "contributor/example",
+                {"head_repository": {"full_name": "contributor/example", "owner": {}}},
+            ),
+            (
+                "contributor/example",
+                {"head_repository": {"full_name": "contributor/example", "owner": "contributor"}},
+            ),
+            ("contributor/example", {"head_repository": None}),
+        ]
+        for repository, overrides in cases:
+            with self.subTest(repository=repository, overrides=overrides):
+                self.assertEqual(
+                    self.publish(
+                        head_repository=repository,
+                        associations=[{"number": 3}],
+                        run_overrides=overrides,
+                    ),
+                    [],
+                )
+
+    def test_pr_head_must_belong_to_the_source_repository(self) -> None:
+        self.assertEqual(
+            self.publish(
+                head_repository="contributor/example",
+                pull_repository="someone-else/example",
+                associations=[{"number": 3}],
+            ),
+            [],
+        )
+
+    def test_associations_must_identify_exactly_one_valid_pr(self) -> None:
+        self.assertEqual(self.publish(associations=[]), [])
+        self.assertEqual(self.publish(associations=[{"number": 3}, {"number": 4}]), [])
+        self.assertEqual(len(self.publish(associations=[{"number": 3}, {"number": 3}])), 2)
+
+    def test_invalid_association_numbers_cannot_publish(self) -> None:
+        for number in (True, 0, -1, 1.5, "3", 9007199254740992):
+            with self.subTest(number=number):
+                self.assertEqual(self.publish(associations=[{"number": number}]), [])
 
     def test_stale_pr_head_is_not_published(self) -> None:
         self.assertEqual(self.publish(head_changed=True), [])
@@ -408,6 +523,86 @@ class StatusPublisherTests(unittest.TestCase):
 
 
 class GitHubBudgetTests(unittest.TestCase):
+    def test_missing_associations_are_resolved_from_the_source_repository(self) -> None:
+        base, head = "a" * 40, "b" * 40
+        for source in ("openai/example", "contributor/example", "contributor/renamed-fork"):
+            with self.subTest(source=source), tempfile.TemporaryDirectory() as temp:
+                owner, name = source.split("/")
+                run = {
+                    **source_run(head),
+                    "head_repository": {
+                        "full_name": source,
+                        "name": name,
+                        "owner": {"login": owner},
+                    },
+                    "pull_requests": [],
+                }
+                event = {"repository": {"full_name": "openai/example"}, "workflow_run": run}
+                pull = {
+                    "number": 3,
+                    "state": "open",
+                    "head": {"sha": head, "repo": {"full_name": source}},
+                    "base": {
+                        "sha": base,
+                        "ref": "main",
+                        "repo": {"full_name": "openai/example"},
+                    },
+                }
+                responses = [
+                    {"default_branch": "main", "private": False},
+                    {"object": {"sha": base}},
+                    run,
+                    [{"number": 3}],
+                    pull,
+                    [{"type": "merge_queue"}],
+                ]
+                with (
+                    mock.patch.object(budget.report, "api", side_effect=responses) as api,
+                    mock.patch.object(budget.report, "git"),
+                    mock.patch.object(budget, "evaluate", return_value=({}, b"")) as evaluate,
+                ):
+                    budget.github_evaluate(
+                        Path(temp) / "objects.git", "openai/example", event, base
+                    )
+
+                api.assert_any_call("GET", f"repos/{source}/commits/{head}/pulls?per_page=100")
+                api.assert_any_call("GET", "repos/openai/example/pulls/3")
+                evaluate.assert_called_once()
+
+    def test_ambiguous_fork_associations_fail_before_creating_objects(self) -> None:
+        base, head = "a" * 40, "b" * 40
+        run = {
+            **source_run(head),
+            "head_repository": {"full_name": "contributor/example"},
+            "pull_requests": [],
+        }
+        event = {"repository": {"full_name": "openai/example"}, "workflow_run": run}
+        pull = {
+            "number": 3,
+            "state": "open",
+            "head": {"sha": head, "repo": {"full_name": "contributor/example"}},
+            "base": {"sha": base, "ref": "main", "repo": {"full_name": "openai/example"}},
+        }
+        with (
+            tempfile.TemporaryDirectory() as temp,
+            mock.patch.object(
+                budget.report,
+                "api",
+                side_effect=[
+                    {"default_branch": "main"},
+                    {"object": {"sha": base}},
+                    run,
+                    [{"number": 3}, {"number": 4}],
+                    pull,
+                    {**pull, "number": 4},
+                ],
+            ),
+        ):
+            repo = Path(temp) / "objects.git"
+            with self.assertRaises(ValueError):
+                budget.github_evaluate(repo, "openai/example", event, base)
+            self.assertFalse(repo.exists())
+
     def test_merge_queue_rule_is_required_before_passing(self) -> None:
         base, head = "a" * 40, "b" * 40
         event = {
@@ -464,8 +659,9 @@ class GitHubBudgetTests(unittest.TestCase):
         base, head = "a" * 40, "b" * 40
         event = {"repository": {"full_name": "openai/example"}, "workflow_run": source_run(head)}
         pull = {
+            "number": 3,
             "state": "open",
-            "head": {"sha": head},
+            "head": {"sha": head, "repo": {"full_name": "openai/example"}},
             "base": {
                 "sha": base,
                 "ref": "main",
@@ -564,8 +760,9 @@ class GitHubBudgetTests(unittest.TestCase):
             "workflow_run": source_run(head),
         }
         pull = {
+            "number": 3,
             "state": "open",
-            "head": {"sha": head},
+            "head": {"sha": head, "repo": {"full_name": "openai/example"}},
             "base": {"sha": base, "ref": "main", "repo": {"full_name": "openai/example"}},
         }
         responses = [
@@ -594,7 +791,7 @@ class GitHubBudgetTests(unittest.TestCase):
             )
 
     def test_stale_pull_and_wrong_target_fail_before_objects_created(self) -> None:
-        for kind in ("head", "base", "repository", "branch", "closed"):
+        for kind in ("head", "source_repository", "base", "repository", "branch", "closed"):
             with self.subTest(kind=kind), tempfile.TemporaryDirectory() as temp:
                 base, head = "a" * 40, "b" * 40
                 event = {
@@ -602,12 +799,15 @@ class GitHubBudgetTests(unittest.TestCase):
                     "workflow_run": source_run(head),
                 }
                 pull: dict[str, Any] = {
+                    "number": 3,
                     "state": "open",
-                    "head": {"sha": head},
+                    "head": {"sha": head, "repo": {"full_name": "openai/example"}},
                     "base": {"sha": base, "ref": "main", "repo": {"full_name": "openai/example"}},
                 }
                 if kind == "head":
                     pull["head"]["sha"] = "c" * 40
+                elif kind == "source_repository":
+                    pull["head"]["repo"]["full_name"] = "someone-else/example"
                 elif kind == "base":
                     pull["base"]["sha"] = "c" * 40
                 elif kind == "repository":

--- a/scripts/castiron/test_custom_code_report.py
+++ b/scripts/castiron/test_custom_code_report.py
@@ -283,16 +283,37 @@ class CustomCodeTests(unittest.TestCase):
         harness = r"""
 const assert = require('node:assert/strict');
 const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
-async function check(stale, exists, priorRun, expected) {
+async function check({stale = false, exists = true, priorRun = 10, expected = 'update',
+  source = 'openai/example', embedded = true, associations = [{number: 1}],
+  sourceOverride = {}, runOverride = {}, pullOverride = {}} = {}) {
   const writes = [];
-  const event = {id: 20, run_attempt: 1, event: 'pull_request', path: '.github/workflows/castiron-custom-code.yml', head_sha: 'a'.repeat(40), pull_requests: [{number: 1}]};
-  const current = {state: 'open', head: {sha: (stale ? 'c' : 'a').repeat(40)}};
+  const queries = [];
+  const [owner, name] = source.split('/');
+  const event = {id: 20, run_attempt: 1, event: 'pull_request', status: 'completed',
+    path: '.github/workflows/castiron-custom-code.yml', head_sha: 'a'.repeat(40),
+    repository: {full_name: 'openai/example'},
+    head_repository: {full_name: source, name, owner: {login: owner}, ...sourceOverride},
+    pull_requests: embedded ? associations : []};
+  const run = {...event, ...runOverride};
+  const current = {number: 1, state: 'open',
+    head: {sha: (stale ? 'c' : 'a').repeat(40), repo: {full_name: source}},
+    base: {ref: 'main', repo: {full_name: 'openai/example'}}, ...pullOverride};
   const previous = {id: 42, user: {type: 'Bot', login: 'github-actions[bot]'},
     body: `<!-- castiron:custom-code-report:v1 -->\n<!-- castiron:run:v1:${priorRun}:1 -->`};
-  const github = {paginate: async () => exists ? [previous] : [], rest: {
-    pulls: {get: async () => ({data: current})},
+  const github = {rest: {
+    actions: {getWorkflowRun: async () => ({data: run})},
+    repos: {listPullRequestsAssociatedWithCommit() {}},
+    pulls: {get: async ({pull_number}) => ({data: {...current, number: pull_number}})},
     issues: {listComments() {}, updateComment: async x => writes.push(['update', x]),
       createComment: async x => writes.push(['create', x])}}};
+  github.paginate = async (method, parameters) => {
+    if (method === github.rest.repos.listPullRequestsAssociatedWithCommit) {
+      queries.push(parameters);
+      return associations;
+    }
+    assert.equal(method, github.rest.issues.listComments);
+    return exists ? [previous] : [];
+  };
   const context = {payload: {workflow_run: event}, repo: {owner: 'openai', repo: 'example'},
     runId: 20, serverUrl: 'https://github.com'};
   await new AsyncFunction('github', 'context', SCRIPT)(github, context);
@@ -302,12 +323,28 @@ async function check(stale, exists, priorRun, expected) {
     assert.match(writes[0][1].body, /Report unavailable/);
     assert.match(writes[0][1].body, /castiron:run:v1:20:1/);
   }
+  if (!embedded && expected) {
+    assert.deepEqual(queries, [{owner, repo: name, commit_sha: 'a'.repeat(40)}]);
+  }
 }
 (async () => {
-  await check(false, true, 10, 'update');
-  await check(false, false, 10, 'create');
-  await check(true, true, 10, null);
-  await check(false, true, 21, null);
+  await check();
+  await check({exists: false, expected: 'create'});
+  await check({stale: true, expected: null});
+  await check({priorRun: 21, expected: null});
+  await check({source: 'contributor/example', embedded: false});
+  await check({source: 'contributor/renamed-example', embedded: false});
+  await check({source: '../example', embedded: false, expected: null});
+  await check({sourceOverride: {owner: {login: 'spoofed'}}, expected: null});
+  await check({runOverride: {repository: {full_name: 'other/example'}}, expected: null});
+  await check({pullOverride: {head: {sha: 'a'.repeat(40),
+    repo: {full_name: 'spoofed/example'}}}, expected: null});
+  await check({pullOverride: {base: {ref: 'other',
+    repo: {full_name: 'openai/example'}}}, expected: null});
+  await check({associations: [{number: 1}, {number: 2}], expected: null});
+  await check({associations: [{number: 1}, {number: 1}]});
+  await check({associations: [{number: true}], expected: null});
+  await check({runOverride: {run_attempt: 2}, expected: null});
 })().catch(error => { console.error(error); process.exitCode = 1; });
 """
         subprocess.run(
@@ -382,16 +419,27 @@ async function check(stale, exists, priorRun, expected) {
 
         _, base = self.baseline()
         result, _ = report.build_report(self.repo, base, base)
-        pull = {"state": "open", "head": {"sha": base}, "base": {"sha": base}}
+        pull = {
+            "number": 1,
+            "state": "open",
+            "head": {"sha": base, "repo": {"full_name": "openai/example"}},
+            "base": {
+                "sha": base,
+                "ref": "main",
+                "repo": {"full_name": "openai/example"},
+            },
+        }
         run = {
             "event": "pull_request",
             "path": ".github/workflows/castiron-custom-code.yml",
             "head_sha": base,
+            "repository": {"full_name": "openai/example"},
+            "head_repository": {"full_name": "openai/example"},
             "run_attempt": 1,
             "pull_requests": [{"number": 1}],
         }
         with mock.patch.object(
-            report, "api", side_effect=[pull, run, [], pull, {"html_url": "published"}]
+            report, "api", side_effect=[pull, run, pull, [], pull, {"html_url": "published"}]
         ) as api:
             self.assertEqual(
                 report.publish_comment(
@@ -448,20 +496,37 @@ async function check(stale, exists, priorRun, expected) {
             self.assertNotIn("checkout", args)
             return real_git(repo, *args, input_bytes=input_bytes)
 
-        for label, revision in (("genuine", base), ("custom", head), ("broken", broken)):
+        for label, revision, source in (
+            ("genuine", base, "openai/example"),
+            ("custom", head, "openai/example"),
+            ("broken", broken, "openai/example"),
+            ("fork", head, "contributor/example"),
+            ("renamed-fork", head, "contributor/renamed-example"),
+        ):
             with self.subTest(label=label):
                 calls: list[tuple[str, str]] = []
                 bodies: list[str] = []
                 pull = {
+                    "number": 1,
                     "state": "open",
-                    "head": {"sha": revision},
-                    "base": {"sha": base, "repo": {"full_name": "openai/example"}},
+                    "head": {"sha": revision, "repo": {"full_name": source}},
+                    "base": {
+                        "sha": base,
+                        "ref": "main",
+                        "repo": {"full_name": "openai/example"},
+                    },
                 }
                 run: dict[str, Any] = {
                     "event": "pull_request",
                     "status": "completed",
                     "path": ".github/workflows/castiron-custom-code.yml",
                     "head_sha": revision,
+                    "repository": {"full_name": "openai/example"},
+                    "head_repository": {
+                        "full_name": source,
+                        "name": source.partition("/")[2],
+                        "owner": {"login": source.partition("/")[0]},
+                    },
                     "run_attempt": 1,
                     "pull_requests": [],
                 }
@@ -471,13 +536,19 @@ async function check(stale, exists, priorRun, expected) {
                 producer.mkdir()
                 (producer / "report.json").write_text(json.dumps(forged))
 
-                def fake_api(method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
+                def fake_api(
+                    method: str,
+                    path: str,
+                    payload: dict[str, Any] | None = None,
+                    *,
+                    source_name: str = source,
+                ) -> Any:
                     calls.append((method, path))
                     if method == "GET":
                         responses: dict[str, Any] = {
                             "repos/openai/example": {"private": False},
                             "repos/openai/example/actions/runs/2": run,
-                            f"repos/openai/example/commits/{revision}/pulls?per_page=100": [
+                            f"repos/{source_name}/commits/{revision}/pulls?per_page=100": [
                                 {"number": 1}
                             ],
                             "repos/openai/example/pulls/1": pull,
@@ -525,7 +596,7 @@ async function check(stale, exists, priorRun, expected) {
                 if label == "broken":
                     self.assertIn("Report unavailable", body)
                     self.assertNotIn("Generated baselines verified", body)
-                elif label == "custom":
+                elif label in {"custom", "fork", "renamed-fork"}:
                     self.assertIn("1 newly customized", body)
                     self.assertIn("generated.py", body)
                     self.assertIn(b"+# custom", (out / "custom-code.patch").read_bytes())
@@ -535,19 +606,136 @@ async function check(stale, exists, priorRun, expected) {
                     self.assertIn("Generated baselines verified", body)
                     self.assertIn("--name castiron-custom-code-9-3", body)
 
+    def test_associated_pull_request_rejects_spoofed_ambiguous_or_stale_sources(self) -> None:
+        head, base = "a" * 40, "b" * 40
+        source = {
+            "full_name": "contributor/renamed-example",
+            "name": "renamed-example",
+            "owner": {"login": "contributor"},
+        }
+        run: dict[str, Any] = {
+            "head_sha": head,
+            "repository": {"full_name": "openai/example"},
+            "head_repository": source,
+            "pull_requests": [{"number": 1}],
+        }
+        pull: dict[str, Any] = {
+            "number": 1,
+            "state": "open",
+            "head": {"sha": head, "repo": {"full_name": source["full_name"]}},
+            "base": {
+                "sha": base,
+                "ref": "main",
+                "repo": {"full_name": "openai/example"},
+            },
+        }
+
+        invalid_runs = (
+            {"repository": {"full_name": "other/example"}},
+            {"head_repository": None},
+            {"head_repository": {"full_name": "../example"}},
+            {"head_repository": {"full_name": "contributor/.."}},
+            {"head_repository": {"full_name": "contributor/example/extra"}},
+            {"head_repository": {**source, "name": "spoofed"}},
+            {"head_repository": {**source, "owner": {"login": "spoofed"}}},
+            {"head_repository": {**source, "owner": "contributor"}},
+        )
+        for override in invalid_runs:
+            with (
+                self.subTest(override=override),
+                mock.patch.object(report, "api") as api,
+                self.assertRaisesRegex(report.ReportError, "source repository"),
+            ):
+                report.associated_pull_request("openai/example", {**run, **override})
+            api.assert_not_called()
+
+        for number in (True, False, 0, -1, "1", 1.0):
+            with (
+                self.subTest(number=number),
+                mock.patch.object(report, "api") as api,
+                self.assertRaisesRegex(report.ReportError, "associated pull request"),
+            ):
+                report.associated_pull_request(
+                    "openai/example", {**run, "pull_requests": [{"number": number}]}
+                )
+            api.assert_not_called()
+
+        stale_pulls = (
+            {"state": "closed"},
+            {"head": {"sha": "c" * 40, "repo": {"full_name": source["full_name"]}}},
+            {"head": {"sha": head, "repo": {"full_name": "unrelated/renamed-example"}}},
+            {
+                "base": {
+                    "sha": base,
+                    "ref": "main",
+                    "repo": {"full_name": "other/example"},
+                }
+            },
+            {
+                "base": {
+                    "sha": base,
+                    "ref": "other",
+                    "repo": {"full_name": "openai/example"},
+                }
+            },
+            {
+                "base": {
+                    "sha": "c" * 40,
+                    "ref": "main",
+                    "repo": {"full_name": "openai/example"},
+                }
+            },
+        )
+        for override in stale_pulls:
+            with (
+                self.subTest(stale=override),
+                mock.patch.object(report, "api", return_value={**pull, **override}) as api,
+            ):
+                self.assertIsNone(
+                    report.associated_pull_request("openai/example", run, base_sha=base)
+                )
+            api.assert_called_once_with("GET", "repos/openai/example/pulls/1")
+
+        ambiguous = {**run, "pull_requests": [{"number": 1}, {"number": 2}]}
+        with (
+            mock.patch.object(report, "api", side_effect=[pull, {**pull, "number": 2}]),
+            self.assertRaisesRegex(report.ReportError, "multiple current pull requests"),
+        ):
+            report.associated_pull_request("openai/example", ambiguous, base_sha=base)
+
+        duplicate = {**run, "pull_requests": [{"number": 1}, {"number": 1}]}
+        with mock.patch.object(report, "api", return_value=pull) as api:
+            self.assertEqual(
+                report.associated_pull_request("openai/example", duplicate, base_sha=base), pull
+            )
+        api.assert_called_once_with("GET", "repos/openai/example/pulls/1")
+
+        with (
+            mock.patch.object(report, "api", return_value={**pull, "number": 2}),
+            self.assertRaisesRegex(report.ReportError, "associated pull request"),
+        ):
+            report.associated_pull_request("openai/example", run, base_sha=base)
+
     def test_trusted_report_rejects_invalid_or_stale_association_before_fetch(self) -> None:
         run = {
             "event": "pull_request",
             "status": "completed",
             "path": ".github/workflows/castiron-custom-code.yml",
             "head_sha": "a" * 40,
+            "repository": {"full_name": "openai/example"},
+            "head_repository": {"full_name": "openai/example"},
             "run_attempt": 1,
             "pull_requests": [{"number": 1}],
         }
         pull = {
+            "number": 1,
             "state": "open",
-            "head": {"sha": "a" * 40},
-            "base": {"sha": "b" * 40, "repo": {"full_name": "openai/example"}},
+            "head": {"sha": "a" * 40, "repo": {"full_name": "openai/example"}},
+            "base": {
+                "sha": "b" * 40,
+                "ref": "main",
+                "repo": {"full_name": "openai/example"},
+            },
         }
         cases: list[tuple[list[Any], bool]] = [
             ([{**run, "path": "other.yml"}], True),
@@ -560,7 +748,14 @@ async function check(stale, exists, priorRun, expected) {
                 False,
             ),
             ([{**run, "pull_requests": []}, []], False),
-            ([{**run, "pull_requests": [{"number": 1}, {"number": 2}]}, pull, pull], True),
+            (
+                [
+                    {**run, "pull_requests": [{"number": 1}, {"number": 2}]},
+                    pull,
+                    {**pull, "number": 2},
+                ],
+                True,
+            ),
         ]
         for responses, raises in cases:
             with (
@@ -816,12 +1011,23 @@ async function check(stale, exists, priorRun, expected) {
         def fake_api(method: str, path: str, payload: object = None) -> object:
             calls.append((method, path, payload))
             if "/pulls/" in path:
-                return {"state": "open", "head": {"sha": base}, "base": {"sha": base}}
+                return {
+                    "number": 1,
+                    "state": "open",
+                    "head": {"sha": base, "repo": {"full_name": "openai/example"}},
+                    "base": {
+                        "sha": base,
+                        "ref": "main",
+                        "repo": {"full_name": "openai/example"},
+                    },
+                }
             if "/actions/runs/" in path:
                 return {
                     "event": "pull_request",
                     "path": ".github/workflows/castiron-custom-code.yml",
                     "head_sha": base,
+                    "repository": {"full_name": "openai/example"},
+                    "head_repository": {"full_name": "openai/example"},
                     "run_attempt": 1,
                     "pull_requests": [{"number": 1}],
                 }
@@ -850,11 +1056,22 @@ async function check(stale, exists, priorRun, expected) {
     def test_comment_rejects_older_runs_attempts_and_wrong_pr(self) -> None:
         _, base = self.baseline()
         result, _ = report.build_report(self.repo, base, base)
-        pull = {"state": "open", "head": {"sha": base}, "base": {"sha": base}}
+        pull = {
+            "number": 1,
+            "state": "open",
+            "head": {"sha": base, "repo": {"full_name": "openai/example"}},
+            "base": {
+                "sha": base,
+                "ref": "main",
+                "repo": {"full_name": "openai/example"},
+            },
+        }
         run = {
             "event": "pull_request",
             "path": ".github/workflows/castiron-custom-code.yml",
             "head_sha": base,
+            "repository": {"full_name": "openai/example"},
+            "head_repository": {"full_name": "openai/example"},
             "run_attempt": 2,
             "pull_requests": [{"number": 1}],
         }
@@ -869,11 +1086,11 @@ async function check(stale, exists, priorRun, expected) {
                 report.publish_comment(result, "openai/example", 1, 2, 1), "Skipped stale report"
             )
             self.assertEqual(api.call_count, 2)
-        with mock.patch.object(report, "api", side_effect=[pull, run, [comment]]) as api:
+        with mock.patch.object(report, "api", side_effect=[pull, run, pull, [comment]]) as api:
             self.assertEqual(
                 report.publish_comment(result, "openai/example", 1, 2, 2), "Skipped stale report"
             )
-            self.assertEqual(api.call_count, 3)
+            self.assertEqual(api.call_count, 4)
         with (
             mock.patch.object(report, "api", side_effect=[pull, {**run, "pull_requests": []}, []]),
             self.assertRaisesRegex(report.ReportError, "does not match report PR"),
@@ -887,18 +1104,18 @@ async function check(stale, exists, priorRun, expected) {
         with mock.patch.object(
             report,
             "api",
-            side_effect=[pull, {**run, "pull_requests": []}, [{"number": 1}], [comment]],
+            side_effect=[pull, {**run, "pull_requests": []}, [{"number": 1}], pull, [comment]],
         ) as api:
             self.assertEqual(
                 report.publish_comment(result, "openai/example", 1, 2, 2), "Skipped stale report"
             )
             self.assertIn(f"/commits/{base}/pulls", api.call_args_list[2].args[1])
         changed = {**pull, "head": {"sha": "f" * 40}}
-        with mock.patch.object(report, "api", side_effect=[pull, run, [], changed]) as api:
+        with mock.patch.object(report, "api", side_effect=[pull, run, pull, [], changed]) as api:
             self.assertEqual(
                 report.publish_comment(result, "openai/example", 1, 2, 2), "Skipped stale report"
             )
-            self.assertEqual(api.call_count, 4)
+            self.assertEqual(api.call_count, 5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

GitHub omits `workflow_run.pull_requests` for external-fork runs, and querying the upstream repository's commit-association endpoint returns no pull requests for those fork commits. That leaves the required `Castiron / budget-only change` and `Castiron / custom-code budget` contexts permanently expected even when the candidate workflow succeeds.

- Centralize trusted Python pull-request association in `custom_code_report.py` and reuse it from trusted report generation, comment publication, and budget evaluation.
- Resolve missing associations from the authenticated source run's `head_repository`, including legitimately renamed forks, then independently re-fetch every candidate PR from `openai/openai-node`.
- Apply equivalent validation in both privileged JavaScript publishers: required commit statuses and failure-report comments.
- Refresh the candidate workflow's pinned reporter SHA-256 after the trusted reporter change.

## Security model

Fork-side associations and PR numbers are discovery hints, never authorization. The trusted paths:

1. Re-fetch the workflow run from the upstream Actions API and verify its repository, immutable candidate SHA, workflow path, completion, and run attempt as applicable.
2. Strictly validate the source repository's owner/name syntax and consistency with authenticated `head_repository` metadata; reject traversal-like components and spoofed identities.
3. Re-fetch each hinted PR from the upstream repository and require an open PR with the exact candidate SHA, the exact source head repository, the intended upstream repository and `main` base ref, and exactly one valid current association.
4. Require the current `main` base SHA wherever budget evaluation or status publication needs freshness; preserve existing stale-run behavior and merge-group validation.

The existing trusted `workflow_run`/main-checkout boundary, bare Git object store, candidate-artifact isolation, least-privilege job permissions, merge-queue protections, and exact required status names remain unchanged. No candidate workflow definition, mutable ref, contributor artifact, or fork-supplied PR number is trusted.

## Affected contributor PRs

- #2463: live fork workflow run `32877584723` has `pull_requests: []`; the updated resolver correctly finds its upstream PR through `cmun2/openai-node`.
- #2444 and #2431: independently reproduced the same fork-only association behavior; both PRs merged while this fix was being prepared.

## Verification

- `env PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/castiron -p 'test_custom_code*.py'` — 60 tests pass, with one pre-existing skip.
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/castiron-custom-code.yml .github/workflows/castiron-custom-code-comment.yml` — both workflows pass actionlint v1.7.12.
- `ruff format --check scripts/castiron/custom_code_report.py scripts/castiron/custom_code_budget.py scripts/castiron/test_custom_code_report.py scripts/castiron/test_custom_code_budget.py`.
- Ruff lint passes when ignoring only the same pre-existing baseline rule findings; `git diff --check` passes.
- Executable publisher and Python regression coverage includes external forks with empty run associations, fork-side lookup, same-repository and renamed-fork PRs, malformed/spoofed repositories, unrelated source heads, ambiguous/duplicate/invalid associations, stale heads/bases/run attempts, exact required contexts, and merge groups.
