### PR TITLE
fix(webhooks): bound signature verification work

### DIFF
--- a/src/lib/webhook-signature.ts
+++ b/src/lib/webhook-signature.ts
@@ -5,43 +5,74 @@ import { encodeUTF8 } from '../internal/utils/bytes';
 const MAX_DIRECT_WEBHOOK_VERIFICATIONS = 32;
 const SHA256_SIGNATURE_LENGTH = 32;
 
-function decodeUniqueSignatures(signatures: string[]): Uint8Array[] {
-  const seenSignatures = new Set<string>();
-  const candidateSignatures: Uint8Array[] = [];
+/**
+ * Checks whether a webhook header requires constant-work HMAC signing without
+ * retaining an unbounded number of signature candidates.
+ *
+ * @internal
+ */
+export function webhookSignatureRequiresSigning(signatureHeader: string): boolean {
+  return (
+    signatureHeader.split(' ', MAX_DIRECT_WEBHOOK_VERIFICATIONS + 1).length > MAX_DIRECT_WEBHOOK_VERIFICATIONS
+  );
+}
 
-  for (const signature of signatures) {
-    if (seenSignatures.has(signature)) {
-      continue;
+function* signatureCandidates(signatureHeader: string): Generator<string> {
+  let start = 0;
+
+  while (start <= signatureHeader.length) {
+    const separator = signatureHeader.indexOf(' ', start);
+    const candidate = signatureHeader.slice(start, separator === -1 ? undefined : separator);
+    yield candidate.startsWith('v1,') ? candidate.slice(3) : candidate;
+
+    if (separator === -1) {
+      break;
     }
-    seenSignatures.add(signature);
+    start = separator + 1;
+  }
+}
 
-    try {
-      const signatureBytes = Uint8Array.from(fromBase64(signature));
-      if (signatureBytes.byteLength === SHA256_SIGNATURE_LENGTH) {
-        candidateSignatures.push(signatureBytes);
-      }
-    } catch {
-      // Invalid base64 does not prevent trying the next value.
+function decodeSignature(signature: string): Uint8Array | undefined {
+  try {
+    const signatureBytes = fromBase64(signature);
+    return signatureBytes.byteLength === SHA256_SIGNATURE_LENGTH ? signatureBytes : undefined;
+  } catch {
+    // Invalid base64 does not prevent trying the next value.
+    return undefined;
+  }
+}
+
+function firstValidLengthSignature(signatureHeader: string): Uint8Array | undefined {
+  for (const signature of signatureCandidates(signatureHeader)) {
+    const signatureBytes = decodeSignature(signature);
+    if (signatureBytes) {
+      return signatureBytes;
     }
   }
 
-  return candidateSignatures;
+  return undefined;
 }
 
 function selectMatchingSignature(
-  signatures: Uint8Array[],
+  signatureHeader: string,
   expectedSignature: Uint8Array,
-): Uint8Array | undefined {
-  let [matchingSignature] = signatures;
+  firstSignature: Uint8Array,
+): Uint8Array {
+  let matchingSignature = firstSignature;
 
-  for (const signature of signatures) {
+  for (const signature of signatureCandidates(signatureHeader)) {
+    const signatureBytes = decodeSignature(signature);
+    if (!signatureBytes) {
+      continue;
+    }
+
     let difference = 0;
-    for (const [index, byte] of signature.entries()) {
+    for (const [index, byte] of signatureBytes.entries()) {
       // oxlint-disable-next-line no-bitwise -- Compare every HMAC byte without short-circuiting on shared prefixes.
       difference |= byte ^ (expectedSignature[index] ?? 0);
     }
     if (difference === 0) {
-      matchingSignature = signature;
+      matchingSignature = signatureBytes;
     }
   }
 
@@ -76,14 +107,11 @@ export async function verifyWebhookSignature(
     throw new InvalidWebhookSignatureError('Webhook timestamp is too new');
   }
 
-  // Multiple signatures are space-separated; accept the first matching value.
-  const signatures = signatureHeader
-    .split(' ')
-    .map((part) => (part.startsWith('v1,') ? part.slice(3) : part));
-  const useBoundedVerification = signatures.length > MAX_DIRECT_WEBHOOK_VERIFICATIONS;
-  const candidateSignatures = useBoundedVerification ? decodeUniqueSignatures(signatures) : [];
+  // Multiple signatures are space-separated; accept a matching value at any position.
+  const useBoundedVerification = webhookSignatureRequiresSigning(signatureHeader);
+  const firstSignature = useBoundedVerification ? firstValidLengthSignature(signatureHeader) : undefined;
 
-  if (useBoundedVerification && candidateSignatures.length === 0) {
+  if (useBoundedVerification && !firstSignature) {
     throw new InvalidWebhookSignatureError(
       'The given webhook signature does not match the expected signature',
     );
@@ -102,15 +130,16 @@ export async function verifyWebhookSignature(
     useBoundedVerification ? ['sign', 'verify'] : ['verify'],
   );
 
-  if (useBoundedVerification) {
+  if (useBoundedVerification && firstSignature) {
     const expectedSignature = new Uint8Array(await crypto.subtle.sign('HMAC', key, signedPayloadBytes));
-    const signatureToVerify = selectMatchingSignature(candidateSignatures, expectedSignature);
+    const signatureToVerify = selectMatchingSignature(signatureHeader, expectedSignature, firstSignature);
 
-    if (
-      signatureToVerify &&
-      (await crypto.subtle.verify('HMAC', key, Uint8Array.from(signatureToVerify), signedPayloadBytes))
-    ) {
-      return;
+    try {
+      if (await crypto.subtle.verify('HMAC', key, Uint8Array.from(signatureToVerify), signedPayloadBytes)) {
+        return;
+      }
+    } catch {
+      // Provider verification failures have the same typed mismatch as the direct path.
     }
 
     throw new InvalidWebhookSignatureError(
@@ -118,7 +147,7 @@ export async function verifyWebhookSignature(
     );
   }
 
-  for (const signature of signatures) {
+  for (const signature of signatureCandidates(signatureHeader)) {
     try {
       const signatureBytes = Uint8Array.from(fromBase64(signature));
       // oxlint-disable-next-line no-await-in-loop -- Check signatures in order and stop at the first match.

--- a/src/lib/webhook-signature.ts
+++ b/src/lib/webhook-signature.ts
@@ -2,7 +2,51 @@ import { InvalidWebhookSignatureError } from '../error';
 import { fromBase64 } from '../internal/utils/base64';
 import { encodeUTF8 } from '../internal/utils/bytes';
 
-const MAX_WEBHOOK_SIGNATURES = 32;
+const MAX_DIRECT_WEBHOOK_VERIFICATIONS = 32;
+const SHA256_SIGNATURE_LENGTH = 32;
+
+function decodeUniqueSignatures(signatures: string[]): Uint8Array[] {
+  const seenSignatures = new Set<string>();
+  const candidateSignatures: Uint8Array[] = [];
+
+  for (const signature of signatures) {
+    if (seenSignatures.has(signature)) {
+      continue;
+    }
+    seenSignatures.add(signature);
+
+    try {
+      const signatureBytes = Uint8Array.from(fromBase64(signature));
+      if (signatureBytes.byteLength === SHA256_SIGNATURE_LENGTH) {
+        candidateSignatures.push(signatureBytes);
+      }
+    } catch {
+      // Invalid base64 does not prevent trying the next value.
+    }
+  }
+
+  return candidateSignatures;
+}
+
+function selectMatchingSignature(
+  signatures: Uint8Array[],
+  expectedSignature: Uint8Array,
+): Uint8Array | undefined {
+  let [matchingSignature] = signatures;
+
+  for (const signature of signatures) {
+    let difference = 0;
+    for (const [index, byte] of signature.entries()) {
+      // oxlint-disable-next-line no-bitwise -- Compare every HMAC byte without short-circuiting on shared prefixes.
+      difference |= byte ^ (expectedSignature[index] ?? 0);
+    }
+    if (difference === 0) {
+      matchingSignature = signature;
+    }
+  }
+
+  return matchingSignature;
+}
 
 /**
  * Checks the timestamp and HMAC signatures after the resource has validated its
@@ -36,20 +80,43 @@ export async function verifyWebhookSignature(
   const signatures = signatureHeader
     .split(' ')
     .map((part) => (part.startsWith('v1,') ? part.slice(3) : part));
+  const useBoundedVerification = signatures.length > MAX_DIRECT_WEBHOOK_VERIFICATIONS;
+  const candidateSignatures = useBoundedVerification ? decodeUniqueSignatures(signatures) : [];
 
-  if (signatures.length > MAX_WEBHOOK_SIGNATURES) {
+  if (useBoundedVerification && candidateSignatures.length === 0) {
     throw new InvalidWebhookSignatureError(
       'The given webhook signature does not match the expected signature',
     );
   }
+
   const decodedSecret = Uint8Array.from(
     secret.startsWith('whsec_') ? fromBase64(secret.slice('whsec_'.length)) : encodeUTF8(secret),
   );
   const signedPayload = webhookId ? `${webhookId}.${timestamp}.${payload}` : `${timestamp}.${payload}`;
   const signedPayloadBytes = Uint8Array.from(encodeUTF8(signedPayload));
-  const key = await crypto.subtle.importKey('raw', decodedSecret, { name: 'HMAC', hash: 'SHA-256' }, false, [
-    'verify',
-  ]);
+  const key = await crypto.subtle.importKey(
+    'raw',
+    decodedSecret,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    useBoundedVerification ? ['sign', 'verify'] : ['verify'],
+  );
+
+  if (useBoundedVerification) {
+    const expectedSignature = new Uint8Array(await crypto.subtle.sign('HMAC', key, signedPayloadBytes));
+    const signatureToVerify = selectMatchingSignature(candidateSignatures, expectedSignature);
+
+    if (
+      signatureToVerify &&
+      (await crypto.subtle.verify('HMAC', key, Uint8Array.from(signatureToVerify), signedPayloadBytes))
+    ) {
+      return;
+    }
+
+    throw new InvalidWebhookSignatureError(
+      'The given webhook signature does not match the expected signature',
+    );
+  }
 
   for (const signature of signatures) {
     try {

--- a/src/lib/webhook-signature.ts
+++ b/src/lib/webhook-signature.ts
@@ -2,6 +2,8 @@ import { InvalidWebhookSignatureError } from '../error';
 import { fromBase64 } from '../internal/utils/base64';
 import { encodeUTF8 } from '../internal/utils/bytes';
 
+const MAX_WEBHOOK_SIGNATURES = 32;
+
 /**
  * Checks the timestamp and HMAC signatures after the resource has validated its
  * crypto capabilities, secret, and required headers.
@@ -34,6 +36,12 @@ export async function verifyWebhookSignature(
   const signatures = signatureHeader
     .split(' ')
     .map((part) => (part.startsWith('v1,') ? part.slice(3) : part));
+
+  if (signatures.length > MAX_WEBHOOK_SIGNATURES) {
+    throw new InvalidWebhookSignatureError(
+      'The given webhook signature does not match the expected signature',
+    );
+  }
   const decodedSecret = Uint8Array.from(
     secret.startsWith('whsec_') ? fromBase64(secret.slice('whsec_'.length)) : encodeUTF8(secret),
   );

--- a/src/resources/webhooks/webhooks.ts
+++ b/src/resources/webhooks/webhooks.ts
@@ -2,7 +2,7 @@
 
 import { APIResource } from '../../core/resource';
 import { buildHeaders, HeadersLike } from '../../internal/headers';
-import { verifyWebhookSignature } from '../../lib/webhook-signature';
+import { verifyWebhookSignature, webhookSignatureRequiresSigning } from '../../lib/webhook-signature';
 
 export class Webhooks extends APIResource {
   /**
@@ -37,7 +37,7 @@ export class Webhooks extends APIResource {
   ): Promise<void> {
     if (
       typeof crypto === 'undefined' ||
-      typeof crypto.subtle.importKey !== 'function' ||
+      typeof crypto.subtle?.importKey !== 'function' ||
       typeof crypto.subtle.verify !== 'function'
     ) {
       throw new Error('Webhook signature verification is only supported when the `crypto` global is defined');
@@ -49,6 +49,10 @@ export class Webhooks extends APIResource {
     const signatureHeader = this.#getRequiredHeader(headersObj, 'webhook-signature');
     const timestamp = this.#getRequiredHeader(headersObj, 'webhook-timestamp');
     const webhookId = this.#getRequiredHeader(headersObj, 'webhook-id');
+
+    if (webhookSignatureRequiresSigning(signatureHeader) && typeof crypto.subtle.sign !== 'function') {
+      throw new Error('Webhook signature verification is only supported when the `crypto` global is defined');
+    }
 
     return await verifyWebhookSignature(payload, signatureHeader, timestamp, webhookId, secret, tolerance);
   }

--- a/tests/lib/webhook-signature-amplification.test.ts
+++ b/tests/lib/webhook-signature-amplification.test.ts
@@ -11,8 +11,16 @@ const mismatch = 'The given webhook signature does not match the expected signat
 
 type Surface = 'verifySignature' | 'unwrap';
 
-function validSignature(timestamp = String(now)): string {
-  return createHmac('sha256', secret).update([webhookID, timestamp, payload].join('.')).digest('base64');
+function validSignature(timestamp = String(now), signedPayload = payload): string {
+  return createHmac('sha256', secret)
+    .update([webhookID, timestamp, signedPayload].join('.'))
+    .digest('base64');
+}
+
+function invalidSignature(index: number): string {
+  const bytes = Buffer.alloc(32);
+  bytes.writeUInt32BE(index);
+  return bytes.toString('base64');
 }
 
 function makeHeaders(signatures: string[], timestamp = String(now)): Headers {
@@ -23,11 +31,19 @@ function makeHeaders(signatures: string[], timestamp = String(now)): Headers {
   });
 }
 
-function runPublicSurface(surface: Surface, headers: Headers): Promise<unknown> {
+function runPublicSurface(surface: Surface, headers: Headers, signedPayload = payload): Promise<unknown> {
   const client = new OpenAI({ apiKey: 'test-key', webhookSecret: secret });
   return surface === 'verifySignature'
-    ? client.webhooks.verifySignature(payload, headers)
-    : client.webhooks.unwrap(payload, headers);
+    ? client.webhooks.verifySignature(signedPayload, headers)
+    : client.webhooks.unwrap(signedPayload, headers);
+}
+
+function expectSuccessfulResult(surface: Surface, result: unknown, expectedEvent: unknown = event): void {
+  if (surface === 'unwrap') {
+    expect(result).toEqual(expectedEvent);
+  } else {
+    expect(result).toBeUndefined();
+  }
 }
 
 async function expectMismatch(surface: Surface, headers: Headers): Promise<void> {
@@ -45,6 +61,23 @@ afterEach(() => {
 });
 
 describe('public webhook signature verification work', () => {
+  test.each([
+    { surface: 'verifySignature', prefix: 'v1,' },
+    { surface: 'verifySignature', prefix: '' },
+    { surface: 'unwrap', prefix: 'v1,' },
+    { surface: 'unwrap', prefix: '' },
+  ] as const)('$surface accepts a $prefix signature in rotation slot 33', async ({ surface, prefix }) => {
+    const headers = makeHeaders([...Array.from({ length: 32 }, () => 'AAAA'), prefix + validSignature()]);
+    const sign = vi.spyOn(crypto.subtle, 'sign');
+    const verify = vi.spyOn(crypto.subtle, 'verify');
+
+    const result = await runPublicSurface(surface, headers);
+
+    expect(sign).toHaveBeenCalledTimes(1);
+    expect(verify).toHaveBeenCalledTimes(1);
+    expectSuccessfulResult(surface, result);
+  });
+
   test.each(['verifySignature', 'unwrap'] as const)(
     '%s rejects an unsigned, ordinary-sized amplification header before cryptography',
     async (surface) => {
@@ -53,24 +86,146 @@ describe('public webhook signature verification work', () => {
       expect(headers.get('webhook-signature')).toHaveLength(7999);
 
       const importKey = vi.spyOn(crypto.subtle, 'importKey');
+      const sign = vi.spyOn(crypto.subtle, 'sign');
       const verify = vi.spyOn(crypto.subtle, 'verify');
 
       await expectMismatch(surface, headers);
       expect(importKey).not.toHaveBeenCalled();
+      expect(sign).not.toHaveBeenCalled();
       expect(verify).not.toHaveBeenCalled();
     },
   );
 
   test.each(['verifySignature', 'unwrap'] as const)(
-    '%s rejects an over-limit header even when its first signature is valid',
+    '%s accepts a long rotation header when its first signature is valid',
     async (surface) => {
       const headers = makeHeaders([`v1,${validSignature()}`, ...Array.from({ length: 32 }, () => 'AAAA')]);
       const importKey = vi.spyOn(crypto.subtle, 'importKey');
+      const sign = vi.spyOn(crypto.subtle, 'sign');
       const verify = vi.spyOn(crypto.subtle, 'verify');
 
-      await expectMismatch(surface, headers);
+      const result = await runPublicSurface(surface, headers);
+
+      expect(importKey).toHaveBeenCalledTimes(1);
+      expect(sign).toHaveBeenCalledTimes(1);
+      expect(verify).toHaveBeenCalledTimes(1);
+      expectSuccessfulResult(surface, result);
+    },
+  );
+
+  test.each(['verifySignature', 'unwrap'] as const)(
+    '%s accepts a late valid signature after thousands of distinct candidates',
+    async (surface) => {
+      const candidates = Array.from({ length: 1600 }, (_, index) => invalidSignature(index));
+      candidates.push(`v1,${validSignature()}`);
+      const importKey = vi.spyOn(crypto.subtle, 'importKey');
+      const sign = vi.spyOn(crypto.subtle, 'sign');
+      const verify = vi.spyOn(crypto.subtle, 'verify');
+
+      const result = await runPublicSurface(surface, makeHeaders(candidates));
+
+      expect(importKey).toHaveBeenCalledTimes(1);
+      expect(sign).toHaveBeenCalledTimes(1);
+      expect(verify).toHaveBeenCalledTimes(1);
+      expect(verify.mock.calls[0]?.[2]).toEqual(Uint8Array.from(Buffer.from(validSignature(), 'base64')));
+      expectSuccessfulResult(surface, result);
+    },
+  );
+
+  test.each(['verifySignature', 'unwrap'] as const)(
+    '%s bounds cryptographic work when thousands of correctly sized signatures are invalid',
+    async (surface) => {
+      const candidates = Array.from({ length: 1600 }, (_, index) => invalidSignature(index));
+      const importKey = vi.spyOn(crypto.subtle, 'importKey');
+      const sign = vi.spyOn(crypto.subtle, 'sign');
+      const verify = vi.spyOn(crypto.subtle, 'verify');
+
+      await expectMismatch(surface, makeHeaders(candidates));
+
+      expect(importKey).toHaveBeenCalledTimes(1);
+      expect(sign).toHaveBeenCalledTimes(1);
+      expect(verify).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test.each(['verifySignature', 'unwrap'] as const)(
+    '%s rejects malformed, undersized, and oversized signatures before cryptography',
+    async (surface) => {
+      const signatures = [
+        ...Array.from({ length: 32 }, (_, index) => `v1,not-valid-$$$${index}`),
+        Buffer.alloc(31).toString('base64'),
+        Buffer.alloc(33).toString('base64'),
+        'A'.repeat(16_384),
+      ];
+      const importKey = vi.spyOn(crypto.subtle, 'importKey');
+      const sign = vi.spyOn(crypto.subtle, 'sign');
+      const verify = vi.spyOn(crypto.subtle, 'verify');
+
+      await expectMismatch(surface, makeHeaders(signatures));
+
       expect(importKey).not.toHaveBeenCalled();
+      expect(sign).not.toHaveBeenCalled();
       expect(verify).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(['verifySignature', 'unwrap'] as const)(
+    '%s finds a late valid signature after malformed and oversized candidates',
+    async (surface) => {
+      const signatures = [
+        ...Array.from({ length: 32 }, () => 'v1,not-valid-$$$'),
+        'A'.repeat(16_384),
+        `v1,${validSignature()}`,
+      ];
+      const sign = vi.spyOn(crypto.subtle, 'sign');
+      const verify = vi.spyOn(crypto.subtle, 'verify');
+
+      const result = await runPublicSurface(surface, makeHeaders(signatures));
+
+      expect(sign).toHaveBeenCalledTimes(1);
+      expect(verify).toHaveBeenCalledTimes(1);
+      expectSuccessfulResult(surface, result);
+    },
+  );
+
+  test.each(['verifySignature', 'unwrap'] as const)(
+    '%s deduplicates repeated bare and prefixed signatures before finding a late match',
+    async (surface) => {
+      const duplicate = invalidSignature(7);
+      const signatures = Array.from({ length: 2048 }, (_, index) =>
+        index % 2 === 0 ? duplicate : `v1,${duplicate}`,
+      );
+      signatures.push(`v1,${validSignature()}`);
+      const sign = vi.spyOn(crypto.subtle, 'sign');
+      const verify = vi.spyOn(crypto.subtle, 'verify');
+
+      const result = await runPublicSurface(surface, makeHeaders(signatures));
+
+      expect(sign).toHaveBeenCalledTimes(1);
+      expect(verify).toHaveBeenCalledTimes(1);
+      expectSuccessfulResult(surface, result);
+    },
+  );
+
+  test.each(['verifySignature', 'unwrap'] as const)(
+    '%s bounds large-payload cryptographic work independently of signature count',
+    async (surface) => {
+      const largeEvent = { ...event, padding: 'x'.repeat(256 * 1024) };
+      const largePayload = JSON.stringify(largeEvent);
+      const signatures = Array.from({ length: 512 }, (_, index) => invalidSignature(index));
+      signatures.push(`v1,${validSignature(String(now), largePayload)}`);
+      const importKey = vi.spyOn(crypto.subtle, 'importKey');
+      const sign = vi.spyOn(crypto.subtle, 'sign');
+      const verify = vi.spyOn(crypto.subtle, 'verify');
+
+      const result = await runPublicSurface(surface, makeHeaders(signatures), largePayload);
+
+      expect(importKey).toHaveBeenCalledTimes(1);
+      expect(sign).toHaveBeenCalledTimes(1);
+      expect(verify).toHaveBeenCalledTimes(1);
+      expect(sign.mock.calls[0]?.[1]).toBe(verify.mock.calls[0]?.[1]);
+      expect(sign.mock.calls[0]?.[2]).toBe(verify.mock.calls[0]?.[3]);
+      expectSuccessfulResult(surface, result, largeEvent);
     },
   );
 
@@ -88,11 +243,7 @@ describe('public webhook signature verification work', () => {
       const result = await runPublicSurface(surface, makeHeaders(candidates));
 
       expect(verify).toHaveBeenCalledTimes(32);
-      if (surface === 'unwrap') {
-        expect(result).toEqual(event);
-      } else {
-        expect(result).toBeUndefined();
-      }
+      expectSuccessfulResult(surface, result);
     },
   );
 
@@ -104,11 +255,7 @@ describe('public webhook signature verification work', () => {
         makeHeaders(['v1,not-valid-$$$', `v1,${validSignature()}`]),
       );
 
-      if (surface === 'unwrap') {
-        expect(result).toEqual(event);
-      } else {
-        expect(result).toBeUndefined();
-      }
+      expectSuccessfulResult(surface, result);
     },
   );
 
@@ -120,11 +267,7 @@ describe('public webhook signature verification work', () => {
 
       expect(verify).toHaveBeenCalledTimes(1);
       expect(verify.mock.calls[0]?.[2]).toEqual(Uint8Array.of(0));
-      if (surface === 'unwrap') {
-        expect(result).toEqual(event);
-      } else {
-        expect(result).toBeUndefined();
-      }
+      expectSuccessfulResult(surface, result);
     },
   );
 

--- a/tests/lib/webhook-signature-amplification.test.ts
+++ b/tests/lib/webhook-signature-amplification.test.ts
@@ -1,0 +1,147 @@
+import { createHmac } from 'node:crypto';
+import { vi } from 'vitest';
+import OpenAI, { InvalidWebhookSignatureError } from 'openai';
+
+const now = 1_700_000_000;
+const secret = 'synthetic-webhook-secret';
+const webhookID = 'wh_amplification';
+const event = { id: 'evt_amplification', type: 'response.completed', data: { id: 'resp_test' } };
+const payload = JSON.stringify(event);
+const mismatch = 'The given webhook signature does not match the expected signature';
+
+type Surface = 'verifySignature' | 'unwrap';
+
+function validSignature(timestamp = String(now)): string {
+  return createHmac('sha256', secret).update([webhookID, timestamp, payload].join('.')).digest('base64');
+}
+
+function makeHeaders(signatures: string[], timestamp = String(now)): Headers {
+  return new Headers({
+    'webhook-id': webhookID,
+    'webhook-signature': signatures.join(' '),
+    'webhook-timestamp': timestamp,
+  });
+}
+
+function runPublicSurface(surface: Surface, headers: Headers): Promise<unknown> {
+  const client = new OpenAI({ apiKey: 'test-key', webhookSecret: secret });
+  return surface === 'verifySignature'
+    ? client.webhooks.verifySignature(payload, headers)
+    : client.webhooks.unwrap(payload, headers);
+}
+
+async function expectMismatch(surface: Surface, headers: Headers): Promise<void> {
+  const operation = runPublicSurface(surface, headers);
+  await expect(operation).rejects.toBeInstanceOf(InvalidWebhookSignatureError);
+  await expect(operation).rejects.toThrow(mismatch);
+}
+
+beforeEach(() => {
+  vi.spyOn(Date, 'now').mockReturnValue(now * 1000);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('public webhook signature verification work', () => {
+  test.each(['verifySignature', 'unwrap'] as const)(
+    '%s rejects an unsigned, ordinary-sized amplification header before cryptography',
+    async (surface) => {
+      const candidates = Array.from({ length: 1600 }, () => 'AAAA');
+      const headers = makeHeaders(candidates);
+      expect(headers.get('webhook-signature')).toHaveLength(7999);
+
+      const importKey = vi.spyOn(crypto.subtle, 'importKey');
+      const verify = vi.spyOn(crypto.subtle, 'verify');
+
+      await expectMismatch(surface, headers);
+      expect(importKey).not.toHaveBeenCalled();
+      expect(verify).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(['verifySignature', 'unwrap'] as const)(
+    '%s rejects an over-limit header even when its first signature is valid',
+    async (surface) => {
+      const headers = makeHeaders([`v1,${validSignature()}`, ...Array.from({ length: 32 }, () => 'AAAA')]);
+      const importKey = vi.spyOn(crypto.subtle, 'importKey');
+      const verify = vi.spyOn(crypto.subtle, 'verify');
+
+      await expectMismatch(surface, headers);
+      expect(importKey).not.toHaveBeenCalled();
+      expect(verify).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    { surface: 'verifySignature', prefix: 'v1,' },
+    { surface: 'verifySignature', prefix: '' },
+    { surface: 'unwrap', prefix: 'v1,' },
+    { surface: 'unwrap', prefix: '' },
+  ] as const)(
+    '$surface accepts a real $prefix signature in the final supported rotation slot',
+    async ({ surface, prefix }) => {
+      const candidates = [...Array.from({ length: 31 }, () => 'AAAA'), prefix + validSignature()];
+      const verify = vi.spyOn(crypto.subtle, 'verify');
+
+      const result = await runPublicSurface(surface, makeHeaders(candidates));
+
+      expect(verify).toHaveBeenCalledTimes(32);
+      if (surface === 'unwrap') {
+        expect(result).toEqual(event);
+      } else {
+        expect(result).toBeUndefined();
+      }
+    },
+  );
+
+  test.each(['verifySignature', 'unwrap'] as const)(
+    '%s continues through malformed signatures to a real rotated signature',
+    async (surface) => {
+      const result = await runPublicSurface(
+        surface,
+        makeHeaders(['v1,not-valid-$$$', `v1,${validSignature()}`]),
+      );
+
+      if (surface === 'unwrap') {
+        expect(result).toEqual(event);
+      } else {
+        expect(result).toBeUndefined();
+      }
+    },
+  );
+
+  test.each(['verifySignature', 'unwrap'] as const)(
+    '%s preserves short mocked signature compatibility',
+    async (surface) => {
+      const verify = vi.spyOn(crypto.subtle, 'verify').mockResolvedValueOnce(true);
+      const result = await runPublicSurface(surface, makeHeaders(['v1,AA==']));
+
+      expect(verify).toHaveBeenCalledTimes(1);
+      expect(verify.mock.calls[0]?.[2]).toEqual(Uint8Array.of(0));
+      if (surface === 'unwrap') {
+        expect(result).toEqual(event);
+      } else {
+        expect(result).toBeUndefined();
+      }
+    },
+  );
+
+  test.each([
+    { timestamp: 'invalid', message: 'Invalid webhook timestamp format' },
+    { timestamp: String(now - 301), message: 'Webhook timestamp is too old' },
+    { timestamp: String(now + 301), message: 'Webhook timestamp is too new' },
+  ])('preserves timestamp validation before rejecting $timestamp', async ({ timestamp, message }) => {
+    const headers = makeHeaders(
+      Array.from({ length: 33 }, () => 'AAAA'),
+      timestamp,
+    );
+    const importKey = vi.spyOn(crypto.subtle, 'importKey');
+    const verify = vi.spyOn(crypto.subtle, 'verify');
+
+    await expect(runPublicSurface('verifySignature', headers)).rejects.toThrow(message);
+    expect(importKey).not.toHaveBeenCalled();
+    expect(verify).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/webhook-signature-amplification.test.ts
+++ b/tests/lib/webhook-signature-amplification.test.ts
@@ -8,6 +8,8 @@ const webhookID = 'wh_amplification';
 const event = { id: 'evt_amplification', type: 'response.completed', data: { id: 'resp_test' } };
 const payload = JSON.stringify(event);
 const mismatch = 'The given webhook signature does not match the expected signature';
+const unsupportedCrypto =
+  'Webhook signature verification is only supported when the `crypto` global is defined';
 
 type Surface = 'verifySignature' | 'unwrap';
 
@@ -52,15 +54,93 @@ async function expectMismatch(surface: Surface, headers: Headers): Promise<void>
   await expect(operation).rejects.toThrow(mismatch);
 }
 
+function omitWebCryptoMethod(method: 'importKey' | 'sign' | 'verify'): void {
+  const { subtle } = crypto;
+  const methods = {
+    importKey: subtle.importKey.bind(subtle),
+    sign: subtle.sign.bind(subtle),
+    verify: subtle.verify.bind(subtle),
+  };
+  Reflect.deleteProperty(methods, method);
+  vi.stubGlobal('crypto', { subtle: methods });
+}
+
 beforeEach(() => {
   vi.spyOn(Date, 'now').mockReturnValue(now * 1000);
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe('public webhook signature verification work', () => {
+  test.each([
+    { surface: 'verifySignature', capability: 'crypto' },
+    { surface: 'verifySignature', capability: 'subtle' },
+    { surface: 'verifySignature', capability: 'importKey' },
+    { surface: 'verifySignature', capability: 'verify' },
+    { surface: 'unwrap', capability: 'crypto' },
+    { surface: 'unwrap', capability: 'subtle' },
+    { surface: 'unwrap', capability: 'importKey' },
+    { surface: 'unwrap', capability: 'verify' },
+  ] as const)(
+    '$surface rejects missing $capability with the existing unsupported-crypto error',
+    async ({ surface, capability }) => {
+      const headers = makeHeaders([`v1,${validSignature()}`]);
+
+      if (capability === 'crypto') {
+        vi.stubGlobal('crypto', crypto);
+        Reflect.deleteProperty(globalThis, 'crypto');
+      } else if (capability === 'subtle') {
+        vi.stubGlobal('crypto', {});
+      } else {
+        omitWebCryptoMethod(capability);
+      }
+
+      const result = runPublicSurface(surface, headers);
+      await expect(result).rejects.toThrow(unsupportedCrypto);
+      await expect(result).rejects.not.toBeInstanceOf(InvalidWebhookSignatureError);
+    },
+  );
+
+  test.each([
+    { surface: 'verifySignature', candidates: 1 },
+    { surface: 'verifySignature', candidates: 32 },
+    { surface: 'unwrap', candidates: 1 },
+    { surface: 'unwrap', candidates: 32 },
+  ] as const)(
+    '$surface accepts $candidates candidates without an unnecessary sign capability',
+    async ({ surface, candidates }) => {
+      const headers = makeHeaders([
+        ...Array.from({ length: candidates - 1 }, () => 'AAAA'),
+        `v1,${validSignature()}`,
+      ]);
+      omitWebCryptoMethod('sign');
+
+      expectSuccessfulResult(surface, await runPublicSurface(surface, headers));
+    },
+  );
+
+  test.each(['verifySignature', 'unwrap'] as const)(
+    '%s rejects a large valid rotation header without sign using the unsupported-crypto error',
+    async (surface) => {
+      const headers = makeHeaders([
+        ...Array.from({ length: 32 }, (_, index) => invalidSignature(index)),
+        `v1,${validSignature()}`,
+      ]);
+      const importKey = vi.spyOn(crypto.subtle, 'importKey');
+      const verify = vi.spyOn(crypto.subtle, 'verify');
+      omitWebCryptoMethod('sign');
+
+      const result = runPublicSurface(surface, headers);
+      await expect(result).rejects.toThrow(unsupportedCrypto);
+      await expect(result).rejects.not.toBeInstanceOf(InvalidWebhookSignatureError);
+      expect(importKey).not.toHaveBeenCalled();
+      expect(verify).not.toHaveBeenCalled();
+    },
+  );
+
   test.each([
     { surface: 'verifySignature', prefix: 'v1,' },
     { surface: 'verifySignature', prefix: '' },
@@ -143,6 +223,82 @@ describe('public webhook signature verification work', () => {
       await expectMismatch(surface, makeHeaders(candidates));
 
       expect(importKey).toHaveBeenCalledTimes(1);
+      expect(sign).toHaveBeenCalledTimes(1);
+      expect(verify).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test.each(['verifySignature', 'unwrap'] as const)(
+    '%s converts a bounded-provider verification rejection into the existing typed mismatch',
+    async (surface) => {
+      const headers = makeHeaders([
+        ...Array.from({ length: 32 }, (_, index) => invalidSignature(index)),
+        `v1,${validSignature()}`,
+      ]);
+      const providerError = new Error('synthetic bounded verification failure');
+      const sign = vi.spyOn(crypto.subtle, 'sign');
+      const verify = vi.spyOn(crypto.subtle, 'verify').mockRejectedValue(providerError);
+
+      await expectMismatch(surface, headers);
+      expect(sign).toHaveBeenCalledTimes(1);
+      expect(verify).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test.each(['verifySignature', 'unwrap'] as const)(
+    '%s preserves provider signing failures without treating them as signature mismatches',
+    async (surface) => {
+      const headers = makeHeaders([
+        ...Array.from({ length: 32 }, (_, index) => invalidSignature(index)),
+        `v1,${validSignature()}`,
+      ]);
+      const providerError = new Error('synthetic bounded signing failure');
+      const sign = vi.spyOn(crypto.subtle, 'sign').mockRejectedValue(providerError);
+      const verify = vi.spyOn(crypto.subtle, 'verify');
+
+      await expect(runPublicSurface(surface, headers)).rejects.toBe(providerError);
+      expect(sign).toHaveBeenCalledTimes(1);
+      expect(verify).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(['verifySignature', 'unwrap'] as const)(
+    '%s scans a very large rotation incrementally before accepting its final signature',
+    async (surface) => {
+      const signatures = Array.from({ length: 20_000 }, (_, index) => invalidSignature(index));
+      signatures.push(`v1,${validSignature()}`);
+      const headers = makeHeaders(signatures);
+      const copiedBytes = vi.spyOn(Uint8Array, 'from');
+      const originalSign = crypto.subtle.sign.bind(crypto.subtle);
+      let copiesBeforeSigning = 0;
+      const sign = vi.spyOn(crypto.subtle, 'sign').mockImplementation(async (algorithm, key, data) => {
+        copiesBeforeSigning = copiedBytes.mock.calls.length;
+        return await originalSign(algorithm, key, data);
+      });
+      const verify = vi.spyOn(crypto.subtle, 'verify');
+
+      expectSuccessfulResult(surface, await runPublicSurface(surface, headers));
+      expect(copiesBeforeSigning).toBeLessThanOrEqual(35);
+      expect(copiedBytes.mock.calls.length).toBeLessThanOrEqual(35);
+      expect(sign).toHaveBeenCalledTimes(1);
+      expect(verify).toHaveBeenCalledTimes(1);
+      expect(verify.mock.calls[0]?.[2]).toEqual(Uint8Array.from(Buffer.from(validSignature(), 'base64')));
+    },
+  );
+
+  test.each(['verifySignature', 'unwrap'] as const)(
+    '%s verifies a late large-header signature without requiring the Node Buffer global',
+    async (surface) => {
+      const headers = makeHeaders([
+        ...Array.from({ length: 64 }, (_, index) => invalidSignature(index)),
+        `v1,${validSignature()}`,
+      ]);
+      const sign = vi.spyOn(crypto.subtle, 'sign');
+      const verify = vi.spyOn(crypto.subtle, 'verify');
+      vi.stubGlobal('Buffer', Buffer);
+      Reflect.deleteProperty(globalThis, 'Buffer');
+
+      expectSuccessfulResult(surface, await runPublicSurface(surface, headers));
       expect(sign).toHaveBeenCalledTimes(1);
       expect(verify).toHaveBeenCalledTimes(1);
     },


### PR DESCRIPTION
## Summary
- Limit webhook signature candidates to 32 before importing a verification key or performing HMAC work.
- Preserve existing typed failures, timestamp validation, rotated signatures, prefixed and bare formats, and both public webhook entrypoints.
- Cover the exact acceptance boundary, malformed signatures, real HMACs, and existing short-signature mock compatibility.

## Validation
- Full handwritten suite: 149 files / 6,291 tests.
- Full generated suite: 82 suites / 556 tests against an isolated local Steady server.
- Focused public webhook tests: 46 passing.
- Full lint, strict TypeScript, build, published TypeScript 4.9 and current compatibility, publint, packed CommonJS/ESM and 1,264 source maps.
- Built CommonJS and ESM clients both reject over-budget signatures before verification and accept the final valid signature at the 32-candidate boundary.