### PR TITLE
fix(tests): make credential-lifecycle held-inode scenarios portable to macOS

### DIFF
--- a/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
+++ b/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
@@ -134,7 +134,7 @@ function withFixture(run: (fixture: Fixture) => void) {
       '    }',
       '  }',
       "  if (failure === 'capture-original' || failure === 'edit-original') {",
-      "    const held = '/proc/' + process.ppid + '/fd/' + process.env.CLOUDFLARE_HELD_FD;",
+      '    const held = process.env.CLOUDFLARE_HELD_LINK;',
       "    if (failure === 'capture-original') {",
       '      fs.writeFileSync(process.env.CLOUDFLARE_HELD_CAPTURE, fs.readFileSync(held), { mode: 0o600 });',
       '    } else {',
@@ -176,18 +176,29 @@ function setExistingCredentials(fixture: Fixture, state: CredentialState) {
 
 function holdOriginalCredentialDescriptor(fixture: Fixture): string {
   const preload = path.join(fixture.directory, 'hold-original-credential.cjs');
+  const heldLink = path.join(fixture.directory, 'held-original-credential');
   writeFileSync(
     preload,
     [
       "const fs = require('node:fs');",
       "const promises = require('node:fs/promises');",
+      `const heldLink = ${JSON.stringify(heldLink)};`,
       'const originalOpen = promises.open;',
+      'const originalLink = promises.link;',
       'promises.open = async (...args) => {',
       '  const file = await originalOpen(...args);',
       "  if (args[0] === '.dev.vars' && !process.env.CLOUDFLARE_HELD_FD) {",
       "    process.env.CLOUDFLARE_HELD_FD = String(fs.openSync(args[0], 'r+'));",
       '  }',
       '  return file;',
+      '};',
+      'promises.link = async (...args) => {',
+      '  const result = await originalLink(...args);',
+      "  if (args[0] === '.dev.vars' && !process.env.CLOUDFLARE_HELD_LINK) {",
+      '    fs.linkSync(args[0], heldLink);',
+      '    process.env.CLOUDFLARE_HELD_LINK = heldLink;',
+      '  }',
+      '  return result;',
       '};',
     ].join('\n'),
   );


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

`./scripts/test` currently fails on macOS at the two held-inode scenarios in `tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts`. The generated npm stub addresses the parent process's held descriptor through `/proc/<ppid>/fd/<n>`, which exists only on Linux. On macOS the stub exits with `ENOENT: no such file or directory, open '/proc/<pid>/fd/16'`, so both tests report child status 1. CI runs on ubuntu-latest only, so the failure shows up on contributor machines rather than in CI, and the two scenarios currently have no coverage on macOS.

This change keeps the preload's pre-opened descriptor exactly as before and adds a portable route to the same inode: immediately after the CLI's own backup link of `.dev.vars` succeeds (that is, after the `nlink === 1` validation has already run, so the invariant check is unaffected), the preload hard-links the original inode to a fixture-root path and exports it as `CLOUDFLARE_HELD_LINK`. The stub reads, writes, and chmods through that link instead of the procfs path. A hard link addresses the same inode, so the scenarios still prove the original guarantees: a reader of the original inode never observes the staged key, and concurrent edits plus mode changes made through the original inode survive restoration. Linux and macOS run the same code path, and no assertions changed.

Verified on macOS (Node 24.18.0): both tests fail on `main` and pass with this change; the full file passes 79/79; lint, build, and the full test battery pass.

## Additional context & links

The link lives outside the worker directory, so the `.dev.vars.openai-*` artifact assertions are unaffected, and the fixture cleanup removes it.
