### PR TITLE
feat(auth): harden X.509 token lifecycle and tenant isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ For secure, automated environments like cloud-managed Kubernetes, Azure, and GCP
 
 The `workloadIdentity` parameter is mutually exclusive with `apiKey`.
 
-The required fields are `identityProviderId`, `serviceAccountId`, and `provider`.
+For subject-token workload identity, the required fields are `identityProviderId`, `serviceAccountId`, and `provider`. X.509 workload identity instead uses an enrolled client certificate and its separately configured transport.
 
 ### Kubernetes (service account tokens)
 
@@ -184,7 +184,7 @@ const client = new OpenAI({
 });
 ```
 
-You can also customize the token refresh buffer (default is 1200 seconds (20 minutes) before expiration):
+You can also customize the subject-token refresh buffer (default is 1200 seconds (20 minutes) before expiration):
 
 ```ts
 import OpenAI from 'openai';
@@ -199,6 +199,50 @@ const client = new OpenAI({
   },
 });
 ```
+
+### X.509 client certificates
+
+Applications enrolled for X.509 workload identity can authenticate using a caller-owned, static client certificate instead of a subject-token provider or API key. This Node.js-only integration requires the optional `undici` peer and currently supports only the global `https://mtls.api.openai.com/v1` API endpoint.
+
+```ts
+import OpenAI from 'openai';
+import { createX509Transport } from 'openai/auth/x509-transport';
+import { Agent } from 'undici';
+
+const dispatcher = new Agent({
+  connect: {
+    cert: process.env['OPENAI_X509_CLIENT_CERTIFICATE_CHAIN_PEM'],
+    key: process.env['OPENAI_X509_CLIENT_PRIVATE_KEY_PEM'],
+  },
+});
+
+const client = new OpenAI({
+  apiKey: null,
+  adminAPIKey: null,
+  baseURL: null,
+  organization: null,
+  project: process.env['OPENAI_X509_PROJECT_ID'] ?? null,
+  workloadIdentity: {
+    type: 'x509',
+    identityProviderId: process.env['OPENAI_X509_IDENTITY_PROVIDER_ID']!,
+    serviceAccountId: process.env['OPENAI_X509_SERVICE_ACCOUNT_ID']!,
+  },
+  x509Transport: createX509Transport({
+    runtime: 'node',
+    dispatcher,
+    certificateIdentity: 'static',
+    proxy: 'direct',
+  }),
+});
+
+try {
+  console.log((await client.models.list()).data.length);
+} finally {
+  await dispatcher.close();
+}
+```
+
+The SDK caches short-lived credentials in memory, isolates certificate generations, bounds retries and cancellation, and never closes the caller-owned dispatcher. Configure proactive refresh with optional `workloadIdentity.refreshBufferMs`; it defaults to 1,200,000 milliseconds (20 minutes) and is capped at half of the actual token lifetime. For CONNECT proxies, encrypted private keys, live verification, and certificate rotation, see the [X.509 workload-identity example](./examples/mtls/README.md#x509-workload-identity-nodejs).
 
 ## Streaming responses
 

--- a/examples/mtls/README.md
+++ b/examples/mtls/README.md
@@ -49,3 +49,40 @@ The Bun example passes `tls: { cert, key }` to Bun's native `fetch`.
 ## Advanced transports
 
 Because the SDK does not own the mTLS transport, applications can use runtime-native features such as proxies, custom trust stores, encrypted keys, hardware-backed keys, or certificate rotation where their chosen HTTP client supports them. Keep the certificate-bearing transport scoped to the OpenAI mTLS endpoint, and close or replace it when rotating credentials.
+
+## X.509 workload identity (Node.js)
+
+X.509 workload identity is separate from API-key + HTTP mTLS: an enrolled client certificate authenticates a workload-identity token exchange, and the resulting short-lived bearer authenticates requests through the same caller-owned certificate transport. The resulting access token is an ordinary bearer credential, so protect it like any other secret; reusing the approved certificate transport does not cryptographically bind the token to that certificate. Only `https://mtls.api.openai.com/v1` is approved; EU, Azure, Bedrock, custom gateways, and data-residency overrides are not supported.
+
+Install the SDK and its optional Node.js transport peer:
+
+```sh
+npm install openai "undici@^7"
+```
+
+Undici 7 supports the SDK's complete Node.js 22 compatibility range; Undici 8 requires Node.js 22.19 or later.
+
+Provide the complete PEM certificate chain, private key, enrolled identity-provider ID, and service-account ID through environment variables. The chain must contain the leaf certificate followed by any required intermediates:
+
+```sh
+export OPENAI_X509_CLIENT_CERTIFICATE_CHAIN_PEM="$(cat /secure/path/client-chain.pem)"
+export OPENAI_X509_CLIENT_PRIVATE_KEY_PEM="$(cat /secure/path/client-key.pem)"
+export OPENAI_X509_IDENTITY_PROVIDER_ID='your-enrolled-identity-provider-id'
+export OPENAI_X509_SERVICE_ACCOUNT_ID='your-enrolled-service-account-id'
+
+# Build package self-imports when running the example from an SDK repository checkout.
+pnpm build
+node examples/mtls/x509-workload-identity.mjs
+```
+
+Set `OPENAI_X509_CLIENT_KEY_PASSPHRASE` when the PEM private key is encrypted. Existing local fixtures can instead provide certificate and key paths through `OPENAI_MTLS_CERT_CHAIN` and `OPENAI_MTLS_KEY`, identity selectors through `OPENAI_IDENTITY_PROVIDER_ID` and `OPENAI_SERVICE_ACCOUNT_ID`, and an optional tenant through `OPENAI_X509_PROJECT_ID`. The example ignores ambient API keys, admin keys, base URLs, organizations, and ordinary API-key projects so only the selected X.509 identity and tenant determine the request. Keep private-key files readable only by their owner, use managed secret injection where available, and never log PEM contents, passphrases, issued bearer tokens, or proxy credentials.
+
+Proxying is always explicit: set `OPENAI_X509_PROXY_MODE=http_connect` or `OPENAI_X509_PROXY_MODE=https_connect` together with a matching `HTTPS_PROXY` URL. The default `direct` mode ignores ambient proxy variables. The workload certificate is configured only for target TLS, never proxy TLS. The example closes its caller-owned dispatcher after the request.
+
+From a repository checkout, the following command builds the SDK first and then runs the same explicit live-service check:
+
+```sh
+pnpm test:live:x509
+```
+
+This check fails without owner-provisioned, enrolled credentials. Rotate a certificate by constructing a new Undici dispatcher and `createX509Transport` capability, then creating or cloning the client with that new top-level `x509Transport`; close the previous dispatcher after in-flight requests finish.

--- a/examples/mtls/x509-workload-identity.mjs
+++ b/examples/mtls/x509-workload-identity.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+// Uses one caller-owned static client certificate for both OpenAI's issuer and API.
+import { readFile } from 'node:fs/promises';
+import { Agent, ProxyAgent } from 'undici';
+
+const cert = await requiredPem('OPENAI_X509_CLIENT_CERTIFICATE_CHAIN_PEM', 'OPENAI_MTLS_CERT_CHAIN');
+const key = await requiredPem('OPENAI_X509_CLIENT_PRIVATE_KEY_PEM', 'OPENAI_MTLS_KEY');
+const passphrase = process.env['OPENAI_X509_CLIENT_KEY_PASSPHRASE'];
+const requestTls = { cert, key, ...(passphrase === undefined ? {} : { passphrase }) };
+const proxyMode = process.env['OPENAI_X509_PROXY_MODE'] ?? 'direct';
+const proxy = new Map([
+  ['direct', 'direct'],
+  ['http_connect', 'http-connect'],
+  ['https_connect', 'https-connect'],
+]).get(proxyMode);
+if (!proxy) {
+  throw new Error('OPENAI_X509_PROXY_MODE must be direct, http_connect, or https_connect.');
+}
+const proxyURL = proxy === 'direct' ? undefined : approvedProxyURL(requiredEnv('HTTPS_PROXY', 'https_proxy'));
+if (proxyURL && proxyURL.protocol !== (proxy === 'https-connect' ? 'https:' : 'http:')) {
+  throw new Error('OPENAI_X509_PROXY_MODE must match the HTTPS_PROXY protocol.');
+}
+const identityProviderId = requiredEnv('OPENAI_X509_IDENTITY_PROVIDER_ID', 'OPENAI_IDENTITY_PROVIDER_ID');
+const serviceAccountId = requiredEnv('OPENAI_X509_SERVICE_ACCOUNT_ID', 'OPENAI_SERVICE_ACCOUNT_ID');
+const [{ default: OpenAI }, { createX509Transport }] = await Promise.all([
+  import('openai'),
+  import('openai/auth/x509-transport'),
+]);
+const dispatcher = createDispatcher(proxyURL, requestTls);
+try {
+  const x509Transport = createX509Transport({
+    runtime: 'node',
+    dispatcher,
+    certificateIdentity: 'static',
+    proxy,
+  });
+  const client = new OpenAI({
+    apiKey: null,
+    adminAPIKey: null,
+    baseURL: null,
+    organization: null,
+    project: process.env['OPENAI_X509_PROJECT_ID'] ?? null,
+    workloadIdentity: {
+      type: 'x509',
+      identityProviderId,
+      serviceAccountId,
+    },
+    x509Transport,
+  });
+
+  const models = await client.models.list();
+  console.log(`X.509 workload identity succeeded; received ${models.data.length} models.`);
+} finally {
+  await dispatcher.close();
+}
+
+function requiredEnv(name, alternative) {
+  const value = process.env[name] ?? (alternative ? process.env[alternative] : undefined);
+  if (!value) {
+    throw new Error(
+      `Missing required X.509 environment variable: ${name}${alternative ? ` or ${alternative}` : ''}`,
+    );
+  }
+  return value;
+}
+
+async function requiredPem(valueName, pathName) {
+  const value = process.env[valueName];
+  if (value) {
+    return value;
+  }
+  const certificatePath = process.env[pathName];
+  if (!certificatePath) {
+    throw new Error(`Missing required X.509 environment variable: ${valueName} or ${pathName}`);
+  }
+  return await readFile(certificatePath, 'utf-8');
+}
+
+function approvedProxyURL(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('HTTPS_PROXY must contain a valid CONNECT proxy URL.');
+  }
+  if (url.pathname !== '/' || url.search || url.hash) {
+    throw new Error('HTTPS_PROXY must not contain a path, query, or fragment.');
+  }
+  return url;
+}
+
+function createDispatcher(approvedURL, targetTls) {
+  if (!approvedURL) {
+    return new Agent({ connect: targetTls });
+  }
+  try {
+    return new ProxyAgent({ uri: approvedURL.href, requestTls: targetTls });
+  } catch {
+    throw new Error('Unable to initialize the approved X.509 CONNECT proxy.');
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:unit": "vitest run --config vitest.config.mts",
     "test:generated": "OPENAI_TEST_SUITE=generated ./scripts/test",
     "test:live:bedrock": "jest --config jest.live.config.ts --runInBand tests/live/bedrock.live.test.ts",
+    "test:live:x509": "pnpm build && node --input-type=module < examples/mtls/x509-workload-identity.mjs",
     "bench": "vitest bench --run --config vitest.bench.config.mts",
     "bench:json": "vitest bench --run --config vitest.bench.config.mts --outputJson benchmark-results.json",
     "build": "./scripts/build",

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -36,6 +36,9 @@ export interface X509WorkloadIdentity {
   /** OpenAI service account authorized for the verified certificate identity. */
   serviceAccountId: string;
 
+  /** Optional milliseconds before expiry when the certificate-backed token should refresh. */
+  refreshBufferMs?: number;
+
   /** X.509 federation proves certificate possession instead of supplying a subject token. */
   provider?: never;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -465,6 +465,8 @@ export class OpenAI {
       timeout: number;
       retriesRemaining: number;
       hasStreamingBody: boolean;
+      authentication?: X509WorkloadIdentityAuth;
+      helperMethod?: unknown;
       continueRequest?: <T>(operation: () => Promise<T>) => Promise<T>;
     }
   >();
@@ -753,32 +755,37 @@ export class OpenAI {
       bearerAuth: true,
       adminAPIKeyAuth: true,
     },
+    authentication: WorkloadIdentityAuth | X509WorkloadIdentityAuth | undefined = this._workloadIdentityAuth,
   ): Promise<NullableHeaders | undefined> {
     if (
-      this._workloadIdentityAuth instanceof X509WorkloadIdentityAuth &&
+      authentication instanceof X509WorkloadIdentityAuth &&
       schemes.adminAPIKeyAuth &&
       this.adminAPIKey !== null
     ) {
       return await this.adminAPIKeyAuth(opts);
     }
     return buildHeaders([
-      schemes.bearerAuth ? await this.bearerAuth(opts) : null,
+      schemes.bearerAuth ? await this.bearerAuth(opts, authentication) : null,
       schemes.adminAPIKeyAuth ? await this.adminAPIKeyAuth(opts) : null,
     ]);
   }
 
-  protected async bearerAuth(opts: FinalRequestOptions): Promise<NullableHeaders | undefined> {
-    if (this._workloadIdentityAuth) {
-      if (this._workloadIdentityAuth instanceof X509WorkloadIdentityAuth) {
+  protected async bearerAuth(
+    opts: FinalRequestOptions,
+    authentication: WorkloadIdentityAuth | X509WorkloadIdentityAuth | undefined = this._workloadIdentityAuth,
+  ): Promise<NullableHeaders | undefined> {
+    if (authentication) {
+      if (authentication instanceof X509WorkloadIdentityAuth) {
         if (
-          this.fetchWithAuth !== OpenAI.prototype.fetchWithAuth ||
-          this.fetchWithTimeout !== OpenAI.prototype.fetchWithTimeout
+          authentication === this._workloadIdentityAuth &&
+          (this.fetchWithAuth !== OpenAI.prototype.fetchWithAuth ||
+            this.fetchWithTimeout !== OpenAI.prototype.fetchWithTimeout)
         ) {
           throw new Errors.OpenAIError(
             'X.509 workload identity does not support overridden fetch dispatch hooks.',
           );
         }
-        const snapshots = this._workloadIdentityAuth.headerSnapshots();
+        const snapshots = authentication.headerSnapshots();
         if (
           !X509WorkloadIdentityAuth.shouldAuthenticate(
             opts,
@@ -790,15 +797,15 @@ export class OpenAI {
         }
       }
       const token =
-        this._workloadIdentityAuth instanceof X509WorkloadIdentityAuth
-          ? await this._workloadIdentityAuth.getToken(opts, {
-              apiURL: this._workloadIdentityAuth.requestAPIURL(),
-              ...this._workloadIdentityAuth.headerSnapshots(),
-              ...this._workloadIdentityAuth.requestSnapshot(),
-              signal: this._workloadIdentityAuth.effectiveSignal(),
-              ...this._workloadIdentityAuth.tenantSnapshot(),
+        authentication instanceof X509WorkloadIdentityAuth
+          ? await authentication.getToken(opts, {
+              apiURL: authentication.requestAPIURL(),
+              ...authentication.headerSnapshots(),
+              ...authentication.requestSnapshot(),
+              signal: authentication.effectiveSignal(),
+              ...authentication.tenantSnapshot(),
             })
-          : await this._workloadIdentityAuth.getToken();
+          : await authentication.getToken();
       return buildHeaders([{ Authorization: `Bearer ${token}` }]);
     }
     if (this.apiKey == null) {
@@ -994,10 +1001,7 @@ export class OpenAI {
     while (true) {
       const attempt = this.#responseAttempts.get(props.controller);
       const timeout = attempt?.timeout ?? props.options.timeout ?? this.timeout;
-      const x509Authentication =
-        this._workloadIdentityAuth instanceof X509WorkloadIdentityAuth
-          ? this._workloadIdentityAuth
-          : undefined;
+      const x509Authentication = attempt?.authentication;
       const callerSignal = x509Authentication ? props.controller.signal : props.options.signal;
       const abortError = () =>
         x509Authentication && callerSignal
@@ -1020,7 +1024,7 @@ export class OpenAI {
 
       try {
         // Tool runners preserve a completed buffered turn before cancellation stops the next request.
-        if (callerSignal?.aborted && props.options.__metadata?.['helperMethod'] !== 'runTools') {
+        if (callerSignal?.aborted && attempt?.helperMethod !== 'runTools') {
           throw abortError();
         }
 
@@ -1164,8 +1168,25 @@ export class OpenAI {
         if (X509WorkloadIdentityAuth.isStreamingRequestBody(built.req.body)) {
           options.__metadata = { ...options.__metadata, hasStreamingBody: true };
         }
+        await this.prepareRequest(built.req, { url: built.url, options });
+        await this._provider?.prepareRequest?.(built.req, { url: built.url, options });
+        x509Authentication.beginRequestPlanning();
+        x509Authentication.authorizePlannedRequest(built.url, built.req, built.timeout, true);
+        if (X509WorkloadIdentityAuth.isStreamingRequestBody(built.req.body)) {
+          options.__metadata = { ...options.__metadata, hasStreamingBody: true };
+        }
+        const callerSignal = x509Authentication.requestSnapshot().signal;
+        if (callerSignal?.aborted || built.req.signal?.aborted) {
+          throw this._makeUserAbortError(callerSignal?.aborted ? callerSignal : built.req.signal!);
+        }
+        x509Authentication.setEffectiveSignal(
+          built.req.signal || callerSignal
+            ? createRequestController(built.req.signal ?? callerSignal, callerSignal).signal
+            : undefined,
+        );
+        x509Authentication.beginRequestNetwork();
         const security = options.__security ?? { bearerAuth: true };
-        const authenticationHeaders = await this.authHeaders(options, security);
+        const authenticationHeaders = await this.authHeaders(options, security, x509Authentication);
         const suppliedHeaders = x509Authentication.headerSnapshots();
         const supplied = buildHeaders([suppliedHeaders.defaultHeaders, suppliedHeaders.requestHeaders]);
         for (const [name, value] of authenticationHeaders?.values ?? []) {
@@ -1199,8 +1220,10 @@ export class OpenAI {
     x509Authentication?.bindRequest(options, req, this.adminAPIKey);
     let hasStreamingBody = options.__metadata?.['hasStreamingBody'] === true;
 
-    await this.prepareRequest(req, { url, options });
-    await this._provider?.prepareRequest?.(req, { url, options });
+    if (!x509Authentication) {
+      await this.prepareRequest(req, { url, options });
+      await this._provider?.prepareRequest?.(req, { url, options });
+    }
     x509Authentication?.adoptRequestHeaders(req);
     if (x509Authentication && X509WorkloadIdentityAuth.isStreamingRequestBody(req.body)) {
       hasStreamingBody = true;
@@ -1226,18 +1249,10 @@ export class OpenAI {
     if (callerSignal?.aborted || req.signal?.aborted) {
       throw this._makeUserAbortError(callerSignal?.aborted ? callerSignal : req.signal!);
     }
-    if (x509Authentication) {
-      x509Authentication.setEffectiveSignal(
-        req.signal || callerSignal
-          ? createRequestController(req.signal ?? callerSignal, callerSignal).signal
-          : undefined,
-      );
-    }
-
     const security = options.__security ?? { bearerAuth: true };
     // Request hooks may replace the caller signal before it reaches fetch.
     const controller =
-      this.fetchWithTimeout === OpenAI.prototype.fetchWithTimeout
+      x509Authentication || this.fetchWithTimeout === OpenAI.prototype.fetchWithTimeout
         ? createRequestController(
             req.signal ?? (x509Authentication ? callerSignal : undefined),
             x509Authentication ? callerSignal : undefined,
@@ -1455,6 +1470,8 @@ export class OpenAI {
       timeout,
       retriesRemaining,
       hasStreamingBody,
+      ...(x509Authentication ? { authentication: x509Authentication } : {}),
+      helperMethod: options.__metadata?.['helperMethod'],
       ...(continueRequest ? { continueRequest } : {}),
     });
     return { response, options, controller, requestLogID, retryOfRequestLogID, startTime };

--- a/src/client.ts
+++ b/src/client.ts
@@ -1161,6 +1161,9 @@ export class OpenAI {
       if (x509Authentication) {
         validatePositiveInteger('timeout', built.timeout);
         x509Authentication.authorizePlannedRequest(built.url, built.req, built.timeout);
+        if (X509WorkloadIdentityAuth.isStreamingRequestBody(built.req.body)) {
+          options.__metadata = { ...options.__metadata, hasStreamingBody: true };
+        }
         const security = options.__security ?? { bearerAuth: true };
         const authenticationHeaders = await this.authHeaders(options, security);
         const suppliedHeaders = x509Authentication.headerSnapshots();
@@ -1199,14 +1202,7 @@ export class OpenAI {
     await this.prepareRequest(req, { url, options });
     await this._provider?.prepareRequest?.(req, { url, options });
     x509Authentication?.adoptRequestHeaders(req);
-    if (
-      x509Authentication &&
-      ((globalThis.ReadableStream && req.body instanceof globalThis.ReadableStream) ||
-        (typeof req.body === 'object' &&
-          req.body !== null &&
-          (Symbol.asyncIterator in req.body ||
-            (Symbol.iterator in req.body && 'next' in req.body && typeof req.body.next === 'function'))))
-    ) {
+    if (x509Authentication && X509WorkloadIdentityAuth.isStreamingRequestBody(req.body)) {
       hasStreamingBody = true;
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -456,6 +456,7 @@ export class OpenAI {
 
   private fetch: Fetch;
   #encoder: Opts.RequestEncoder;
+  #x509Authentication: X509WorkloadIdentityAuth | undefined;
   #x509Fetch: Fetch | undefined;
   // Preserve an explicit global selection without storing a second routing URL.
   #explicitDataResidency = false;
@@ -618,6 +619,7 @@ export class OpenAI {
     if (x509Identity) {
       const authentication = new X509WorkloadIdentityAuth(x509Identity, x509Transport, organization, project);
       this._workloadIdentityAuth = authentication;
+      this.#x509Authentication = authentication;
       this.#x509Fetch = authentication.fetch();
       this.fetch = this.#x509Fetch;
       markApprovedX509Client(this);
@@ -639,8 +641,7 @@ export class OpenAI {
     const residencyBaseURL = resolveDataResidency(options);
     const inheritedProvider = this._options.provider;
     const provider = options.provider ?? inheritedProvider;
-    const x509Authentication =
-      this._workloadIdentityAuth instanceof X509WorkloadIdentityAuth ? this._workloadIdentityAuth : undefined;
+    const x509Authentication = this.#x509Authentication;
     const inheritedOptions: ClientOptions = {
       ...this._options,
       baseURL: this.baseURL,
@@ -648,7 +649,7 @@ export class OpenAI {
       timeout: this.timeout,
       logger: this.logger,
       logLevel: this.logLevel,
-      fetch: this._workloadIdentityAuth instanceof X509WorkloadIdentityAuth ? undefined : this.fetch,
+      fetch: this.#x509Authentication ? undefined : this.fetch,
       fetchOptions: this.fetchOptions,
       apiKey: this._options.apiKey,
       adminAPIKey: this.adminAPIKey,
@@ -700,12 +701,13 @@ export class OpenAI {
     };
     const client = new (this.constructor as any as new (props: ClientOptions) => typeof this)(clientOptions);
     if (
-      this._workloadIdentityAuth instanceof X509WorkloadIdentityAuth &&
-      client._workloadIdentityAuth instanceof X509WorkloadIdentityAuth &&
+      this.#x509Authentication &&
+      client.#x509Authentication &&
       this.baseURL === client.baseURL &&
-      this._workloadIdentityAuth.matches(client._workloadIdentityAuth)
+      this.#x509Authentication.matches(client.#x509Authentication)
     ) {
-      client._workloadIdentityAuth = this._workloadIdentityAuth;
+      client._workloadIdentityAuth = this.#x509Authentication;
+      client.#x509Authentication = this.#x509Authentication;
       client.#x509Fetch = this.#x509Fetch;
     }
     return client;
@@ -755,8 +757,8 @@ export class OpenAI {
       bearerAuth: true,
       adminAPIKeyAuth: true,
     },
-    authentication: WorkloadIdentityAuth | X509WorkloadIdentityAuth | undefined = this._workloadIdentityAuth,
   ): Promise<NullableHeaders | undefined> {
+    const authentication = this.#x509Authentication ?? this._workloadIdentityAuth;
     if (
       authentication instanceof X509WorkloadIdentityAuth &&
       schemes.adminAPIKeyAuth &&
@@ -765,15 +767,13 @@ export class OpenAI {
       return await this.adminAPIKeyAuth(opts);
     }
     return buildHeaders([
-      schemes.bearerAuth ? await this.bearerAuth(opts, authentication) : null,
+      schemes.bearerAuth ? await this.bearerAuth(opts) : null,
       schemes.adminAPIKeyAuth ? await this.adminAPIKeyAuth(opts) : null,
     ]);
   }
 
-  protected async bearerAuth(
-    opts: FinalRequestOptions,
-    authentication: WorkloadIdentityAuth | X509WorkloadIdentityAuth | undefined = this._workloadIdentityAuth,
-  ): Promise<NullableHeaders | undefined> {
+  protected async bearerAuth(opts: FinalRequestOptions): Promise<NullableHeaders | undefined> {
+    const authentication = this.#x509Authentication ?? this._workloadIdentityAuth;
     if (authentication) {
       if (authentication instanceof X509WorkloadIdentityAuth) {
         if (
@@ -953,7 +953,7 @@ export class OpenAI {
     options: PromiseOrValue<FinalRequestOptions>,
     remainingRetries: number | null = null,
   ): APIPromise<Rsp> {
-    const authentication = this._workloadIdentityAuth;
+    const authentication = this.#x509Authentication ?? this._workloadIdentityAuth;
     const request =
       authentication instanceof X509WorkloadIdentityAuth
         ? Promise.resolve(options).then((resolved) =>
@@ -1153,8 +1153,7 @@ export class OpenAI {
 
     await this.prepareOptions(options);
 
-    const x509Authentication =
-      this._workloadIdentityAuth instanceof X509WorkloadIdentityAuth ? this._workloadIdentityAuth : undefined;
+    const x509Authentication = this.#x509Authentication;
     x509Authentication?.beginRequestPlanning();
     let built: { req: FinalizedRequestInit; url: string; timeout: number };
     try {
@@ -1186,7 +1185,7 @@ export class OpenAI {
         );
         x509Authentication.beginRequestNetwork();
         const security = options.__security ?? { bearerAuth: true };
-        const authenticationHeaders = await this.authHeaders(options, security, x509Authentication);
+        const authenticationHeaders = await this.authHeaders(options, security);
         const suppliedHeaders = x509Authentication.headerSnapshots();
         const supplied = buildHeaders([suppliedHeaders.defaultHeaders, suppliedHeaders.requestHeaders]);
         for (const [name, value] of authenticationHeaders?.values ?? []) {
@@ -1362,7 +1361,7 @@ export class OpenAI {
       }
       if (
         response.status === 401 &&
-        this._workloadIdentityAuth &&
+        (x509Authentication || this._workloadIdentityAuth) &&
         security.bearerAuth &&
         (!x509Authentication || x509Authentication.usedWorkloadToken(options)) &&
         (!x509Authentication || retriesRemaining > 0) &&
@@ -1373,7 +1372,7 @@ export class OpenAI {
           void Shims.CancelReadableStream(response.body).catch(() => undefined);
         } else {
           await Shims.CancelReadableStream(response.body);
-          this._workloadIdentityAuth.invalidateToken();
+          this._workloadIdentityAuth?.invalidateToken();
         }
 
         const replayOptions = {
@@ -1497,7 +1496,7 @@ export class OpenAI {
     Page: new (...args: ConstructorParameters<typeof Pagination.AbstractPage>) => PageClass,
     options: PromiseOrValue<FinalRequestOptions>,
   ): Pagination.PagePromise<PageClass, Item> {
-    const authentication = this._workloadIdentityAuth;
+    const authentication = this.#x509Authentication ?? this._workloadIdentityAuth;
     const request =
       authentication instanceof X509WorkloadIdentityAuth
         ? Promise.resolve(options).then((resolved) =>
@@ -1644,8 +1643,7 @@ export class OpenAI {
       const maxRetries = options.maxRetries ?? this.maxRetries;
       timeoutMillis = this.calculateDefaultRetryTimeoutMillis(retriesRemaining, maxRetries);
     }
-    const x509Authentication =
-      this._workloadIdentityAuth instanceof X509WorkloadIdentityAuth ? this._workloadIdentityAuth : undefined;
+    const x509Authentication = this.#x509Authentication;
     if (x509Authentication) {
       const remaining = x509Authentication.remainingTimeout(
         options,
@@ -1683,11 +1681,8 @@ export class OpenAI {
     inputOptions: FinalRequestOptions,
     { retryCount = 0 }: { retryCount?: number } = {},
   ): Promise<{ req: FinalizedRequestInit; url: string; timeout: number }> {
-    if (
-      this._workloadIdentityAuth instanceof X509WorkloadIdentityAuth &&
-      !this._workloadIdentityAuth.inRequest(this)
-    ) {
-      const authentication = this._workloadIdentityAuth;
+    if (this.#x509Authentication && !this.#x509Authentication.inRequest(this)) {
+      const authentication = this.#x509Authentication;
       return await authentication.runRequest(async () => {
         const built = await OpenAI.prototype.buildRequest.call(this, inputOptions, { retryCount });
         authentication.releaseRequestBody(built.req.body);
@@ -1695,8 +1690,7 @@ export class OpenAI {
       }, this);
     }
     const options = { ...inputOptions };
-    const x509Authentication =
-      this._workloadIdentityAuth instanceof X509WorkloadIdentityAuth ? this._workloadIdentityAuth : undefined;
+    const x509Authentication = this.#x509Authentication;
     const x509Tenant = x509Authentication?.snapshotTenant(this.organization, this.project);
     const x509Headers = x509Authentication?.snapshotHeaders(this._options.defaultHeaders, options.headers);
     if (x509Headers) {
@@ -1798,9 +1792,7 @@ export class OpenAI {
         'OpenAI-Organization': x509Tenant ? x509Tenant.organization : this.organization,
         'OpenAI-Project': x509Tenant ? x509Tenant.project : this.project,
       },
-      this._provider ||
-      (this._workloadIdentityAuth instanceof X509WorkloadIdentityAuth &&
-        this._workloadIdentityAuth.isPlanningRequest())
+      this._provider || this.#x509Authentication?.isPlanningRequest()
         ? undefined
         : await this.authHeaders(options, options.__security ?? { bearerAuth: true }),
       x509Headers?.defaultHeaders ?? this._options.defaultHeaders,
@@ -1808,13 +1800,7 @@ export class OpenAI {
       x509Headers?.requestHeaders ?? options.headers,
     ]);
 
-    if (
-      !this._provider &&
-      !(
-        this._workloadIdentityAuth instanceof X509WorkloadIdentityAuth &&
-        this._workloadIdentityAuth.isPlanningRequest()
-      )
-    ) {
+    if (!this._provider && !this.#x509Authentication?.isPlanningRequest()) {
       this.validateHeaders(headers, options.__security ?? { bearerAuth: true });
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -950,7 +950,7 @@ export class OpenAI {
     const request =
       authentication instanceof X509WorkloadIdentityAuth
         ? Promise.resolve(options).then((resolved) =>
-            authentication.runRequest(() => this.makeRequest(resolved, remainingRetries, undefined)),
+            authentication.runRequest(() => this.makeRequest(resolved, remainingRetries, undefined), this),
           )
         : this.makeRequest(options, remainingRetries, undefined);
     return this.responsePromise<Rsp>(request);
@@ -1488,7 +1488,7 @@ export class OpenAI {
     const request =
       authentication instanceof X509WorkloadIdentityAuth
         ? Promise.resolve(options).then((resolved) =>
-            authentication.runRequest(() => this.makeRequest(resolved, null, undefined)),
+            authentication.runRequest(() => this.makeRequest(resolved, null, undefined), this),
           )
         : this.makeRequest(options, null, undefined);
     const page = new Pagination.PagePromise<PageClass, Item>(this as any as OpenAI, request, Page);
@@ -1672,14 +1672,14 @@ export class OpenAI {
   ): Promise<{ req: FinalizedRequestInit; url: string; timeout: number }> {
     if (
       this._workloadIdentityAuth instanceof X509WorkloadIdentityAuth &&
-      !this._workloadIdentityAuth.inRequest()
+      !this._workloadIdentityAuth.inRequest(this)
     ) {
       const authentication = this._workloadIdentityAuth;
       return await authentication.runRequest(async () => {
         const built = await OpenAI.prototype.buildRequest.call(this, inputOptions, { retryCount });
         authentication.releaseRequestBody(built.req.body);
         return built;
-      });
+      }, this);
     }
     const options = { ...inputOptions };
     const x509Authentication =

--- a/src/client.ts
+++ b/src/client.ts
@@ -796,8 +796,7 @@ export class OpenAI {
               ...this._workloadIdentityAuth.headerSnapshots(),
               ...this._workloadIdentityAuth.requestSnapshot(),
               signal: this._workloadIdentityAuth.effectiveSignal(),
-              organization: this.organization,
-              project: this.project,
+              ...this._workloadIdentityAuth.tenantSnapshot(),
             })
           : await this._workloadIdentityAuth.getToken();
       return buildHeaders([{ Authorization: `Bearer ${token}` }]);
@@ -1046,11 +1045,10 @@ export class OpenAI {
           throw abortError();
         }
         if (!timedOut) {
-          if (
-            x509Authentication &&
-            !(error instanceof SyntaxError) &&
-            !(error instanceof Errors.OpenAIError)
-          ) {
+          if (x509Authentication && error instanceof SyntaxError) {
+            throw new SyntaxError('X.509 workload identity API response contains invalid JSON.');
+          }
+          if (x509Authentication && !(error instanceof Errors.OpenAIError)) {
             throw new Errors.APIConnectionError({
               message: 'X.509 workload identity API response body could not be read.',
             });
@@ -1686,6 +1684,7 @@ export class OpenAI {
     const options = { ...inputOptions };
     const x509Authentication =
       this._workloadIdentityAuth instanceof X509WorkloadIdentityAuth ? this._workloadIdentityAuth : undefined;
+    const x509Tenant = x509Authentication?.snapshotTenant(this.organization, this.project);
     const x509Headers = x509Authentication?.snapshotHeaders(this._options.defaultHeaders, options.headers);
     if (x509Headers) {
       options.headers = x509Headers.requestHeaders;
@@ -1732,6 +1731,7 @@ export class OpenAI {
       retryCount,
       x509Headers,
       x509Timeout: explicitTimeout ? options.timeout : undefined,
+      x509Tenant,
     });
 
     const req: FinalizedRequestInit = {
@@ -1755,6 +1755,7 @@ export class OpenAI {
     retryCount,
     x509Headers,
     x509Timeout,
+    x509Tenant,
   }: {
     options: FinalRequestOptions;
     method: HTTPMethod;
@@ -1762,6 +1763,7 @@ export class OpenAI {
     retryCount: number;
     x509Headers?: { defaultHeaders: NullableHeaders; requestHeaders: NullableHeaders } | undefined;
     x509Timeout: number | undefined;
+    x509Tenant?: { organization: string | null; project: string | null } | undefined;
   }): Promise<Headers> {
     let idempotencyHeaders: HeadersLike = {};
     if (this.idempotencyHeader && method !== 'get') {
@@ -1780,8 +1782,8 @@ export class OpenAI {
         ...(timeout ? { 'X-Stainless-Timeout': String(Math.trunc(timeout / 1000)) } : {}),
         ...getPlatformHeaders(),
         ...(typeof helperMethod === 'string' ? { 'X-Stainless-Helper-Method': helperMethod } : {}),
-        'OpenAI-Organization': this.organization,
-        'OpenAI-Project': this.project,
+        'OpenAI-Organization': x509Tenant ? x509Tenant.organization : this.organization,
+        'OpenAI-Project': x509Tenant ? x509Tenant.project : this.project,
       },
       this._provider ||
       (this._workloadIdentityAuth instanceof X509WorkloadIdentityAuth &&

--- a/src/client.ts
+++ b/src/client.ts
@@ -1381,7 +1381,10 @@ export class OpenAI {
         );
       }
 
-      const shouldRetry = await this.shouldRetry(response);
+      const shouldRetry =
+        rejectedX509Credential && options.__metadata?.['workloadIdentityTokenRefreshed']
+          ? false
+          : await this.shouldRetry(response);
       if (retriesRemaining && shouldRetry && !hasStreamingBody) {
         const retryMessage = `retrying, ${retriesRemaining} attempts remaining`;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -28,7 +28,7 @@ import {
   snapshotX509RequestOptions,
 } from './internal/auth/x509-workload-identity-auth';
 import type { X509Transport } from './internal/auth/x509-transport-registry';
-import { markApprovedX509Client } from '#x509-transport-state';
+import { isTransientX509ConnectionError, markApprovedX509Client } from '#x509-transport-state';
 import { OAuthError, SubjectTokenProviderError } from './core/error';
 import {
   type ConversationCursorPageParams,
@@ -614,7 +614,7 @@ export class OpenAI {
     this._provider = providerRuntime;
 
     if (x509Identity) {
-      const authentication = new X509WorkloadIdentityAuth(x509Identity, x509Transport);
+      const authentication = new X509WorkloadIdentityAuth(x509Identity, x509Transport, organization, project);
       this._workloadIdentityAuth = authentication;
       this.#x509Fetch = authentication.fetch();
       this.fetch = this.#x509Fetch;
@@ -696,7 +696,17 @@ export class OpenAI {
         !hasOwn(options, 'baseURL') &&
         !provider,
     };
-    return new (this.constructor as any as new (props: ClientOptions) => typeof this)(clientOptions);
+    const client = new (this.constructor as any as new (props: ClientOptions) => typeof this)(clientOptions);
+    if (
+      this._workloadIdentityAuth instanceof X509WorkloadIdentityAuth &&
+      client._workloadIdentityAuth instanceof X509WorkloadIdentityAuth &&
+      this.baseURL === client.baseURL &&
+      this._workloadIdentityAuth.matches(client._workloadIdentityAuth)
+    ) {
+      client._workloadIdentityAuth = this._workloadIdentityAuth;
+      client.#x509Fetch = this.#x509Fetch;
+    }
+    return client;
   }
 
   /**
@@ -786,6 +796,8 @@ export class OpenAI {
               ...this._workloadIdentityAuth.headerSnapshots(),
               ...this._workloadIdentityAuth.requestSnapshot(),
               signal: this._workloadIdentityAuth.effectiveSignal(),
+              organization: this.organization,
+              project: this.project,
             })
           : await this._workloadIdentityAuth.getToken();
       return buildHeaders([{ Authorization: `Bearer ${token}` }]);
@@ -1034,6 +1046,15 @@ export class OpenAI {
           throw abortError();
         }
         if (!timedOut) {
+          if (
+            x509Authentication &&
+            !(error instanceof SyntaxError) &&
+            !(error instanceof Errors.OpenAIError)
+          ) {
+            throw new Errors.APIConnectionError({
+              message: 'X.509 workload identity API response body could not be read.',
+            });
+          }
           throw error;
         }
 
@@ -1248,7 +1269,11 @@ export class OpenAI {
       const isTimeout =
         isAbortError(response) ||
         /timed? ?out/i.test(String(response) + ('cause' in response ? String(response.cause) : ''));
-      if (retriesRemaining && !hasStreamingBody) {
+      if (
+        retriesRemaining &&
+        !hasStreamingBody &&
+        (!x509Authentication || isTransientX509ConnectionError(response))
+      ) {
         loggerFor(this).info(
           `[${requestLogID}] connection ${isTimeout ? 'timed out' : 'failed'} - ${retryMessage}`,
         );
@@ -1258,7 +1283,7 @@ export class OpenAI {
             retryOfRequestLogID,
             url,
             durationMs: headersTime - startTime,
-            message: response.message,
+            message: x509Authentication ? 'X.509 workload identity API connection failed.' : response.message,
           }),
         );
         return this.retryRequest(options, retriesRemaining, retryOfRequestLogID ?? requestLogID);
@@ -1275,7 +1300,7 @@ export class OpenAI {
           retryOfRequestLogID,
           url,
           durationMs: headersTime - startTime,
-          message: response.message,
+          message: x509Authentication ? 'X.509 workload identity API connection failed.' : response.message,
         }),
       );
       if (response instanceof OAuthError || response instanceof SubjectTokenProviderError) {
@@ -1295,7 +1320,13 @@ export class OpenAI {
                 'configure a matching undici fetch and fetchOptions.dispatcher with an Agent whose headersTimeout is at least the SDK timeout.',
             })
           : new Errors.APIConnectionTimeoutError();
+        if (x509Authentication) {
+          throw new Errors.APIConnectionTimeoutError();
+        }
         throw Object.assign(timeoutError, { cause: response });
+      }
+      if (x509Authentication) {
+        throw new Errors.APIConnectionError({ message: 'X.509 workload identity API connection failed.' });
       }
       throw new Errors.APIConnectionError({
         message: getConnectionErrorMessage(response),
@@ -1312,6 +1343,14 @@ export class OpenAI {
     } with status ${response.status} in ${headersTime - startTime}ms`;
 
     if (!response.ok) {
+      const rejectedX509Credential =
+        response.status === 401 &&
+        x509Authentication &&
+        security.bearerAuth &&
+        x509Authentication.usedWorkloadToken(options);
+      if (rejectedX509Credential) {
+        x509Authentication.invalidateToken();
+      }
       if (
         response.status === 401 &&
         this._workloadIdentityAuth &&
@@ -1325,8 +1364,8 @@ export class OpenAI {
           void Shims.CancelReadableStream(response.body).catch(() => undefined);
         } else {
           await Shims.CancelReadableStream(response.body);
+          this._workloadIdentityAuth.invalidateToken();
         }
-        this._workloadIdentityAuth.invalidateToken();
 
         const replayOptions = {
           ...options,

--- a/src/internal/auth/x509-transport-registry.ts
+++ b/src/internal/auth/x509-transport-registry.ts
@@ -70,6 +70,7 @@ export interface X509RequestScope {
   defaultHeaders?: NullableHeaders;
   requestHeaders?: NullableHeaders;
   token?: string;
+  tokenGeneration?: number;
   headers?: Headers;
   authorization?: string | null;
 }

--- a/src/internal/auth/x509-transport-registry.ts
+++ b/src/internal/auth/x509-transport-registry.ts
@@ -66,7 +66,9 @@ export interface X509RequestScope {
   phase?: 'planning' | 'authorizing';
   effectiveSignal?: AbortSignal;
   materializedBody?: ReadableStream;
+  owner?: object;
   apiURL?: string;
+  tenant?: { organization: string | null; project: string | null };
   defaultHeaders?: NullableHeaders;
   requestHeaders?: NullableHeaders;
   token?: string;

--- a/src/internal/auth/x509-transport-registry.ts
+++ b/src/internal/auth/x509-transport-registry.ts
@@ -62,6 +62,7 @@ export interface X509ExchangedToken {
 export interface X509RequestScope {
   wallStartedAt: number;
   monotonicStartedAt: number;
+  deadlineArmed?: boolean;
   request?: { signal: AbortSignal | null | undefined; timeout: number; fetchOptions: MergedRequestInit };
   phase?: 'planning' | 'authorizing';
   effectiveSignal?: AbortSignal;

--- a/src/internal/auth/x509-transport-registry.ts
+++ b/src/internal/auth/x509-transport-registry.ts
@@ -67,6 +67,7 @@ export interface X509RequestScope {
   effectiveSignal?: AbortSignal;
   materializedBody?: ReadableStream;
   owner?: object;
+  requestOwner?: object;
   apiURL?: string;
   tenant?: { organization: string | null; project: string | null };
   defaultHeaders?: NullableHeaders;

--- a/src/internal/auth/x509-workload-identity-auth.ts
+++ b/src/internal/auth/x509-workload-identity-auth.ts
@@ -14,7 +14,12 @@ import {
   isRetryableX509IssuerError,
   isTransientX509ConnectionError,
 } from '#x509-transport-state';
-import type { RegisteredX509Transport, X509RequestScope, X509Transport } from './x509-transport-registry';
+import type {
+  RegisteredX509Transport,
+  X509ExchangedToken,
+  X509RequestScope,
+  X509Transport,
+} from './x509-transport-registry';
 
 /** Sole API authority approved for OpenAI X.509 workload-identity federation. */
 export const X509_API_BASE_URL = 'https://mtls.api.openai.com/v1';
@@ -23,7 +28,8 @@ const X509_API_ORIGIN = 'https://mtls.api.openai.com';
 const FORBIDDEN_TRANSPORT_OPTIONS = ['dispatcher', 'agent', 'client', 'tls', 'proxy'];
 const headerValue = (headers: Headers, name: string): string | null =>
   Headers.prototype.get.call(headers, name);
-const invalidateUncachedToken = (): undefined => undefined;
+const DEFAULT_REFRESH_BUFFER_MS = 20 * 60 * 1000;
+const FAILED_REFRESH_COOLDOWN_MS = 1000;
 const userAbortError = (signal: AbortSignal): APIUserAbortError => {
   const error = new APIUserAbortError();
   Object.defineProperty(error, 'cause', { value: signal.reason, writable: true, configurable: true });
@@ -73,6 +79,57 @@ function exchangeDeadline(
       callerSignal?.removeEventListener('abort', cancel);
       if (timer) {
         clearTimeout(timer);
+      }
+    },
+  };
+}
+
+interface CachedX509Token {
+  accessToken: string;
+  generation: number;
+  expiresAt: number;
+  refreshAt: number;
+  wallExpiresAt: number;
+  wallRefreshAt: number;
+}
+
+interface X509RefreshAttempt {
+  controller: AbortController;
+  generation: number;
+  promise: Promise<X509ExchangedToken>;
+  waiters: number;
+}
+
+interface X509TokenRequestContext {
+  apiURL: string;
+  defaultHeaders: HeadersLike | undefined;
+  requestHeaders: HeadersLike;
+  signal: AbortSignal | null | undefined;
+  organization: string | null;
+  project: string | null;
+  timeout: number;
+  fetchOptions: MergedRequestInit;
+}
+
+function waitForRefresh(
+  attempt: X509RefreshAttempt,
+  signal: AbortSignal,
+): { result: Promise<X509ExchangedToken>; dispose: () => void } {
+  let abort: (() => void) | undefined;
+  // AbortSignal remains callback-only on supported TypeScript/runtime combinations.
+  // oxlint-disable-next-line promise/avoid-new -- A callback-only AbortSignal must race a shared refresh.
+  const canceled = new Promise<never>((_resolve, reject) => {
+    abort = () => reject(signal.reason);
+    signal.addEventListener('abort', abort, { once: true });
+    if (signal.aborted) {
+      abort();
+    }
+  });
+  return {
+    result: Promise.race([attempt.promise, canceled]),
+    dispose: () => {
+      if (abort) {
+        signal.removeEventListener('abort', abort);
       }
     },
   };
@@ -155,7 +212,7 @@ export function assertX509FetchOptions(options: MergedRequestInit | RequestInit 
   }
 }
 
-/** Rejects caller body replacement while allowing the SDK's legitimate final RequestInit body. */
+/** Rejects caller overrides while allowing the SDK-owned fields on the final RequestInit. */
 export function assertX509RequestOptions(options: MergedRequestInit | RequestInit | undefined): void {
   assertX509FetchOptions(options);
   if (options && ['body', 'headers', 'method', 'signal'].some((name) => hasOwn(options, name))) {
@@ -177,13 +234,32 @@ export function snapshotX509RequestOptions(options: MergedRequestInit | undefine
 export class X509WorkloadIdentityAuth {
   readonly #identityProviderId: string;
   readonly #serviceAccountId: string;
+  readonly #configuredRefreshBufferMs: number | undefined;
+  readonly #organization: string | null;
+  readonly #project: string | null;
   readonly #transport: RegisteredX509Transport;
+  readonly #refreshBufferMs: number;
+  #cachedToken: CachedX509Token | undefined;
+  #refresh: X509RefreshAttempt | undefined;
+  #tokenGeneration = 0;
 
   /** Captures one registered, immutable certificate identity and its enrolled selectors. */
-  constructor(identity: X509WorkloadIdentity, transport: X509Transport | undefined) {
+  constructor(
+    identity: X509WorkloadIdentity,
+    transport: X509Transport | undefined,
+    organization: string | null,
+    project: string | null,
+  ) {
     this.#transport = resolveX509Transport(transport);
     this.#identityProviderId = identity.identityProviderId;
     this.#serviceAccountId = identity.serviceAccountId;
+    this.#configuredRefreshBufferMs = identity.refreshBufferMs;
+    this.#organization = organization;
+    this.#project = project;
+    this.#refreshBufferMs = this.#configuredRefreshBufferMs ?? DEFAULT_REFRESH_BUFFER_MS;
+    if (!Number.isSafeInteger(this.#refreshBufferMs) || this.#refreshBufferMs < 0) {
+      throw new OpenAIError('X.509 workload identity requires a nonnegative integer refreshBufferMs.');
+    }
   }
 
   /** Reconstructs the immutable selectors captured before caller-owned identity mutation. */
@@ -192,6 +268,9 @@ export class X509WorkloadIdentityAuth {
       type: 'x509',
       identityProviderId: this.#identityProviderId,
       serviceAccountId: this.#serviceAccountId,
+      ...(this.#configuredRefreshBufferMs === undefined
+        ? {}
+        : { refreshBufferMs: this.#configuredRefreshBufferMs }),
     };
   }
 
@@ -377,6 +456,18 @@ export class X509WorkloadIdentityAuth {
     return this.#transport.current() !== undefined;
   }
 
+  /** Shares a cache only when the complete, privately snapshotted credential identity matches. */
+  matches(other: X509WorkloadIdentityAuth): boolean {
+    return (
+      this.#transport === other.#transport &&
+      this.#identityProviderId === other.#identityProviderId &&
+      this.#serviceAccountId === other.#serviceAccountId &&
+      this.#organization === other.#organization &&
+      this.#project === other.#project &&
+      this.#refreshBufferMs === other.#refreshBufferMs
+    );
+  }
+
   /** Binds deferred response parsing to the original logical request and its unchanged deadline. */
   continuation(): <T>(operation: () => Promise<T>) => Promise<T> {
     const { wallStartedAt, monotonicStartedAt, request, effectiveSignal } = this.#scope();
@@ -407,6 +498,7 @@ export class X509WorkloadIdentityAuth {
     delete scope.token;
     delete scope.defaultHeaders;
     delete scope.requestHeaders;
+    delete scope.tokenGeneration;
     delete scope.headers;
     delete scope.authorization;
   }
@@ -465,80 +557,197 @@ export class X509WorkloadIdentityAuth {
   }
 
   /** Exchanges the exact certificate capability selected for the matching API dispatch. */
-  async getToken(
-    options?: FinalRequestOptions,
-    context?: {
-      apiURL: string;
-      defaultHeaders: HeadersLike | undefined;
-      requestHeaders: HeadersLike;
-      signal: AbortSignal | null | undefined;
-      timeout: number;
-      fetchOptions: MergedRequestInit;
-    },
+  async getToken(options?: FinalRequestOptions, context?: X509TokenRequestContext): Promise<string> {
+    const callerSignal = context ? context.signal : options?.signal;
+    if (callerSignal?.aborted) {
+      throw userAbortError(callerSignal);
+    }
+    this.#preflight(options, context);
+
+    const scope = options ? this.#scope() : undefined;
+    const cached = this.#cachedToken;
+    if (cached && performance.now() < cached.refreshAt && Date.now() < cached.wallRefreshAt) {
+      return X509WorkloadIdentityAuth.#assignToken(scope, cached);
+    }
+
+    const remaining = context && options ? this.remainingTimeout(options, context.timeout) : context?.timeout;
+    const { signal, dispose } = exchangeDeadline(remaining, callerSignal);
+    if (callerSignal?.aborted) {
+      dispose();
+      throw userAbortError(callerSignal);
+    }
+    const attempt = this.#refresh ?? this.#beginRefresh();
+    attempt.waiters += 1;
+    const waiter = waitForRefresh(attempt, signal);
+
+    try {
+      const exchanged = await waiter.result;
+      const refreshed = this.#cachedToken;
+      if (!refreshed || refreshed.accessToken !== exchanged.accessToken) {
+        throw new APIUserAbortError();
+      }
+      return X509WorkloadIdentityAuth.#assignToken(scope, refreshed);
+    } catch (error) {
+      return await this.#recoverRefreshFailure(error, attempt, cached, scope, options, context);
+    } finally {
+      waiter.dispose();
+      dispose();
+      attempt.waiters -= 1;
+      this.#retireRefresh(attempt);
+    }
+  }
+
+  static #assignToken(scope: X509RequestScope | undefined, token: CachedX509Token): string {
+    if (scope) {
+      scope.token = token.accessToken;
+      scope.tokenGeneration = token.generation;
+    }
+    return token.accessToken;
+  }
+
+  async #recoverRefreshFailure(
+    error: unknown,
+    attempt: X509RefreshAttempt,
+    cached: CachedX509Token | undefined,
+    scope: X509RequestScope | undefined,
+    options: FinalRequestOptions | undefined,
+    context: X509TokenRequestContext | undefined,
   ): Promise<string> {
     const callerSignal = context ? context.signal : options?.signal;
     if (callerSignal?.aborted) {
       throw userAbortError(callerSignal);
     }
-    X509WorkloadIdentityAuth.#preflight(options, context);
-
-    const scope = options ? this.#scope() : undefined;
-    const remaining = context && options ? this.remainingTimeout(options, context.timeout) : context?.timeout;
-    const { signal, dispose } = exchangeDeadline(remaining, callerSignal);
-
-    try {
-      if (callerSignal?.aborted) {
-        throw userAbortError(callerSignal);
+    if (attempt.controller.signal.aborted && attempt.generation !== this.#tokenGeneration) {
+      return await this.getToken(options, context);
+    }
+    const fallback = this.#fallbackToken(error, cached, scope);
+    if (fallback !== undefined) {
+      return fallback;
+    }
+    if (error && typeof error === 'object' && !(error instanceof OAuthError)) {
+      const oauth:
+        | { status: 400 | 401 | 403; error: { error: string } | undefined; headers: Headers }
+        | undefined = findX509OAuthError(error);
+      if (oauth) {
+        throw new OAuthError(oauth.status, oauth.error, oauth.headers);
       }
-      const exchanged = await this.#transport.exchange(
+    }
+    throw error;
+  }
+
+  #fallbackToken(
+    error: unknown,
+    cached: CachedX509Token | undefined,
+    scope: X509RequestScope | undefined,
+  ): string | undefined {
+    if (
+      !cached ||
+      cached !== this.#cachedToken ||
+      performance.now() >= cached.expiresAt ||
+      Date.now() >= cached.wallExpiresAt ||
+      !X509WorkloadIdentityAuth.isRetryableFailure(error)
+    ) {
+      return undefined;
+    }
+    cached.refreshAt = Math.min(cached.expiresAt, performance.now() + FAILED_REFRESH_COOLDOWN_MS);
+    cached.wallRefreshAt = Math.min(cached.wallExpiresAt, Date.now() + FAILED_REFRESH_COOLDOWN_MS);
+    return X509WorkloadIdentityAuth.#assignToken(scope, cached);
+  }
+
+  #retireRefresh(attempt: X509RefreshAttempt): void {
+    if (attempt.waiters !== 0 || this.#refresh !== attempt) {
+      return;
+    }
+    queueMicrotask(() => {
+      if (attempt.waiters === 0 && this.#refresh === attempt) {
+        this.#refresh = undefined;
+        this.#tokenGeneration += 1;
+        attempt.controller.abort(new APIUserAbortError());
+      }
+    });
+  }
+
+  #beginRefresh(): X509RefreshAttempt {
+    const controller = new AbortController();
+    const generation = this.#tokenGeneration;
+    const attempt: X509RefreshAttempt = {
+      controller,
+      generation,
+      waiters: 0,
+      promise: this.#refreshToken(controller, generation),
+    };
+    this.#refresh = attempt;
+    return attempt;
+  }
+
+  async #refreshToken(controller: AbortController, generation: number): Promise<X509ExchangedToken> {
+    const startedAt = performance.now();
+    const wallStartedAt = Date.now();
+    try {
+      const token = await this.#transport.exchange(
         this.#identityProviderId,
         this.#serviceAccountId,
-        signal,
+        controller.signal,
       );
-      if (scope) {
-        scope.token = exchanged.accessToken;
+      const lifetime = token.expiresIn * 1000;
+      const expiresAt = startedAt + lifetime;
+      const wallExpiresAt = wallStartedAt + lifetime;
+      if (performance.now() >= expiresAt || Date.now() >= wallExpiresAt) {
+        throw new OpenAIError('X.509 workload identity token expired before its exchange completed.');
       }
-      return exchanged.accessToken;
-    } catch (error) {
-      if (callerSignal?.aborted) {
-        throw userAbortError(callerSignal);
+      if (
+        this.#tokenGeneration !== generation ||
+        controller.signal.aborted ||
+        this.#refresh?.controller !== controller
+      ) {
+        throw new APIUserAbortError();
       }
-      if (error && typeof error === 'object' && !(error instanceof OAuthError)) {
-        const oauth:
-          | { status: 400 | 401 | 403; error: { error: string } | undefined; headers: Headers }
-          | undefined = findX509OAuthError(error);
-        if (oauth) {
-          throw new OAuthError(oauth.status, oauth.error, oauth.headers);
-        }
-      }
-      throw error;
+      this.#tokenGeneration += 1;
+      this.#cachedToken = {
+        accessToken: token.accessToken,
+        generation: this.#tokenGeneration,
+        expiresAt,
+        refreshAt: expiresAt - Math.min(this.#refreshBufferMs, lifetime / 2),
+        wallExpiresAt,
+        wallRefreshAt: wallExpiresAt - Math.min(this.#refreshBufferMs, lifetime / 2),
+      };
+      return token;
     } finally {
-      dispose();
+      if (this.#refresh?.controller === controller) {
+        this.#refresh = undefined;
+      }
     }
   }
 
-  static #preflight(
-    options: FinalRequestOptions | undefined,
-    context:
-      | {
-          apiURL: string;
-          defaultHeaders: HeadersLike | undefined;
-          requestHeaders: HeadersLike;
-          timeout: number;
-          fetchOptions: MergedRequestInit;
-        }
-      | undefined,
-  ): void {
+  #preflight(options: FinalRequestOptions | undefined, context: X509TokenRequestContext | undefined): void {
     if (options) {
       assertX509RequestOptions(context ? context.fetchOptions : options.fetchOptions);
     }
     if (!context) {
       return;
     }
+    if (context.organization !== this.#organization || context.project !== this.#project) {
+      throw new OpenAIError('X.509 workload identity cannot override its enrolled organization or project.');
+    }
     assertX509APIOrigin(context.apiURL);
     const supplied = buildHeaders([context.defaultHeaders, context.requestHeaders]);
+    if (
+      (this.#organization !== null && supplied.nulls.has('openai-organization')) ||
+      (this.#project !== null && supplied.nulls.has('openai-project'))
+    ) {
+      throw new OpenAIError('X.509 workload identity cannot omit its enrolled organization or project.');
+    }
     for (const name of supplied.values.keys()) {
       const canonical = name.toLowerCase().split('_').join('-');
+      if (
+        (canonical === 'openai-organization' &&
+          headerValue(supplied.values, name) !== context.organization) ||
+        (canonical === 'openai-project' && headerValue(supplied.values, name) !== context.project)
+      ) {
+        throw new OpenAIError(
+          'X.509 workload identity cannot override its enrolled organization or project.',
+        );
+      }
       if (
         canonical === 'authorization' ||
         canonical === 'api-key' ||
@@ -553,8 +762,22 @@ export class X509WorkloadIdentityAuth {
     }
   }
 
-  /** Token caching is added separately; every current exchange already produces a fresh credential. */
-  readonly invalidateToken = invalidateUncachedToken;
+  /** Invalidates only the workload-token generation actually rejected by the current request. */
+  invalidateToken(): void {
+    const rejected = this.#transport.current();
+    if (
+      !rejected?.token ||
+      this.#cachedToken?.accessToken !== rejected.token ||
+      this.#cachedToken.generation !== rejected.tokenGeneration
+    ) {
+      return;
+    }
+    this.#tokenGeneration += 1;
+    this.#cachedToken = undefined;
+    const refresh = this.#refresh;
+    this.#refresh = undefined;
+    refresh?.controller.abort(new APIUserAbortError());
+  }
 
   #scope(): X509RequestScope {
     const scope = this.#transport.current();
@@ -616,6 +839,20 @@ export class X509WorkloadIdentityAuth {
       headerValue(headers, 'Authorization') !== scope.authorization
     ) {
       throw new OpenAIError('X.509 workload identity must preserve its issued workload authorization.');
+    }
+    if (
+      headerValue(headers, 'OpenAI-Organization') !== this.#organization ||
+      headerValue(headers, 'OpenAI-Project') !== this.#project
+    ) {
+      throw new OpenAIError('X.509 workload identity cannot override its enrolled organization or project.');
+    }
+    for (const name of Headers.prototype.keys.call(headers)) {
+      const canonical = name.toLowerCase().split('_').join('-');
+      if ((canonical === 'openai-organization' || canonical === 'openai-project') && name !== canonical) {
+        throw new OpenAIError(
+          'X.509 workload identity cannot override its enrolled organization or project.',
+        );
+      }
     }
     assertSafeHeaders(headers);
   }

--- a/src/internal/auth/x509-workload-identity-auth.ts
+++ b/src/internal/auth/x509-workload-identity-auth.ts
@@ -504,7 +504,7 @@ export class X509WorkloadIdentityAuth {
   /** Reports whether a public request-building call already belongs to an active logical operation. */
   inRequest(requestOwner: object): boolean {
     const scope = this.#transport.current();
-    return scope?.owner === this && scope.requestOwner === requestOwner;
+    return scope?.owner === this && scope.requestOwner === requestOwner && scope.phase !== 'authorizing';
   }
 
   /** Shares a cache only when the complete, privately snapshotted credential identity matches. */

--- a/src/internal/auth/x509-workload-identity-auth.ts
+++ b/src/internal/auth/x509-workload-identity-auth.ts
@@ -303,6 +303,28 @@ export class X509WorkloadIdentityAuth {
     return { defaultHeaders, requestHeaders };
   }
 
+  /** Captures enrolled public tenant selectors once before certificate presentation. */
+  snapshotTenant(
+    organization: string | null,
+    project: string | null,
+  ): { organization: string | null; project: string | null } {
+    if (organization !== this.#organization || project !== this.#project) {
+      throw new OpenAIError('X.509 workload identity cannot override its enrolled organization or project.');
+    }
+    const scope = this.#scope();
+    scope.tenant = { organization, project };
+    return scope.tenant;
+  }
+
+  /** Returns the tenant selectors already approved for this logical request. */
+  tenantSnapshot(): { organization: string | null; project: string | null } {
+    const { tenant } = this.#scope();
+    if (!tenant) {
+      throw new OpenAIError('X.509 workload identity requires snapshotted tenant selectors.');
+    }
+    return tenant;
+  }
+
   /** Validates and retains the exact destination that authenticated dispatch will use. */
   snapshotAPIURL(value: string): void {
     assertX509APIOrigin(value);
@@ -442,18 +464,24 @@ export class X509WorkloadIdentityAuth {
   /** Establishes an independent scope even when concurrent requests share caller options. */
   runRequest<T>(operation: () => Promise<T>): Promise<T> {
     return this.#transport.run(async () => {
+      const scope = this.#transport.current();
+      if (!scope) {
+        throw new OpenAIError('X.509 workload identity requires an active certificate request scope.');
+      }
+      scope.owner = this;
       try {
         return await operation();
       } finally {
         this.retireRequestBody();
         this.releaseRequestCredentials();
+        delete scope.owner;
       }
     });
   }
 
   /** Reports whether a public request-building call already belongs to an active logical operation. */
   inRequest(): boolean {
-    return this.#transport.current() !== undefined;
+    return this.#transport.current()?.owner === this;
   }
 
   /** Shares a cache only when the complete, privately snapshotted credential identity matches. */
@@ -474,6 +502,7 @@ export class X509WorkloadIdentityAuth {
     const scope: X509RequestScope = {
       wallStartedAt,
       monotonicStartedAt,
+      owner: this,
       ...(request ? { request } : {}),
       ...(effectiveSignal ? { effectiveSignal } : {}),
     };
@@ -483,6 +512,7 @@ export class X509WorkloadIdentityAuth {
           return await operation();
         } finally {
           this.releaseRequestCredentials();
+          delete scope.owner;
         }
       });
   }
@@ -495,6 +525,7 @@ export class X509WorkloadIdentityAuth {
     delete scope.effectiveSignal;
     delete scope.materializedBody;
     delete scope.apiURL;
+    delete scope.tenant;
     delete scope.token;
     delete scope.defaultHeaders;
     delete scope.requestHeaders;
@@ -782,7 +813,7 @@ export class X509WorkloadIdentityAuth {
 
   #scope(): X509RequestScope {
     const scope = this.#transport.current();
-    if (!scope) {
+    if (!scope || scope.owner !== this) {
       throw new OpenAIError('X.509 workload identity requires an active certificate request scope.');
     }
     return scope;

--- a/src/internal/auth/x509-workload-identity-auth.ts
+++ b/src/internal/auth/x509-workload-identity-auth.ts
@@ -601,7 +601,10 @@ export class X509WorkloadIdentityAuth {
     if (callerSignal?.aborted) {
       throw userAbortError(callerSignal);
     }
-    this.#preflight(options, context);
+    if (options) {
+      assertX509RequestOptions(context ? context.fetchOptions : options.fetchOptions);
+    }
+    this.#preflight(context);
 
     const scope = options ? this.#scope() : undefined;
     const cached = this.#cachedToken;
@@ -770,10 +773,7 @@ export class X509WorkloadIdentityAuth {
     }
   }
 
-  #preflight(options: FinalRequestOptions | undefined, context: X509TokenRequestContext | undefined): void {
-    if (options) {
-      assertX509RequestOptions(context ? context.fetchOptions : options.fetchOptions);
-    }
+  #preflight(context: X509TokenRequestContext | undefined): void {
     if (!context) {
       return;
     }

--- a/src/internal/auth/x509-workload-identity-auth.ts
+++ b/src/internal/auth/x509-workload-identity-auth.ts
@@ -422,6 +422,17 @@ export class X509WorkloadIdentityAuth {
     }
   }
 
+  /** Recognizes every one-shot upload before issuer authentication or request replay. */
+  static isStreamingRequestBody(body: unknown): boolean {
+    return (
+      (globalThis.ReadableStream !== undefined && body instanceof globalThis.ReadableStream) ||
+      (typeof body === 'object' &&
+        body !== null &&
+        (Symbol.asyncIterator in body ||
+          (Symbol.iterator in body && 'next' in body && typeof body.next === 'function')))
+    );
+  }
+
   /** Retires abandoned upload adapters without masking or blocking their authentication failure. */
   retireRequestBody(): void {
     const scope = this.#scope();

--- a/src/internal/auth/x509-workload-identity-auth.ts
+++ b/src/internal/auth/x509-workload-identity-auth.ts
@@ -256,10 +256,13 @@ export class X509WorkloadIdentityAuth {
     this.#configuredRefreshBufferMs = identity.refreshBufferMs;
     this.#organization = organization;
     this.#project = project;
-    this.#refreshBufferMs = this.#configuredRefreshBufferMs ?? DEFAULT_REFRESH_BUFFER_MS;
-    if (!Number.isSafeInteger(this.#refreshBufferMs) || this.#refreshBufferMs < 0) {
+    if (
+      this.#configuredRefreshBufferMs !== undefined &&
+      (!Number.isSafeInteger(this.#configuredRefreshBufferMs) || this.#configuredRefreshBufferMs < 0)
+    ) {
       throw new OpenAIError('X.509 workload identity requires a nonnegative integer refreshBufferMs.');
     }
+    this.#refreshBufferMs = this.#configuredRefreshBufferMs ?? DEFAULT_REFRESH_BUFFER_MS;
   }
 
   /** Reconstructs the immutable selectors captured before caller-owned identity mutation. */
@@ -462,26 +465,29 @@ export class X509WorkloadIdentityAuth {
   }
 
   /** Establishes an independent scope even when concurrent requests share caller options. */
-  runRequest<T>(operation: () => Promise<T>): Promise<T> {
+  runRequest<T>(operation: () => Promise<T>, requestOwner: object): Promise<T> {
     return this.#transport.run(async () => {
       const scope = this.#transport.current();
       if (!scope) {
         throw new OpenAIError('X.509 workload identity requires an active certificate request scope.');
       }
       scope.owner = this;
+      scope.requestOwner = requestOwner;
       try {
         return await operation();
       } finally {
         this.retireRequestBody();
         this.releaseRequestCredentials();
+        delete scope.requestOwner;
         delete scope.owner;
       }
     });
   }
 
   /** Reports whether a public request-building call already belongs to an active logical operation. */
-  inRequest(): boolean {
-    return this.#transport.current()?.owner === this;
+  inRequest(requestOwner: object): boolean {
+    const scope = this.#transport.current();
+    return scope?.owner === this && scope.requestOwner === requestOwner;
   }
 
   /** Shares a cache only when the complete, privately snapshotted credential identity matches. */
@@ -498,13 +504,14 @@ export class X509WorkloadIdentityAuth {
 
   /** Binds deferred response parsing to the original logical request and its unchanged deadline. */
   continuation(): <T>(operation: () => Promise<T>) => Promise<T> {
-    const { wallStartedAt, monotonicStartedAt, request, effectiveSignal } = this.#scope();
+    const { wallStartedAt, monotonicStartedAt, request, requestOwner, effectiveSignal } = this.#scope();
     const scope: X509RequestScope = {
       wallStartedAt,
       monotonicStartedAt,
       owner: this,
       ...(request ? { request } : {}),
       ...(effectiveSignal ? { effectiveSignal } : {}),
+      ...(requestOwner ? { requestOwner } : {}),
     };
     return (operation) =>
       this.#transport.resume(scope, async () => {
@@ -512,6 +519,7 @@ export class X509WorkloadIdentityAuth {
           return await operation();
         } finally {
           this.releaseRequestCredentials();
+          delete scope.requestOwner;
           delete scope.owner;
         }
       });
@@ -680,8 +688,20 @@ export class X509WorkloadIdentityAuth {
     ) {
       return undefined;
     }
-    cached.refreshAt = Math.min(cached.expiresAt, performance.now() + FAILED_REFRESH_COOLDOWN_MS);
-    cached.wallRefreshAt = Math.min(cached.wallExpiresAt, Date.now() + FAILED_REFRESH_COOLDOWN_MS);
+    const headers = X509WorkloadIdentityAuth.retryHeaders(error);
+    const milliseconds = headers?.get('retry-after-ms');
+    let requested = milliseconds ? Number(milliseconds) : undefined;
+    const retryAfter = headers?.get('retry-after');
+    if (retryAfter && (requested === undefined || Number.isNaN(requested))) {
+      const seconds = Number(retryAfter);
+      requested = Number.isNaN(seconds) ? Date.parse(retryAfter) - Date.now() : seconds * 1000;
+    }
+    const cooldown =
+      requested !== undefined && Number.isFinite(requested) && requested >= 0 && requested <= 60_000
+        ? Math.max(FAILED_REFRESH_COOLDOWN_MS, requested)
+        : FAILED_REFRESH_COOLDOWN_MS;
+    cached.refreshAt = Math.min(cached.expiresAt, performance.now() + cooldown);
+    cached.wallRefreshAt = Math.min(cached.wallExpiresAt, Date.now() + cooldown);
     return X509WorkloadIdentityAuth.#assignToken(scope, cached);
   }
 

--- a/src/internal/auth/x509-workload-identity-auth.ts
+++ b/src/internal/auth/x509-workload-identity-auth.ts
@@ -384,6 +384,7 @@ export class X509WorkloadIdentityAuth {
   authorizePlannedRequest(url: string, request: RequestInit, timeout: number): void {
     const scope = this.#scope();
     const headers = Object.getOwnPropertyDescriptor(request, 'headers');
+    const body = Object.getOwnPropertyDescriptor(request, 'body');
     const signal = Object.getOwnPropertyDescriptor(request, 'signal');
     const redirect = Object.getOwnPropertyDescriptor(request, 'redirect');
     if (
@@ -391,6 +392,8 @@ export class X509WorkloadIdentityAuth {
       !headers ||
       !('value' in headers) ||
       !(headers.value instanceof Headers) ||
+      (body && !('value' in body)) ||
+      (!body && 'body' in request) ||
       (signal && !('value' in signal)) ||
       (redirect && !('value' in redirect))
     ) {

--- a/src/internal/auth/x509-workload-identity-auth.ts
+++ b/src/internal/auth/x509-workload-identity-auth.ts
@@ -365,14 +365,19 @@ export class X509WorkloadIdentityAuth {
     return request;
   }
 
-  /** Arms one logical network deadline only after protected option preparation completes. */
+  /** Begins local request construction without charging protected hook latency to the network. */
   beginRequestPlanning(): void {
+    this.#scope().phase = 'planning';
+  }
+
+  /** Arms one absolute network deadline only after all local request preparation completes. */
+  beginRequestNetwork(): void {
     const scope = this.#scope();
-    if (!scope.request) {
+    if (!scope.deadlineArmed) {
       scope.wallStartedAt = Date.now();
       scope.monotonicStartedAt = performance.now();
+      scope.deadlineArmed = true;
     }
-    scope.phase = 'planning';
   }
 
   /** Keeps certificate authentication outside overridable request construction. */
@@ -381,7 +386,7 @@ export class X509WorkloadIdentityAuth {
   }
 
   /** Approves the final overridden destination and transport before minting a bearer. */
-  authorizePlannedRequest(url: string, request: RequestInit, timeout: number): void {
+  authorizePlannedRequest(url: string, request: RequestInit, timeout: number, allowHookSignal = false): void {
     const scope = this.#scope();
     const headers = Object.getOwnPropertyDescriptor(request, 'headers');
     const body = Object.getOwnPropertyDescriptor(request, 'body');
@@ -390,12 +395,9 @@ export class X509WorkloadIdentityAuth {
     if (
       scope.phase !== 'planning' ||
       !headers ||
-      !('value' in headers) ||
       !(headers.value instanceof Headers) ||
-      (body && !('value' in body)) ||
       (!body && 'body' in request) ||
-      (signal && !('value' in signal)) ||
-      (redirect && !('value' in redirect))
+      [body, signal, redirect].some((descriptor) => descriptor && !('value' in descriptor))
     ) {
       throw new OpenAIError('X.509 workload identity requires an approved final request.');
     }
@@ -410,7 +412,7 @@ export class X509WorkloadIdentityAuth {
       throw new OpenAIError('X.509 workload identity cannot use caller-supplied authorization credentials.');
     }
     this.#assertTenantHeaders(headers.value);
-    if ((signal?.value ?? undefined) !== (this.requestSnapshot().signal ?? undefined)) {
+    if (!allowHookSignal && (signal?.value ?? undefined) !== (this.requestSnapshot().signal ?? undefined)) {
       throw new OpenAIError('X.509 workload identity must preserve its approved request signal.');
     }
     const approved = this.requestSnapshot();
@@ -519,11 +521,13 @@ export class X509WorkloadIdentityAuth {
 
   /** Binds deferred response parsing to the original logical request and its unchanged deadline. */
   continuation(): <T>(operation: () => Promise<T>) => Promise<T> {
-    const { wallStartedAt, monotonicStartedAt, request, requestOwner, effectiveSignal } = this.#scope();
+    const { wallStartedAt, monotonicStartedAt, deadlineArmed, request, requestOwner, effectiveSignal } =
+      this.#scope();
     const scope: X509RequestScope = {
       wallStartedAt,
       monotonicStartedAt,
       owner: this,
+      ...(deadlineArmed ? { deadlineArmed } : {}),
       ...(request ? { request } : {}),
       ...(effectiveSignal ? { effectiveSignal } : {}),
       ...(requestOwner ? { requestOwner } : {}),
@@ -545,6 +549,7 @@ export class X509WorkloadIdentityAuth {
     const scope = this.#scope();
     delete scope.request;
     delete scope.phase;
+    delete scope.deadlineArmed;
     delete scope.effectiveSignal;
     delete scope.materializedBody;
     delete scope.apiURL;

--- a/src/internal/auth/x509-workload-identity-auth.ts
+++ b/src/internal/auth/x509-workload-identity-auth.ts
@@ -406,6 +406,7 @@ export class X509WorkloadIdentityAuth {
     if (headerValue(headers.value, 'Authorization') !== null) {
       throw new OpenAIError('X.509 workload identity cannot use caller-supplied authorization credentials.');
     }
+    this.#assertTenantHeaders(headers.value);
     if ((signal?.value ?? undefined) !== (this.requestSnapshot().signal ?? undefined)) {
       throw new OpenAIError('X.509 workload identity must preserve its approved request signal.');
     }
@@ -892,6 +893,12 @@ export class X509WorkloadIdentityAuth {
     ) {
       throw new OpenAIError('X.509 workload identity must preserve its issued workload authorization.');
     }
+    this.#assertTenantHeaders(headers);
+    assertSafeHeaders(headers);
+  }
+
+  /** Enforces the same enrolled selectors before certificate issuance and final dispatch. */
+  #assertTenantHeaders(headers: Headers): void {
     if (
       headerValue(headers, 'OpenAI-Organization') !== this.#organization ||
       headerValue(headers, 'OpenAI-Project') !== this.#project
@@ -906,7 +913,6 @@ export class X509WorkloadIdentityAuth {
         );
       }
     }
-    assertSafeHeaders(headers);
   }
 
   /** Returns a guarded final dispatcher while preserving all existing request hook object identities. */

--- a/src/internal/auth/x509-workload-identity-auth.ts
+++ b/src/internal/auth/x509-workload-identity-auth.ts
@@ -740,9 +740,10 @@ export class X509WorkloadIdentityAuth {
     for (const name of supplied.values.keys()) {
       const canonical = name.toLowerCase().split('_').join('-');
       if (
-        (canonical === 'openai-organization' &&
-          headerValue(supplied.values, name) !== context.organization) ||
-        (canonical === 'openai-project' && headerValue(supplied.values, name) !== context.project)
+        (canonical === 'openai-organization' || canonical === 'openai-project') &&
+        (name !== canonical ||
+          headerValue(supplied.values, name) !==
+            (canonical === 'openai-organization' ? context.organization : context.project))
       ) {
         throw new OpenAIError(
           'X.509 workload identity cannot override its enrolled organization or project.',

--- a/tests/lib/x509-workload-example.test.ts
+++ b/tests/lib/x509-workload-example.test.ts
@@ -1,0 +1,88 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const example = readFileSync(
+  path.resolve(process.cwd(), 'examples/mtls/x509-workload-identity.mjs'),
+  'utf-8',
+);
+const exampleDocumentation = readFileSync(path.resolve(process.cwd(), 'examples/mtls/README.md'), 'utf-8');
+const packageDocumentation = readFileSync(path.resolve(process.cwd(), 'README.md'), 'utf-8');
+const packageScripts = JSON.parse(readFileSync(path.resolve(process.cwd(), 'package.json'), 'utf-8')) as {
+  scripts: Record<string, string>;
+};
+
+function runExample(environment: Record<string, string>) {
+  return spawnSync(process.execPath, ['--input-type=module'], {
+    cwd: process.cwd(),
+    encoding: 'utf-8',
+    input: example,
+    env: {
+      PATH: process.env['PATH'],
+      OPENAI_X509_CLIENT_CERTIFICATE_CHAIN_PEM: 'synthetic-certificate-chain',
+      OPENAI_X509_CLIENT_PRIVATE_KEY_PEM: 'synthetic-private-key',
+      ...environment,
+    },
+  });
+}
+
+describe('X.509 workload-identity runnable example', () => {
+  test('builds the SDK before running its clean-checkout live validation command', () => {
+    expect(packageScripts.scripts['test:live:x509']).toMatch(/^pnpm build && node /u);
+  });
+
+  test('documents an Undici version compatible with the complete supported Node 22 range', () => {
+    expect(exampleDocumentation).toContain('npm install openai "undici@^7"');
+  });
+
+  test('builds repository self-imports before documenting the direct example command', () => {
+    expect(exampleDocumentation).toMatch(/pnpm build\s+node examples\/mtls\/x509-workload-identity\.mjs/u);
+  });
+
+  test('preserves an explicitly empty encrypted-key passphrase', () => {
+    expect(example).toContain('passphrase === undefined ? {} : { passphrase }');
+  });
+
+  test.each([
+    ['runnable', example],
+    ['documented', packageDocumentation],
+  ])('keeps the %s X.509 example isolated from ambient credentials and routing', (_name, source) => {
+    expect(source).toContain('apiKey: null');
+    expect(source).toContain('adminAPIKey: null');
+    expect(source).toContain('baseURL: null');
+    expect(source).toContain('organization: null');
+    expect(source).toContain("project: process.env['OPENAI_X509_PROJECT_ID'] ?? null");
+  });
+
+  test('never exposes credentials from a malformed CONNECT proxy URL', () => {
+    const secret = 'synthetic-private-proxy-password';
+    const result = runExample({
+      OPENAI_X509_PROXY_MODE: 'http_connect',
+      HTTPS_PROXY: `http://user:${secret}@[invalid`,
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('valid CONNECT proxy URL');
+    expect(result.stderr).not.toContain(secret);
+    expect(result.stdout).not.toContain(secret);
+  });
+
+  test('rejects a CONNECT proxy whose protocol does not match the explicitly selected mode', () => {
+    const result = runExample({
+      OPENAI_X509_PROXY_MODE: 'https_connect',
+      HTTPS_PROXY: 'http://127.0.0.1:8080',
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('must match the HTTPS_PROXY protocol');
+  });
+
+  test('ignores ambient proxy settings unless a CONNECT proxy mode is explicitly requested', () => {
+    const secret = 'synthetic-ignored-ambient-proxy-password';
+    const result = runExample({ HTTPS_PROXY: `http://user:${secret}@[invalid` });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('OPENAI_X509_IDENTITY_PROVIDER_ID');
+    expect(result.stderr).not.toContain(secret);
+  });
+});

--- a/tests/lib/x509-workload-identity.test.ts
+++ b/tests/lib/x509-workload-identity.test.ts
@@ -510,7 +510,7 @@ describe('OpenAI X.509 workload-identity client integration', () => {
 
       await expect(client.models.list()).resolves.toMatchObject({ data: [] });
       expect(dispatches).toBe(2);
-      expect(send).toHaveBeenCalledTimes(4);
+      expect(send).toHaveBeenCalledTimes(status === 401 ? 4 : 3);
     },
   );
 
@@ -588,10 +588,8 @@ describe('OpenAI X.509 workload-identity client integration', () => {
 
     await Promise.all([client.request(shared), client.request(shared)]);
 
-    expect(exchangeCount).toBe(2);
-    expect(dispatched).toEqual(
-      new Set(['Bearer synthetic-concurrent-token-1', 'Bearer synthetic-concurrent-token-2']),
-    );
+    expect(exchangeCount).toBe(1);
+    expect(dispatched).toEqual(new Set(['Bearer synthetic-concurrent-token-1']));
   });
 
   test('starts a new isolated operation when caller options are reused sequentially', async () => {
@@ -603,7 +601,7 @@ describe('OpenAI X.509 workload-identity client integration', () => {
     await delay(60);
     await client.request(shared);
 
-    expect(send).toHaveBeenCalledTimes(4);
+    expect(send).toHaveBeenCalledTimes(3);
   });
 
   test('rejects protected hooks that replace the issued workload bearer', async () => {

--- a/tests/lib/x509-workload-identity.test.ts
+++ b/tests/lib/x509-workload-identity.test.ts
@@ -616,8 +616,8 @@ describe('OpenAI X.509 workload-identity client integration', () => {
       },
     });
 
-    await expect(client.models.list()).rejects.toThrow(/issued workload authorization/iu);
-    expect(send).toHaveBeenCalledTimes(1);
+    await expect(client.models.list()).rejects.toThrow(/caller-supplied.*authorization/iu);
+    expect(send).not.toHaveBeenCalled();
   });
 
   test.each([401, 503])(
@@ -662,8 +662,8 @@ describe('OpenAI X.509 workload-identity client integration', () => {
       },
     });
 
-    await expect(client.models.list()).rejects.toThrow(/issued workload authorization/iu);
-    expect(send).toHaveBeenCalledTimes(1);
+    await expect(client.models.list()).rejects.toThrow(/caller-supplied.*authorization/iu);
+    expect(send).not.toHaveBeenCalled();
   });
 
   test('rejects forbidden proxy credentials before they can reach an enabled debug logger', async () => {
@@ -679,9 +679,9 @@ describe('OpenAI X.509 workload-identity client integration', () => {
       },
     });
 
-    await expect(client.models.list()).rejects.toThrow(/conflicting authentication/iu);
+    await expect(client.models.list()).rejects.toThrow(/caller-supplied.*authentication/iu);
     expect(JSON.stringify(logger.debug.mock.calls)).not.toContain(secret);
-    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).not.toHaveBeenCalled();
   });
 
   test.each(['fetchWithAuth', 'fetchWithTimeout'])(

--- a/tests/lib/x509-workload-identity.test.ts
+++ b/tests/lib/x509-workload-identity.test.ts
@@ -829,22 +829,28 @@ describe('OpenAI X.509 workload-identity client integration', () => {
     expect(client.baseURL).toBe('https://api.openai.com/v1');
   });
 
-  test('uses the exact same attested TLS identity for the real issuer and API handshakes', async () => {
+  test('reuses and rotates real TLS-issued credentials without exposing them to a CONNECT proxy', async () => {
     const lab = createX509TestLab();
+    let exchanges = 0;
+    let dispatches = 0;
     const issuer = createMutualTLSServer(
       lab,
       (_request, response) => {
+        exchanges += 1;
         response.writeHead(200, { 'Content-Type': 'application/json' });
-        response.end(JSON.stringify(TOKEN_RESPONSE));
+        response.end(
+          JSON.stringify({ ...TOKEN_RESPONSE, access_token: `synthetic-wire-token-${exchanges}` }),
+        );
       },
       lab.issuerServer,
     );
     const api = createMutualTLSServer(
       lab,
       (request, response) => {
-        if (request.headers.authorization !== `Bearer ${ACCESS_TOKEN}`) {
-          response.writeHead(401);
-          response.end();
+        dispatches += 1;
+        if (dispatches === 2) {
+          response.writeHead(401, { 'Content-Type': 'application/json' });
+          response.end(JSON.stringify({ error: { message: 'synthetic rejected workload credential' } }));
           return;
         }
         response.writeHead(200, { 'Content-Type': 'application/json' });
@@ -881,34 +887,46 @@ describe('OpenAI X.509 workload-identity client integration', () => {
         certificateIdentity: 'static',
         proxy: 'http-connect',
       });
-      const client = new OpenAI(options({ x509Transport: approved }));
+      const client = new OpenAI(options({ x509Transport: approved, maxRetries: 1 }));
 
-      const models = await client.models.list();
+      const models = [await client.models.list(), await client.models.list(), await client.models.list()];
 
-      expect(models.data).toEqual([]);
+      expect(models.map((result) => result.data)).toEqual([[], [], []]);
+      expect(exchanges).toBe(2);
+      expect(dispatches).toBe(4);
       const fingerprint = new X509Certificate(lab.firstClient.certificate).fingerprint256;
-      expect(issuer.requests).toEqual([
-        expect.objectContaining({
+      expect(issuer.requests).toHaveLength(2);
+      for (const request of issuer.requests) {
+        expect(request).toMatchObject({
           authority: 'mtls.auth.openai.com',
           authorization: undefined,
           certificateFingerprint: fingerprint,
           path: '/oauth/token',
           serverName: 'mtls.auth.openai.com',
-        }),
+        });
+      }
+      expect(api.requests.map((request) => request.authorization)).toEqual([
+        'Bearer synthetic-wire-token-1',
+        'Bearer synthetic-wire-token-1',
+        'Bearer synthetic-wire-token-2',
+        'Bearer synthetic-wire-token-2',
       ]);
-      expect(api.requests).toEqual([
-        expect.objectContaining({
+      for (const request of api.requests) {
+        expect(request).toMatchObject({
           authority: 'mtls.api.openai.com',
-          authorization: `Bearer ${ACCESS_TOKEN}`,
           certificateFingerprint: fingerprint,
           path: '/v1/models',
           serverName: 'mtls.api.openai.com',
-        }),
-      ]);
-      expect(proxy.requests.map((request) => request.path)).toEqual([
-        'mtls.auth.openai.com:443',
-        'mtls.api.openai.com:443',
-      ]);
+        });
+      }
+      expect(new Set(proxy.requests.map((request) => request.path))).toEqual(
+        new Set(['mtls.auth.openai.com:443', 'mtls.api.openai.com:443']),
+      );
+      for (const request of proxy.requests) {
+        expect(request.authorization).toBeUndefined();
+        expect(request.proxyAuthorization).toBeUndefined();
+        expect(request.certificateFingerprint).toBeUndefined();
+      }
     } finally {
       await proxyDispatcher?.close();
       await closeObservedServers(issuer, api, ...(proxy ? [proxy] : []));

--- a/tests/lib/x509-workload-lifecycle.test.ts
+++ b/tests/lib/x509-workload-lifecycle.test.ts
@@ -167,7 +167,11 @@ describe('X.509 workload credential lifecycle', () => {
     expect(exchanges).toBe(2);
   });
 
-  test('keeps a still-valid cached bearer after failed proactive refresh and applies a cooldown', async () => {
+  test.each([
+    ['default', {}, 1000],
+    ['issuer milliseconds', { 'retry-after-ms': '5000' }, 5000],
+    ['issuer seconds', { 'retry-after': '5' }, 5000],
+  ] as const)('honors the %s cooldown after failed proactive refresh', async (_kind, headers, cooldown) => {
     vi.useFakeTimers({ toFake: ['Date', 'performance', 'setTimeout', 'clearTimeout'] });
     let exchanges = 0;
     let dispatches = 0;
@@ -175,8 +179,8 @@ describe('X.509 workload credential lifecycle', () => {
       if (url.origin === 'https://mtls.auth.openai.com') {
         exchanges += 1;
         return exchanges === 1
-          ? token('synthetic-still-valid-bearer', 10)
-          : new Response(null, { status: 503 });
+          ? token('synthetic-still-valid-bearer', 20)
+          : new Response(null, { status: 503, headers });
       }
       dispatches += 1;
       return Response.json({ data: [] });
@@ -184,12 +188,18 @@ describe('X.509 workload credential lifecycle', () => {
     const client = new OpenAI(options());
 
     await client.models.list();
-    await vi.advanceTimersByTimeAsync(5001);
+    await vi.advanceTimersByTimeAsync(10_001);
     await client.models.list();
+    await client.models.list();
+    await vi.advanceTimersByTimeAsync(cooldown - 1);
     await client.models.list();
 
     expect(exchanges).toBe(2);
-    expect(dispatches).toBe(3);
+    expect(dispatches).toBe(4);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await client.models.list();
+    expect(exchanges).toBe(3);
   });
 
   test.each(['permanent-tls', 'permanent-body', 'invalid-token', 'retry-disabled'])(

--- a/tests/lib/x509-workload-lifecycle.test.ts
+++ b/tests/lib/x509-workload-lifecycle.test.ts
@@ -539,7 +539,7 @@ describe('X.509 workload credential lifecycle', () => {
       });
 
       await expect(client.models.list()).rejects.toThrow(/organization or project/iu);
-      expect(send).toHaveBeenCalledTimes(1);
+      expect(send).not.toHaveBeenCalled();
     },
   );
 

--- a/tests/lib/x509-workload-lifecycle.test.ts
+++ b/tests/lib/x509-workload-lifecycle.test.ts
@@ -1,0 +1,980 @@
+import { once } from 'node:events';
+import { setTimeout as delay } from 'node:timers/promises';
+import { Agent } from 'undici';
+import { vi } from 'vitest';
+
+import OpenAI, { APIConnectionError, APIUserAbortError, OAuthError } from 'openai';
+import type { ClientOptions } from 'openai';
+import { createX509Transport } from 'openai/auth/x509-transport';
+import type { X509Transport } from 'openai/auth/x509-transport';
+import * as transportCapability from 'openai/internal/auth/x509-transport-capability';
+
+const TOKEN_RESPONSE = {
+  issued_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+  token_type: 'Bearer',
+  expires_in: 3600,
+};
+
+let dispatcher: Agent;
+let transport: X509Transport;
+
+function options(overrides: Partial<ClientOptions> = {}): ClientOptions {
+  return {
+    apiKey: null,
+    maxRetries: 0,
+    workloadIdentity: {
+      type: 'x509',
+      identityProviderId: 'synthetic-lifecycle-provider',
+      serviceAccountId: 'synthetic-lifecycle-account',
+    },
+    x509Transport: transport,
+    ...overrides,
+  };
+}
+
+function token(value: string, expiresIn = 3600): Response {
+  return Response.json({ ...TOKEN_RESPONSE, access_token: value, expires_in: expiresIn });
+}
+
+beforeEach(() => {
+  dispatcher = new Agent();
+  transport = createX509Transport({
+    runtime: 'node',
+    dispatcher,
+    certificateIdentity: 'static',
+    proxy: 'direct',
+  });
+});
+
+afterEach(async () => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  await dispatcher.close();
+});
+
+describe('X.509 workload credential lifecycle', () => {
+  test('lazily exchanges and reuses one service-account credential across sequential requests', async () => {
+    const issued: string[] = [];
+    const send = vi
+      .spyOn(transportCapability, 'sendX509Request')
+      .mockImplementation(async (_transport, target, request) => {
+        if (target.origin === 'https://mtls.auth.openai.com') {
+          return token('synthetic-cached-bearer');
+        }
+        issued.push(new Headers(request.headers).get('Authorization') ?? '');
+        return Response.json({ data: [] });
+      });
+    const client = new OpenAI(options());
+
+    expect(send).not.toHaveBeenCalled();
+    await client.models.list();
+    await client.models.list();
+    await client.models.list();
+
+    expect(send).toHaveBeenCalledTimes(4);
+    expect(issued).toEqual([
+      'Bearer synthetic-cached-bearer',
+      'Bearer synthetic-cached-bearer',
+      'Bearer synthetic-cached-bearer',
+    ]);
+  });
+
+  test('shares one in-flight certificate exchange across concurrent isolated requests', async () => {
+    const send = vi
+      .spyOn(transportCapability, 'sendX509Request')
+      .mockImplementation(async (_transport, url) => {
+        if (url.origin === 'https://mtls.auth.openai.com') {
+          await delay(15);
+          return token('synthetic-shared-bearer');
+        }
+        return Response.json({ data: [] });
+      });
+    const client = new OpenAI(options());
+
+    await Promise.all([
+      client.models.list(),
+      client.models.list(),
+      client.models.list(),
+      client.models.list(),
+    ]);
+
+    expect(send).toHaveBeenCalledTimes(5);
+    expect(send.mock.calls.filter(([, url]) => url.origin === 'https://mtls.auth.openai.com')).toHaveLength(
+      1,
+    );
+  });
+
+  test.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid refreshBufferMs %s before certificate presentation',
+    (refreshBufferMs) => {
+      const send = vi.spyOn(transportCapability, 'sendX509Request');
+
+      expect(
+        () =>
+          new OpenAI(
+            options({
+              workloadIdentity: {
+                type: 'x509',
+                identityProviderId: 'synthetic-provider',
+                serviceAccountId: 'synthetic-account',
+                refreshBufferMs,
+              },
+            }),
+          ),
+      ).toThrow(/refreshBufferMs/iu);
+      expect(send).not.toHaveBeenCalled();
+    },
+  );
+
+  test('caps proactive refresh at half of a short issuer-approved token lifetime', async () => {
+    vi.useFakeTimers({ toFake: ['Date', 'performance', 'setTimeout', 'clearTimeout'] });
+    let exchanges = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        exchanges += 1;
+        return token(`synthetic-short-token-${exchanges}`, 10);
+      }
+      return Response.json({ data: [] });
+    });
+    const client = new OpenAI(options());
+
+    await client.models.list();
+    await vi.advanceTimersByTimeAsync(4999);
+    await client.models.list();
+    expect(exchanges).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(2);
+    await client.models.list();
+    expect(exchanges).toBe(2);
+  });
+
+  test('refreshes expired credentials after wall-clock suspend without monotonic-clock advancement', async () => {
+    vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] });
+    let exchanges = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        exchanges += 1;
+        return token(`synthetic-suspend-token-${exchanges}`, 10);
+      }
+      return Response.json({ data: [] });
+    });
+    const client = new OpenAI(options());
+
+    await client.models.list();
+    vi.setSystemTime(Date.now() + 10_001);
+    await client.models.list();
+
+    expect(exchanges).toBe(2);
+  });
+
+  test('keeps a still-valid cached bearer after failed proactive refresh and applies a cooldown', async () => {
+    vi.useFakeTimers({ toFake: ['Date', 'performance', 'setTimeout', 'clearTimeout'] });
+    let exchanges = 0;
+    let dispatches = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        exchanges += 1;
+        return exchanges === 1
+          ? token('synthetic-still-valid-bearer', 10)
+          : new Response(null, { status: 503 });
+      }
+      dispatches += 1;
+      return Response.json({ data: [] });
+    });
+    const client = new OpenAI(options());
+
+    await client.models.list();
+    await vi.advanceTimersByTimeAsync(5001);
+    await client.models.list();
+    await client.models.list();
+
+    expect(exchanges).toBe(2);
+    expect(dispatches).toBe(3);
+  });
+
+  test.each(['permanent-tls', 'permanent-body', 'invalid-token', 'retry-disabled'])(
+    'never falls back to a cached bearer after a terminal %s refresh failure',
+    async (failure) => {
+      vi.useFakeTimers({ toFake: ['Date', 'performance', 'setTimeout', 'clearTimeout'] });
+      let exchanges = 0;
+      let dispatches = 0;
+      vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+        if (url.origin !== 'https://mtls.auth.openai.com') {
+          dispatches += 1;
+          return Response.json({ data: [] });
+        }
+        exchanges += 1;
+        if (exchanges === 1) {
+          return token('synthetic-still-valid-bearer', 10);
+        }
+        if (failure === 'permanent-tls') {
+          throw Object.assign(new Error('synthetic permanent certificate failure'), {
+            code: 'ERR_TLS_CERT_ALTNAME_INVALID',
+          });
+        }
+        if (failure === 'permanent-body') {
+          return new Response(
+            new ReadableStream({
+              pull(controller) {
+                controller.error(
+                  Object.assign(new Error('synthetic invalid issuer body'), { code: 'Z_DATA_ERROR' }),
+                );
+              },
+            }),
+          );
+        }
+        return failure === 'invalid-token'
+          ? Response.json({ ...TOKEN_RESPONSE, access_token: 'synthetic-invalid-token', token_type: 'MAC' })
+          : new Response(null, { status: 503, headers: { 'x-should-retry': 'false' } });
+      });
+      const client = new OpenAI(options());
+
+      await client.models.list();
+      await vi.advanceTimersByTimeAsync(5001);
+
+      await expect(client.models.list()).rejects.toThrow();
+      expect(exchanges).toBe(2);
+      expect(dispatches).toBe(1);
+    },
+  );
+
+  test('allows a still-valid cached bearer only after a classified transient transport failure', async () => {
+    vi.useFakeTimers({ toFake: ['Date', 'performance', 'setTimeout', 'clearTimeout'] });
+    let exchanges = 0;
+    let dispatches = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin !== 'https://mtls.auth.openai.com') {
+        dispatches += 1;
+        return Response.json({ data: [] });
+      }
+      exchanges += 1;
+      if (exchanges === 1) {
+        return token('synthetic-still-valid-bearer', 10);
+      }
+      throw Object.assign(new Error('synthetic connection reset'), { code: 'ECONNRESET' });
+    });
+    const client = new OpenAI(options());
+
+    await client.models.list();
+    await vi.advanceTimersByTimeAsync(5001);
+    await client.models.list();
+
+    expect(exchanges).toBe(2);
+    expect(dispatches).toBe(2);
+  });
+
+  test('never reuses an expired cached token after a failed refresh', async () => {
+    vi.useFakeTimers({ toFake: ['Date', 'performance', 'setTimeout', 'clearTimeout'] });
+    let exchanges = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        exchanges += 1;
+        return exchanges === 1 ? token('synthetic-expiring-bearer', 2) : new Response(null, { status: 503 });
+      }
+      return Response.json({ data: [] });
+    });
+    const client = new OpenAI(options());
+
+    await client.models.list();
+    await vi.advanceTimersByTimeAsync(2001);
+
+    await expect(client.models.list()).rejects.toThrow(/503/u);
+    expect(exchanges).toBe(2);
+  });
+
+  test('does not cancel a shared refresh when only one waiting request is aborted', async () => {
+    const first = new AbortController();
+    const reason = new Error('synthetic-first-waiter-canceled');
+    const send = vi
+      .spyOn(transportCapability, 'sendX509Request')
+      .mockImplementation(async (_transport, url, request) => {
+        if (url.origin === 'https://mtls.auth.openai.com') {
+          await delay(30, undefined, { signal: request.signal ?? undefined });
+          return token('synthetic-surviving-bearer');
+        }
+        return Response.json({ data: [] });
+      });
+    const client = new OpenAI(options());
+    const canceled = client.models.list({ signal: first.signal });
+    const surviving = client.models.list();
+    setTimeout(() => first.abort(reason), 5);
+
+    await expect(canceled).rejects.toMatchObject({ constructor: APIUserAbortError, cause: reason });
+    await expect(surviving).resolves.toMatchObject({ data: [] });
+    expect(send.mock.calls.filter(([, url]) => url.origin === 'https://mtls.auth.openai.com')).toHaveLength(
+      1,
+    );
+  });
+
+  test('handles cancellation fired synchronously while the first exchange begins', async () => {
+    const caller = new AbortController();
+    const reason = new Error('synthetic-synchronous-cancellation');
+    let issuerSignal: AbortSignal | null | undefined;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, _url, request) => {
+      issuerSignal = request.signal;
+      caller.abort(reason);
+      await delay(5000, undefined, { signal: request.signal ?? undefined });
+      return token('synthetic-must-not-be-cached');
+    });
+    const client = new OpenAI(options({ timeout: 100 }));
+
+    await expect(client.models.list({ signal: caller.signal })).rejects.toMatchObject({
+      constructor: APIUserAbortError,
+      cause: reason,
+    });
+    await vi.waitFor(() => expect(issuerSignal?.aborted).toBe(true));
+  });
+
+  test('never lets an abandoned, noncooperative certificate exchange overwrite a newer token', async () => {
+    const first = new AbortController();
+    const second = new AbortController();
+    let exchanges = 0;
+    let abandonedSignal: AbortSignal | null | undefined;
+    const dispatched: string[] = [];
+    const abandonedCompletion = new EventTarget();
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url, request) => {
+      if (url.origin !== 'https://mtls.auth.openai.com') {
+        dispatched.push(new Headers(request.headers).get('Authorization') ?? '');
+        return Response.json({ data: [] });
+      }
+      exchanges += 1;
+      if (exchanges === 1) {
+        abandonedSignal = request.signal;
+        await once(abandonedCompletion, 'complete');
+        return token('synthetic-abandoned-bearer');
+      }
+      return token('synthetic-current-bearer');
+    });
+    const client = new OpenAI(options());
+    const abandoned = [
+      client.models.list({ signal: first.signal }),
+      client.models.list({ signal: second.signal }),
+    ];
+    await vi.waitFor(() => expect(abandonedSignal).toBeDefined(), { interval: 1 });
+    first.abort(new Error('synthetic-first-waiter-canceled'));
+    second.abort(new Error('synthetic-second-waiter-canceled'));
+
+    await Promise.all(
+      abandoned.map(async (request) => await expect(request).rejects.toBeInstanceOf(APIUserAbortError)),
+    );
+    await vi.waitFor(() => expect(abandonedSignal?.aborted).toBe(true));
+    await client.models.list();
+    abandonedCompletion.dispatchEvent(new Event('complete'));
+    await delay(0);
+    await client.models.list();
+
+    expect(exchanges).toBe(2);
+    expect(dispatched).toEqual(['Bearer synthetic-current-bearer', 'Bearer synthetic-current-bearer']);
+  });
+
+  test('keeps token caches separate for distinct clients and service-account selectors', async () => {
+    let exchanges = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        exchanges += 1;
+        return token(`synthetic-client-token-${exchanges}`);
+      }
+      return Response.json({ data: [] });
+    });
+    const first = new OpenAI(options());
+    const second = new OpenAI(
+      options({
+        workloadIdentity: {
+          type: 'x509',
+          identityProviderId: 'synthetic-lifecycle-provider',
+          serviceAccountId: 'synthetic-other-account',
+        },
+      }),
+    );
+
+    await first.models.list();
+    await second.models.list();
+    await first.models.list();
+
+    expect(exchanges).toBe(2);
+  });
+
+  test('shares cached credentials across clones with the same transport and enrolled account', async () => {
+    const send = vi
+      .spyOn(transportCapability, 'sendX509Request')
+      .mockImplementation(async (_transport, url) =>
+        url.origin === 'https://mtls.auth.openai.com'
+          ? token('synthetic-shared-clone-bearer')
+          : Response.json({ data: [] }),
+      );
+    const original = new OpenAI(options());
+
+    await original.models.list();
+    await original.withOptions({ timeout: 2500 }).models.list();
+
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(send.mock.calls.filter(([, url]) => url.origin === 'https://mtls.auth.openai.com')).toHaveLength(
+      1,
+    );
+  });
+
+  test('does not reuse clone credentials after changing the enrolled service account', async () => {
+    let exchanges = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        exchanges += 1;
+        return token(`synthetic-account-bearer-${exchanges}`);
+      }
+      return Response.json({ data: [] });
+    });
+    const original = new OpenAI(options());
+
+    await original.models.list();
+    await original
+      .withOptions({
+        workloadIdentity: {
+          type: 'x509',
+          identityProviderId: 'synthetic-lifecycle-provider',
+          serviceAccountId: 'synthetic-changed-account',
+        },
+      })
+      .models.list();
+
+    expect(exchanges).toBe(2);
+  });
+
+  test('never re-reads a mutable clone identity when deciding whether credentials can be shared', async () => {
+    const accounts: string[] = [];
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url, request) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        const body: unknown = JSON.parse(String(request.body));
+        if (typeof body === 'object' && body && 'service_account_id' in body) {
+          accounts.push(String(body.service_account_id));
+        }
+        return token(`synthetic-account-token-${accounts.length}`);
+      }
+      return Response.json({ data: [] });
+    });
+    const original = new OpenAI(options());
+    await original.models.list();
+    let reads = 0;
+
+    const clone = original.withOptions({
+      workloadIdentity: {
+        type: 'x509',
+        identityProviderId: 'synthetic-lifecycle-provider',
+        get serviceAccountId() {
+          reads += 1;
+          return reads === 1 ? 'synthetic-other-account' : 'synthetic-lifecycle-account';
+        },
+      },
+    });
+    await clone.models.list();
+
+    expect(accounts).toEqual(['synthetic-lifecycle-account', 'synthetic-other-account']);
+    expect(reads).toBe(1);
+  });
+
+  test.each(['OpenAI-Organization', 'OpenAI-Project'])(
+    'rejects per-request %s tenant overrides before reusing a cached bearer',
+    async (header) => {
+      const send = vi
+        .spyOn(transportCapability, 'sendX509Request')
+        .mockImplementation(async (_transport, url) =>
+          url.origin === 'https://mtls.auth.openai.com'
+            ? token('synthetic-tenant-scoped-bearer')
+            : Response.json({ data: [] }),
+        );
+      const client = new OpenAI(options({ organization: 'synthetic-org', project: 'synthetic-project' }));
+
+      await client.models.list();
+      await expect(client.models.list({ headers: { [header]: 'synthetic-other-tenant' } })).rejects.toThrow(
+        /organization or project/iu,
+      );
+      expect(send).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  test('rejects a clone that overrides its effective tenant through default headers', async () => {
+    const send = vi
+      .spyOn(transportCapability, 'sendX509Request')
+      .mockImplementation(async (_transport, url) =>
+        url.origin === 'https://mtls.auth.openai.com'
+          ? token('synthetic-tenant-scoped-bearer')
+          : Response.json({ data: [] }),
+      );
+    const original = new OpenAI(options({ organization: 'synthetic-org' }));
+
+    await original.models.list();
+    await expect(
+      original
+        .withOptions({ defaultHeaders: { 'OpenAI-Organization': 'synthetic-other-org' } })
+        .models.list(),
+    ).rejects.toThrow(/organization or project/iu);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  test.each(['OpenAI_Organization', 'OpenAI_Project'])(
+    'rejects a protected-hook %s alias before dispatching a tenant-scoped bearer',
+    async (header) => {
+      const send = vi
+        .spyOn(transportCapability, 'sendX509Request')
+        .mockImplementation(async (_transport, url) =>
+          url.origin === 'https://mtls.auth.openai.com'
+            ? token('synthetic-tenant-scoped-bearer')
+            : Response.json({ data: [] }),
+        );
+      const client = new OpenAI(options({ organization: 'synthetic-org', project: 'synthetic-project' }));
+      Object.defineProperty(client, 'prepareRequest', {
+        value: async (request: RequestInit) => {
+          if (request.headers instanceof Headers) {
+            request.headers.set(header, 'synthetic-other-tenant');
+          }
+        },
+      });
+
+      await expect(client.models.list()).rejects.toThrow(/organization or project/iu);
+      expect(send).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test.each(['organization', 'project'] as const)(
+    'rejects a mutable public %s change before reusing a cached bearer',
+    async (selector) => {
+      const send = vi
+        .spyOn(transportCapability, 'sendX509Request')
+        .mockImplementation(async (_transport, url) =>
+          url.origin === 'https://mtls.auth.openai.com'
+            ? token('synthetic-tenant-scoped-bearer')
+            : Response.json({ data: [] }),
+        );
+      const client = new OpenAI(options({ organization: 'synthetic-org', project: 'synthetic-project' }));
+      await client.models.list();
+      client[selector] = 'synthetic-other-tenant';
+
+      await expect(client.models.list()).rejects.toThrow(/organization or project/iu);
+      expect(send).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  test('rotates to a new approved certificate capability without reusing its predecessors token', async () => {
+    const rotatedDispatcher = new Agent();
+    const rotated = createX509Transport({
+      runtime: 'node',
+      dispatcher: rotatedDispatcher,
+      certificateIdentity: 'static',
+      proxy: 'direct',
+    });
+    const issuerCapabilities: X509Transport[] = [];
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (capability, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        issuerCapabilities.push(capability);
+        return token(`synthetic-rotated-token-${issuerCapabilities.length}`);
+      }
+      return Response.json({ data: [] });
+    });
+
+    try {
+      const original = new OpenAI(options());
+      await original.models.list();
+      await original.withOptions({ x509Transport: rotated }).models.list();
+
+      expect(issuerCapabilities).toEqual([transport, rotated]);
+    } finally {
+      await rotatedDispatcher.close();
+    }
+  });
+
+  test.each([408, 409, 429, 500, 503])(
+    'retries an eligible issuer %i once within the same overall retry budget',
+    async (status) => {
+      let exchanges = 0;
+      let dispatches = 0;
+      vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+        if (url.origin === 'https://mtls.auth.openai.com') {
+          exchanges += 1;
+          return exchanges === 1
+            ? new Response(null, { status, headers: { 'retry-after-ms': '1' } })
+            : token('synthetic-retried-bearer');
+        }
+        dispatches += 1;
+        return Response.json({ data: [] });
+      });
+      const client = new OpenAI(options({ maxRetries: 1 }));
+
+      await expect(client.models.list()).resolves.toMatchObject({ data: [] });
+      expect(exchanges).toBe(2);
+      expect(dispatches).toBe(1);
+    },
+  );
+
+  test('does not retry a terminal issuer OAuth rejection', async () => {
+    const send = vi
+      .spyOn(transportCapability, 'sendX509Request')
+      .mockResolvedValue(Response.json({ error: 'invalid_grant' }, { status: 400 }));
+    const client = new OpenAI(options({ maxRetries: 2 }));
+
+    await expect(client.models.list()).rejects.toBeInstanceOf(OAuthError);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  test('keeps an issuer OAuth rejection terminal even when its error body reaches the issuer deadline', async () => {
+    vi.useFakeTimers({ toFake: ['Date', 'performance', 'setTimeout', 'clearTimeout'] });
+    const send = vi
+      .spyOn(transportCapability, 'sendX509Request')
+      .mockResolvedValue(new Response(new ReadableStream(), { status: 400 }));
+    const client = new OpenAI(options({ maxRetries: 1 }));
+    const rejected = expect(client.models.list()).rejects.toBeInstanceOf(OAuthError);
+
+    await vi.advanceTimersByTimeAsync(5001);
+    await rejected;
+
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  test.each(['ERR_TLS_CERT_ALTNAME_INVALID', 'SELF_SIGNED_CERT_IN_CHAIN'])(
+    'never retries a permanent final API certificate failure: %s',
+    async (code) => {
+      let exchanges = 0;
+      let dispatches = 0;
+      vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+        if (url.origin === 'https://mtls.auth.openai.com') {
+          exchanges += 1;
+          return token('synthetic-approved-bearer');
+        }
+        dispatches += 1;
+        throw Object.assign(new Error('synthetic permanent certificate failure'), { code });
+      });
+      const client = new OpenAI(options({ maxRetries: 2 }));
+
+      await expect(client.models.list()).rejects.toThrow();
+      expect(exchanges).toBe(1);
+      expect(dispatches).toBe(1);
+    },
+  );
+
+  test('retries a classified transient final API connection failure without exchanging another bearer', async () => {
+    let exchanges = 0;
+    let dispatches = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        exchanges += 1;
+        return token('synthetic-approved-bearer');
+      }
+      dispatches += 1;
+      if (dispatches === 1) {
+        throw Object.assign(new Error('synthetic connection reset'), { code: 'ECONNRESET' });
+      }
+      return Response.json({ data: [] });
+    });
+    const client = new OpenAI(options({ maxRetries: 1 }));
+
+    await expect(client.models.list()).resolves.toMatchObject({ data: [] });
+    expect(exchanges).toBe(1);
+    expect(dispatches).toBe(2);
+  });
+
+  test('never exposes a secret-bearing final transport failure through a public error cause', async () => {
+    const secret = 'synthetic-private-proxy-credential';
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        return token('synthetic-approved-bearer');
+      }
+      throw Object.assign(new Error(`synthetic proxy failure: ${secret}`), {
+        code: 'ERR_TLS_CERT_ALTNAME_INVALID',
+      });
+    });
+    const client = new OpenAI(options());
+
+    try {
+      await client.models.list();
+      throw new Error('synthetic expected connection failure');
+    } catch (error) {
+      expect(error).toBeInstanceOf(APIConnectionError);
+      if (error instanceof Error) {
+        expect(error.message).not.toContain(secret);
+        expect(Object.getOwnPropertyDescriptor(error, 'cause')?.value).toBeUndefined();
+      }
+    }
+  });
+
+  test('cancels issuer or API retry backoff immediately and preserves the caller reason', async () => {
+    const caller = new AbortController();
+    const reason = new Error('synthetic-backoff-cancellation');
+    let dispatches = 0;
+    const send = vi
+      .spyOn(transportCapability, 'sendX509Request')
+      .mockImplementation(async (_transport, url) => {
+        if (url.origin === 'https://mtls.auth.openai.com') {
+          return token('synthetic-approved-bearer');
+        }
+        dispatches += 1;
+        return new Response(null, { status: 429, headers: { 'retry-after-ms': '700' } });
+      });
+    const client = new OpenAI(options({ maxRetries: 1 }));
+    const startedAt = performance.now();
+    setTimeout(() => caller.abort(reason), 20);
+
+    await expect(client.models.list({ signal: caller.signal })).rejects.toMatchObject({
+      constructor: APIUserAbortError,
+      cause: reason,
+    });
+    expect(performance.now() - startedAt).toBeLessThan(400);
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(dispatches).toBe(1);
+  });
+
+  test('applies the original monotonic deadline while reading a terminal API error body', async () => {
+    let exchanges = 0;
+    let dispatches = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        exchanges += 1;
+        return token('synthetic-approved-bearer');
+      }
+      dispatches += 1;
+      return new Response(new ReadableStream(), { status: 403 });
+    });
+    const client = new OpenAI(options({ timeout: 50, maxRetries: 0 }));
+    const startedAt = performance.now();
+
+    await expect(client.models.list()).rejects.toThrow(/timed out/iu);
+    expect(performance.now() - startedAt).toBeLessThan(500);
+    expect(exchanges).toBe(1);
+    expect(dispatches).toBe(1);
+  });
+
+  test('preserves the caller cancellation reason while reading a terminal API error body', async () => {
+    const caller = new AbortController();
+    const reason = new Error('synthetic-error-body-cancellation');
+    const send = vi
+      .spyOn(transportCapability, 'sendX509Request')
+      .mockImplementation(async (_transport, url) =>
+        url.origin === 'https://mtls.auth.openai.com'
+          ? token('synthetic-approved-bearer')
+          : new Response(new ReadableStream(), { status: 403 }),
+      );
+    const client = new OpenAI(options({ timeout: 1000 }));
+    setTimeout(() => caller.abort(reason), 10);
+
+    await expect(client.models.list({ signal: caller.signal })).rejects.toMatchObject({
+      constructor: APIUserAbortError,
+      cause: reason,
+    });
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  test('never exposes secret-bearing transport failures while reading a terminal API error body', async () => {
+    const secret = 'synthetic-private-error-body-credential';
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) =>
+      url.origin === 'https://mtls.auth.openai.com'
+        ? token('synthetic-approved-bearer')
+        : new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.error(new Error(`synthetic response-body failure: ${secret}`));
+              },
+            }),
+            { status: 403 },
+          ),
+    );
+    const client = new OpenAI(options());
+
+    try {
+      await client.models.list();
+      throw new Error('synthetic expected response failure');
+    } catch (error) {
+      if (error instanceof Error) {
+        expect(error.message).toContain('403');
+        expect(error.message).not.toContain(secret);
+      }
+    }
+  });
+
+  test('never exposes secret-bearing transport failures while reading a successful API response body', async () => {
+    const secret = 'synthetic-private-success-body-credential';
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) =>
+      url.origin === 'https://mtls.auth.openai.com'
+        ? token('synthetic-approved-bearer')
+        : new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.error(new Error(`synthetic response-body failure: ${secret}`));
+              },
+            }),
+            { headers: { 'content-type': 'application/json' } },
+          ),
+    );
+    const client = new OpenAI(options());
+
+    try {
+      await client.models.list();
+      throw new Error('synthetic expected response failure');
+    } catch (error) {
+      expect(error).toBeInstanceOf(APIConnectionError);
+      if (error instanceof Error) {
+        expect(error.message).not.toContain(secret);
+        expect(Object.getOwnPropertyDescriptor(error, 'cause')?.value).toBeUndefined();
+      }
+    }
+  });
+
+  test('honors an issuer instruction not to retry an otherwise transient status', async () => {
+    const send = vi.spyOn(transportCapability, 'sendX509Request').mockResolvedValue(
+      new Response(null, {
+        status: 429,
+        headers: { 'x-should-retry': 'false', 'retry-after-ms': '1' },
+      }),
+    );
+    const client = new OpenAI(options({ maxRetries: 2 }));
+
+    await expect(client.models.list()).rejects.toThrow(/429/u);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  test('refreshes a rejected workload token exactly once while consuming the shared retry budget', async () => {
+    let exchanges = 0;
+    let dispatches = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        exchanges += 1;
+        return token(`synthetic-replayed-token-${exchanges}`);
+      }
+      dispatches += 1;
+      return dispatches === 1
+        ? Response.json({ error: { message: 'synthetic expired bearer' } }, { status: 401 })
+        : Response.json({ data: [] });
+    });
+    const client = new OpenAI(options({ maxRetries: 1 }));
+
+    await expect(client.models.list()).resolves.toMatchObject({ data: [] });
+    expect(exchanges).toBe(2);
+    expect(dispatches).toBe(2);
+  });
+
+  test('invalidates a rejected token without replaying when the retry budget is already exhausted', async () => {
+    let exchanges = 0;
+    let dispatches = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        exchanges += 1;
+        return token(`synthetic-invalidated-token-${exchanges}`);
+      }
+      dispatches += 1;
+      return dispatches === 1
+        ? Response.json({ error: { message: 'synthetic expired bearer' } }, { status: 401 })
+        : Response.json({ data: [] });
+    });
+    const client = new OpenAI(options({ maxRetries: 0 }));
+
+    await expect(client.models.list()).rejects.toThrow(/expired bearer/iu);
+    expect(exchanges).toBe(1);
+    expect(dispatches).toBe(1);
+
+    await expect(client.models.list()).resolves.toMatchObject({ data: [] });
+    expect(exchanges).toBe(2);
+    expect(dispatches).toBe(2);
+  });
+
+  test('invalidates the refreshed token after a second rejected replay before the next logical request', async () => {
+    let exchanges = 0;
+    let dispatches = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        exchanges += 1;
+        return token(`synthetic-generation-${exchanges}`);
+      }
+      dispatches += 1;
+      return dispatches <= 2
+        ? Response.json({ error: { message: 'synthetic rejected credential' } }, { status: 401 })
+        : Response.json({ data: [] });
+    });
+    const client = new OpenAI(options({ maxRetries: 1 }));
+
+    await expect(client.models.list()).rejects.toThrow(/rejected credential/iu);
+    expect(exchanges).toBe(2);
+    await expect(client.models.list()).resolves.toMatchObject({ data: [] });
+
+    expect(exchanges).toBe(3);
+    expect(dispatches).toBe(3);
+  });
+
+  test('does not let a delayed rejection evict a newer generation containing identical bearer bytes', async () => {
+    let exchanges = 0;
+    let dispatches = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        exchanges += 1;
+        return token('synthetic-identical-bearer');
+      }
+      dispatches += 1;
+      const attempt = dispatches;
+      if (attempt === 1) {
+        await delay(30);
+      }
+      return attempt <= 2
+        ? Response.json({ error: { message: 'synthetic stale generation' } }, { status: 401 })
+        : Response.json({ data: [] });
+    });
+    const client = new OpenAI(options({ maxRetries: 1 }));
+    const first = client.models.list();
+    await delay(5);
+    const second = client.models.list();
+
+    await Promise.all([first, second]);
+    await client.models.list();
+
+    expect(exchanges).toBe(2);
+    expect(dispatches).toBe(5);
+  });
+
+  test('invalidates a rejected bearer even when a streaming request body cannot be replayed', async () => {
+    let exchanges = 0;
+    let dispatches = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        exchanges += 1;
+        return token(`synthetic-stream-token-${exchanges}`);
+      }
+      dispatches += 1;
+      return dispatches === 1
+        ? Response.json({ error: { message: 'synthetic rejected stream' } }, { status: 401 })
+        : Response.json({ data: [] });
+    });
+    const client = new OpenAI(options({ maxRetries: 1 }));
+
+    await expect(
+      client.request({
+        path: '/models',
+        method: 'post',
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new Uint8Array([1]));
+            controller.close();
+          },
+        }),
+      }),
+    ).rejects.toThrow(/rejected stream/iu);
+    expect(exchanges).toBe(1);
+    expect(dispatches).toBe(1);
+
+    await client.models.list();
+    expect(exchanges).toBe(2);
+    expect(dispatches).toBe(2);
+  });
+
+  test('shares one retry allowance across an issuer retry and a later rejected API bearer', async () => {
+    let exchanges = 0;
+    let dispatches = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        exchanges += 1;
+        return exchanges === 1
+          ? new Response(null, { status: 429, headers: { 'retry-after-ms': '1' } })
+          : token('synthetic-last-allowance-token');
+      }
+      dispatches += 1;
+      return Response.json({ error: { message: 'synthetic exhausted allowance' } }, { status: 401 });
+    });
+    const client = new OpenAI(options({ maxRetries: 1 }));
+
+    await expect(client.models.list()).rejects.toThrow(/exhausted allowance/iu);
+    expect(exchanges).toBe(2);
+    expect(dispatches).toBe(1);
+  });
+});

--- a/tests/lib/x509-workload-request-boundaries.test.ts
+++ b/tests/lib/x509-workload-request-boundaries.test.ts
@@ -124,6 +124,27 @@ describe('X.509 request ownership boundaries', () => {
     },
   );
 
+  test('rejects an accessor-backed final override body before certificate authentication', async () => {
+    const hiddenStream = new ReadableStream();
+    const getter = vi.fn(() => hiddenStream);
+    const send = vi
+      .spyOn(transportCapability, 'sendX509Request')
+      .mockResolvedValue(new Response(null, { status: 503, headers: { 'retry-after-ms': '1' } }));
+    const client = new OpenAI(options({ maxRetries: 1 }));
+    const original = client.buildRequest.bind(client);
+    Object.defineProperty(client, 'buildRequest', {
+      value: async (...args: Parameters<OpenAI['buildRequest']>) => {
+        const built = await original(...args);
+        Object.defineProperty(built.req, 'body', { configurable: true, enumerable: true, get: getter });
+        return built;
+      },
+    });
+
+    await expect(client.models.list()).rejects.toThrow(/approved final request/iu);
+    expect(getter).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+  });
+
   test('retires an unread error response when its headers exhaust the request deadline', async () => {
     let elapsed = 0;
     let apiSignal: AbortSignal | undefined;

--- a/tests/lib/x509-workload-request-boundaries.test.ts
+++ b/tests/lib/x509-workload-request-boundaries.test.ts
@@ -368,6 +368,29 @@ describe('X.509 request ownership boundaries', () => {
     },
   );
 
+  test.each(['OpenAI-Organization', 'OpenAI-Project', 'OpenAI_Organization', 'OpenAI_Project'])(
+    'rejects overridden final tenant selector %s before certificate exchange',
+    async (name) => {
+      const send = vi
+        .spyOn(transportCapability, 'sendX509Request')
+        .mockResolvedValue(Response.json(tokenResponse));
+      const client = new OpenAI(
+        options({ organization: 'synthetic-enrolled-org', project: 'synthetic-enrolled-project' }),
+      );
+      const original = client.buildRequest.bind(client);
+      Object.defineProperty(client, 'buildRequest', {
+        value: async (...args: Parameters<OpenAI['buildRequest']>) => {
+          const built = await original(...args);
+          built.req.headers.set(name, 'synthetic-unapproved-tenant');
+          return built;
+        },
+      });
+
+      await expect(client.models.list()).rejects.toThrow(/organization|project/iu);
+      expect(send).not.toHaveBeenCalled();
+    },
+  );
+
   test('starts its network deadline only after asynchronous request preparation completes', async () => {
     const send = vi
       .spyOn(transportCapability, 'sendX509Request')

--- a/tests/lib/x509-workload-request-boundaries.test.ts
+++ b/tests/lib/x509-workload-request-boundaries.test.ts
@@ -484,6 +484,105 @@ describe('X.509 request ownership boundaries', () => {
     expect(send).toHaveBeenCalledTimes(2);
   });
 
+  test('starts its network deadline only after an asynchronous protected request hook completes', async () => {
+    const send = vi
+      .spyOn(transportCapability, 'sendX509Request')
+      .mockImplementation(async (_transport, url) =>
+        url.origin === 'https://mtls.auth.openai.com'
+          ? Response.json(tokenResponse)
+          : Response.json({ data: [] }),
+      );
+    const client = new OpenAI(options({ timeout: 45 }));
+    Object.defineProperty(client, 'prepareRequest', {
+      value: async () => await delay(90),
+    });
+
+    await expect(client.models.list()).resolves.toMatchObject({ data: [] });
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  test.each(['dispatcher', 'redirect', 'authorization', 'failure'] as const)(
+    'rejects a protected request hook %s before presenting a certificate',
+    async (mutation) => {
+      const send = vi
+        .spyOn(transportCapability, 'sendX509Request')
+        .mockResolvedValue(Response.json(tokenResponse));
+      const client = new OpenAI(options());
+      Object.defineProperty(client, 'prepareRequest', {
+        value: async (request: RequestInit) => {
+          if (mutation === 'dispatcher') {
+            Object.defineProperty(request, 'dispatcher', { value: {}, enumerable: true });
+          } else if (mutation === 'redirect') {
+            request.redirect = 'follow';
+          } else if (mutation === 'authorization') {
+            if (request.headers instanceof Headers) {
+              request.headers.set('Authorization', 'Bearer synthetic-unapproved-hook-secret');
+            }
+          } else {
+            throw new Error('synthetic-preauthentication-hook-failure');
+          }
+        },
+      });
+
+      await expect(client.models.list()).rejects.toThrow();
+      expect(send).not.toHaveBeenCalled();
+    },
+  );
+
+  test('retains response authentication mode when a protected hook changes mutable client state', async () => {
+    const hook = new AbortController();
+    const reason = new Error('synthetic-preserved-response-authentication-mode');
+    const canceled = vi.fn();
+    const send = vi
+      .spyOn(transportCapability, 'sendX509Request')
+      .mockImplementation(async (_transport, url) =>
+        url.origin === 'https://mtls.auth.openai.com'
+          ? Response.json(tokenResponse)
+          : new Response(new ReadableStream({ cancel: canceled }), {
+              headers: { 'content-type': 'application/json' },
+            }),
+      );
+    const client = new OpenAI(options({ timeout: 75 }));
+    Object.defineProperty(client, 'prepareRequest', {
+      value: async (request: RequestInit) => {
+        request.signal = hook.signal;
+        Object.defineProperty(client, '_workloadIdentityAuth', { value: undefined });
+      },
+    });
+    const pending = client.models.list();
+
+    await pending.asResponse();
+    hook.abort(reason);
+
+    await expect(pending).rejects.toMatchObject({ constructor: APIUserAbortError, cause: reason });
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  test('retains its private authentication owner when a protected hook changes client state before retry', async () => {
+    let apiCalls = 0;
+    const send = vi
+      .spyOn(transportCapability, 'sendX509Request')
+      .mockImplementation(async (_transport, url) => {
+        if (url.origin === 'https://mtls.auth.openai.com') {
+          return Response.json(tokenResponse);
+        }
+        apiCalls += 1;
+        return apiCalls === 1
+          ? new Response(null, { status: 503, headers: { 'retry-after-ms': '1' } })
+          : Response.json({ data: [] });
+      });
+    const client = new OpenAI(options({ maxRetries: 1 }));
+    Object.defineProperty(client, 'prepareRequest', {
+      value: async () => {
+        Object.defineProperty(client, '_workloadIdentityAuth', { value: undefined });
+      },
+    });
+
+    await expect(client.models.list()).resolves.toMatchObject({ data: [] });
+    expect(apiCalls).toBe(2);
+    expect(send).toHaveBeenCalledTimes(4);
+  });
+
   test('cancels retry backoff promptly through the effective protected-hook signal', async () => {
     const hookController = new AbortController();
     const send = vi

--- a/tests/lib/x509-workload-request-boundaries.test.ts
+++ b/tests/lib/x509-workload-request-boundaries.test.ts
@@ -580,7 +580,42 @@ describe('X.509 request ownership boundaries', () => {
 
     await expect(client.models.list()).resolves.toMatchObject({ data: [] });
     expect(apiCalls).toBe(2);
-    expect(send).toHaveBeenCalledTimes(4);
+    expect(send).toHaveBeenCalledTimes(3);
+  });
+
+  test('isolates a same-client request built from inside a protected request hook', async () => {
+    let nestedHeaders: Headers | undefined;
+    let dispatchedHeaders: Headers | undefined;
+    const send = vi
+      .spyOn(transportCapability, 'sendX509Request')
+      .mockImplementation(async (_transport, url, request) => {
+        if (url.origin === 'https://mtls.auth.openai.com') {
+          return Response.json(tokenResponse);
+        }
+        dispatchedHeaders = new Headers(request.headers);
+        return Response.json({ data: [] });
+      });
+    const client = new OpenAI(options());
+    Object.defineProperty(client, 'prepareRequest', {
+      value: async () => {
+        const nested = await client.buildRequest({
+          path: '/models',
+          method: 'get',
+          headers: { 'X-Synthetic-Nested': 'nested' },
+        });
+        nestedHeaders = nested.req.headers;
+      },
+    });
+
+    await client.request({ path: '/models', method: 'get', headers: { 'X-Synthetic-Outer': 'outer' } });
+
+    expect(nestedHeaders?.get('X-Synthetic-Nested')).toBe('nested');
+    expect(nestedHeaders?.get('X-Synthetic-Outer')).toBeNull();
+    expect(dispatchedHeaders?.get('X-Synthetic-Outer')).toBe('outer');
+    expect(dispatchedHeaders?.get('X-Synthetic-Nested')).toBeNull();
+    expect(send.mock.calls.filter((call) => call[1].origin === 'https://mtls.auth.openai.com')).toHaveLength(
+      1,
+    );
   });
 
   test('cancels retry backoff promptly through the effective protected-hook signal', async () => {

--- a/tests/lib/x509-workload-request-boundaries.test.ts
+++ b/tests/lib/x509-workload-request-boundaries.test.ts
@@ -71,6 +71,59 @@ describe('X.509 request ownership boundaries', () => {
     expect(send).toHaveBeenCalledTimes(1);
   });
 
+  test.each(['ReadableStream', 'async iterator', 'sync iterator'] as const)(
+    'never retries certificate authentication after a buildRequest override installs a %s',
+    async (kind) => {
+      let pulledChunks = 0;
+      let canceled = false;
+      const chunks = (function* sharedChunks() {
+        pulledChunks += 1;
+        yield new TextEncoder().encode('synthetic-first-override-chunk');
+        pulledChunks += 1;
+        yield new TextEncoder().encode('synthetic-second-override-chunk');
+      })();
+      const send = vi
+        .spyOn(transportCapability, 'sendX509Request')
+        .mockResolvedValue(new Response(null, { status: 503, headers: { 'retry-after-ms': '1' } }));
+      const client = new OpenAI(options({ maxRetries: 1 }));
+      const original = client.buildRequest.bind(client);
+      const builds = vi.fn(async (...args: Parameters<OpenAI['buildRequest']>) => {
+        const built = await original(...args);
+        let body: unknown;
+        if (kind === 'ReadableStream') {
+          body = new ReadableStream({
+            start(controller) {
+              const next = chunks.next();
+              if (!next.done) {
+                controller.enqueue(next.value);
+              }
+            },
+            cancel() {
+              canceled = true;
+            },
+          });
+        } else if (kind === 'async iterator') {
+          body = {
+            async *[Symbol.asyncIterator]() {
+              yield* chunks;
+            },
+          };
+        } else {
+          body = chunks;
+        }
+        Object.defineProperty(built.req, 'body', { configurable: true, enumerable: true, value: body });
+        return built;
+      });
+      Object.defineProperty(client, 'buildRequest', { value: builds });
+
+      await expect(client.models.list()).rejects.toMatchObject({ status: 503 });
+      expect(send).toHaveBeenCalledTimes(1);
+      expect(builds).toHaveBeenCalledTimes(1);
+      expect(pulledChunks).toBe(kind === 'ReadableStream' ? 1 : 0);
+      expect(canceled).toBe(false);
+    },
+  );
+
   test('retires an unread error response when its headers exhaust the request deadline', async () => {
     let elapsed = 0;
     let apiSignal: AbortSignal | undefined;

--- a/tests/lib/x509-workload-review-regressions.test.ts
+++ b/tests/lib/x509-workload-review-regressions.test.ts
@@ -540,6 +540,83 @@ describe('X.509 review regressions', () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  test.each(['organization', 'project'] as const)(
+    'rejects a mutable public %s before presenting its certificate',
+    async (selector) => {
+      const enrolled = `synthetic-enrolled-${selector}`;
+      const getter = vi.fn(() => (getter.mock.calls.length === 1 ? 'synthetic-other-tenant' : enrolled));
+      const client = new OpenAI(options({ [selector]: enrolled }));
+      Object.defineProperty(client, selector, { get: getter });
+      const send = vi.spyOn(transportCapability, 'sendX509Request');
+
+      await expect(client.models.list()).rejects.toThrow(/organization or project/iu);
+      expect(getter).toHaveBeenCalledTimes(1);
+      expect(send).not.toHaveBeenCalled();
+    },
+  );
+
+  test('sanitizes malformed X.509 JSON without changing its SyntaxError contract', async () => {
+    const secret = 'sekret42!';
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) =>
+      url.origin === 'https://mtls.auth.openai.com'
+        ? Response.json(TOKEN_RESPONSE)
+        : new Response(secret, { headers: { 'content-type': 'application/json' } }),
+    );
+
+    const failure: unknown = await new OpenAI(options()).models.list().catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(SyntaxError);
+    if (failure instanceof Error) {
+      expect(failure.message).not.toContain(secret);
+      expect(Object.getOwnPropertyDescriptor(failure, 'cause')).toBeUndefined();
+    }
+  });
+
+  test('keeps nested clients sharing a transport in separately owned authentication scopes', async () => {
+    const exchangedAccounts: string[] = [];
+    let apiRequests = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url, request) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        const payload = JSON.parse(String(request.body)) as { service_account_id: string };
+        exchangedAccounts.push(payload.service_account_id);
+        return Response.json({
+          ...TOKEN_RESPONSE,
+          access_token: `synthetic-account-token-${exchangedAccounts.length}`,
+        });
+      }
+      apiRequests += 1;
+      return apiRequests === 1 ? new Response(null, { status: 401 }) : Response.json({ data: [] });
+    });
+    const first = new OpenAI(options());
+    const second = new OpenAI(
+      options({
+        workloadIdentity: {
+          type: 'x509',
+          identityProviderId: 'synthetic-review-provider',
+          serviceAccountId: 'synthetic-other-account',
+        },
+      }),
+    );
+    let nested = false;
+    Object.defineProperty(first, 'prepareRequest', {
+      value: async () => {
+        if (!nested) {
+          nested = true;
+          await second.buildRequest({ path: '/models', method: 'get' });
+        }
+      },
+    });
+
+    await expect(first.models.list()).rejects.toMatchObject({ status: 401 });
+    await first.models.list();
+
+    expect(exchangedAccounts).toEqual([
+      'synthetic-review-account',
+      'synthetic-other-account',
+      'synthetic-review-account',
+    ]);
+  });
+
   test('preserves caller request and header identities while snapshotting authenticated headers', async () => {
     const headers = { 'X-Synthetic-Request': 'synthetic-value' };
     const request = { path: '/models', method: 'get' as const, headers };
@@ -621,6 +698,9 @@ describe('X.509 review regressions', () => {
     await expect(client.models.list()).rejects.toThrow('synthetic-request-hook-failure');
     expect(observedScope).toBeDefined();
     expect(observedScope).not.toHaveProperty('token');
+    expect(observedScope).not.toHaveProperty('owner');
+    expect(observedScope).not.toHaveProperty('apiURL');
+    expect(observedScope).not.toHaveProperty('tenant');
     expect(observedScope).not.toHaveProperty('headers');
     expect(observedScope).not.toHaveProperty('authorization');
     expect(observedScope).not.toHaveProperty('defaultHeaders');

--- a/tests/lib/x509-workload-review-regressions.test.ts
+++ b/tests/lib/x509-workload-review-regressions.test.ts
@@ -525,6 +525,21 @@ describe('X.509 review regressions', () => {
     },
   );
 
+  test.each([
+    ['OpenAI_Organization', 'synthetic-enrolled-organization'],
+    ['OpenAI_Project', 'synthetic-enrolled-project'],
+  ])('rejects an equal-valued %s alias before presenting its certificate', async (header, value) => {
+    const send = vi.spyOn(transportCapability, 'sendX509Request');
+    const client = new OpenAI(
+      options({ organization: 'synthetic-enrolled-organization', project: 'synthetic-enrolled-project' }),
+    );
+
+    await expect(client.models.list({ headers: { [header]: value } })).rejects.toThrow(
+      /organization or project/iu,
+    );
+    expect(send).not.toHaveBeenCalled();
+  });
+
   test('preserves caller request and header identities while snapshotting authenticated headers', async () => {
     const headers = { 'X-Synthetic-Request': 'synthetic-value' };
     const request = { path: '/models', method: 'get' as const, headers };

--- a/tests/lib/x509-workload-review-regressions.test.ts
+++ b/tests/lib/x509-workload-review-regressions.test.ts
@@ -96,6 +96,19 @@ describe('X.509 review regressions', () => {
     expect(send).toHaveBeenCalledTimes(2);
   });
 
+  test('rejects an explicitly null X.509 refresh buffer before presenting its certificate', () => {
+    const identity = {
+      type: 'x509' as const,
+      identityProviderId: 'synthetic-null-refresh-provider',
+      serviceAccountId: 'synthetic-null-refresh-account',
+    };
+    Object.defineProperty(identity, 'refreshBufferMs', { value: null, enumerable: true });
+    const send = vi.spyOn(transportCapability, 'sendX509Request');
+
+    expect(() => new OpenAI(options({ workloadIdentity: identity }))).toThrow(/refreshBufferMs/iu);
+    expect(send).not.toHaveBeenCalled();
+  });
+
   test('preserves an explicitly empty admin credential without presenting its certificate', async () => {
     const send = vi
       .spyOn(transportCapability, 'sendX509Request')
@@ -235,6 +248,38 @@ describe('X.509 review regressions', () => {
     expect(scopes[0]).not.toBe(scopes[1]);
     expect(send.mock.calls.filter((call) => call[1].origin === 'https://mtls.api.openai.com')).toHaveLength(
       2,
+    );
+  });
+
+  test('keeps nested clone header scopes separate while sharing its enrolled credential cache', async () => {
+    const send = vi
+      .spyOn(transportCapability, 'sendX509Request')
+      .mockImplementation(async (_transport, url) =>
+        url.origin === 'https://mtls.auth.openai.com'
+          ? Response.json(TOKEN_RESPONSE)
+          : Response.json({ data: [] }),
+      );
+    const original = new OpenAI(options({ defaultHeaders: { 'X-Synthetic-Original': 'yes' } }));
+    const clone = original.withOptions({ defaultHeaders: { 'X-Synthetic-Clone': 'yes' } });
+    let nestedHeaders: Headers | undefined;
+    Object.defineProperty(original, 'prepareRequest', {
+      value: async () => {
+        const nested = await clone.buildRequest({
+          path: '/models',
+          method: 'get',
+          headers: { 'X-Synthetic-Request': 'yes' },
+        });
+        nestedHeaders = nested.req.headers;
+      },
+    });
+
+    await original.models.list();
+
+    expect(nestedHeaders?.get('X-Synthetic-Original')).toBeNull();
+    expect(nestedHeaders?.get('X-Synthetic-Clone')).toBe('yes');
+    expect(nestedHeaders?.get('X-Synthetic-Request')).toBe('yes');
+    expect(send.mock.calls.filter((call) => call[1].origin === 'https://mtls.auth.openai.com')).toHaveLength(
+      1,
     );
   });
 
@@ -774,6 +819,38 @@ describe('X.509 review regressions', () => {
 
     await expect(pending).rejects.toBeInstanceOf(APIUserAbortError);
     expect(performance.now() - startedAt).toBeLessThan(350);
+  });
+
+  test('preserves hook-signal cancellation after successful response headers arrive', async () => {
+    const replacement = new AbortController();
+    const reason = new Error('synthetic-hook-response-body-canceled');
+    const send = vi
+      .spyOn(transportCapability, 'sendX509Request')
+      .mockImplementation(async (_transport, url, request) =>
+        url.origin === 'https://mtls.auth.openai.com'
+          ? Response.json(TOKEN_RESPONSE)
+          : new Response(
+              new ReadableStream({
+                start(stream) {
+                  request.signal?.addEventListener('abort', () => stream.error(request.signal?.reason), {
+                    once: true,
+                  });
+                },
+              }),
+              { headers: { 'content-type': 'application/json' } },
+            ),
+      );
+    const client = new OpenAI(options({ timeout: 1000 }));
+    Object.defineProperty(client, 'prepareRequest', {
+      value: async (request: RequestInit) => {
+        request.signal = replacement.signal;
+      },
+    });
+    const pending = client.models.list();
+    await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(2));
+    replacement.abort(reason);
+
+    await expect(pending).rejects.toMatchObject({ constructor: APIUserAbortError, cause: reason });
   });
 
   test('recognizes an inherited plain-data X.509 identity discriminator', () => {

--- a/tests/lib/x509-workload-review-regressions.test.ts
+++ b/tests/lib/x509-workload-review-regressions.test.ts
@@ -682,8 +682,8 @@ describe('X.509 review regressions', () => {
     await first.models.list();
 
     expect(exchangedAccounts).toEqual([
-      'synthetic-review-account',
       'synthetic-other-account',
+      'synthetic-review-account',
       'synthetic-review-account',
     ]);
   });

--- a/tests/lib/x509-workload-review-regressions.test.ts
+++ b/tests/lib/x509-workload-review-regressions.test.ts
@@ -348,6 +348,33 @@ describe('X.509 review regressions', () => {
     expect(send).toHaveBeenCalledTimes(3);
   });
 
+  test('never generically retries a rejected X.509 credential after refreshing it once', async () => {
+    let issuerRequests = 0;
+    let apiRequests = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        issuerRequests += 1;
+        return Response.json({
+          ...TOKEN_RESPONSE,
+          access_token: `synthetic-review-bearer-${issuerRequests}`,
+        });
+      }
+      apiRequests += 1;
+      return apiRequests === 3
+        ? Response.json({ data: [] })
+        : new Response(null, { status: 401, headers: { 'x-should-retry': 'true' } });
+    });
+    const client = new OpenAI(options({ maxRetries: 5 }));
+
+    await expect(client.models.list()).rejects.toMatchObject({ status: 401 });
+    expect(issuerRequests).toBe(2);
+    expect(apiRequests).toBe(2);
+
+    await client.models.list();
+    expect(issuerRequests).toBe(3);
+    expect(apiRequests).toBe(3);
+  });
+
   test('never retries issuer authentication after a one-shot request body starts pulling', async () => {
     let pulledChunks = 0;
     const body = {

--- a/tests/lib/x509-workload-review-regressions.test.ts
+++ b/tests/lib/x509-workload-review-regressions.test.ts
@@ -113,6 +113,32 @@ describe('X.509 review regressions', () => {
     expect(new Headers(send.mock.calls[0]?.[2].headers).get('Authorization')).toBe('Bearer');
   });
 
+  test('preserves explicit X.509 refresh configuration when cloning a client', async () => {
+    let issuerRequests = 0;
+    vi.spyOn(transportCapability, 'sendX509Request').mockImplementation(async (_transport, url) => {
+      if (url.origin === 'https://mtls.auth.openai.com') {
+        issuerRequests += 1;
+        return Response.json(TOKEN_RESPONSE);
+      }
+      return Response.json({ data: [] });
+    });
+    const client = new OpenAI(
+      options({
+        workloadIdentity: {
+          type: 'x509',
+          identityProviderId: 'synthetic-review-provider',
+          serviceAccountId: 'synthetic-review-account',
+          refreshBufferMs: 42,
+        },
+      }),
+    );
+
+    await client.models.list();
+    await client.withOptions({ timeout: 1000 }).models.list();
+
+    expect(issuerRequests).toBe(1);
+  });
+
   test('never approves caller-substituted admin credentials', async () => {
     const send = vi.spyOn(transportCapability, 'sendX509Request');
     const client = new OpenAI(options({ adminAPIKey: '' }));

--- a/tests/lib/x509-workload-review-regressions.test.ts
+++ b/tests/lib/x509-workload-review-regressions.test.ts
@@ -752,7 +752,7 @@ describe('X.509 review regressions', () => {
     });
 
     await expect(client.models.list()).rejects.toThrow(/authorization|authentication/iu);
-    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).not.toHaveBeenCalled();
   });
 
   test('clears authenticated request credentials when a protected request hook fails', async () => {


### PR DESCRIPTION
## Summary

Part 4 of 5; based on `codex/x509-03-client-integration`.

- Add tenant/account/certificate-scoped, generation-safe token caching, singleflight refresh, clone sharing, proactive refresh, and bounded 401 rotation.
- Classify issuer/API transport failures privately: retry or temporarily reuse a still-valid bearer only for approved transient failures; permanent TLS, protocol, OAuth, and tenant failures are terminal.
- Enforce exact tenant-header snapshots, reject underscore aliases, cancel abandoned refreshes/backoff, sanitize nested transport/body errors, and apply one monotonic deadline to successful and failing responses.

## Verification

- 243 focused lifecycle/security/transport/client regressions, including stale same-byte generations, repeated 401s, noncooperative abandoned refreshes, TLS trust failures, tenant aliases, and hung response bodies.
- Exact minimum Node 22.22.0, `pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm build`, and packed npm artifact checks.
- Two independent security-review rounds and a completed full-stack Codex Security diff scan: zero remaining findings.

Next: `codex/x509-05-e2e-docs-hardening`.
