### PR TITLE
fix(auth): honor an explicit zero GCP metadata timeout

### DIFF
--- a/src/auth/subject-token-providers.ts
+++ b/src/auth/subject-token-providers.ts
@@ -370,7 +370,7 @@ export function gcpIDTokenProvider(
     fetch?: Fetch;
   },
 ): SubjectTokenProvider {
-  const timeout = config?.timeout || 10_000;
+  const timeout = config?.timeout ?? 10_000;
 
   return {
     tokenType: 'id',

--- a/tests/auth/subject-token-providers.test.ts
+++ b/tests/auth/subject-token-providers.test.ts
@@ -131,6 +131,22 @@ describe('Azure IMDS Token Provider', () => {
     expect(customFetch).toHaveBeenCalledTimes(1);
   });
 
+  test('honors an explicit zero-millisecond metadata timeout', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    try {
+      const provider = azureManagedIdentityTokenProvider(undefined, {
+        timeout: 0,
+        fetch: async () => Response.json({ access_token: 'azure-token' }, { status: 200 }),
+      });
+
+      await expect(provider.getToken()).resolves.toBe('azure-token');
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 0);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   test('throws SubjectTokenProviderError on failed request', async () => {
     global.fetch = vi.fn(async () => new Response('Not found', { status: 404 })) as typeof fetch;
 
@@ -186,6 +202,22 @@ describe('GCP Metadata Server Token Provider', () => {
     await provider.getToken();
 
     expect(customFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('honors an explicit zero-millisecond metadata timeout', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    try {
+      const provider = gcpIDTokenProvider(undefined, {
+        timeout: 0,
+        fetch: async () => new Response('gcp-id-token', { status: 200 }),
+      });
+
+      await expect(provider.getToken()).resolves.toBe('gcp-id-token');
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 0);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
   });
 
   test('throws SubjectTokenProviderError on failed request', async () => {


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

`gcpIDTokenProvider` computes its metadata request timeout with `config?.timeout || 10_000`, so an explicit `timeout: 0` is silently replaced with 10,000 ms. The Azure IMDS provider in the same file uses `config?.timeout ?? 10_000` for the identically documented option, so the two providers currently behave differently for the same configuration.

This change switches the GCP provider to the nullish coalescing the file already uses for Azure, and adds explicit-zero regression tests for both providers in `tests/auth/subject-token-providers.test.ts` (mocked fetch, no live network; the Azure test is a parity control pinning the already-correct behavior).

Verified locally (Node 24.18.0): the GCP regression fails on `main` (the single `setTimeout` call receives `10000` instead of `0`) and passes with this change; the provider test file passes 14/14; lint, build, and the full test suite pass apart from the two pre-existing macOS-only failures addressed in #2480.

## Additional context & links

One-line production change; the only other `config?.timeout` default in the file already used `??`.
