### PR TITLE
docs(auth): verify X.509 workload identity end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ For secure, automated environments like cloud-managed Kubernetes, Azure, and GCP
 
 The `workloadIdentity` parameter is mutually exclusive with `apiKey`.
 
-The required fields are `identityProviderId`, `serviceAccountId`, and `provider`.
+For subject-token workload identity, the required fields are `identityProviderId`, `serviceAccountId`, and `provider`. X.509 workload identity instead uses an enrolled client certificate and its separately configured transport.
 
 ### Kubernetes (service account tokens)
 
@@ -184,7 +184,7 @@ const client = new OpenAI({
 });
 ```
 
-You can also customize the token refresh buffer (default is 1200 seconds (20 minutes) before expiration):
+You can also customize the subject-token refresh buffer (default is 1200 seconds (20 minutes) before expiration):
 
 ```ts
 import OpenAI from 'openai';
@@ -199,6 +199,46 @@ const client = new OpenAI({
   },
 });
 ```
+
+### X.509 client certificates
+
+Applications enrolled for X.509 workload identity can authenticate using a caller-owned, static client certificate instead of a subject-token provider or API key. This Node.js-only integration requires the optional `undici` peer and currently supports only the global `https://mtls.api.openai.com/v1` API endpoint.
+
+```ts
+import OpenAI from 'openai';
+import { createX509Transport } from 'openai/auth/x509-transport';
+import { Agent } from 'undici';
+
+const dispatcher = new Agent({
+  connect: {
+    cert: process.env['OPENAI_X509_CLIENT_CERTIFICATE_CHAIN_PEM'],
+    key: process.env['OPENAI_X509_CLIENT_PRIVATE_KEY_PEM'],
+  },
+});
+
+const client = new OpenAI({
+  apiKey: null,
+  workloadIdentity: {
+    type: 'x509',
+    identityProviderId: process.env['OPENAI_X509_IDENTITY_PROVIDER_ID']!,
+    serviceAccountId: process.env['OPENAI_X509_SERVICE_ACCOUNT_ID']!,
+  },
+  x509Transport: createX509Transport({
+    runtime: 'node',
+    dispatcher,
+    certificateIdentity: 'static',
+    proxy: 'direct',
+  }),
+});
+
+try {
+  console.log((await client.models.list()).data.length);
+} finally {
+  await dispatcher.close();
+}
+```
+
+The SDK caches short-lived credentials in memory, isolates certificate generations, bounds retries and cancellation, and never closes the caller-owned dispatcher. Configure proactive refresh with optional `workloadIdentity.refreshBufferMs`; it defaults to 1,200,000 milliseconds (20 minutes) and is capped at half of the actual token lifetime. For CONNECT proxies, encrypted private keys, live verification, and certificate rotation, see the [X.509 workload-identity example](./examples/mtls/README.md#x509-workload-identity-nodejs).
 
 ## Streaming responses
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ const dispatcher = new Agent({
 
 const client = new OpenAI({
   apiKey: null,
+  adminAPIKey: null,
+  baseURL: null,
+  organization: null,
+  project: process.env['OPENAI_X509_PROJECT_ID'] ?? null,
   workloadIdentity: {
     type: 'x509',
     identityProviderId: process.env['OPENAI_X509_IDENTITY_PROVIDER_ID']!,

--- a/examples/mtls/README.md
+++ b/examples/mtls/README.md
@@ -57,7 +57,7 @@ X.509 workload identity is separate from API-key + HTTP mTLS: an enrolled client
 Install the SDK and its optional Node.js transport peer:
 
 ```sh
-npm install openai 'undici@^7'
+npm install openai "undici@^7"
 ```
 
 Undici 7 supports the SDK's complete Node.js 22 compatibility range; Undici 8 requires Node.js 22.19 or later.

--- a/examples/mtls/README.md
+++ b/examples/mtls/README.md
@@ -49,3 +49,36 @@ The Bun example passes `tls: { cert, key }` to Bun's native `fetch`.
 ## Advanced transports
 
 Because the SDK does not own the mTLS transport, applications can use runtime-native features such as proxies, custom trust stores, encrypted keys, hardware-backed keys, or certificate rotation where their chosen HTTP client supports them. Keep the certificate-bearing transport scoped to the OpenAI mTLS endpoint, and close or replace it when rotating credentials.
+
+## X.509 workload identity (Node.js)
+
+X.509 workload identity is separate from API-key + HTTP mTLS: an enrolled client certificate authenticates a workload-identity token exchange, and the resulting short-lived bearer authenticates requests through the same caller-owned certificate transport. The resulting access token is an ordinary bearer credential, so protect it like any other secret; reusing the approved certificate transport does not cryptographically bind the token to that certificate. Only `https://mtls.api.openai.com/v1` is approved; EU, Azure, Bedrock, custom gateways, and data-residency overrides are not supported.
+
+Install the SDK and its optional Node.js transport peer:
+
+```sh
+npm install openai undici
+```
+
+Provide the complete PEM certificate chain, private key, enrolled identity-provider ID, and service-account ID through environment variables. The chain must contain the leaf certificate followed by any required intermediates:
+
+```sh
+export OPENAI_X509_CLIENT_CERTIFICATE_CHAIN_PEM="$(cat /secure/path/client-chain.pem)"
+export OPENAI_X509_CLIENT_PRIVATE_KEY_PEM="$(cat /secure/path/client-key.pem)"
+export OPENAI_X509_IDENTITY_PROVIDER_ID='your-enrolled-identity-provider-id'
+export OPENAI_X509_SERVICE_ACCOUNT_ID='your-enrolled-service-account-id'
+
+node examples/mtls/x509-workload-identity.mjs
+```
+
+Set `OPENAI_X509_CLIENT_KEY_PASSPHRASE` when the PEM private key is encrypted. Existing local fixtures can instead provide certificate and key paths through `OPENAI_MTLS_CERT_CHAIN` and `OPENAI_MTLS_KEY`, identity selectors through `OPENAI_IDENTITY_PROVIDER_ID` and `OPENAI_SERVICE_ACCOUNT_ID`, and an optional tenant through `OPENAI_X509_PROJECT_ID`. Keep private-key files readable only by their owner, use managed secret injection where available, and never log PEM contents, passphrases, issued bearer tokens, or proxy credentials.
+
+Proxying is always explicit: set `OPENAI_X509_PROXY_MODE=http_connect` or `OPENAI_X509_PROXY_MODE=https_connect` together with a matching `HTTPS_PROXY` URL. The default `direct` mode ignores ambient proxy variables. The workload certificate is configured only for target TLS, never proxy TLS. The example closes its caller-owned dispatcher after the request.
+
+From a repository checkout, run the same explicit live-service check with:
+
+```sh
+pnpm test:live:x509
+```
+
+This check fails without owner-provisioned, enrolled credentials. Rotate a certificate by constructing a new Undici dispatcher and `createX509Transport` capability, then creating or cloning the client with that new top-level `x509Transport`; close the previous dispatcher after in-flight requests finish.

--- a/examples/mtls/README.md
+++ b/examples/mtls/README.md
@@ -70,6 +70,8 @@ export OPENAI_X509_CLIENT_PRIVATE_KEY_PEM="$(cat /secure/path/client-key.pem)"
 export OPENAI_X509_IDENTITY_PROVIDER_ID='your-enrolled-identity-provider-id'
 export OPENAI_X509_SERVICE_ACCOUNT_ID='your-enrolled-service-account-id'
 
+# Build package self-imports when running the example from an SDK repository checkout.
+pnpm build
 node examples/mtls/x509-workload-identity.mjs
 ```
 

--- a/examples/mtls/README.md
+++ b/examples/mtls/README.md
@@ -57,8 +57,10 @@ X.509 workload identity is separate from API-key + HTTP mTLS: an enrolled client
 Install the SDK and its optional Node.js transport peer:
 
 ```sh
-npm install openai undici
+npm install openai 'undici@^7'
 ```
+
+Undici 7 supports the SDK's complete Node.js 22 compatibility range; Undici 8 requires Node.js 22.19 or later.
 
 Provide the complete PEM certificate chain, private key, enrolled identity-provider ID, and service-account ID through environment variables. The chain must contain the leaf certificate followed by any required intermediates:
 
@@ -75,7 +77,7 @@ Set `OPENAI_X509_CLIENT_KEY_PASSPHRASE` when the PEM private key is encrypted. E
 
 Proxying is always explicit: set `OPENAI_X509_PROXY_MODE=http_connect` or `OPENAI_X509_PROXY_MODE=https_connect` together with a matching `HTTPS_PROXY` URL. The default `direct` mode ignores ambient proxy variables. The workload certificate is configured only for target TLS, never proxy TLS. The example closes its caller-owned dispatcher after the request.
 
-From a repository checkout, run the same explicit live-service check with:
+From a repository checkout, the following command builds the SDK first and then runs the same explicit live-service check:
 
 ```sh
 pnpm test:live:x509

--- a/examples/mtls/README.md
+++ b/examples/mtls/README.md
@@ -75,7 +75,7 @@ pnpm build
 node examples/mtls/x509-workload-identity.mjs
 ```
 
-Set `OPENAI_X509_CLIENT_KEY_PASSPHRASE` when the PEM private key is encrypted. Existing local fixtures can instead provide certificate and key paths through `OPENAI_MTLS_CERT_CHAIN` and `OPENAI_MTLS_KEY`, identity selectors through `OPENAI_IDENTITY_PROVIDER_ID` and `OPENAI_SERVICE_ACCOUNT_ID`, and an optional tenant through `OPENAI_X509_PROJECT_ID`. Keep private-key files readable only by their owner, use managed secret injection where available, and never log PEM contents, passphrases, issued bearer tokens, or proxy credentials.
+Set `OPENAI_X509_CLIENT_KEY_PASSPHRASE` when the PEM private key is encrypted. Existing local fixtures can instead provide certificate and key paths through `OPENAI_MTLS_CERT_CHAIN` and `OPENAI_MTLS_KEY`, identity selectors through `OPENAI_IDENTITY_PROVIDER_ID` and `OPENAI_SERVICE_ACCOUNT_ID`, and an optional tenant through `OPENAI_X509_PROJECT_ID`. The example ignores ambient API keys, admin keys, base URLs, organizations, and ordinary API-key projects so only the selected X.509 identity and tenant determine the request. Keep private-key files readable only by their owner, use managed secret injection where available, and never log PEM contents, passphrases, issued bearer tokens, or proxy credentials.
 
 Proxying is always explicit: set `OPENAI_X509_PROXY_MODE=http_connect` or `OPENAI_X509_PROXY_MODE=https_connect` together with a matching `HTTPS_PROXY` URL. The default `direct` mode ignores ambient proxy variables. The workload certificate is configured only for target TLS, never proxy TLS. The example closes its caller-owned dispatcher after the request.
 

--- a/examples/mtls/x509-workload-identity.mjs
+++ b/examples/mtls/x509-workload-identity.mjs
@@ -7,7 +7,7 @@ import { Agent, ProxyAgent } from 'undici';
 const cert = await requiredPem('OPENAI_X509_CLIENT_CERTIFICATE_CHAIN_PEM', 'OPENAI_MTLS_CERT_CHAIN');
 const key = await requiredPem('OPENAI_X509_CLIENT_PRIVATE_KEY_PEM', 'OPENAI_MTLS_KEY');
 const passphrase = process.env['OPENAI_X509_CLIENT_KEY_PASSPHRASE'];
-const requestTls = { cert, key, ...(passphrase !== undefined ? { passphrase } : {}) };
+const requestTls = { cert, key, ...(passphrase === undefined ? {} : { passphrase }) };
 const proxyMode = process.env['OPENAI_X509_PROXY_MODE'] ?? 'direct';
 const proxy = new Map([
   ['direct', 'direct'],

--- a/examples/mtls/x509-workload-identity.mjs
+++ b/examples/mtls/x509-workload-identity.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+// Uses one caller-owned static client certificate for both OpenAI's issuer and API.
+import { readFile } from 'node:fs/promises';
+import { Agent, ProxyAgent } from 'undici';
+
+const cert = await requiredPem('OPENAI_X509_CLIENT_CERTIFICATE_CHAIN_PEM', 'OPENAI_MTLS_CERT_CHAIN');
+const key = await requiredPem('OPENAI_X509_CLIENT_PRIVATE_KEY_PEM', 'OPENAI_MTLS_KEY');
+const passphrase = process.env['OPENAI_X509_CLIENT_KEY_PASSPHRASE'];
+const requestTls = { cert, key, ...(passphrase ? { passphrase } : {}) };
+const proxyMode = process.env['OPENAI_X509_PROXY_MODE'] ?? 'direct';
+const proxy = new Map([
+  ['direct', 'direct'],
+  ['http_connect', 'http-connect'],
+  ['https_connect', 'https-connect'],
+]).get(proxyMode);
+if (!proxy) {
+  throw new Error('OPENAI_X509_PROXY_MODE must be direct, http_connect, or https_connect.');
+}
+const proxyURL = proxy === 'direct' ? undefined : approvedProxyURL(requiredEnv('HTTPS_PROXY', 'https_proxy'));
+if (proxyURL && proxyURL.protocol !== (proxy === 'https-connect' ? 'https:' : 'http:')) {
+  throw new Error('OPENAI_X509_PROXY_MODE must match the HTTPS_PROXY protocol.');
+}
+const identityProviderId = requiredEnv('OPENAI_X509_IDENTITY_PROVIDER_ID', 'OPENAI_IDENTITY_PROVIDER_ID');
+const serviceAccountId = requiredEnv('OPENAI_X509_SERVICE_ACCOUNT_ID', 'OPENAI_SERVICE_ACCOUNT_ID');
+const [{ default: OpenAI }, { createX509Transport }] = await Promise.all([
+  import('openai'),
+  import('openai/auth/x509-transport'),
+]);
+const dispatcher = createDispatcher(proxyURL, requestTls);
+try {
+  const x509Transport = createX509Transport({
+    runtime: 'node',
+    dispatcher,
+    certificateIdentity: 'static',
+    proxy,
+  });
+  const client = new OpenAI({
+    apiKey: null,
+    workloadIdentity: {
+      type: 'x509',
+      identityProviderId,
+      serviceAccountId,
+    },
+    ...(process.env['OPENAI_X509_PROJECT_ID'] ? { project: process.env['OPENAI_X509_PROJECT_ID'] } : {}),
+    x509Transport,
+  });
+
+  const models = await client.models.list();
+  console.log(`X.509 workload identity succeeded; received ${models.data.length} models.`);
+} finally {
+  await dispatcher.close();
+}
+
+function requiredEnv(name, alternative) {
+  const value = process.env[name] ?? (alternative ? process.env[alternative] : undefined);
+  if (!value) {
+    throw new Error(
+      `Missing required X.509 environment variable: ${name}${alternative ? ` or ${alternative}` : ''}`,
+    );
+  }
+  return value;
+}
+
+async function requiredPem(valueName, pathName) {
+  const value = process.env[valueName];
+  if (value) {
+    return value;
+  }
+  const certificatePath = process.env[pathName];
+  if (!certificatePath) {
+    throw new Error(`Missing required X.509 environment variable: ${valueName} or ${pathName}`);
+  }
+  return await readFile(certificatePath, 'utf-8');
+}
+
+function approvedProxyURL(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('HTTPS_PROXY must contain a valid CONNECT proxy URL.');
+  }
+  if (url.pathname !== '/' || url.search || url.hash) {
+    throw new Error('HTTPS_PROXY must not contain a path, query, or fragment.');
+  }
+  return url;
+}
+
+function createDispatcher(approvedURL, targetTls) {
+  if (!approvedURL) {
+    return new Agent({ connect: targetTls });
+  }
+  try {
+    return new ProxyAgent({ uri: approvedURL.href, requestTls: targetTls });
+  } catch {
+    throw new Error('Unable to initialize the approved X.509 CONNECT proxy.');
+  }
+}

--- a/examples/mtls/x509-workload-identity.mjs
+++ b/examples/mtls/x509-workload-identity.mjs
@@ -7,7 +7,7 @@ import { Agent, ProxyAgent } from 'undici';
 const cert = await requiredPem('OPENAI_X509_CLIENT_CERTIFICATE_CHAIN_PEM', 'OPENAI_MTLS_CERT_CHAIN');
 const key = await requiredPem('OPENAI_X509_CLIENT_PRIVATE_KEY_PEM', 'OPENAI_MTLS_KEY');
 const passphrase = process.env['OPENAI_X509_CLIENT_KEY_PASSPHRASE'];
-const requestTls = { cert, key, ...(passphrase ? { passphrase } : {}) };
+const requestTls = { cert, key, ...(passphrase !== undefined ? { passphrase } : {}) };
 const proxyMode = process.env['OPENAI_X509_PROXY_MODE'] ?? 'direct';
 const proxy = new Map([
   ['direct', 'direct'],
@@ -42,7 +42,7 @@ try {
       identityProviderId,
       serviceAccountId,
     },
-    ...(process.env['OPENAI_X509_PROJECT_ID'] ? { project: process.env['OPENAI_X509_PROJECT_ID'] } : {}),
+    project: process.env['OPENAI_X509_PROJECT_ID'] ?? null,
     x509Transport,
   });
 

--- a/examples/mtls/x509-workload-identity.mjs
+++ b/examples/mtls/x509-workload-identity.mjs
@@ -37,12 +37,15 @@ try {
   });
   const client = new OpenAI({
     apiKey: null,
+    adminAPIKey: null,
+    baseURL: null,
+    organization: null,
+    project: process.env['OPENAI_X509_PROJECT_ID'] ?? null,
     workloadIdentity: {
       type: 'x509',
       identityProviderId,
       serviceAccountId,
     },
-    project: process.env['OPENAI_X509_PROJECT_ID'] ?? null,
     x509Transport,
   });
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:unit": "vitest run --config vitest.config.mts",
     "test:generated": "OPENAI_TEST_SUITE=generated ./scripts/test",
     "test:live:bedrock": "jest --config jest.live.config.ts --runInBand tests/live/bedrock.live.test.ts",
-    "test:live:x509": "node --input-type=module < examples/mtls/x509-workload-identity.mjs",
+    "test:live:x509": "pnpm build && node --input-type=module < examples/mtls/x509-workload-identity.mjs",
     "bench": "vitest bench --run --config vitest.bench.config.mts",
     "bench:json": "vitest bench --run --config vitest.bench.config.mts --outputJson benchmark-results.json",
     "build": "./scripts/build",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:unit": "vitest run --config vitest.config.mts",
     "test:generated": "OPENAI_TEST_SUITE=generated ./scripts/test",
     "test:live:bedrock": "jest --config jest.live.config.ts --runInBand tests/live/bedrock.live.test.ts",
+    "test:live:x509": "node --input-type=module < examples/mtls/x509-workload-identity.mjs",
     "bench": "vitest bench --run --config vitest.bench.config.mts",
     "bench:json": "vitest bench --run --config vitest.bench.config.mts --outputJson benchmark-results.json",
     "build": "./scripts/build",

--- a/tests/lib/x509-workload-example.test.ts
+++ b/tests/lib/x509-workload-example.test.ts
@@ -6,6 +6,10 @@ const example = readFileSync(
   path.resolve(process.cwd(), 'examples/mtls/x509-workload-identity.mjs'),
   'utf-8',
 );
+const exampleDocumentation = readFileSync(path.resolve(process.cwd(), 'examples/mtls/README.md'), 'utf-8');
+const packageScripts = JSON.parse(readFileSync(path.resolve(process.cwd(), 'package.json'), 'utf-8')) as {
+  scripts: Record<string, string>;
+};
 
 function runExample(environment: Record<string, string>) {
   return spawnSync(process.execPath, ['--input-type=module'], {
@@ -22,6 +26,14 @@ function runExample(environment: Record<string, string>) {
 }
 
 describe('X.509 workload-identity runnable example', () => {
+  test('builds the SDK before running its clean-checkout live validation command', () => {
+    expect(packageScripts.scripts['test:live:x509']).toMatch(/^pnpm build && node /u);
+  });
+
+  test('documents an Undici version compatible with the complete supported Node 22 range', () => {
+    expect(exampleDocumentation).toContain("npm install openai 'undici@^7'");
+  });
+
   test('never exposes credentials from a malformed CONNECT proxy URL', () => {
     const secret = 'synthetic-private-proxy-password';
     const result = runExample({

--- a/tests/lib/x509-workload-example.test.ts
+++ b/tests/lib/x509-workload-example.test.ts
@@ -34,6 +34,18 @@ describe('X.509 workload-identity runnable example', () => {
     expect(exampleDocumentation).toContain("npm install openai 'undici@^7'");
   });
 
+  test('builds repository self-imports before documenting the direct example command', () => {
+    expect(exampleDocumentation).toMatch(/pnpm build\s+node examples\/mtls\/x509-workload-identity\.mjs/u);
+  });
+
+  test('preserves an explicitly empty encrypted-key passphrase', () => {
+    expect(example).toContain('passphrase !== undefined ? { passphrase } : {}');
+  });
+
+  test('does not inherit the ordinary API-key project when no X.509 project is configured', () => {
+    expect(example).toContain("project: process.env['OPENAI_X509_PROJECT_ID'] ?? null");
+  });
+
   test('never exposes credentials from a malformed CONNECT proxy URL', () => {
     const secret = 'synthetic-private-proxy-password';
     const result = runExample({

--- a/tests/lib/x509-workload-example.test.ts
+++ b/tests/lib/x509-workload-example.test.ts
@@ -7,6 +7,7 @@ const example = readFileSync(
   'utf-8',
 );
 const exampleDocumentation = readFileSync(path.resolve(process.cwd(), 'examples/mtls/README.md'), 'utf-8');
+const packageDocumentation = readFileSync(path.resolve(process.cwd(), 'README.md'), 'utf-8');
 const packageScripts = JSON.parse(readFileSync(path.resolve(process.cwd(), 'package.json'), 'utf-8')) as {
   scripts: Record<string, string>;
 };
@@ -42,8 +43,15 @@ describe('X.509 workload-identity runnable example', () => {
     expect(example).toContain('passphrase === undefined ? {} : { passphrase }');
   });
 
-  test('does not inherit the ordinary API-key project when no X.509 project is configured', () => {
-    expect(example).toContain("project: process.env['OPENAI_X509_PROJECT_ID'] ?? null");
+  test.each([
+    ['runnable', example],
+    ['documented', packageDocumentation],
+  ])('keeps the %s X.509 example isolated from ambient credentials and routing', (_name, source) => {
+    expect(source).toContain('apiKey: null');
+    expect(source).toContain('adminAPIKey: null');
+    expect(source).toContain('baseURL: null');
+    expect(source).toContain('organization: null');
+    expect(source).toContain("project: process.env['OPENAI_X509_PROJECT_ID'] ?? null");
   });
 
   test('never exposes credentials from a malformed CONNECT proxy URL', () => {

--- a/tests/lib/x509-workload-example.test.ts
+++ b/tests/lib/x509-workload-example.test.ts
@@ -39,7 +39,7 @@ describe('X.509 workload-identity runnable example', () => {
   });
 
   test('preserves an explicitly empty encrypted-key passphrase', () => {
-    expect(example).toContain('passphrase !== undefined ? { passphrase } : {}');
+    expect(example).toContain('passphrase === undefined ? {} : { passphrase }');
   });
 
   test('does not inherit the ordinary API-key project when no X.509 project is configured', () => {

--- a/tests/lib/x509-workload-example.test.ts
+++ b/tests/lib/x509-workload-example.test.ts
@@ -32,7 +32,7 @@ describe('X.509 workload-identity runnable example', () => {
   });
 
   test('documents an Undici version compatible with the complete supported Node 22 range', () => {
-    expect(exampleDocumentation).toContain("npm install openai 'undici@^7'");
+    expect(exampleDocumentation).toContain('npm install openai "undici@^7"');
   });
 
   test('builds repository self-imports before documenting the direct example command', () => {

--- a/tests/lib/x509-workload-example.test.ts
+++ b/tests/lib/x509-workload-example.test.ts
@@ -1,0 +1,56 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const example = readFileSync(
+  path.resolve(process.cwd(), 'examples/mtls/x509-workload-identity.mjs'),
+  'utf-8',
+);
+
+function runExample(environment: Record<string, string>) {
+  return spawnSync(process.execPath, ['--input-type=module'], {
+    cwd: process.cwd(),
+    encoding: 'utf-8',
+    input: example,
+    env: {
+      PATH: process.env['PATH'],
+      OPENAI_X509_CLIENT_CERTIFICATE_CHAIN_PEM: 'synthetic-certificate-chain',
+      OPENAI_X509_CLIENT_PRIVATE_KEY_PEM: 'synthetic-private-key',
+      ...environment,
+    },
+  });
+}
+
+describe('X.509 workload-identity runnable example', () => {
+  test('never exposes credentials from a malformed CONNECT proxy URL', () => {
+    const secret = 'synthetic-private-proxy-password';
+    const result = runExample({
+      OPENAI_X509_PROXY_MODE: 'http_connect',
+      HTTPS_PROXY: `http://user:${secret}@[invalid`,
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('valid CONNECT proxy URL');
+    expect(result.stderr).not.toContain(secret);
+    expect(result.stdout).not.toContain(secret);
+  });
+
+  test('rejects a CONNECT proxy whose protocol does not match the explicitly selected mode', () => {
+    const result = runExample({
+      OPENAI_X509_PROXY_MODE: 'https_connect',
+      HTTPS_PROXY: 'http://127.0.0.1:8080',
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('must match the HTTPS_PROXY protocol');
+  });
+
+  test('ignores ambient proxy settings unless a CONNECT proxy mode is explicitly requested', () => {
+    const secret = 'synthetic-ignored-ambient-proxy-password';
+    const result = runExample({ HTTPS_PROXY: `http://user:${secret}@[invalid` });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('OPENAI_X509_IDENTITY_PROVIDER_ID');
+    expect(result.stderr).not.toContain(secret);
+  });
+});

--- a/tests/lib/x509-workload-identity.test.ts
+++ b/tests/lib/x509-workload-identity.test.ts
@@ -829,22 +829,28 @@ describe('OpenAI X.509 workload-identity client integration', () => {
     expect(client.baseURL).toBe('https://api.openai.com/v1');
   });
 
-  test('uses the exact same attested TLS identity for the real issuer and API handshakes', async () => {
+  test('reuses and rotates real TLS-issued credentials without exposing them to a CONNECT proxy', async () => {
     const lab = createX509TestLab();
+    let exchanges = 0;
+    let dispatches = 0;
     const issuer = createMutualTLSServer(
       lab,
       (_request, response) => {
+        exchanges += 1;
         response.writeHead(200, { 'Content-Type': 'application/json' });
-        response.end(JSON.stringify(TOKEN_RESPONSE));
+        response.end(
+          JSON.stringify({ ...TOKEN_RESPONSE, access_token: `synthetic-wire-token-${exchanges}` }),
+        );
       },
       lab.issuerServer,
     );
     const api = createMutualTLSServer(
       lab,
       (request, response) => {
-        if (request.headers.authorization !== `Bearer ${ACCESS_TOKEN}`) {
-          response.writeHead(401);
-          response.end();
+        dispatches += 1;
+        if (dispatches === 2) {
+          response.writeHead(401, { 'Content-Type': 'application/json' });
+          response.end(JSON.stringify({ error: { message: 'synthetic rejected workload credential' } }));
           return;
         }
         response.writeHead(200, { 'Content-Type': 'application/json' });
@@ -881,34 +887,46 @@ describe('OpenAI X.509 workload-identity client integration', () => {
         certificateIdentity: 'static',
         proxy: 'http-connect',
       });
-      const client = new OpenAI(options({ x509Transport: approved }));
+      const client = new OpenAI(options({ x509Transport: approved, maxRetries: 1 }));
 
-      const models = await client.models.list();
+      const models = [await client.models.list(), await client.models.list(), await client.models.list()];
 
-      expect(models.data).toEqual([]);
+      expect(models.map((result) => result.data)).toEqual([[], [], []]);
+      expect(exchanges).toBe(2);
+      expect(dispatches).toBe(4);
       const fingerprint = new X509Certificate(lab.firstClient.certificate).fingerprint256;
-      expect(issuer.requests).toEqual([
-        expect.objectContaining({
+      expect(issuer.requests).toHaveLength(2);
+      for (const request of issuer.requests) {
+        expect(request).toMatchObject({
           authority: 'mtls.auth.openai.com',
           authorization: undefined,
           certificateFingerprint: fingerprint,
           path: '/oauth/token',
           serverName: 'mtls.auth.openai.com',
-        }),
+        });
+      }
+      expect(api.requests.map((request) => request.authorization)).toEqual([
+        'Bearer synthetic-wire-token-1',
+        'Bearer synthetic-wire-token-1',
+        'Bearer synthetic-wire-token-2',
+        'Bearer synthetic-wire-token-2',
       ]);
-      expect(api.requests).toEqual([
-        expect.objectContaining({
+      for (const request of api.requests) {
+        expect(request).toMatchObject({
           authority: 'mtls.api.openai.com',
-          authorization: `Bearer ${ACCESS_TOKEN}`,
           certificateFingerprint: fingerprint,
           path: '/v1/models',
           serverName: 'mtls.api.openai.com',
-        }),
-      ]);
-      expect(proxy.requests.map((request) => request.path)).toEqual([
-        'mtls.auth.openai.com:443',
-        'mtls.api.openai.com:443',
-      ]);
+        });
+      }
+      expect(new Set(proxy.requests.map((request) => request.path))).toEqual(
+        new Set(['mtls.auth.openai.com:443', 'mtls.api.openai.com:443']),
+      );
+      for (const request of proxy.requests) {
+        expect(request.authorization).toBeUndefined();
+        expect(request.proxyAuthorization).toBeUndefined();
+        expect(request.certificateFingerprint).toBeUndefined();
+      }
     } finally {
       await proxyDispatcher?.close();
       await closeObservedServers(issuer, api, ...(proxy ? [proxy] : []));


### PR DESCRIPTION
## Summary

Part 5 of 5; based on `codex/x509-04-token-lifecycle`.

- Document the Node-only X.509 contract, refresh policy, bearer-token handling, approved global endpoint, caller-owned dispatcher, and manual live-validation workflow.
- Add a runnable example supporting both protected PEM variables and documented local certificate-path/identity fixtures, encrypted keys, explicit direct/CONNECT proxy modes, optional project selection, and sanitized proxy failures.
- Extend the genuine local mTLS + CONNECT integration to verify cache reuse, a real API 401, one token refresh/replay, renewed-token reuse, issuer/API certificate identity/SNI, and zero proxy credential leakage.
- Add child-process regressions for malformed secret-bearing proxy URLs, mismatched proxy modes, and ignored ambient proxies; verified against a fresh checkout with no prebuilt `dist/`.

## Verification

- 246 focused X.509/client/transport/example regressions; exact minimum Node 22.22.0; real ephemeral certificate/CONNECT wire test.
- `pnpm lint`, `pnpm exec tsc --noEmit`, `pnpm build`, packed npm artifact/export checks, Node version-policy validation, and the trusted custom-code budget check (2,791 / 3,000 lines).
- Two independent security/code-review rounds; full-stack Codex Security diff scan completed across 12 production/package files with zero findings.
- `pnpm test:live:x509` is intentionally manual and correctly fails closed without owner-provisioned enrolled credentials; no production-live success is claimed.
