### PR TITLE
fix(uploads): preserve Blob files and multipart media types

### DIFF
--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -121,7 +121,7 @@ export const checkFileSupport = () => {
 /**
  * Values accepted by SDK methods that upload multipart files.
  *
- * Supports native files, fetch responses, named blobs, Node.js filesystem read
+ * Supports native files, fetch responses, blobs, Node.js filesystem read
  * streams, async byte sources, web readable streams, and files created with
  * {@link toStreamingFile}. Use {@link toFile} to materialize compatible content
  * as a native `File` when buffering the complete upload is acceptable.
@@ -203,7 +203,7 @@ export const isAsyncIterable = (value: any): value is AsyncIterable<any> =>
 /**
  * Converts a request to multipart form data when its body contains an upload.
  *
- * Uploads include files, named blobs, responses, async iterables, readable
+ * Uploads include files, blobs, responses, async iterables, readable
  * streams, and {@link StreamingFile} values anywhere in a nested body. Bodies
  * containing streaming values are encoded lazily; other uploads use `FormData`.
  * Requests without uploads are returned unchanged.
@@ -295,7 +295,7 @@ export type CreateFormOptions = {
 /**
  * Materializes an object into platform `FormData` after verifying fetch support.
  *
- * Strings, numbers, and booleans become text fields; responses, named blobs,
+ * Strings, numbers, and booleans become text fields; responses, blobs,
  * and async byte sources become file fields. Arrays and nested objects use
  * bracketed field names, while `undefined` values are omitted.
  *
@@ -319,9 +319,8 @@ export const createForm = async <T = Record<string, unknown>>(
   return form;
 };
 
-// We check for Blob not File because Bun.File doesn't inherit from File,
-// but they both inherit from Blob and have a `name` property at runtime.
-const isNamedBlob = (value: unknown): value is NamedBlob => value instanceof Blob && 'name' in value;
+// Native files, Bun files, and unnamed upload values all inherit from Blob.
+const isBlob = (value: unknown): value is Blob => value instanceof Blob;
 
 const isReadableStream = (value: unknown): value is ReadableStream<BlobPart> =>
   typeof value === 'object' &&
@@ -339,7 +338,7 @@ const isUploadable = (value: unknown): value is Uploadable =>
     isAsyncIterable(value) ||
     isReadableStream(value) ||
     isStreamingFile(value) ||
-    isNamedBlob(value));
+    isBlob(value));
 
 const hasStreamingUploadableValue = (value: unknown): boolean => {
   if (isStreamingFile(value) || isAsyncIterable(value) || isReadableStream(value)) {
@@ -348,7 +347,7 @@ const hasStreamingUploadableValue = (value: unknown): boolean => {
   if (Array.isArray(value)) {
     return value.some(hasStreamingUploadableValue);
   }
-  if (value && typeof value === 'object' && !isNamedBlob(value) && !(value instanceof Response)) {
+  if (value && typeof value === 'object' && !isBlob(value) && !(value instanceof Response)) {
     for (const k in value) {
       if (hasStreamingUploadableValue((value as Record<string, unknown>)[k])) {
         return true;
@@ -501,7 +500,7 @@ function getStreamingFileName(value: Uploadable, options: CreateFormOptions): st
 function getStreamingFileType(value: Uploadable): string {
   let type: string | undefined;
 
-  if (isStreamingFile(value) || isNamedBlob(value)) {
+  if (isStreamingFile(value) || isBlob(value)) {
     ({ type } = value);
   } else if (value instanceof Response) {
     type = value.headers.get('content-type') ?? undefined;
@@ -588,9 +587,10 @@ const addFormValue = async (
   if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
     form.append(key, String(value));
   } else if (value instanceof Response) {
+    const blob = await value.blob();
     form.append(
       key,
-      makeFile([await value.blob()], getName(value, { stripFilename: options.stripFilenames })),
+      makeFile([blob], getName(value, { stripFilename: options.stripFilenames }), { type: blob.type }),
     );
   } else if (isAsyncIterable(value)) {
     form.append(
@@ -600,8 +600,13 @@ const addFormValue = async (
         getName(value, { stripFilename: options.stripFilenames }),
       ),
     );
-  } else if (isNamedBlob(value)) {
-    form.append(key, value, getName(value, { stripFilename: options.stripFilenames }));
+  } else if (isBlob(value)) {
+    const filename = getName(value, { stripFilename: options.stripFilenames });
+    if (filename === undefined) {
+      form.append(key, value);
+    } else {
+      form.append(key, value, filename);
+    }
   } else if (Array.isArray(value)) {
     // Prepare array elements concurrently, then preserve their repeated-field order.
     const entries = await Promise.all(

--- a/tests/internal/uploads-blob-multipart-integrity.test.ts
+++ b/tests/internal/uploads-blob-multipart-integrity.test.ts
@@ -1,0 +1,239 @@
+import { vi } from 'vitest';
+
+import OpenAI from 'openai';
+import {
+  maybeMultipartFormRequestOptions,
+  multipartFormRequestOptions,
+  toStreamingFile,
+} from 'openai/internal/uploads';
+
+interface RecordedRequest {
+  body: RequestInit['body'];
+}
+
+function captureImageRequests() {
+  const requests: RecordedRequest[] = [];
+  const transport = Object.assign(
+    async (_request: Request | URL | string, options?: RequestInit): Promise<Response> => {
+      requests.push({ body: options?.body });
+      return Response.json({ created: 0, data: [], text: 'transcribed' });
+    },
+    { Response },
+  );
+
+  return {
+    client: new OpenAI({ apiKey: 'test-api-key', fetch: transport as typeof fetch }),
+    requests,
+    transport,
+  };
+}
+
+function capturedForm(requests: RecordedRequest[], index = 0): FormData {
+  const body = requests[index]?.body;
+  if (!(body instanceof FormData)) {
+    throw new Error('Expected a buffered multipart request');
+  }
+  return body;
+}
+
+function capturedStream(requests: RecordedRequest[], index = 0): ReadableStream {
+  const body = requests[index]?.body;
+  if (!(body instanceof ReadableStream)) {
+    throw new Error('Expected a streaming multipart request');
+  }
+  return body;
+}
+
+describe('multipart Blob upload integrity', () => {
+  test('preserves plain image Blobs, their order, and an actual public image-edit mask', async () => {
+    const { client, requests } = captureImageRequests();
+    const image = new Blob(['private intended base image'], { type: 'image/png' });
+    const overlay = new File(['named overlay'], 'overlay.png', { type: 'image/png' });
+    const mask = new Blob(['private intended edit mask'], { type: 'image/png' });
+
+    await client.images.edit({
+      model: 'gpt-image-1',
+      prompt: 'Edit only the masked portion of the first image',
+      image: [image, overlay],
+      mask,
+    });
+
+    const form = capturedForm(requests);
+    const images = form.getAll('image[]') as File[];
+    expect(images.map((entry) => entry.name)).toEqual(['blob', 'overlay.png']);
+    expect(images.map((entry) => entry.type)).toEqual(['image/png', 'image/png']);
+    await expect(Promise.all(images.map((entry) => entry.text()))).resolves.toEqual([
+      'private intended base image',
+      'named overlay',
+    ]);
+
+    const uploadedMask = form.get('mask');
+    expect(uploadedMask).toBeInstanceOf(File);
+    expect((uploadedMask as File).name).toBe('blob');
+    expect((uploadedMask as File).type).toBe('image/png');
+    await expect((uploadedMask as File).text()).resolves.toBe('private intended edit mask');
+  });
+
+  test('detects nested plain Blobs for optional multipart requests without changing ordinary JSON', async () => {
+    const image = new Blob(['nested image bytes'], { type: 'image/png' });
+    const options = await maybeMultipartFormRequestOptions(
+      { body: { nested: { images: [undefined, image], label: 'kept' } } },
+      fetch,
+    );
+
+    expect(options.body).toBeInstanceOf(FormData);
+    const form = options.body as FormData;
+    const uploaded = form.get('nested[images][]') as File;
+    expect(uploaded.name).toBe('blob');
+    expect(uploaded.type).toBe('image/png');
+    await expect(uploaded.text()).resolves.toBe('nested image bytes');
+    expect(form.get('nested[label]')).toBe('kept');
+
+    const ordinary = { body: { nested: { count: 2 } } };
+    await expect(maybeMultipartFormRequestOptions(ordinary, fetch)).resolves.toBe(ordinary);
+  });
+
+  test('keeps Blob images and Blob masks alongside a lazy public streaming image upload', async () => {
+    const { client, requests } = captureImageRequests();
+    let completed = false;
+
+    async function* streamedImage() {
+      yield new TextEncoder().encode('streamed base image bytes');
+      yield new TextEncoder().encode(' streamed final bytes');
+      completed = true;
+    }
+
+    const overlay = new Blob(['plain overlay image bytes'], { type: 'image/png' });
+    const mask = new Blob(['plain streaming edit mask bytes'], { type: 'image/png' });
+
+    await client.images.edit({
+      model: 'gpt-image-1',
+      prompt: 'Preserve every source image and the mask',
+      image: [toStreamingFile(streamedImage(), '/private/source/base.png', { type: 'image/png' }), overlay],
+      mask,
+    });
+
+    expect(completed).toBe(false);
+    const encoded = await new Response(capturedStream(requests)).text();
+    expect(completed).toBe(true);
+    expect(encoded).not.toContain('/private/source');
+    expect(encoded).toContain('name="image[]"; filename="base.png"');
+    expect(encoded).toContain('name="image[]"; filename="unknown_file"');
+    expect(encoded).toContain('name="mask"; filename="unknown_file"');
+    expect(encoded).toContain('streamed base image bytes streamed final bytes');
+    expect(encoded).toContain('plain overlay image bytes');
+    expect(encoded).toContain('plain streaming edit mask bytes');
+    expect(encoded.match(/Content-Type: image\/png/gu)).toHaveLength(3);
+    expect(encoded.indexOf('streamed base image bytes')).toBeLessThan(
+      encoded.indexOf('plain overlay image bytes'),
+    );
+    expect(encoded.split('plain overlay image bytes')).toHaveLength(2);
+    expect(encoded.split('plain streaming edit mask bytes')).toHaveLength(2);
+  });
+
+  test('preserves Response media types and safe inferred names in actual public image requests', async () => {
+    const { client, requests } = captureImageRequests();
+    const image = new Response('downloaded private image', {
+      headers: { 'content-type': 'image/png' },
+    });
+    Object.defineProperty(image, 'url', {
+      value: 'https://example.invalid/private/response-image.png',
+    });
+
+    await client.images.edit({
+      model: 'gpt-image-1',
+      prompt: 'Preserve the downloaded image format',
+      image,
+    });
+
+    const uploaded = capturedForm(requests).get('image') as File;
+    expect(uploaded.name).toBe('response-image.png');
+    expect(uploaded.type).toBe('image/png');
+    await expect(uploaded.text()).resolves.toBe('downloaded private image');
+  });
+
+  test('preserves Response audio formats through the actual public transcription client', async () => {
+    const { client, requests } = captureImageRequests();
+    const audio = new Response('downloaded audio bytes', {
+      headers: { 'content-type': 'audio/wav' },
+    });
+    Object.defineProperty(audio, 'url', {
+      value: 'https://example.invalid/private/recording.wav',
+    });
+
+    await client.audio.transcriptions.create({ model: 'whisper-1', file: audio });
+
+    const uploaded = capturedForm(requests).get('file') as File;
+    expect(uploaded.name).toBe('recording.wav');
+    expect(uploaded.type).toBe('audio/wav');
+    await expect(uploaded.text()).resolves.toBe('downloaded audio bytes');
+  });
+
+  test('retains custom Blob filenames, caller-selected path preservation, and anonymous browser defaults', async () => {
+    const named = Object.assign(new Blob(['skill manifest'], { type: 'text/markdown' }), {
+      name: 'my-skill/SKILL.md',
+    });
+    const anonymous = new Blob(['anonymous bytes'], { type: 'application/json' });
+
+    const defaultOptions = await multipartFormRequestOptions({ body: { named, anonymous } }, fetch);
+    const defaultForm = defaultOptions.body as FormData;
+    expect((defaultForm.get('named') as File).name).toBe('SKILL.md');
+    expect((defaultForm.get('anonymous') as File).name).toBe('blob');
+    expect((defaultForm.get('anonymous') as File).type).toBe('application/json');
+
+    const preservedOptions = await multipartFormRequestOptions({ body: { named, anonymous } }, fetch, {
+      stripFilenames: false,
+    });
+    const preservedForm = preservedOptions.body as FormData;
+    expect((preservedForm.get('named') as File).name).toBe('my-skill/SKILL.md');
+    expect((preservedForm.get('anonymous') as File).name).toBe('blob');
+  });
+
+  test('keeps sparse asynchronous Response and plain Blob entries in their original order', async () => {
+    const { client, requests } = captureImageRequests();
+    const response = new Response('first delayed image', {
+      headers: { 'content-type': 'image/png' },
+    });
+    Object.defineProperty(response, 'url', { value: 'https://example.invalid/first.png' });
+    const originalBlob = response.blob.bind(response);
+    vi.spyOn(response, 'blob').mockImplementation(async () => {
+      await Promise.resolve();
+      return originalBlob();
+    });
+
+    const images: (Blob | Response | undefined)[] = [];
+    images[1] = response;
+    images[3] = new Blob(['second anonymous image'], { type: 'image/png' });
+    images.length = 5;
+
+    await client.images.edit({
+      model: 'gpt-image-1',
+      prompt: 'Keep sparse and asynchronous upload order',
+      image: images as (Blob | Response)[],
+    });
+
+    const uploaded = capturedForm(requests).getAll('image[]') as File[];
+    expect(uploaded.map((entry) => entry.name)).toEqual(['first.png', 'blob']);
+    expect(uploaded.map((entry) => entry.type)).toEqual(['image/png', 'image/png']);
+    await expect(Promise.all(uploaded.map((entry) => entry.text()))).resolves.toEqual([
+      'first delayed image',
+      'second anonymous image',
+    ]);
+  });
+
+  test('keeps missing Response content types and anonymous Blob content types unchanged', async () => {
+    const { client, requests } = captureImageRequests();
+    const image = new Response(new Uint8Array([1, 2, 3]));
+    const overlay = new Blob([new Uint8Array([4, 5])]);
+
+    await client.images.edit({
+      model: 'gpt-image-1',
+      prompt: 'Preserve absent content types',
+      image: [image, overlay],
+    });
+
+    const uploaded = capturedForm(requests).getAll('image[]') as File[];
+    expect(uploaded.map((entry) => entry.type)).toEqual(['', '']);
+    expect(uploaded.map((entry) => entry.name)).toEqual(['unknown_file', 'blob']);
+  });
+});


### PR DESCRIPTION
## Summary

- Keep ordinary unnamed Blob uploads in buffered and streaming multipart requests so public image-edit inputs and masks are never silently omitted.
- Preserve standard FormData Blob filenames, existing streaming fallbacks, safe custom filenames, sparse input ordering, and lazy multipart consumption.
- Retain fetched Response MIME types for public image and audio-transcription uploads.

## Validation

- Added eight regression-first public-client and multipart tests; all eight fail on the original code and pass with this change.
- Full handwritten suite: 6,195 passing tests.
- Full generated suite against an isolated owner-verified Steady instance: 556 passing tests, one pre-existing skip.
- Canonical lint, strict repository typecheck, build, published TypeScript 4.9 and current TypeScript checks, and publint all pass.
- Packed npm verification passes 275/314 source checks across 1,256 source maps.
- Confirmed the actual built npm client preserves Blob image/mask bytes and audio/wav Response uploads.