### PR TITLE
fix(standard-schema): preserve validator bindings across helpers

### DIFF
--- a/src/helpers/standard-schema.ts
+++ b/src/helpers/standard-schema.ts
@@ -505,12 +505,30 @@ function normalizeStructuredOutputSchema(schema: JSONSchema): JSONSchema {
   return normalizedSchema;
 }
 
+type StandardSchemaBinding<Schema extends StandardSchemaLike> = {
+  standard: Schema['~standard'];
+  validate: Schema['~standard']['validate'];
+};
+
+function bindStandardSchema<Schema extends StandardSchemaLike>(standardSchema: Schema) {
+  let binding: StandardSchemaBinding<Schema> | undefined;
+
+  return (): StandardSchemaBinding<Schema> => {
+    if (!binding) {
+      const standard = standardSchema['~standard'];
+      binding = { standard, validate: standard.validate };
+    }
+    return binding;
+  };
+}
+
 function parseStandardSchema<Schema extends StandardSchemaLike>(
-  standardSchema: Schema,
+  getBinding: () => StandardSchemaBinding<Schema>,
   content: string,
 ): InferStandardOutput<Schema> {
   const parsed = parseResponseFormatContent({ type: 'json_schema', $parseRaw: undefined }, content);
-  const result = standardSchema['~standard'].validate(parsed);
+  const { standard, validate } = getBinding();
+  const result = Reflect.apply(validate, standard, [parsed]);
 
   if (isPromiseLike(result)) {
     void Promise.resolve(result).catch(() => undefined);
@@ -526,11 +544,11 @@ function parseStandardSchema<Schema extends StandardSchemaLike>(
   return result.value as InferStandardOutput<Schema>;
 }
 
-function resolveStandardJSONSchema(
-  standardSchema: StandardSchemaLike,
+function resolveStandardJSONSchema<Schema extends StandardSchemaLike>(
+  getBinding: () => StandardSchemaBinding<Schema>,
   schemaOverride?: JSONSchema | Record<string, unknown> | undefined,
 ): Record<string, unknown> {
-  const schema = (schemaOverride ?? standardSchema['~standard'].jsonSchema?.input({ target: 'draft-07' })) as
+  const schema = (schemaOverride ?? getBinding().standard.jsonSchema?.input({ target: 'draft-07' })) as
     | JSONSchema
     | undefined;
 
@@ -570,6 +588,7 @@ export function standardResponseFormat<Schema extends StandardSchemaLike>(
   props?: StandardResponseFormatProps,
 ): AutoParseableResponseFormat<InferStandardOutput<Schema>> {
   const { schema, ...formatProps } = props ?? {};
+  const getBinding = bindStandardSchema(standardSchema);
 
   return makeParseableResponseFormat<InferStandardOutput<Schema>>(
     {
@@ -578,10 +597,10 @@ export function standardResponseFormat<Schema extends StandardSchemaLike>(
         ...formatProps,
         name,
         strict: true,
-        schema: resolveStandardJSONSchema(standardSchema, schema),
+        schema: resolveStandardJSONSchema(getBinding, schema),
       },
     },
-    (content) => parseStandardSchema(standardSchema, content),
+    (content) => parseStandardSchema(getBinding, content),
   );
 }
 
@@ -608,6 +627,7 @@ export function standardTextFormat<Schema extends StandardSchemaLike>(
   props?: StandardTextFormatProps,
 ): AutoParseableTextFormat<InferStandardOutput<Schema>> {
   const { schema, ...formatProps } = props ?? {};
+  const getBinding = bindStandardSchema(standardSchema);
 
   return makeParseableTextFormat<InferStandardOutput<Schema>>(
     {
@@ -615,9 +635,9 @@ export function standardTextFormat<Schema extends StandardSchemaLike>(
       ...formatProps,
       name,
       strict: true,
-      schema: resolveStandardJSONSchema(standardSchema, schema),
+      schema: resolveStandardJSONSchema(getBinding, schema),
     },
-    (content) => parseStandardSchema(standardSchema, content),
+    (content) => parseStandardSchema(getBinding, content),
   );
 }
 
@@ -684,19 +704,23 @@ export function standardFunction<Parameters extends StandardSchemaLike>(
 export function standardFunction<Parameters extends StandardSchemaLike>(
   options: StandardToolOptions<Parameters>,
 ) {
+  const name = options.name;
+  const parameters = options.parameters;
+  const getBinding = bindStandardSchema(parameters);
+
   return makeParseableTool<any>(
     {
       type: 'function',
       function: {
-        name: options.name,
-        parameters: resolveStandardJSONSchema(options.parameters, options.schema),
+        name,
+        parameters: resolveStandardJSONSchema(getBinding, options.schema),
         strict: true,
         ...(options.description ? { description: options.description } : undefined),
       },
     },
     {
       callback: options.function,
-      parser: (args) => parseStandardSchema(options.parameters, args),
+      parser: (args) => parseStandardSchema(getBinding, args),
     },
   );
 }
@@ -763,17 +787,21 @@ export function standardResponsesFunction<Parameters extends StandardSchemaLike>
 export function standardResponsesFunction<Parameters extends StandardSchemaLike>(
   options: StandardToolOptions<Parameters>,
 ) {
+  const name = options.name;
+  const parameters = options.parameters;
+  const getBinding = bindStandardSchema(parameters);
+
   return makeParseableResponseTool<any>(
     {
       type: 'function',
-      name: options.name,
-      parameters: resolveStandardJSONSchema(options.parameters, options.schema),
+      name,
+      parameters: resolveStandardJSONSchema(getBinding, options.schema),
       strict: true,
       ...(options.description ? { description: options.description } : undefined),
     },
     {
       callback: options.function,
-      parser: (args) => parseStandardSchema(options.parameters, args),
+      parser: (args) => parseStandardSchema(getBinding, args),
     },
   );
 }

--- a/tests/helpers/standard-schema.test.ts
+++ b/tests/helpers/standard-schema.test.ts
@@ -121,6 +121,35 @@ function makeValidationOnlySchema() {
 }
 
 describe('Standard Schema helpers', () => {
+  type TestSchema = Parameters<typeof standardResponseFormat>[0];
+
+  const helperFactories = [
+    [
+      'response format',
+      (schema: TestSchema, override?: JSONSchema) =>
+        standardResponseFormat(schema, 'weather', { schema: override }),
+    ],
+    [
+      'text format',
+      (schema: TestSchema, override?: JSONSchema) =>
+        standardTextFormat(schema, 'weather', { schema: override }),
+    ],
+    [
+      'chat function',
+      (schema: TestSchema, override?: JSONSchema) =>
+        standardFunction({ name: 'get_weather', parameters: schema, schema: override }),
+    ],
+    [
+      'response function',
+      (schema: TestSchema, override?: JSONSchema) =>
+        standardResponsesFunction({ name: 'get_weather', parameters: schema, schema: override }),
+    ],
+  ] as const;
+
+  const permissiveValidation = (_value: unknown): ReturnType<typeof validateWeather> => ({
+    value: { city: 'unvalidated', unit: 'c', normalized: true },
+  });
+
   it('uses the input JSON Schema for parseable response formats', () => {
     const { standardSchema, input, output } = makeStandardSchema();
 
@@ -192,6 +221,114 @@ describe('Standard Schema helpers', () => {
 
     expect(format.json_schema.schema).toEqual(strictWeatherJSONSchema);
   });
+
+  it.each(helperFactories)('keeps %s bound to its original metadata and validator', (_name, makeHelper) => {
+    const { standardSchema } = makeStandardSchema();
+    const metadata = { ...standardSchema['~standard'] };
+    const originalInput = metadata.jsonSchema.input;
+    let metadataReads = 0;
+
+    const strictValidator = function strictValidator(this: typeof metadata, value: unknown) {
+      expect(this).toBe(metadata);
+      return validateWeather(value);
+    };
+    Object.defineProperty(strictValidator, 'call', { value: undefined });
+    metadata.validate = strictValidator;
+    metadata.jsonSchema.input = vi.fn(function convertOriginalMetadata(this: typeof metadata.jsonSchema) {
+      expect(this).toBe(metadata.jsonSchema);
+      metadata.validate = permissiveValidation;
+      return originalInput();
+    });
+
+    const schema = {
+      get '~standard'() {
+        metadataReads += 1;
+        return metadataReads === 1 ? metadata : { ...metadata, validate: permissiveValidation };
+      },
+    };
+    const helper = makeHelper(schema);
+
+    expect(metadataReads).toBe(1);
+    expect(() => helper.$parseRaw('{"city":123,"unit":"c"}')).toThrow('expected weather input');
+    expect(helper.$parseRaw('{"city":"Paris","unit":"c"}')).toEqual({
+      city: 'Paris',
+      unit: 'c',
+      normalized: true,
+    });
+    expect(metadataReads).toBe(1);
+  });
+
+  it.each(helperFactories)(
+    'defers and then reuses the %s validator for explicit schemas',
+    (_name, makeHelper) => {
+      const { standardSchema } = makeStandardSchema();
+      let metadataReads = 0;
+      const schema = {
+        get '~standard'() {
+          metadataReads += 1;
+          return metadataReads === 1
+            ? standardSchema['~standard']
+            : { ...standardSchema['~standard'], validate: permissiveValidation };
+        },
+      };
+      const helper = makeHelper(schema, weatherJSONSchema);
+
+      expect(metadataReads).toBe(0);
+      expect(() => helper.$parseRaw('{')).toThrow('invalid structured output JSON');
+      expect(metadataReads).toBe(0);
+      expect(() => helper.$parseRaw('{"city":123,"unit":"c"}')).toThrow('expected weather input');
+      expect(metadataReads).toBe(1);
+      expect(helper.$parseRaw('{"city":"Paris","unit":"c"}')).toEqual({
+        city: 'Paris',
+        unit: 'c',
+        normalized: true,
+      });
+      expect(metadataReads).toBe(1);
+    },
+  );
+
+  it.each(['chat function', 'response function'] as const)(
+    'keeps %s validation bound across reentrant option getters',
+    (name) => {
+      const { standardSchema } = makeStandardSchema();
+      const permissiveSchema = {
+        '~standard': { ...standardSchema['~standard'], validate: permissiveValidation },
+      };
+      let current = standardSchema;
+      const accesses: string[] = [];
+      const callback = vi.fn();
+      const options = {
+        get name() {
+          accesses.push('name');
+          return 'get_weather';
+        },
+        get parameters() {
+          accesses.push('parameters');
+          return current;
+        },
+        get schema() {
+          accesses.push('schema');
+          current = permissiveSchema;
+          return weatherJSONSchema;
+        },
+        get description() {
+          accesses.push('description');
+          return 'Get the weather';
+        },
+        get function() {
+          accesses.push('function');
+          return callback;
+        },
+      };
+      const helper =
+        name === 'chat function' ? standardFunction(options) : standardResponsesFunction(options);
+
+      expect(accesses).toEqual(['name', 'parameters', 'schema', 'description', 'description', 'function']);
+      expect(() => helper.$parseRaw('{"city":123,"unit":"c"}')).toThrow('expected weather input');
+      expect(accesses).toEqual(['name', 'parameters', 'schema', 'description', 'description', 'function']);
+      expect(callback).not.toHaveBeenCalled();
+    },
+  );
 
   it('normalizes provably exclusive oneOf branches before strictifying schemas', () => {
     const oneOfSchema = {


### PR DESCRIPTION
## Summary

- Bind all four Standard Schema helpers to the same validator metadata used for strict schema generation.
- Preserve explicit-schema laziness, original method receivers, and existing tool-option getter ordering.
- Add focused integrated regressions for fresh metadata, converter mutation, validator swapping, and malformed JSON.

## Validation

- Node 22.23 and Node 26.7: 6,541 handwritten and 556 generated tests on each runtime.
- Canonical lint, strict TypeScript 6, published TypeScript 4.9/6 declarations, and package builds on both runtimes.
- publint and installed packed-package CJS/ESM adversarial helper checks on both runtimes.