### PR TITLE
fix(responses): reject lifecycle events from another response

### DIFF
--- a/src/internal/responses/canonical-output-text.ts
+++ b/src/internal/responses/canonical-output-text.ts
@@ -51,11 +51,16 @@ export function ensureCanonicalOutputText(context: ResponseAccumulatorContext, s
   context.canonicalSnapshot = snapshot;
 }
 
-export function cloneResponse(context: ResponseAccumulatorContext, response: Response): Response {
+export function cloneResponse(
+  context: ResponseAccumulatorContext,
+  response: Response,
+  onClonedResponse?: (response: Response) => void,
+): Response {
   context.canonicalSnapshot = undefined;
   context.outputTextLengths = new WeakMap();
   context.outputTextIndex = new OutputTextIndex();
   const snapshot = structuredClone(response);
+  onClonedResponse?.(snapshot);
   if (
     !Object.getOwnPropertyDescriptor(snapshot, 'output_text') ||
     snapshot.output_text === null ||

--- a/src/internal/responses/response-accumulator.ts
+++ b/src/internal/responses/response-accumulator.ts
@@ -351,8 +351,11 @@ function snapshotResponseLifecycleEvent(
       source !== null && source !== Object.prototype;
       source = Object.getPrototypeOf(source) as object | null
     ) {
-      if (visited.has(source) || visited.size >= MAX_RESPONSE_LIFECYCLE_PROTOTYPE_DEPTH) {
+      if (visited.has(source)) {
         throw new OpenAIError('Response event does not match the active response.');
+      }
+      if (visited.size >= MAX_RESPONSE_LIFECYCLE_PROTOTYPE_DEPTH) {
+        break;
       }
       visited.add(source);
 
@@ -1278,7 +1281,10 @@ export function accumulateResponseWithContext(
   snapshot: Response | undefined,
   context: ResponseAccumulatorContext,
   rejectInvalidShellTargets = false,
-  onSanitizedEvent?: (event: ResponseStreamEvent, emittedEvent?: ResponseStreamEvent) => void,
+  onSanitizedEvent?: (
+    event: ResponseStreamEvent,
+    materializeLifecycleEvent?: () => ResponseStreamEvent,
+  ) => void,
 ): Response {
   const dispatchEvent = sanitizeResponseEvent(event);
 
@@ -1292,7 +1298,9 @@ export function accumulateResponseWithContext(
       );
     }
     return cloneValidatedResponse(context, dispatchEvent.response, undefined, (validatedResponse) =>
-      onSanitizedEvent?.(dispatchEvent, snapshotResponseLifecycleEvent(dispatchEvent, validatedResponse)),
+      onSanitizedEvent?.(dispatchEvent, () =>
+        snapshotResponseLifecycleEvent(dispatchEvent, validatedResponse),
+      ),
     );
   }
 
@@ -1300,7 +1308,9 @@ export function accumulateResponseWithContext(
     const expectedResponseID = getResponseID(snapshot);
     const { response } = dispatchEvent;
     return cloneValidatedResponse(context, response, expectedResponseID, (validatedResponse) =>
-      onSanitizedEvent?.(dispatchEvent, snapshotResponseLifecycleEvent(dispatchEvent, validatedResponse)),
+      onSanitizedEvent?.(dispatchEvent, () =>
+        snapshotResponseLifecycleEvent(dispatchEvent, validatedResponse),
+      ),
     );
   }
 

--- a/src/internal/responses/response-accumulator.ts
+++ b/src/internal/responses/response-accumulator.ts
@@ -280,17 +280,22 @@ function getResponseID(snapshot: Response): string {
     return activeResponseID;
   }
 
-  let id: string | undefined;
+  let responseID: PropertyDescriptor | undefined;
   try {
-    ({ id } = snapshot);
+    responseID = Object.getOwnPropertyDescriptor(snapshot, 'id');
   } catch {
     throw new OpenAIError('Response event does not match the active response.');
   }
-  if (typeof id !== 'string') {
+  if (
+    !responseID ||
+    !responseID.enumerable ||
+    !('value' in responseID) ||
+    typeof responseID.value !== 'string'
+  ) {
     throw new OpenAIError('Response event does not match the active response.');
   }
-  activeResponseIDs.set(snapshot, id);
-  return id;
+  activeResponseIDs.set(snapshot, responseID.value);
+  return responseID.value;
 }
 
 function cloneValidatedResponse(

--- a/src/internal/responses/response-accumulator.ts
+++ b/src/internal/responses/response-accumulator.ts
@@ -273,10 +273,44 @@ function getResponseOutputIdentityIndex(
   return identityIndex;
 }
 
-function cloneValidatedResponse(context: ResponseAccumulatorContext, response: Response): Response {
+function getResponseID(snapshot: Response): string {
+  let id: string | undefined;
+  try {
+    ({ id } = snapshot);
+  } catch {
+    throw new OpenAIError('Response event does not match the active response.');
+  }
+  if (typeof id !== 'string') {
+    throw new OpenAIError('Response event does not match the active response.');
+  }
+  return id;
+}
+
+function cloneValidatedResponse(
+  context: ResponseAccumulatorContext,
+  response: Response,
+  expectedResponseID?: string,
+  onValidatedResponse?: () => void,
+): Response {
+  if (expectedResponseID !== undefined) {
+    let responseID: PropertyDescriptor | undefined;
+    try {
+      responseID = Object.getOwnPropertyDescriptor(response, 'id');
+    } catch {
+      throw new OpenAIError('Response event does not match the active response.');
+    }
+    if (responseID && 'value' in responseID && responseID.value !== expectedResponseID) {
+      throw new OpenAIError('Response event does not match the active response.');
+    }
+  }
+
   const nextContext = createCanonicalResponseContext();
   const snapshot = cloneResponse(nextContext, response);
+  if (expectedResponseID !== undefined && snapshot.id !== expectedResponseID) {
+    throw new OpenAIError('Response event does not match the active response.');
+  }
   const identityIndex = createResponseOutputIdentityIndex(snapshot);
+  onValidatedResponse?.();
 
   context.canonicalSnapshot = nextContext.canonicalSnapshot;
   context.outputTextLengths = nextContext.outputTextLengths;
@@ -1176,17 +1210,29 @@ export function accumulateResponseWithContext(
   onSanitizedEvent?: (event: ResponseStreamEvent) => void,
 ): Response {
   const dispatchEvent = sanitizeResponseEvent(event);
-  if (onSanitizedEvent && dispatchEvent.type !== 'keepalive') {
-    onSanitizedEvent(dispatchEvent);
-  }
 
   if (!snapshot) {
+    if (onSanitizedEvent && dispatchEvent.type !== 'keepalive') {
+      onSanitizedEvent(dispatchEvent);
+    }
     if (dispatchEvent.type !== 'response.created') {
       throw new OpenAIError(
         `When snapshot hasn't been set yet, expected 'response.created' event, got ${dispatchEvent.type}`,
       );
     }
     return cloneValidatedResponse(context, dispatchEvent.response);
+  }
+
+  if (isResponseLifecycleEvent(dispatchEvent)) {
+    const expectedResponseID = getResponseID(snapshot);
+    const { response } = dispatchEvent;
+    return cloneValidatedResponse(context, response, expectedResponseID, () =>
+      onSanitizedEvent?.(dispatchEvent),
+    );
+  }
+
+  if (onSanitizedEvent && dispatchEvent.type !== 'keepalive') {
+    onSanitizedEvent(dispatchEvent);
   }
 
   validateOutputItemIdentity(dispatchEvent, snapshot, rejectInvalidShellTargets);
@@ -1222,9 +1268,6 @@ export function accumulateResponseWithContext(
     return snapshot;
   }
 
-  if (isResponseLifecycleEvent(dispatchEvent)) {
-    return cloneValidatedResponse(context, dispatchEvent.response);
-  }
   if (isIgnoredResponseEvent(dispatchEvent)) {
     return snapshot;
   }

--- a/src/internal/responses/response-accumulator.ts
+++ b/src/internal/responses/response-accumulator.ts
@@ -342,15 +342,43 @@ function snapshotResponseLifecycleEvent(
   response: Response,
 ): ResponseLifecycleEvent {
   try {
-    const descriptors = Object.getOwnPropertyDescriptors(event);
-    descriptors.type.value = event.type;
-    descriptors.response = {
+    const detached = Object.create(Object.prototype) as ResponseLifecycleEvent;
+
+    for (
+      let source = event as object | null;
+      source !== null && source !== Object.prototype;
+      source = Object.getPrototypeOf(source) as object | null
+    ) {
+      for (const key of Reflect.ownKeys(source)) {
+        if (key === 'response' || hasOwn(detached, key) || (source !== event && key === 'constructor')) {
+          continue;
+        }
+
+        const descriptor = Object.getOwnPropertyDescriptor(source, key);
+        if (
+          !descriptor ||
+          (source !== event && 'value' in descriptor && typeof descriptor.value === 'function')
+        ) {
+          continue;
+        }
+
+        const value = 'value' in descriptor ? descriptor.value : Reflect.get(event, key, event);
+        Object.defineProperty(detached, key, {
+          configurable: Boolean(descriptor.configurable),
+          enumerable: Boolean(descriptor.enumerable),
+          value: key === 'type' ? event.type : value,
+          writable: 'writable' in descriptor ? Boolean(descriptor.writable) : true,
+        });
+      }
+    }
+
+    Object.defineProperty(detached, 'response', {
       configurable: true,
       enumerable: true,
       value: structuredClone(response),
       writable: true,
-    };
-    return Object.create(Object.getPrototypeOf(event), descriptors) as ResponseLifecycleEvent;
+    });
+    return detached;
   } catch {
     throw new OpenAIError('Response event does not match the active response.');
   }
@@ -1198,7 +1226,7 @@ function accumulateImageAndMcpStatusEvent(
   }
 }
 
-export function isResponseLifecycleEvent(event: ResponseAccumulatorEvent): event is ResponseLifecycleEvent {
+function isResponseLifecycleEvent(event: ResponseAccumulatorEvent): event is ResponseLifecycleEvent {
   switch (event.type) {
     case 'response.created':
     case 'response.queued':
@@ -1243,7 +1271,7 @@ export function accumulateResponseWithContext(
   snapshot: Response | undefined,
   context: ResponseAccumulatorContext,
   rejectInvalidShellTargets = false,
-  onSanitizedEvent?: (event: ResponseStreamEvent) => void,
+  onSanitizedEvent?: (event: ResponseStreamEvent, emittedEvent?: ResponseStreamEvent) => void,
 ): Response {
   const dispatchEvent = sanitizeResponseEvent(event);
 
@@ -1257,7 +1285,7 @@ export function accumulateResponseWithContext(
       );
     }
     return cloneValidatedResponse(context, dispatchEvent.response, undefined, (validatedResponse) =>
-      onSanitizedEvent?.(snapshotResponseLifecycleEvent(dispatchEvent, validatedResponse)),
+      onSanitizedEvent?.(dispatchEvent, snapshotResponseLifecycleEvent(dispatchEvent, validatedResponse)),
     );
   }
 
@@ -1265,7 +1293,7 @@ export function accumulateResponseWithContext(
     const expectedResponseID = getResponseID(snapshot);
     const { response } = dispatchEvent;
     return cloneValidatedResponse(context, response, expectedResponseID, (validatedResponse) =>
-      onSanitizedEvent?.(snapshotResponseLifecycleEvent(dispatchEvent, validatedResponse)),
+      onSanitizedEvent?.(dispatchEvent, snapshotResponseLifecycleEvent(dispatchEvent, validatedResponse)),
     );
   }
 

--- a/src/internal/responses/response-accumulator.ts
+++ b/src/internal/responses/response-accumulator.ts
@@ -303,7 +303,7 @@ function cloneValidatedResponse(
   context: ResponseAccumulatorContext,
   response: Response,
   expectedResponseID?: string,
-  onValidatedResponse?: (snapshot: Response) => void,
+  onValidatedResponse?: (snapshot: Response, wireOutputText: PropertyDescriptor | undefined) => void,
 ): Response {
   let responseID: PropertyDescriptor | undefined;
   try {
@@ -322,12 +322,15 @@ function cloneValidatedResponse(
   }
 
   const nextContext = createCanonicalResponseContext();
-  const snapshot = cloneResponse(nextContext, response);
+  let wireOutputText: PropertyDescriptor | undefined;
+  const snapshot = cloneResponse(nextContext, response, (wireResponse) => {
+    wireOutputText = Object.getOwnPropertyDescriptor(wireResponse, 'output_text');
+  });
   if (snapshot.id !== responseID.value) {
     throw new OpenAIError('Response event does not match the active response.');
   }
   const identityIndex = createResponseOutputIdentityIndex(snapshot);
-  onValidatedResponse?.(snapshot);
+  onValidatedResponse?.(snapshot, wireOutputText);
 
   context.canonicalSnapshot = nextContext.canonicalSnapshot;
   context.outputTextLengths = nextContext.outputTextLengths;
@@ -338,9 +341,26 @@ function cloneValidatedResponse(
   return snapshot;
 }
 
+function cloneValidatedWireResponse(
+  response: Response,
+  wireOutputText: PropertyDescriptor | undefined,
+): Response {
+  const wireResponse = structuredClone(response);
+  if (!wireOutputText) {
+    Reflect.deleteProperty(wireResponse, 'output_text');
+  } else if (wireOutputText.value === null || wireOutputText.value === undefined) {
+    Object.defineProperty(wireResponse, 'output_text', wireOutputText);
+  }
+  if (getResponseID(wireResponse) !== getResponseID(response)) {
+    throw new OpenAIError('Response event does not match the active response.');
+  }
+  return wireResponse;
+}
+
 function snapshotResponseLifecycleEvent(
   event: ResponseLifecycleEvent,
   response: Response,
+  wireOutputText: PropertyDescriptor | undefined,
 ): ResponseLifecycleEvent {
   try {
     const detached = Object.create(Object.prototype) as ResponseLifecycleEvent;
@@ -385,7 +405,7 @@ function snapshotResponseLifecycleEvent(
     Object.defineProperty(detached, 'response', {
       configurable: true,
       enumerable: true,
-      value: structuredClone(response),
+      value: cloneValidatedWireResponse(response, wireOutputText),
       writable: true,
     });
     return detached;
@@ -688,7 +708,15 @@ function sanitizeResponseEvent(event: ResponseAccumulatorEvent): ResponseAccumul
 
   return new Proxy(event, {
     get(target, property) {
-      return stableValues.has(property) ? stableValues.get(property) : Reflect.get(target, property, target);
+      if (stableValues.has(property)) {
+        return stableValues.get(property);
+      }
+
+      const value = Reflect.get(target, property, target);
+      if (property === 'sequence_number') {
+        stableValues.set(property, value);
+      }
+      return value;
     },
   });
 }
@@ -1297,20 +1325,28 @@ export function accumulateResponseWithContext(
         `When snapshot hasn't been set yet, expected 'response.created' event, got ${dispatchEvent.type}`,
       );
     }
-    return cloneValidatedResponse(context, dispatchEvent.response, undefined, (validatedResponse) =>
-      onSanitizedEvent?.(dispatchEvent, () =>
-        snapshotResponseLifecycleEvent(dispatchEvent, validatedResponse),
-      ),
+    return cloneValidatedResponse(
+      context,
+      dispatchEvent.response,
+      undefined,
+      (validatedResponse, wireOutputText) =>
+        onSanitizedEvent?.(dispatchEvent, () =>
+          snapshotResponseLifecycleEvent(dispatchEvent, validatedResponse, wireOutputText),
+        ),
     );
   }
 
   if (isResponseLifecycleEvent(dispatchEvent)) {
     const expectedResponseID = getResponseID(snapshot);
     const { response } = dispatchEvent;
-    return cloneValidatedResponse(context, response, expectedResponseID, (validatedResponse) =>
-      onSanitizedEvent?.(dispatchEvent, () =>
-        snapshotResponseLifecycleEvent(dispatchEvent, validatedResponse),
-      ),
+    return cloneValidatedResponse(
+      context,
+      response,
+      expectedResponseID,
+      (validatedResponse, wireOutputText) =>
+        onSanitizedEvent?.(dispatchEvent, () =>
+          snapshotResponseLifecycleEvent(dispatchEvent, validatedResponse, wireOutputText),
+        ),
     );
   }
 

--- a/src/internal/responses/response-accumulator.ts
+++ b/src/internal/responses/response-accumulator.ts
@@ -17,6 +17,10 @@ interface ResponseKeepAliveEvent {
 }
 
 type ResponseAccumulatorEvent = ResponseStreamEvent | ResponseKeepAliveEvent;
+interface ValidatedResponseEvent {
+  event: ResponseAccumulatorEvent;
+  typeDescriptor: PropertyDescriptor;
+}
 type ResponseItemScopedEvent = Extract<ResponseAccumulatorEvent, { item_id: string; output_index: number }>;
 type ResponseOutputItemEvent = Extract<
   ResponseAccumulatorEvent,
@@ -359,12 +363,21 @@ function cloneValidatedWireResponse(
 
 function snapshotResponseLifecycleEvent(
   event: ResponseLifecycleEvent,
+  typeDescriptor: PropertyDescriptor,
   response: Response,
   wireOutputText: PropertyDescriptor | undefined,
 ): ResponseLifecycleEvent {
   try {
+    const { type, sequence_number: sequenceNumber } = event;
     const detached = Object.create(Object.prototype) as ResponseLifecycleEvent;
     const visited = new Set<object>();
+
+    Object.defineProperty(detached, 'type', {
+      configurable: Boolean(typeDescriptor.configurable),
+      enumerable: Boolean(typeDescriptor.enumerable),
+      value: type,
+      writable: Boolean(typeDescriptor.writable),
+    });
 
     for (
       let source = event as object | null;
@@ -392,11 +405,14 @@ function snapshotResponseLifecycleEvent(
           continue;
         }
 
-        const value = 'value' in descriptor ? descriptor.value : Reflect.get(event, key, event);
+        let value: unknown = sequenceNumber;
+        if (key !== 'sequence_number') {
+          value = 'value' in descriptor ? descriptor.value : Reflect.get(event, key, event);
+        }
         Object.defineProperty(detached, key, {
           configurable: Boolean(descriptor.configurable),
           enumerable: Boolean(descriptor.enumerable),
-          value: key === 'type' ? event.type : value,
+          value,
           writable: 'writable' in descriptor ? Boolean(descriptor.writable) : true,
         });
       }
@@ -662,7 +678,7 @@ const responseEventRoutingFields = [
   'summary_index',
 ] as const;
 
-function sanitizeResponseEvent(event: ResponseAccumulatorEvent): ResponseAccumulatorEvent {
+function sanitizeResponseEvent(event: ResponseAccumulatorEvent): ValidatedResponseEvent {
   let descriptor: PropertyDescriptor | undefined;
   try {
     descriptor = Object.getOwnPropertyDescriptor(event, 'type');
@@ -672,6 +688,7 @@ function sanitizeResponseEvent(event: ResponseAccumulatorEvent): ResponseAccumul
 
   const type: unknown = descriptor?.value;
   if (
+    !descriptor ||
     typeof type !== 'string' ||
     !supportedResponseEventTypes.has(type as ResponseAccumulatorEvent['type'])
   ) {
@@ -706,19 +723,22 @@ function sanitizeResponseEvent(event: ResponseAccumulatorEvent): ResponseAccumul
     }
   }
 
-  return new Proxy(event, {
-    get(target, property) {
-      if (stableValues.has(property)) {
-        return stableValues.get(property);
-      }
+  return {
+    event: new Proxy(event, {
+      get(target, property) {
+        if (stableValues.has(property)) {
+          return stableValues.get(property);
+        }
 
-      const value = Reflect.get(target, property, target);
-      if (property === 'sequence_number') {
-        stableValues.set(property, value);
-      }
-      return value;
-    },
-  });
+        const value = Reflect.get(target, property, target);
+        if (property === 'sequence_number') {
+          stableValues.set(property, value);
+        }
+        return value;
+      },
+    }),
+    typeDescriptor: descriptor,
+  };
 }
 
 function accumulateOutputItemEvent(
@@ -1314,7 +1334,7 @@ export function accumulateResponseWithContext(
     materializeLifecycleEvent?: () => ResponseStreamEvent,
   ) => void,
 ): Response {
-  const dispatchEvent = sanitizeResponseEvent(event);
+  const { event: dispatchEvent, typeDescriptor } = sanitizeResponseEvent(event);
 
   if (!snapshot) {
     if (dispatchEvent.type !== 'response.created') {
@@ -1331,7 +1351,7 @@ export function accumulateResponseWithContext(
       undefined,
       (validatedResponse, wireOutputText) =>
         onSanitizedEvent?.(dispatchEvent, () =>
-          snapshotResponseLifecycleEvent(dispatchEvent, validatedResponse, wireOutputText),
+          snapshotResponseLifecycleEvent(dispatchEvent, typeDescriptor, validatedResponse, wireOutputText),
         ),
     );
   }
@@ -1345,7 +1365,7 @@ export function accumulateResponseWithContext(
       expectedResponseID,
       (validatedResponse, wireOutputText) =>
         onSanitizedEvent?.(dispatchEvent, () =>
-          snapshotResponseLifecycleEvent(dispatchEvent, validatedResponse, wireOutputText),
+          snapshotResponseLifecycleEvent(dispatchEvent, typeDescriptor, validatedResponse, wireOutputText),
         ),
     );
   }

--- a/src/internal/responses/response-accumulator.ts
+++ b/src/internal/responses/response-accumulator.ts
@@ -341,14 +341,19 @@ function snapshotResponseLifecycleEvent(
   event: ResponseLifecycleEvent,
   response: Response,
 ): ResponseLifecycleEvent {
-  const descriptors = Object.getOwnPropertyDescriptors(event);
-  descriptors.response = {
-    configurable: true,
-    enumerable: true,
-    value: structuredClone(response),
-    writable: true,
-  };
-  return Object.create(Object.getPrototypeOf(event), descriptors) as ResponseLifecycleEvent;
+  try {
+    const descriptors = Object.getOwnPropertyDescriptors(event);
+    descriptors.type.value = event.type;
+    descriptors.response = {
+      configurable: true,
+      enumerable: true,
+      value: structuredClone(response),
+      writable: true,
+    };
+    return Object.create(Object.getPrototypeOf(event), descriptors) as ResponseLifecycleEvent;
+  } catch {
+    throw new OpenAIError('Response event does not match the active response.');
+  }
 }
 
 const expectedOutputItemTypes = {
@@ -1193,7 +1198,7 @@ function accumulateImageAndMcpStatusEvent(
   }
 }
 
-function isResponseLifecycleEvent(event: ResponseAccumulatorEvent): event is ResponseLifecycleEvent {
+export function isResponseLifecycleEvent(event: ResponseAccumulatorEvent): event is ResponseLifecycleEvent {
   switch (event.type) {
     case 'response.created':
     case 'response.queued':

--- a/src/internal/responses/response-accumulator.ts
+++ b/src/internal/responses/response-accumulator.ts
@@ -145,6 +145,7 @@ interface ResponseOutputIdentityIndex {
 }
 
 const responseOutputIdentityIndexes = new WeakMap<ResponseAccumulatorContext, ResponseOutputIdentityIndex>();
+const activeResponseIDs = new WeakMap<Response, string>();
 
 function validateArrayIndex(
   collection: readonly unknown[],
@@ -274,6 +275,11 @@ function getResponseOutputIdentityIndex(
 }
 
 function getResponseID(snapshot: Response): string {
+  const activeResponseID = activeResponseIDs.get(snapshot);
+  if (activeResponseID !== undefined) {
+    return activeResponseID;
+  }
+
   let id: string | undefined;
   try {
     ({ id } = snapshot);
@@ -283,6 +289,7 @@ function getResponseID(snapshot: Response): string {
   if (typeof id !== 'string') {
     throw new OpenAIError('Response event does not match the active response.');
   }
+  activeResponseIDs.set(snapshot, id);
   return id;
 }
 
@@ -290,34 +297,53 @@ function cloneValidatedResponse(
   context: ResponseAccumulatorContext,
   response: Response,
   expectedResponseID?: string,
-  onValidatedResponse?: () => void,
+  onValidatedResponse?: (snapshot: Response) => void,
 ): Response {
-  if (expectedResponseID !== undefined) {
-    let responseID: PropertyDescriptor | undefined;
-    try {
-      responseID = Object.getOwnPropertyDescriptor(response, 'id');
-    } catch {
-      throw new OpenAIError('Response event does not match the active response.');
-    }
-    if (responseID && 'value' in responseID && responseID.value !== expectedResponseID) {
-      throw new OpenAIError('Response event does not match the active response.');
-    }
+  let responseID: PropertyDescriptor | undefined;
+  try {
+    responseID = Object.getOwnPropertyDescriptor(response, 'id');
+  } catch {
+    throw new OpenAIError('Response event does not match the active response.');
+  }
+  if (
+    !responseID ||
+    !responseID.enumerable ||
+    !('value' in responseID) ||
+    typeof responseID.value !== 'string' ||
+    (expectedResponseID !== undefined && responseID.value !== expectedResponseID)
+  ) {
+    throw new OpenAIError('Response event does not match the active response.');
   }
 
   const nextContext = createCanonicalResponseContext();
   const snapshot = cloneResponse(nextContext, response);
-  if (expectedResponseID !== undefined && snapshot.id !== expectedResponseID) {
+  if (snapshot.id !== responseID.value) {
     throw new OpenAIError('Response event does not match the active response.');
   }
   const identityIndex = createResponseOutputIdentityIndex(snapshot);
-  onValidatedResponse?.();
+  onValidatedResponse?.(snapshot);
 
   context.canonicalSnapshot = nextContext.canonicalSnapshot;
   context.outputTextLengths = nextContext.outputTextLengths;
   context.outputTextIndex = nextContext.outputTextIndex;
   responseOutputIdentityIndexes.set(context, identityIndex);
+  activeResponseIDs.set(snapshot, responseID.value);
 
   return snapshot;
+}
+
+function snapshotResponseLifecycleEvent(
+  event: ResponseLifecycleEvent,
+  response: Response,
+): ResponseLifecycleEvent {
+  const descriptors = Object.getOwnPropertyDescriptors(event);
+  descriptors.response = {
+    configurable: true,
+    enumerable: true,
+    value: structuredClone(response),
+    writable: true,
+  };
+  return Object.create(Object.getPrototypeOf(event), descriptors) as ResponseLifecycleEvent;
 }
 
 const expectedOutputItemTypes = {
@@ -1212,22 +1238,24 @@ export function accumulateResponseWithContext(
   const dispatchEvent = sanitizeResponseEvent(event);
 
   if (!snapshot) {
-    if (onSanitizedEvent && dispatchEvent.type !== 'keepalive') {
-      onSanitizedEvent(dispatchEvent);
-    }
     if (dispatchEvent.type !== 'response.created') {
+      if (onSanitizedEvent && dispatchEvent.type !== 'keepalive') {
+        onSanitizedEvent(dispatchEvent);
+      }
       throw new OpenAIError(
         `When snapshot hasn't been set yet, expected 'response.created' event, got ${dispatchEvent.type}`,
       );
     }
-    return cloneValidatedResponse(context, dispatchEvent.response);
+    return cloneValidatedResponse(context, dispatchEvent.response, undefined, (validatedResponse) =>
+      onSanitizedEvent?.(snapshotResponseLifecycleEvent(dispatchEvent, validatedResponse)),
+    );
   }
 
   if (isResponseLifecycleEvent(dispatchEvent)) {
     const expectedResponseID = getResponseID(snapshot);
     const { response } = dispatchEvent;
-    return cloneValidatedResponse(context, response, expectedResponseID, () =>
-      onSanitizedEvent?.(dispatchEvent),
+    return cloneValidatedResponse(context, response, expectedResponseID, (validatedResponse) =>
+      onSanitizedEvent?.(snapshotResponseLifecycleEvent(dispatchEvent, validatedResponse)),
     );
   }
 

--- a/src/internal/responses/response-accumulator.ts
+++ b/src/internal/responses/response-accumulator.ts
@@ -146,6 +146,7 @@ interface ResponseOutputIdentityIndex {
 
 const responseOutputIdentityIndexes = new WeakMap<ResponseAccumulatorContext, ResponseOutputIdentityIndex>();
 const activeResponseIDs = new WeakMap<Response, string>();
+const MAX_RESPONSE_LIFECYCLE_PROTOTYPE_DEPTH = 128;
 
 function validateArrayIndex(
   collection: readonly unknown[],
@@ -343,12 +344,18 @@ function snapshotResponseLifecycleEvent(
 ): ResponseLifecycleEvent {
   try {
     const detached = Object.create(Object.prototype) as ResponseLifecycleEvent;
+    const visited = new Set<object>();
 
     for (
       let source = event as object | null;
       source !== null && source !== Object.prototype;
       source = Object.getPrototypeOf(source) as object | null
     ) {
+      if (visited.has(source) || visited.size >= MAX_RESPONSE_LIFECYCLE_PROTOTYPE_DEPTH) {
+        throw new OpenAIError('Response event does not match the active response.');
+      }
+      visited.add(source);
+
       for (const key of Reflect.ownKeys(source)) {
         if (key === 'response' || hasOwn(detached, key) || (source !== event && key === 'constructor')) {
           continue;

--- a/src/lib/responses/ResponseStream.ts
+++ b/src/lib/responses/ResponseStream.ts
@@ -16,6 +16,7 @@ import type { ResponseFunctionCallArgumentsDeltaEvent, ResponseTextDeltaEvent } 
 import {
   accumulateResponseWithContext,
   createResponseContext,
+  isResponseLifecycleEvent,
 } from '../../internal/responses/response-accumulator';
 import type { ParseableToolsParams } from '../ResponsesParser';
 import { maybeParseResponse } from '../ResponsesParser';
@@ -154,26 +155,25 @@ export class ResponseStream<ParsedT = null>
       throw new APIError(undefined, error, event.message, undefined);
     }
 
+    const shouldEmit = starting_after == null || event.sequence_number > starting_after;
     let dispatchEvent: ResponseStreamEvent = event;
     const response = accumulateResponseWithContext(
       event,
       this.#currentResponseSnapshot,
       this.#accumulatorContext,
       true,
-      (sanitizedEvent) => {
-        dispatchEvent = sanitizedEvent;
-      },
+      shouldEmit
+        ? (sanitizedEvent) => {
+            dispatchEvent = sanitizedEvent;
+          }
+        : undefined,
     );
     this.#currentResponseSnapshot = response;
-    const emittedEvent =
-      dispatchEvent.type === 'response.created' ||
-      dispatchEvent.type === 'response.queued' ||
-      dispatchEvent.type === 'response.in_progress' ||
-      dispatchEvent.type === 'response.completed' ||
-      dispatchEvent.type === 'response.failed' ||
-      dispatchEvent.type === 'response.incomplete'
-        ? dispatchEvent
-        : event;
+    if (!shouldEmit) {
+      return;
+    }
+
+    const emittedEvent = isResponseLifecycleEvent(dispatchEvent) ? dispatchEvent : event;
     maybeEmit('event', emittedEvent);
 
     switch (dispatchEvent.type) {

--- a/src/lib/responses/ResponseStream.ts
+++ b/src/lib/responses/ResponseStream.ts
@@ -16,7 +16,6 @@ import type { ResponseFunctionCallArgumentsDeltaEvent, ResponseTextDeltaEvent } 
 import {
   accumulateResponseWithContext,
   createResponseContext,
-  isResponseLifecycleEvent,
 } from '../../internal/responses/response-accumulator';
 import type { ParseableToolsParams } from '../ResponsesParser';
 import { maybeParseResponse } from '../ResponsesParser';
@@ -141,10 +140,8 @@ export class ResponseStream<ParsedT = null>
       return;
     }
 
-    const maybeEmit = (name: string, event: ResponseStreamEvent & { snapshot?: string }) => {
-      if (starting_after == null || event.sequence_number > starting_after) {
-        this._emit(name as any, event);
-      }
+    const emit = (name: string, event: ResponseStreamEvent & { snapshot?: string }) => {
+      this._emit(name as any, event);
     };
 
     if (event.type === 'error') {
@@ -155,16 +152,26 @@ export class ResponseStream<ParsedT = null>
       throw new APIError(undefined, error, event.message, undefined);
     }
 
-    const shouldEmit = starting_after == null || event.sequence_number > starting_after;
+    let shouldEmit = true;
+    if (starting_after != null) {
+      try {
+        shouldEmit = event.sequence_number > starting_after;
+      } catch {
+        throw new OpenAIError('Response event does not match the active response.');
+      }
+    }
+
     let dispatchEvent: ResponseStreamEvent = event;
+    let emittedEvent: ResponseStreamEvent = event;
     const response = accumulateResponseWithContext(
       event,
       this.#currentResponseSnapshot,
       this.#accumulatorContext,
       true,
       shouldEmit
-        ? (sanitizedEvent) => {
+        ? (sanitizedEvent, sanitizedLifecycleEvent) => {
             dispatchEvent = sanitizedEvent;
+            emittedEvent = sanitizedLifecycleEvent ?? event;
           }
         : undefined,
     );
@@ -173,8 +180,7 @@ export class ResponseStream<ParsedT = null>
       return;
     }
 
-    const emittedEvent = isResponseLifecycleEvent(dispatchEvent) ? dispatchEvent : event;
-    maybeEmit('event', emittedEvent);
+    emit('event', emittedEvent);
 
     switch (dispatchEvent.type) {
       case 'response.output_text.delta': {
@@ -191,7 +197,7 @@ export class ResponseStream<ParsedT = null>
             throw new OpenAIError(`expected content to be 'output_text', got ${content.type}`);
           }
 
-          maybeEmit('response.output_text.delta', {
+          emit('response.output_text.delta', {
             ...dispatchEvent,
             type: dispatchEvent.type,
             item_id: dispatchEvent.item_id,
@@ -208,7 +214,7 @@ export class ResponseStream<ParsedT = null>
           throw new OpenAIError(`missing output at index ${dispatchEvent.output_index}`);
         }
         if (output.type === 'function_call') {
-          maybeEmit('response.function_call_arguments.delta', {
+          emit('response.function_call_arguments.delta', {
             ...dispatchEvent,
             type: dispatchEvent.type,
             item_id: dispatchEvent.item_id,
@@ -219,7 +225,7 @@ export class ResponseStream<ParsedT = null>
         break;
       }
       default: {
-        maybeEmit(dispatchEvent.type, emittedEvent);
+        emit(dispatchEvent.type, emittedEvent);
         break;
       }
     }

--- a/src/lib/responses/ResponseStream.ts
+++ b/src/lib/responses/ResponseStream.ts
@@ -152,35 +152,30 @@ export class ResponseStream<ParsedT = null>
       throw new APIError(undefined, error, event.message, undefined);
     }
 
-    let shouldEmit = true;
     let dispatchEvent: ResponseStreamEvent = event;
-    let emittedEvent: ResponseStreamEvent = event;
+    let materializeLifecycleEvent: (() => ResponseStreamEvent) | undefined;
     const response = accumulateResponseWithContext(
       event,
       this.#currentResponseSnapshot,
       this.#accumulatorContext,
       true,
-      (sanitizedEvent, materializeLifecycleEvent) => {
-        if (starting_after != null) {
-          try {
-            shouldEmit = sanitizedEvent.sequence_number > starting_after;
-          } catch {
-            throw new OpenAIError('Response event does not match the active response.');
-          }
-        }
-        if (!shouldEmit) {
-          return;
-        }
-
+      (sanitizedEvent, materializeEvent) => {
         dispatchEvent = sanitizedEvent;
-        emittedEvent = materializeLifecycleEvent?.() ?? event;
+        materializeLifecycleEvent = materializeEvent;
       },
     );
     this.#currentResponseSnapshot = response;
-    if (!shouldEmit) {
-      return;
+    if (starting_after != null) {
+      try {
+        if (!(dispatchEvent.sequence_number > starting_after)) {
+          return;
+        }
+      } catch {
+        throw new OpenAIError('Response event does not match the active response.');
+      }
     }
 
+    const emittedEvent = materializeLifecycleEvent?.() ?? event;
     emit('event', emittedEvent);
 
     switch (dispatchEvent.type) {

--- a/src/lib/responses/ResponseStream.ts
+++ b/src/lib/responses/ResponseStream.ts
@@ -153,14 +153,6 @@ export class ResponseStream<ParsedT = null>
     }
 
     let shouldEmit = true;
-    if (starting_after != null) {
-      try {
-        shouldEmit = event.sequence_number > starting_after;
-      } catch {
-        throw new OpenAIError('Response event does not match the active response.');
-      }
-    }
-
     let dispatchEvent: ResponseStreamEvent = event;
     let emittedEvent: ResponseStreamEvent = event;
     const response = accumulateResponseWithContext(
@@ -168,12 +160,21 @@ export class ResponseStream<ParsedT = null>
       this.#currentResponseSnapshot,
       this.#accumulatorContext,
       true,
-      shouldEmit
-        ? (sanitizedEvent, sanitizedLifecycleEvent) => {
-            dispatchEvent = sanitizedEvent;
-            emittedEvent = sanitizedLifecycleEvent ?? event;
+      (sanitizedEvent, materializeLifecycleEvent) => {
+        if (starting_after != null) {
+          try {
+            shouldEmit = sanitizedEvent.sequence_number > starting_after;
+          } catch {
+            throw new OpenAIError('Response event does not match the active response.');
           }
-        : undefined,
+        }
+        if (!shouldEmit) {
+          return;
+        }
+
+        dispatchEvent = sanitizedEvent;
+        emittedEvent = materializeLifecycleEvent?.() ?? event;
+      },
     );
     this.#currentResponseSnapshot = response;
     if (!shouldEmit) {

--- a/src/lib/responses/ResponseStream.ts
+++ b/src/lib/responses/ResponseStream.ts
@@ -175,7 +175,10 @@ export class ResponseStream<ParsedT = null>
       }
     }
 
-    const emittedEvent = materializeLifecycleEvent?.() ?? event;
+    const emittedEvent =
+      materializeLifecycleEvent && (this._hasListeners('event') || this._hasListeners(dispatchEvent.type))
+        ? materializeLifecycleEvent()
+        : event;
     emit('event', emittedEvent);
 
     switch (dispatchEvent.type) {

--- a/src/lib/responses/ResponseStream.ts
+++ b/src/lib/responses/ResponseStream.ts
@@ -165,7 +165,16 @@ export class ResponseStream<ParsedT = null>
       },
     );
     this.#currentResponseSnapshot = response;
-    maybeEmit('event', event);
+    const emittedEvent =
+      dispatchEvent.type === 'response.created' ||
+      dispatchEvent.type === 'response.queued' ||
+      dispatchEvent.type === 'response.in_progress' ||
+      dispatchEvent.type === 'response.completed' ||
+      dispatchEvent.type === 'response.failed' ||
+      dispatchEvent.type === 'response.incomplete'
+        ? dispatchEvent
+        : event;
+    maybeEmit('event', emittedEvent);
 
     switch (dispatchEvent.type) {
       case 'response.output_text.delta': {
@@ -210,7 +219,7 @@ export class ResponseStream<ParsedT = null>
         break;
       }
       default: {
-        maybeEmit(dispatchEvent.type, event);
+        maybeEmit(dispatchEvent.type, emittedEvent);
         break;
       }
     }

--- a/tests/lib/ResponseAccumulator.events.test.ts
+++ b/tests/lib/ResponseAccumulator.events.test.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 import { OpenAIError } from 'openai/core/error';
 import { hasOwn } from 'openai/internal/utils';
 import { accumulateResponse } from 'openai/lib/responses/ResponseAccumulator';
+import { ResponseStream } from 'openai/lib/responses/ResponseStream';
 import type { Response, ResponseStreamEvent } from 'openai/resources/responses/responses';
 
 type OutputItem = Response['output'][number];
@@ -689,6 +690,170 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
       expect(result.output_text).toBe('authoritative');
     },
   );
+
+  test.each([
+    'response.created',
+    'response.queued',
+    'response.in_progress',
+    'response.completed',
+    'response.failed',
+    'response.incomplete',
+  ] as const)('rejects a foreign %s response before exposing or mutating it', (type) => {
+    const snapshot = makeResponse();
+    const matching = makeResponse();
+    expect(accumulateResponse({ type, sequence_number: 1, response: matching }, snapshot)).toMatchObject({
+      id: snapshot.id,
+    });
+    const foreign = { ...makeResponse(), id: 'resp_foreign_private' };
+    const readForeignOutput = vi.fn(() => []);
+    Object.defineProperty(foreign, 'output', { enumerable: true, get: readForeignOutput });
+
+    expect(() => accumulateResponse({ type, sequence_number: 1, response: foreign }, snapshot)).toThrow(
+      'Response event does not match the active response.',
+    );
+
+    expect(readForeignOutput).not.toHaveBeenCalled();
+    expect(snapshot.id).toBe('resp_123');
+    expect(snapshot.output).toEqual([]);
+  });
+
+  test.each([
+    ['matching', 'resp_123', 'resp_foreign', false],
+    ['foreign', 'resp_foreign', 'resp_123', true],
+  ] as const)('materializes a %s stateful response ID exactly once', (_case, first, second, rejected) => {
+    const response = makeResponse();
+    const readID = vi.fn(() => (readID.mock.calls.length === 1 ? first : second));
+    Object.defineProperty(response, 'id', { configurable: true, enumerable: true, get: readID });
+    const accumulate = () =>
+      accumulateResponse({ type: 'response.completed', sequence_number: 1, response }, makeResponse());
+
+    if (rejected) {
+      expect(accumulate).toThrow('Response event does not match the active response.');
+    } else {
+      expect(accumulate()).toMatchObject({ id: 'resp_123' });
+    }
+    expect(readID).toHaveBeenCalledTimes(1);
+  });
+
+  test('captures the active response ID before invoking the lifecycle response getter', () => {
+    const foreign = { ...makeResponse(), id: 'resp_foreign' };
+    const readResponse = vi.fn(() => foreign);
+    const snapshot = makeResponse();
+    const readSnapshotID = vi.fn(() => (readResponse.mock.calls.length === 0 ? 'resp_123' : 'resp_foreign'));
+    Object.defineProperty(snapshot, 'id', { configurable: true, enumerable: true, get: readSnapshotID });
+    const event: Extract<ResponseStreamEvent, { type: 'response.completed' }> = {
+      type: 'response.completed',
+      sequence_number: 1,
+      get response() {
+        return readResponse();
+      },
+    };
+
+    expect(() => accumulateResponse(event, snapshot)).toThrow(
+      'Response event does not match the active response.',
+    );
+    expect(readSnapshotID).toHaveBeenCalledTimes(1);
+    expect(readResponse).toHaveBeenCalledTimes(1);
+  });
+
+  test('redacts response ID descriptor-trap failures before reading private output', () => {
+    const readOutput = vi.fn(() => []);
+    const response = makeResponse();
+    Object.defineProperty(response, 'output', { configurable: true, enumerable: true, get: readOutput });
+    const untrusted = new Proxy(response, {
+      getOwnPropertyDescriptor(target, property) {
+        if (property === 'id') {
+          throw new Error('synthetic-private-descriptor-secret');
+        }
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      },
+    });
+
+    expect(() =>
+      accumulateResponse(
+        { type: 'response.completed', sequence_number: 1, response: untrusted },
+        makeResponse(),
+      ),
+    ).toThrow(new OpenAIError('Response event does not match the active response.'));
+    expect(readOutput).not.toHaveBeenCalled();
+  });
+
+  test.each(['missing', 'throwing'] as const)(
+    'rejects a %s established response ID before reading the next response',
+    (kind) => {
+      const snapshot = makeResponse();
+      if (kind === 'missing') {
+        Reflect.deleteProperty(snapshot, 'id');
+      } else {
+        Object.defineProperty(snapshot, 'id', {
+          get() {
+            throw new Error('synthetic-private-snapshot-secret');
+          },
+        });
+      }
+      const readResponse = vi.fn(makeResponse);
+      const event: Extract<ResponseStreamEvent, { type: 'response.completed' }> = {
+        type: 'response.completed',
+        sequence_number: 1,
+        get response() {
+          return readResponse();
+        },
+      };
+
+      expect(() => accumulateResponse(event, snapshot)).toThrow(
+        new OpenAIError('Response event does not match the active response.'),
+      );
+      expect(readResponse).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(['', 'provider:custom/42'] as const)('preserves provider-defined response ID %j', (id) => {
+    const response = { ...makeResponse(), id };
+    const snapshot = accumulateResponse({ type: 'response.created', sequence_number: 0, response });
+
+    expect(
+      accumulateResponse({ type: 'response.completed', sequence_number: 1, response }, snapshot).id,
+    ).toBe(id);
+  });
+
+  test('rejects foreign lifecycle events before public stream listeners can observe them', async () => {
+    const created = {
+      type: 'response.created',
+      sequence_number: 0,
+      response: makeResponse(),
+    } satisfies ResponseStreamEvent;
+    const foreign = {
+      type: 'response.completed',
+      sequence_number: 1,
+      response: {
+        ...makeResponse(),
+        id: 'resp_foreign_private',
+        metadata: { private: 'foreign private output' },
+      },
+    } satisfies ResponseStreamEvent;
+    const readable = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const encoder = new TextEncoder();
+        for (const event of [created, foreign]) {
+          controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`));
+        }
+        controller.close();
+      },
+    });
+    const stream = ResponseStream.fromReadableStream(readable);
+    const exposedEvent = vi.fn();
+    const exposedLifecycle = vi.fn();
+    stream.on('event', exposedEvent);
+    stream.on('response.completed', exposedLifecycle);
+
+    await expect(stream.finalResponse()).rejects.toThrow(
+      'Response event does not match the active response.',
+    );
+
+    expect(exposedEvent).toHaveBeenCalledTimes(1);
+    expect(exposedEvent).toHaveBeenCalledWith(created);
+    expect(exposedLifecycle).not.toHaveBeenCalled();
+  });
 
   test.each([
     'response.audio.delta',

--- a/tests/lib/ResponseAccumulator.events.test.ts
+++ b/tests/lib/ResponseAccumulator.events.test.ts
@@ -761,6 +761,132 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
     },
   );
 
+  test.each([
+    ['missing', undefined],
+    ['inherited', undefined],
+    ['throwing accessor', undefined],
+    ['non-enumerable', undefined],
+    ['undefined', undefined],
+    ['null', null],
+    ['number', 123],
+    ['boolean', false],
+    ['object', {}],
+    ['symbol', Symbol('invalid response ID')],
+  ] as const)(
+    'rejects a caller-supplied snapshot with a %s ID before inspecting private payloads',
+    (kind, invalidID) => {
+      const snapshot = makeResponse();
+      const readID = vi.fn(() => {
+        throw new Error('synthetic-private-snapshot-id');
+      });
+      const readSnapshotOutput = vi.fn(() => {
+        throw new Error('synthetic-private-snapshot-output');
+      });
+      const readResponseOutput = vi.fn(() => {
+        throw new Error('synthetic-private-response-output');
+      });
+      Object.defineProperty(snapshot, 'output', {
+        configurable: true,
+        enumerable: true,
+        get: readSnapshotOutput,
+      });
+
+      if (kind === 'missing' || kind === 'inherited') {
+        Reflect.deleteProperty(snapshot, 'id');
+        if (kind === 'inherited') {
+          Object.setPrototypeOf(snapshot, { id: 'resp_foreign' });
+        }
+      } else if (kind === 'throwing accessor') {
+        Object.defineProperty(snapshot, 'id', { configurable: true, enumerable: true, get: readID });
+      } else if (kind === 'non-enumerable') {
+        Object.defineProperty(snapshot, 'id', { configurable: true, enumerable: false, value: 'resp_123' });
+      } else {
+        Object.defineProperty(snapshot, 'id', {
+          configurable: true,
+          enumerable: true,
+          value: invalidID,
+        });
+      }
+
+      const response = { ...makeResponse(), id: kind === 'inherited' ? 'resp_foreign' : 'resp_123' };
+      Object.defineProperty(response, 'output', {
+        configurable: true,
+        enumerable: true,
+        get: readResponseOutput,
+      });
+      const readResponse = vi.fn(() => response);
+      const event: Extract<ResponseStreamEvent, { type: 'response.completed' }> = {
+        type: 'response.completed',
+        sequence_number: 1,
+        get response() {
+          return readResponse();
+        },
+      };
+
+      expect(() => accumulateResponse(event, snapshot)).toThrow(
+        new OpenAIError('Response event does not match the active response.'),
+      );
+      expect(readID).not.toHaveBeenCalled();
+      expect(readSnapshotOutput).not.toHaveBeenCalled();
+      expect(readResponse).not.toHaveBeenCalled();
+      expect(readResponseOutput).not.toHaveBeenCalled();
+
+      Object.defineProperty(snapshot, 'id', {
+        configurable: true,
+        enumerable: true,
+        value: 'resp_recovered',
+        writable: true,
+      });
+      expect(
+        accumulateResponse(
+          {
+            type: 'response.completed',
+            sequence_number: 2,
+            response: { ...makeResponse(), id: 'resp_recovered' },
+          },
+          snapshot,
+        ),
+      ).toMatchObject({ id: 'resp_recovered' });
+      expect(readSnapshotOutput).not.toHaveBeenCalled();
+    },
+  );
+
+  test('rejects a caller-supplied snapshot ID inherited from a polluted Object prototype', () => {
+    const snapshot = makeResponse();
+    Reflect.deleteProperty(snapshot, 'id');
+    const response = { ...makeResponse(), id: 'resp_foreign' };
+    const readOutput = vi.fn(() => {
+      throw new Error('synthetic-private-polluted-output');
+    });
+    Object.defineProperty(response, 'output', { configurable: true, enumerable: true, get: readOutput });
+    const originalID = Object.getOwnPropertyDescriptor(Object.prototype, 'id');
+    let failure: unknown;
+
+    try {
+      // oxlint-disable-next-line no-extend-native -- Reproduce actual prototype pollution and restore it immediately.
+      Object.defineProperty(Object.prototype, 'id', {
+        configurable: true,
+        enumerable: false,
+        value: 'resp_foreign',
+      });
+      try {
+        accumulateResponse({ type: 'response.completed', sequence_number: 1, response }, snapshot);
+      } catch (error) {
+        failure = error;
+      }
+    } finally {
+      if (originalID) {
+        // oxlint-disable-next-line no-extend-native -- Restore the original Object prototype after the regression.
+        Object.defineProperty(Object.prototype, 'id', originalID);
+      } else {
+        Reflect.deleteProperty(Object.prototype, 'id');
+      }
+    }
+
+    expect(failure).toEqual(new OpenAIError('Response event does not match the active response.'));
+    expect(readOutput).not.toHaveBeenCalled();
+  });
+
   test('rejects a proxy response without an own ID before invoking its get traps', () => {
     const response = makeResponse();
     Reflect.deleteProperty(response, 'id');
@@ -909,8 +1035,50 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
         snapshot,
       ),
     ).toMatchObject({ id: 'resp_123' });
-    expect(readID).toHaveBeenCalledTimes(1);
+    expect(readID).not.toHaveBeenCalled();
   });
+
+  test.each(['changed', 'deleted', 'throwing accessor'] as const)(
+    'preserves a caller-supplied snapshot identity after its own ID is %s',
+    (mutation) => {
+      const snapshot = makeResponse();
+
+      expect(
+        accumulateResponse(
+          { type: 'response.in_progress', sequence_number: 1, response: makeResponse() },
+          snapshot,
+        ),
+      ).toMatchObject({ id: 'resp_123' });
+
+      const readID = vi.fn(() => {
+        throw new Error('synthetic-private-mutated-caller-snapshot-id');
+      });
+      if (mutation === 'changed') {
+        snapshot.id = 'resp_foreign';
+      } else if (mutation === 'deleted') {
+        Reflect.deleteProperty(snapshot, 'id');
+      } else {
+        Object.defineProperty(snapshot, 'id', { configurable: true, enumerable: true, get: readID });
+      }
+
+      expect(
+        accumulateResponse(
+          { type: 'response.completed', sequence_number: 2, response: makeResponse() },
+          snapshot,
+        ),
+      ).toMatchObject({ id: 'resp_123' });
+
+      const foreign = { ...makeResponse(), id: 'resp_foreign' };
+      const readOutput = vi.fn(() => []);
+      Object.defineProperty(foreign, 'output', { configurable: true, enumerable: true, get: readOutput });
+
+      expect(() =>
+        accumulateResponse({ type: 'response.failed', sequence_number: 3, response: foreign }, snapshot),
+      ).toThrow(new OpenAIError('Response event does not match the active response.'));
+      expect(readID).not.toHaveBeenCalled();
+      expect(readOutput).not.toHaveBeenCalled();
+    },
+  );
 
   test('accepts matching lifecycle responses for frozen snapshots without mutating them', () => {
     const snapshot = Object.freeze(
@@ -928,10 +1096,11 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
 
   test('captures the active response ID before invoking the lifecycle response getter', () => {
     const foreign = { ...makeResponse(), id: 'resp_foreign' };
-    const readResponse = vi.fn(() => foreign);
     const snapshot = makeResponse();
-    const readSnapshotID = vi.fn(() => (readResponse.mock.calls.length === 0 ? 'resp_123' : 'resp_foreign'));
-    Object.defineProperty(snapshot, 'id', { configurable: true, enumerable: true, get: readSnapshotID });
+    const readResponse = vi.fn(() => {
+      snapshot.id = 'resp_foreign';
+      return foreign;
+    });
     const event: Extract<ResponseStreamEvent, { type: 'response.completed' }> = {
       type: 'response.completed',
       sequence_number: 1,
@@ -943,8 +1112,38 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
     expect(() => accumulateResponse(event, snapshot)).toThrow(
       'Response event does not match the active response.',
     );
-    expect(readSnapshotID).toHaveBeenCalledTimes(1);
+    expect(snapshot.id).toBe('resp_foreign');
     expect(readResponse).toHaveBeenCalledTimes(1);
+  });
+
+  test('redacts caller-supplied snapshot ID descriptor-trap failures without reading payloads', () => {
+    const readProperty = vi.fn();
+    const snapshot = new Proxy(makeResponse(), {
+      get(target, property, receiver) {
+        readProperty();
+        return Reflect.get(target, property, receiver);
+      },
+      getOwnPropertyDescriptor(target, property) {
+        if (property === 'id') {
+          throw new Error('synthetic-private-snapshot-descriptor-secret');
+        }
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      },
+    });
+    const readResponse = vi.fn(makeResponse);
+    const event: Extract<ResponseStreamEvent, { type: 'response.completed' }> = {
+      type: 'response.completed',
+      sequence_number: 1,
+      get response() {
+        return readResponse();
+      },
+    };
+
+    expect(() => accumulateResponse(event, snapshot)).toThrow(
+      new OpenAIError('Response event does not match the active response.'),
+    );
+    expect(readProperty).not.toHaveBeenCalled();
+    expect(readResponse).not.toHaveBeenCalled();
   });
 
   test('redacts response ID descriptor-trap failures before reading private output', () => {

--- a/tests/lib/ResponseAccumulator.events.test.ts
+++ b/tests/lib/ResponseAccumulator.events.test.ts
@@ -1116,6 +1116,31 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
     expect(readResponse).toHaveBeenCalledTimes(1);
   });
 
+  test.each(['initial', 'subsequent'] as const)(
+    'accumulates the validated %s lifecycle response when its getter changes the raw event type',
+    (position) => {
+      const matching = makeResponse();
+      const foreign = { ...makeResponse(), id: 'resp_foreign' };
+      const readResponse = vi.fn(() => (readResponse.mock.calls.length === 1 ? matching : foreign));
+      const event: ResponseStreamEvent = {
+        type: position === 'initial' ? 'response.created' : 'response.completed',
+        sequence_number: position === 'initial' ? 0 : 1,
+        get response() {
+          const response = readResponse();
+          event.type = 'error';
+          return response;
+        },
+      };
+
+      const snapshot = accumulateResponse(event, position === 'initial' ? undefined : makeResponse());
+
+      expect(snapshot).toMatchObject({ id: 'resp_123' });
+      expect(snapshot).not.toBe(matching);
+      expect(readResponse).toHaveBeenCalledTimes(1);
+      expect(event.type).toBe('error');
+    },
+  );
+
   test('redacts caller-supplied snapshot ID descriptor-trap failures without reading payloads', () => {
     const readProperty = vi.fn();
     const snapshot = new Proxy(makeResponse(), {

--- a/tests/lib/ResponseAccumulator.events.test.ts
+++ b/tests/lib/ResponseAccumulator.events.test.ts
@@ -717,22 +717,213 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
     expect(snapshot.output).toEqual([]);
   });
 
-  test.each([
-    ['matching', 'resp_123', 'resp_foreign', false],
-    ['foreign', 'resp_foreign', 'resp_123', true],
-  ] as const)('materializes a %s stateful response ID exactly once', (_case, first, second, rejected) => {
-    const response = makeResponse();
-    const readID = vi.fn(() => (readID.mock.calls.length === 1 ? first : second));
-    Object.defineProperty(response, 'id', { configurable: true, enumerable: true, get: readID });
-    const accumulate = () =>
-      accumulateResponse({ type: 'response.completed', sequence_number: 1, response }, makeResponse());
+  test.each(
+    (['initial', 'subsequent'] as const).flatMap((position) =>
+      (['missing', 'inherited', 'accessor', 'invalid', 'non-enumerable'] as const).map((kind) => ({
+        position,
+        kind,
+      })),
+    ),
+  )(
+    'rejects an $position lifecycle response with an $kind ID before reading private output',
+    ({ position, kind }) => {
+      const response = makeResponse();
+      const readID = vi.fn(() => 'resp_123');
+      const readOutput = vi.fn(() => {
+        throw new Error('synthetic-private-lifecycle-output');
+      });
+      Object.defineProperty(response, 'output', { configurable: true, enumerable: true, get: readOutput });
 
-    if (rejected) {
-      expect(accumulate).toThrow('Response event does not match the active response.');
-    } else {
-      expect(accumulate()).toMatchObject({ id: 'resp_123' });
-    }
+      if (kind === 'missing' || kind === 'inherited') {
+        Reflect.deleteProperty(response, 'id');
+        if (kind === 'inherited') {
+          Object.setPrototypeOf(response, { id: 'resp_123' });
+        }
+      } else if (kind === 'accessor') {
+        Object.defineProperty(response, 'id', { configurable: true, enumerable: true, get: readID });
+      } else if (kind === 'non-enumerable') {
+        Object.defineProperty(response, 'id', { configurable: true, enumerable: false, value: 'resp_123' });
+      } else {
+        Object.defineProperty(response, 'id', { configurable: true, enumerable: true, value: 123 });
+      }
+
+      const event = {
+        type: position === 'initial' ? ('response.created' as const) : ('response.completed' as const),
+        sequence_number: position === 'initial' ? 0 : 1,
+        response,
+      };
+
+      expect(() => accumulateResponse(event, position === 'initial' ? undefined : makeResponse())).toThrow(
+        new OpenAIError('Response event does not match the active response.'),
+      );
+      expect(readID).not.toHaveBeenCalled();
+      expect(readOutput).not.toHaveBeenCalled();
+    },
+  );
+
+  test('rejects a proxy response without an own ID before invoking its get traps', () => {
+    const response = makeResponse();
+    Reflect.deleteProperty(response, 'id');
+    Object.setPrototypeOf(response, { id: 'resp_123' });
+    const readProperty = vi.fn();
+    const untrusted = new Proxy(response, {
+      get(target, property, receiver) {
+        readProperty();
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    expect(() =>
+      accumulateResponse(
+        { type: 'response.completed', sequence_number: 1, response: untrusted },
+        makeResponse(),
+      ),
+    ).toThrow(new OpenAIError('Response event does not match the active response.'));
+    expect(readProperty).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ['matching', 'resp_123', 'resp_foreign'],
+    ['foreign', 'resp_foreign', 'resp_123'],
+  ] as const)(
+    'rejects a %s stateful lifecycle response ID without invoking its getter',
+    (_case, first, second) => {
+      const response = makeResponse();
+      const readID = vi.fn(() => (readID.mock.calls.length === 1 ? first : second));
+      Object.defineProperty(response, 'id', { configurable: true, enumerable: true, get: readID });
+
+      expect(() =>
+        accumulateResponse({ type: 'response.completed', sequence_number: 1, response }, makeResponse()),
+      ).toThrow('Response event does not match the active response.');
+      expect(readID).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    'response.created',
+    'response.queued',
+    'response.in_progress',
+    'response.completed',
+    'response.failed',
+    'response.incomplete',
+  ] as const)('keeps the canonical response identity after snapshot mutation for %s', (type) => {
+    const snapshot = accumulateResponse({
+      type: 'response.created',
+      sequence_number: 0,
+      response: makeResponse(),
+    });
+    snapshot.id = 'resp_mutated';
+
+    const replacement = accumulateResponse({ type, sequence_number: 1, response: makeResponse() }, snapshot);
+
+    expect(replacement.id).toBe('resp_123');
+    expect(snapshot.id).toBe('resp_mutated');
+
+    replacement.id = 'resp_foreign';
+    const foreign = { ...makeResponse(), id: 'resp_foreign' };
+    const readOutput = vi.fn(() => []);
+    Object.defineProperty(foreign, 'output', { configurable: true, enumerable: true, get: readOutput });
+
+    expect(() => accumulateResponse({ type, sequence_number: 2, response: foreign }, replacement)).toThrow(
+      new OpenAIError('Response event does not match the active response.'),
+    );
+    expect(readOutput).not.toHaveBeenCalled();
+  });
+
+  test('keeps interleaved response snapshots isolated despite swapped mutable IDs', () => {
+    const firstResponse = { ...makeResponse(), id: 'resp_first' };
+    const secondResponse = { ...makeResponse(), id: 'resp_second' };
+    const first = accumulateResponse({
+      type: 'response.created',
+      sequence_number: 0,
+      response: firstResponse,
+    });
+    const second = accumulateResponse({
+      type: 'response.created',
+      sequence_number: 0,
+      response: secondResponse,
+    });
+    first.id = 'resp_second';
+    second.id = 'resp_first';
+
+    expect(
+      accumulateResponse({ type: 'response.completed', sequence_number: 1, response: firstResponse }, first)
+        .id,
+    ).toBe('resp_first');
+    expect(
+      accumulateResponse({ type: 'response.failed', sequence_number: 1, response: secondResponse }, second)
+        .id,
+    ).toBe('resp_second');
+    expect(() =>
+      accumulateResponse({ type: 'response.completed', sequence_number: 2, response: secondResponse }, first),
+    ).toThrow('Response event does not match the active response.');
+  });
+
+  test.each(['deleted', 'throwing accessor'] as const)(
+    'uses the captured response identity when the snapshot ID becomes a %s',
+    (mutation) => {
+      const snapshot = accumulateResponse({
+        type: 'response.created',
+        sequence_number: 0,
+        response: makeResponse(),
+      });
+      const readID = vi.fn(() => {
+        throw new Error('synthetic-private-mutated-snapshot-id');
+      });
+
+      if (mutation === 'deleted') {
+        Reflect.deleteProperty(snapshot, 'id');
+      } else {
+        Object.defineProperty(snapshot, 'id', { configurable: true, enumerable: true, get: readID });
+      }
+
+      expect(
+        accumulateResponse(
+          { type: 'response.completed', sequence_number: 1, response: makeResponse() },
+          snapshot,
+        ),
+      ).toMatchObject({ id: 'resp_123' });
+      expect(readID).not.toHaveBeenCalled();
+    },
+  );
+
+  test('binds a caller-supplied proxy snapshot identity without touching later proxy getters', () => {
+    const response = makeResponse();
+    const readID = vi.fn(() => response.id);
+    const snapshot = new Proxy(response, {
+      get(target, property, receiver) {
+        return property === 'id' ? readID() : Reflect.get(target, property, receiver);
+      },
+    });
+
+    expect(
+      accumulateResponse(
+        { type: 'response.in_progress', sequence_number: 1, response: makeResponse() },
+        snapshot,
+      ),
+    ).toMatchObject({ id: 'resp_123' });
+    response.id = 'resp_foreign';
+    expect(
+      accumulateResponse(
+        { type: 'response.completed', sequence_number: 2, response: makeResponse() },
+        snapshot,
+      ),
+    ).toMatchObject({ id: 'resp_123' });
     expect(readID).toHaveBeenCalledTimes(1);
+  });
+
+  test('accepts matching lifecycle responses for frozen snapshots without mutating them', () => {
+    const snapshot = Object.freeze(
+      accumulateResponse({ type: 'response.created', sequence_number: 0, response: makeResponse() }),
+    );
+
+    expect(
+      accumulateResponse(
+        { type: 'response.completed', sequence_number: 1, response: makeResponse() },
+        snapshot,
+      ),
+    ).toMatchObject({ id: 'resp_123' });
+    expect(Object.isFrozen(snapshot)).toBe(true);
   });
 
   test('captures the active response ID before invoking the lifecycle response getter', () => {
@@ -807,14 +998,17 @@ describe('ResponseAccumulator lifecycle and error handling', () => {
     },
   );
 
-  test.each(['', 'provider:custom/42'] as const)('preserves provider-defined response ID %j', (id) => {
-    const response = { ...makeResponse(), id };
-    const snapshot = accumulateResponse({ type: 'response.created', sequence_number: 0, response });
+  test.each(['', 'provider:custom/42', '__proto__', 'constructor'] as const)(
+    'preserves provider-defined response ID %j',
+    (id) => {
+      const response = { ...makeResponse(), id };
+      const snapshot = accumulateResponse({ type: 'response.created', sequence_number: 0, response });
 
-    expect(
-      accumulateResponse({ type: 'response.completed', sequence_number: 1, response }, snapshot).id,
-    ).toBe(id);
-  });
+      expect(
+        accumulateResponse({ type: 'response.completed', sequence_number: 1, response }, snapshot).id,
+      ).toBe(id);
+    },
+  );
 
   test('rejects foreign lifecycle events before public stream listeners can observe them', async () => {
     const created = {

--- a/tests/lib/ResponseStream.test.ts
+++ b/tests/lib/ResponseStream.test.ts
@@ -115,6 +115,361 @@ describe('.stream()', () => {
     expect(final.id).toBe('resp_123');
   });
 
+  it.each(['create', 'replay', 'readable'] as const)(
+    'preserves omitted lifecycle response fields for %s listeners and iterators',
+    async (mode) => {
+      const created = makeResponse({ output: [makeTextMessage('created wire text')] });
+      const completed = makeResponse({
+        status: 'completed',
+        output: [makeTextMessage('completed wire text')],
+      });
+      Reflect.deleteProperty(created, 'output_text');
+      Reflect.deleteProperty(completed, 'output_text');
+      const events: ResponseStreamEvent[] = [
+        { type: 'response.created', sequence_number: 0, response: created },
+        { type: 'response.completed', sequence_number: 1, response: completed },
+      ];
+      const transport = {
+        controller: new AbortController(),
+        async *[Symbol.asyncIterator]() {
+          yield* events;
+        },
+      };
+      const client = {
+        responses: { create: vi.fn(async () => transport), retrieve: vi.fn(async () => transport) },
+      } as unknown as OpenAI;
+      let stream: ResponseStream<null>;
+      if (mode === 'readable') {
+        stream = ResponseStream.fromReadableStream(readableStreamFromEvents(events));
+      } else if (mode === 'replay') {
+        stream = ResponseStream.createResponse(client, { response_id: 'resp_123', starting_after: 0 });
+      } else {
+        stream = ResponseStream.createResponse(client, { model: 'gpt-test', input: 'preserve wire shape' });
+      }
+      const generic: ResponseStreamEvent[] = [];
+      const typed: ResponseStreamEvent[] = [];
+      stream.on('event', (event) => {
+        if (event.type !== 'response.created' && event.type !== 'response.completed') {
+          return;
+        }
+        expect(Object.getOwnPropertyDescriptor(event.response, 'output_text')).toBeUndefined();
+        expect(JSON.stringify(event.response)).not.toContain('"output_text":');
+        generic.push(event);
+        if (event.type === 'response.completed') {
+          const item = event.response.output[0];
+          if (item?.type === 'message' && item.content[0]?.type === 'output_text') {
+            item.content[0].text = 'listener-only mutation';
+          }
+        }
+      });
+      stream.on('response.created', (event) => typed.push(event));
+      stream.on('response.completed', (event) => typed.push(event));
+      const iteration = (async () => {
+        const iterated: ResponseStreamEvent[] = [];
+        for await (const event of stream) {
+          iterated.push(event);
+        }
+        return iterated;
+      })();
+
+      const [final, iterated] = await Promise.all([stream.finalResponse(), iteration]);
+
+      expect(generic.map((event) => event.type)).toEqual(
+        mode === 'replay' ? ['response.completed'] : ['response.created', 'response.completed'],
+      );
+      expect(typed).toEqual(generic);
+      expect(iterated).toEqual(generic);
+      expect(final.output_text).toBe('completed wire text');
+      expect(final.output[0]).toMatchObject({ content: [{ text: 'completed wire text' }] });
+      expect(completed.output[0]).toMatchObject({ content: [{ text: 'completed wire text' }] });
+      expect(Object.getOwnPropertyDescriptor(completed, 'output_text')).toBeUndefined();
+    },
+  );
+
+  it.each(
+    (['create', 'replay'] as const).flatMap((mode) =>
+      ([null, undefined] as const).map((wireValue) => ({ mode, wireValue })),
+    ),
+  )(
+    'preserves a getter-returned $wireValue lifecycle wire field during $mode',
+    async ({ mode, wireValue }) => {
+      const response = makeResponse({
+        output: [makeTextMessage('canonical text')],
+      });
+      const readOutputText = vi.fn(() => wireValue);
+      Object.defineProperty(response, 'output_text', {
+        configurable: true,
+        enumerable: true,
+        get: readOutputText,
+      });
+      const transport = {
+        controller: new AbortController(),
+        async *[Symbol.asyncIterator]() {
+          yield { type: 'response.created' as const, sequence_number: 0, response };
+        },
+      };
+      const client = {
+        responses: { create: vi.fn(async () => transport), retrieve: vi.fn(async () => transport) },
+      } as unknown as OpenAI;
+      const stream =
+        mode === 'replay'
+          ? ResponseStream.createResponse(client, { response_id: 'resp_123', starting_after: -1 })
+          : ResponseStream.createResponse(client, {
+              model: 'gpt-test',
+              input: 'preserve nullable wire field',
+            });
+      const generic = vi.fn();
+      const typed = vi.fn();
+      stream.on('event', generic);
+      stream.on('response.created', typed);
+
+      await expect(stream.finalResponse()).resolves.toMatchObject({ output_text: 'canonical text' });
+
+      expect(readOutputText).toHaveBeenCalledTimes(1);
+      expect(generic).toHaveBeenCalledTimes(1);
+      expect(typed).toHaveBeenCalledWith(generic.mock.calls[0]?.[0]);
+      const emitted = generic.mock.calls[0]?.[0];
+      expect(Object.getOwnPropertyDescriptor(emitted.response, 'output_text')).toBeDefined();
+      expect(emitted.response.output_text).toBe(wireValue);
+      expect(emitted.response).not.toBe(response);
+    },
+  );
+
+  it('stabilizes a replay lifecycle cursor without exposing later mutations to its wire response', async () => {
+    const response = makeResponse({ output: [makeTextMessage('validated wire text')] });
+    Reflect.deleteProperty(response, 'output_text');
+    const readSequence = vi.fn(() => {
+      response.id = 'resp_foreign';
+      const item = response.output[0];
+      if (item?.type === 'message' && item.content[0]?.type === 'output_text') {
+        item.content[0].text = 'synthetic-private-foreign-payload';
+      }
+      return readSequence.mock.calls.length === 1 ? 1 : 0;
+    });
+    const lifecycle = {
+      type: 'response.created' as const,
+      get sequence_number() {
+        return readSequence();
+      },
+      response,
+    };
+    const transport = {
+      controller: new AbortController(),
+      async *[Symbol.asyncIterator]() {
+        yield lifecycle;
+      },
+    };
+    const client = { responses: { retrieve: vi.fn(async () => transport) } } as unknown as OpenAI;
+    const stream = ResponseStream.createResponse(client, { response_id: 'resp_123', starting_after: 0 });
+    const generic = vi.fn();
+    const typed = vi.fn();
+    stream.on('event', generic);
+    stream.on('response.created', typed);
+
+    await expect(stream.finalResponse()).resolves.toMatchObject({
+      id: 'resp_123',
+      output_text: 'validated wire text',
+    });
+
+    expect(readSequence).toHaveBeenCalledTimes(1);
+    expect(generic).toHaveBeenCalledTimes(1);
+    expect(typed).toHaveBeenCalledWith(generic.mock.calls[0]?.[0]);
+    const emitted = generic.mock.calls[0]?.[0];
+    expect(emitted.sequence_number).toBe(1);
+    expect(emitted.response.id).toBe('resp_123');
+    expect(emitted.response.output[0]).toMatchObject({ content: [{ text: 'validated wire text' }] });
+    expect(Object.getOwnPropertyDescriptor(emitted.response, 'output_text')).toBeUndefined();
+    expect(response.id).toBe('resp_foreign');
+  });
+
+  it.each(['text delta', 'output item'] as const)(
+    'accumulates a replayed %s before its cursor getter can mutate the payload',
+    async (kind) => {
+      const message = makeTextMessage('safe');
+      const initial = makeResponse({
+        output: kind === 'text delta' ? [message] : [],
+        output_text: kind === 'text delta' ? 'safe' : '',
+      });
+      const event: ResponseStreamEvent =
+        kind === 'text delta'
+          ? {
+              type: 'response.output_text.delta',
+              sequence_number: 1,
+              item_id: 'msg_123',
+              output_index: 0,
+              content_index: 0,
+              delta: ' original',
+              logprobs: [],
+            }
+          : {
+              type: 'response.output_item.added',
+              sequence_number: 1,
+              output_index: 0,
+              item: message,
+            };
+      const readSequence = vi.fn(() => {
+        if (event.type === 'response.output_text.delta') {
+          event.delta = ' corrupted';
+        } else if (event.type === 'response.output_item.added' && event.item.type === 'message') {
+          event.item.id = 'msg_corrupted';
+          const part = event.item.content[0];
+          if (part?.type === 'output_text') {
+            part.text = 'corrupted';
+          }
+        }
+        return 1;
+      });
+      Object.defineProperty(event, 'sequence_number', {
+        configurable: true,
+        enumerable: true,
+        get: readSequence,
+      });
+      const transport = {
+        controller: new AbortController(),
+        async *[Symbol.asyncIterator]() {
+          yield { type: 'response.created' as const, sequence_number: 0, response: initial };
+          yield event;
+        },
+      };
+      const client = { responses: { retrieve: vi.fn(async () => transport) } } as unknown as OpenAI;
+      const stream = ResponseStream.createResponse(client, { response_id: 'resp_123', starting_after: 0 });
+      const generic = vi.fn();
+      const typed = vi.fn();
+      stream.on('event', generic);
+      if (kind === 'text delta') {
+        stream.on('response.output_text.delta', typed);
+      } else {
+        stream.on('response.output_item.added', typed);
+      }
+      const iteration = (async () => {
+        const iterated: ResponseStreamEvent[] = [];
+        for await (const emitted of stream) {
+          iterated.push(emitted);
+        }
+        return iterated;
+      })();
+
+      const [final, iterated] = await Promise.all([stream.finalResponse(), iteration]);
+
+      expect(readSequence).toHaveBeenCalledTimes(1);
+      expect(generic).toHaveBeenCalledTimes(1);
+      expect(typed).toHaveBeenCalledTimes(1);
+      expect(iterated).toEqual([event]);
+      expect(final.output[0]).toMatchObject({
+        id: 'msg_123',
+        content: [{ text: kind === 'text delta' ? 'safe original' : 'safe' }],
+      });
+      expect(final.output_text).toBe(kind === 'text delta' ? 'safe original' : 'safe');
+      if (kind === 'text delta') {
+        expect(typed).toHaveBeenCalledWith(expect.objectContaining({ snapshot: 'safe original' }));
+      }
+    },
+  );
+
+  it.each(['keepalive', 'response.audio.delta'] as const)(
+    'redacts a failing replay cursor getter on a supported %s event',
+    async (type) => {
+      const privateMessage = `synthetic-private-${type}-cursor-secret`;
+      const readSequence = vi.fn(() => {
+        throw new Error(privateMessage);
+      });
+      const event = {
+        type,
+        get sequence_number(): number {
+          return readSequence();
+        },
+        ...(type === 'response.audio.delta' ? { delta: 'synthetic-private-audio' } : {}),
+      };
+      const transport = {
+        controller: new AbortController(),
+        async *[Symbol.asyncIterator]() {
+          yield { type: 'response.created' as const, sequence_number: 0, response: makeResponse() };
+          yield event;
+        },
+      };
+      const client = { responses: { retrieve: vi.fn(async () => transport) } } as unknown as OpenAI;
+      const stream = ResponseStream.createResponse(client, { response_id: 'resp_123', starting_after: 0 });
+      const emitted = vi.fn();
+      const errors: OpenAIError[] = [];
+      stream.on('event', emitted);
+      stream.on('error', (error) => errors.push(error));
+
+      await expect(stream.finalResponse()).rejects.toThrow(
+        'Response event does not match the active response.',
+      );
+
+      expect(readSequence).toHaveBeenCalledTimes(1);
+      expect(emitted).not.toHaveBeenCalled();
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(OpenAIError);
+      expect(errors[0]?.message).not.toContain(privateMessage);
+      expect(errors[0]).not.toHaveProperty('cause');
+    },
+  );
+
+  it.each(['create', 'replay', 'readable'] as const)(
+    'applies the replay boundary consistently to %s keepalive listeners and iterators',
+    async (mode) => {
+      const events = [
+        { type: 'response.created' as const, sequence_number: 0, response: makeResponse() },
+        { type: 'keepalive' as const, sequence_number: 1 },
+        { type: 'response.audio.delta' as const, sequence_number: 2, delta: 'stale' },
+        { type: 'keepalive' as const, sequence_number: 3 },
+        { type: 'keepalive' as const, sequence_number: 4 },
+        { type: 'response.audio.delta' as const, sequence_number: 5, delta: 'live' },
+        {
+          type: 'response.completed' as const,
+          sequence_number: 6,
+          response: makeResponse({ status: 'completed' }),
+        },
+      ];
+      const transport = {
+        controller: new AbortController(),
+        async *[Symbol.asyncIterator]() {
+          yield* events;
+        },
+      };
+      const client = {
+        responses: { create: vi.fn(async () => transport), retrieve: vi.fn(async () => transport) },
+      } as unknown as OpenAI;
+      const encoder = new TextEncoder();
+      let stream: ResponseStream<null>;
+      if (mode === 'readable') {
+        stream = ResponseStream.fromReadableStream(
+          ReadableStreamFrom(events.map((event) => encoder.encode(`${JSON.stringify(event)}\n`))),
+        );
+      } else if (mode === 'replay') {
+        stream = ResponseStream.createResponse(client, { response_id: 'resp_123', starting_after: 3 });
+      } else {
+        stream = ResponseStream.createResponse(client, { model: 'gpt-test', input: 'keepalive events' });
+      }
+      const generic: number[] = [];
+      const keepalives: number[] = [];
+      const audio: string[] = [];
+      stream.on('event', (event) => generic.push(event.sequence_number));
+      Reflect.apply(stream.on, stream, [
+        'keepalive',
+        (event: { sequence_number: number }) => keepalives.push(event.sequence_number),
+      ]);
+      stream.on('response.audio.delta', (event) => audio.push(event.delta));
+      const iteration = (async () => {
+        const iterated: number[] = [];
+        for await (const event of stream) {
+          iterated.push(event.sequence_number);
+        }
+        return iterated;
+      })();
+
+      const [final, iterated] = await Promise.all([stream.finalResponse(), iteration]);
+
+      expect(final.id).toBe('resp_123');
+      expect(generic).toEqual(mode === 'replay' ? [4, 5, 6] : [0, 1, 2, 3, 4, 5, 6]);
+      expect(iterated).toEqual(generic);
+      expect(keepalives).toEqual(mode === 'replay' ? [4] : [1, 3, 4]);
+      expect(audio).toEqual(mode === 'replay' ? ['live'] : ['stale', 'live']);
+    },
+  );
+
   it('does not detach lifecycle responses discarded while replaying prior events', async () => {
     const output = {
       id: 'msg_123',
@@ -2015,6 +2370,16 @@ describe('.stream()', () => {
 function readableStreamFromEvents(events: ResponseStreamEvent[]) {
   const encoder = new TextEncoder();
   return ReadableStreamFrom(events.map((event) => encoder.encode(JSON.stringify(event) + '\n')));
+}
+
+function makeTextMessage(text: string): Extract<Response['output'][number], { type: 'message' }> {
+  return {
+    id: 'msg_123',
+    type: 'message',
+    role: 'assistant',
+    status: 'in_progress',
+    content: [{ type: 'output_text', annotations: [], text }],
+  };
 }
 
 function makeResponse(overrides: Partial<Response> = {}): Response {

--- a/tests/lib/ResponseStream.test.ts
+++ b/tests/lib/ResponseStream.test.ts
@@ -336,6 +336,155 @@ describe('.stream()', () => {
     );
   });
 
+  it.each([
+    'response.created',
+    'response.queued',
+    'response.in_progress',
+    'response.completed',
+    'response.failed',
+    'response.incomplete',
+  ] as const)(
+    'emits the exact validated %s response when a transport getter changes identity',
+    async (type) => {
+      const matching = makeResponse({ metadata: { source: 'validated' } });
+      const foreign = makeResponse({ id: 'resp_foreign', metadata: { source: 'private foreign response' } });
+      const readResponse = vi.fn(() => (readResponse.mock.calls.length === 1 ? matching : foreign));
+      const lifecycle = {
+        type,
+        sequence_number: type === 'response.created' ? 0 : 1,
+        get response() {
+          return readResponse();
+        },
+        provider_metadata: 'preserved',
+      } as ResponseStreamEvent;
+      const events: ResponseStreamEvent[] =
+        type === 'response.created'
+          ? [lifecycle]
+          : [{ type: 'response.created', sequence_number: 0, response: makeResponse() }, lifecycle];
+      const transport = {
+        controller: new AbortController(),
+        async *[Symbol.asyncIterator]() {
+          yield* events;
+        },
+      };
+      const client = { responses: { create: vi.fn(async () => transport) } } as unknown as OpenAI;
+      const stream = ResponseStream.createResponse(client, { model: 'gpt-test', input: 'protect lifecycle' });
+      const rawLifecycleResponses: Response[] = [];
+      const typedLifecycleResponses: Response[] = [];
+      const emittedEvents: ResponseStreamEvent[] = [];
+
+      stream.on('event', (event) => {
+        if (event.type === type && event.sequence_number === lifecycle.sequence_number) {
+          emittedEvents.push(event);
+          rawLifecycleResponses.push(event.response);
+        }
+      });
+      stream.on(type, (event: Extract<ResponseStreamEvent, { response: Response }>) =>
+        typedLifecycleResponses.push(event.response),
+      );
+
+      const final = await stream.finalResponse();
+
+      expect(readResponse).toHaveBeenCalledTimes(1);
+      expect(rawLifecycleResponses).toHaveLength(1);
+      expect(typedLifecycleResponses).toHaveLength(1);
+      expect(rawLifecycleResponses[0]).toBe(typedLifecycleResponses[0]);
+      expect(rawLifecycleResponses[0]).not.toBe(matching);
+      expect(rawLifecycleResponses[0]).toMatchObject({ id: 'resp_123', metadata: { source: 'validated' } });
+      expect(emittedEvents[0]).toMatchObject({ type, provider_metadata: 'preserved' });
+      expect(final.id).toBe('resp_123');
+    },
+  );
+
+  it('preserves frozen lifecycle event metadata while exposing its validated response snapshot', async () => {
+    const response = makeResponse({ status: 'completed' });
+    const lifecycle = Object.freeze({
+      type: 'response.completed' as const,
+      sequence_number: 1,
+      response,
+      provider_metadata: 'frozen',
+    });
+    const events: ResponseStreamEvent[] = [
+      { type: 'response.created', sequence_number: 0, response: makeResponse() },
+      lifecycle,
+    ];
+    const transport = {
+      controller: new AbortController(),
+      async *[Symbol.asyncIterator]() {
+        yield* events;
+      },
+    };
+    const client = { responses: { create: vi.fn(async () => transport) } } as unknown as OpenAI;
+    const stream = ResponseStream.createResponse(client, { model: 'gpt-test', input: 'frozen lifecycle' });
+    let raw: ResponseStreamEvent | undefined;
+    let typed: ResponseStreamEvent | undefined;
+
+    stream.on('event', (event) => {
+      if (event.type === 'response.completed') {
+        raw = event;
+      }
+    });
+    stream.on('response.completed', (event) => {
+      typed = event;
+    });
+
+    await expect(stream.finalResponse()).resolves.toMatchObject({ id: 'resp_123' });
+
+    expect(raw).toBe(typed);
+    expect(raw).toMatchObject({ type: 'response.completed', provider_metadata: 'frozen' });
+    expect(raw).not.toBe(lifecycle);
+    expect(raw && 'response' in raw ? raw.response : undefined).not.toBe(response);
+    expect(Object.isFrozen(lifecycle)).toBe(true);
+  });
+
+  it.each(['initial', 'subsequent'] as const)(
+    'rejects an %s lifecycle response ID accessor before exposing private payloads or events',
+    async (position) => {
+      const response = makeResponse();
+      const readID = vi.fn(() => 'resp_123');
+      const readOutput = vi.fn(() => {
+        throw new Error('synthetic-private-stream-output');
+      });
+      Object.defineProperty(response, 'id', { configurable: true, enumerable: true, get: readID });
+      Object.defineProperty(response, 'output', { configurable: true, enumerable: true, get: readOutput });
+      const lifecycle = {
+        type: position === 'initial' ? ('response.created' as const) : ('response.completed' as const),
+        sequence_number: position === 'initial' ? 0 : 1,
+        response,
+      };
+      const events: ResponseStreamEvent[] =
+        position === 'initial'
+          ? [lifecycle]
+          : [{ type: 'response.created', sequence_number: 0, response: makeResponse() }, lifecycle];
+      const transport = {
+        controller: new AbortController(),
+        async *[Symbol.asyncIterator]() {
+          yield* events;
+        },
+      };
+      const client = { responses: { create: vi.fn(async () => transport) } } as unknown as OpenAI;
+      const stream = ResponseStream.createResponse(client, {
+        model: 'gpt-test',
+        input: 'reject private output',
+      });
+      const emitted = vi.fn();
+      const errors: OpenAIError[] = [];
+      stream.on('event', emitted);
+      stream.on('error', (error) => errors.push(error));
+
+      await expect(stream.finalResponse()).rejects.toThrow(
+        'Response event does not match the active response.',
+      );
+
+      expect(readID).not.toHaveBeenCalled();
+      expect(readOutput).not.toHaveBeenCalled();
+      expect(emitted).toHaveBeenCalledTimes(position === 'initial' ? 0 : 1);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(OpenAIError);
+      expect(errors[0]?.message).not.toContain('synthetic-private-stream-output');
+    },
+  );
+
   it('replays hosted shell events, dispatches typed listeners, and preserves each command output', async () => {
     const events: ResponseStreamEvent[] = [
       {

--- a/tests/lib/ResponseStream.test.ts
+++ b/tests/lib/ResponseStream.test.ts
@@ -221,6 +221,61 @@ describe('.stream()', () => {
     }
   });
 
+  it.each([
+    { disposition: 'discarded', sequenceNumber: 1 },
+    { disposition: 'emitted', sequenceNumber: 2 },
+  ])(
+    'rejects a foreign $disposition replay lifecycle response before its cursor can rewrite the identity',
+    async ({ sequenceNumber }) => {
+      const foreign = makeResponse({
+        id: 'resp_foreign',
+        metadata: { source: 'synthetic-private-foreign-response' },
+      });
+      const readSequence = vi.fn(() => {
+        foreign.id = 'resp_123';
+        return sequenceNumber;
+      });
+      const lifecycle = {
+        type: 'response.completed' as const,
+        sequence_number: sequenceNumber,
+        response: foreign,
+      };
+      Object.defineProperty(lifecycle, 'sequence_number', {
+        configurable: true,
+        enumerable: true,
+        get: readSequence,
+      });
+      const transport = {
+        controller: new AbortController(),
+        async *[Symbol.asyncIterator]() {
+          yield { type: 'response.created' as const, sequence_number: 0, response: makeResponse() };
+          yield lifecycle;
+        },
+      };
+      const client = { responses: { retrieve: vi.fn(async () => transport) } } as unknown as OpenAI;
+      const stream = ResponseStream.createResponse(client, { response_id: 'resp_123', starting_after: 1 });
+      const emitted = vi.fn();
+      const completed = vi.fn();
+      const errors: OpenAIError[] = [];
+      stream.on('event', emitted);
+      stream.on('response.completed', completed);
+      stream.on('error', (error) => errors.push(error));
+
+      await expect(stream.finalResponse()).rejects.toThrow(
+        'Response event does not match the active response.',
+      );
+
+      expect(readSequence).not.toHaveBeenCalled();
+      expect(foreign.id).toBe('resp_foreign');
+      expect(emitted).not.toHaveBeenCalled();
+      expect(completed).not.toHaveBeenCalled();
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(OpenAIError);
+      expect(errors[0]?.message).not.toContain('synthetic-private-foreign-response');
+      expect(errors[0]).not.toHaveProperty('cause');
+    },
+  );
+
   it('creates a response stream from a readable stream', async () => {
     const events: ResponseStreamEvent[] = [
       {
@@ -734,7 +789,75 @@ describe('.stream()', () => {
   it.each(
     (['create', 'replay'] as const).flatMap((mode) =>
       (['initial', 'subsequent'] as const).flatMap((position) =>
-        (['self cycle', 'multi-node cycle', 'unbounded chain'] as const).map((chain) => ({
+        ([127, 128, 129, 256] as const).map((prototypeDepth) => ({ mode, position, prototypeDepth })),
+      ),
+    ),
+  )(
+    'accepts an $position lifecycle event with $prototypeDepth ordinary prototypes during $mode',
+    async ({ mode, position, prototypeDepth }) => {
+      let providerPrototype: object = Object.prototype;
+      for (let depth: number = prototypeDepth; depth > 0; depth -= 1) {
+        const prototype = Object.create(providerPrototype) as {
+          provider_metadata?: string;
+          provider_boundary?: string;
+          provider_beyond?: string;
+        };
+        if (depth === 1) {
+          prototype.provider_metadata = 'nearby metadata';
+        } else if (depth === 127) {
+          prototype.provider_boundary = 'metadata within the bound';
+        } else if (depth === 128) {
+          prototype.provider_beyond = 'metadata outside the bound';
+        }
+        providerPrototype = prototype;
+      }
+
+      const lifecycle = Object.assign(Object.create(providerPrototype) as object, {
+        type: position === 'initial' ? ('response.created' as const) : ('response.completed' as const),
+        sequence_number: position === 'initial' ? 0 : 1,
+        response: makeResponse({ status: position === 'initial' ? 'in_progress' : 'completed' }),
+      });
+      const events: ResponseStreamEvent[] =
+        position === 'initial'
+          ? [lifecycle]
+          : [{ type: 'response.created', sequence_number: 0, response: makeResponse() }, lifecycle];
+      const transport = {
+        controller: new AbortController(),
+        async *[Symbol.asyncIterator]() {
+          yield* events;
+        },
+      };
+      const client = {
+        responses: { create: vi.fn(async () => transport), retrieve: vi.fn(async () => transport) },
+      } as unknown as OpenAI;
+      const stream =
+        mode === 'replay'
+          ? ResponseStream.createResponse(client, { response_id: 'resp_123', starting_after: -1 })
+          : ResponseStream.createResponse(client, { model: 'gpt-test', input: 'deep ordinary prototypes' });
+      const emitted: ResponseStreamEvent[] = [];
+      const typed = vi.fn();
+      stream.on('event', (event) => emitted.push(event));
+      stream.on(position === 'initial' ? 'response.created' : 'response.completed', typed);
+
+      await expect(stream.finalResponse()).resolves.toMatchObject({ id: 'resp_123' });
+
+      const emittedLifecycle = emitted[position === 'initial' ? 0 : 1];
+      expect(typed).toHaveBeenCalledWith(emittedLifecycle);
+      expect(emittedLifecycle).toMatchObject({
+        type: lifecycle.type,
+        sequence_number: lifecycle.sequence_number,
+        provider_metadata: 'nearby metadata',
+        provider_boundary: 'metadata within the bound',
+      });
+      expect(emittedLifecycle).not.toHaveProperty('provider_beyond');
+      expect(Object.getPrototypeOf(emittedLifecycle)).toBe(Object.prototype);
+    },
+  );
+
+  it.each(
+    (['create', 'replay'] as const).flatMap((mode) =>
+      (['initial', 'subsequent'] as const).flatMap((position) =>
+        (['self cycle', 'multi-node cycle', 'boundary cycle'] as const).map((chain) => ({
           mode,
           position,
           chain,
@@ -753,17 +876,23 @@ describe('.stream()', () => {
           stopUnsafeFixture();
         }
       });
-      const cyclicPrototype: { root?: ResponseStreamEvent } = {};
-      const createPrototype = (cycleDepth = 2): object =>
-        new Proxy(Object.create(null) as object, {
+      const cyclicPrototype: { root?: ResponseStreamEvent; first?: object } = {};
+      const createPrototype = (cycleDepth = 2): object => {
+        const prototype = new Proxy(Object.create(null) as object, {
           getPrototypeOf() {
             inspectPrototype();
             if (chain === 'multi-node cycle' && cycleDepth === 1) {
               return cyclicPrototype.root ?? null;
             }
+            if (chain === 'boundary cycle' && inspectPrototype.mock.calls.length === 128) {
+              return cyclicPrototype.first ?? null;
+            }
             return createPrototype(cycleDepth - 1);
           },
         });
+        cyclicPrototype.first ??= prototype;
+        return prototype;
+      };
 
       const lifecycle: ResponseStreamEvent = new Proxy(
         {
@@ -809,13 +938,101 @@ describe('.stream()', () => {
       );
 
       expect(stopUnsafeFixture).not.toHaveBeenCalled();
-      const expectedPrototypeReads = { 'self cycle': 2, 'multi-node cycle': 6, 'unbounded chain': 128 };
+      const expectedPrototypeReads = { 'self cycle': 2, 'multi-node cycle': 6, 'boundary cycle': 128 };
       expect(inspectPrototype).toHaveBeenCalledTimes(expectedPrototypeReads[chain]);
       expect(emitted).toHaveBeenCalledTimes(position === 'initial' ? 0 : 1);
       expect(errors).toHaveLength(1);
       expect(errors[0]).toBeInstanceOf(OpenAIError);
       expect(errors[0]?.message).not.toContain(privateMessage);
       expect(errors[0]).not.toHaveProperty('cause');
+    },
+  );
+
+  it.each(
+    (['create', 'replay'] as const).flatMap((mode) =>
+      (['initial', 'subsequent'] as const).map((position) => ({ mode, position })),
+    ),
+  )(
+    'bounds an endlessly fabricated $position lifecycle prototype chain during $mode',
+    async ({ mode, position }) => {
+      const privateMessage = 'synthetic-private-unbounded-prototype-secret';
+      const stopUnsafeFixture = vi.fn(() => {
+        throw new Error(privateMessage);
+      });
+      const readUnsafeMetadata = vi.fn(() => {
+        throw new Error(privateMessage);
+      });
+      const inspectPrototype = vi.fn(() => {
+        if (inspectPrototype.mock.calls.length > 512) {
+          stopUnsafeFixture();
+        }
+      });
+      const createPrototype = (depth: number): object => {
+        const prototype = Object.create(null) as { provider_metadata?: string };
+        if (depth === 1) {
+          prototype.provider_metadata = 'bounded metadata';
+        } else if (depth === 128) {
+          Object.defineProperty(prototype, 'provider_private', {
+            configurable: true,
+            enumerable: true,
+            get: readUnsafeMetadata,
+          });
+        }
+        return new Proxy(prototype, {
+          getPrototypeOf() {
+            inspectPrototype();
+            return createPrototype(depth + 1);
+          },
+        });
+      };
+      const lifecycle = new Proxy(
+        {
+          type: position === 'initial' ? ('response.created' as const) : ('response.completed' as const),
+          sequence_number: position === 'initial' ? 0 : 1,
+          response: makeResponse(),
+        },
+        {
+          getPrototypeOf() {
+            inspectPrototype();
+            return createPrototype(1);
+          },
+        },
+      );
+      const events: ResponseStreamEvent[] =
+        position === 'initial'
+          ? [lifecycle]
+          : [{ type: 'response.created', sequence_number: 0, response: makeResponse() }, lifecycle];
+      const transport = {
+        controller: new AbortController(),
+        async *[Symbol.asyncIterator]() {
+          yield* events;
+        },
+      };
+      const client = {
+        responses: { create: vi.fn(async () => transport), retrieve: vi.fn(async () => transport) },
+      } as unknown as OpenAI;
+      const stream =
+        mode === 'replay'
+          ? ResponseStream.createResponse(client, { response_id: 'resp_123', starting_after: -1 })
+          : ResponseStream.createResponse(client, {
+              model: 'gpt-test',
+              input: 'bound fabricated prototypes',
+            });
+      const emitted: ResponseStreamEvent[] = [];
+      const errors: OpenAIError[] = [];
+      stream.on('event', (event) => emitted.push(event));
+      stream.on('error', (error) => errors.push(error));
+
+      await expect(stream.finalResponse()).resolves.toMatchObject({ id: 'resp_123' });
+
+      expect(inspectPrototype).toHaveBeenCalledTimes(128);
+      expect(stopUnsafeFixture).not.toHaveBeenCalled();
+      expect(readUnsafeMetadata).not.toHaveBeenCalled();
+      expect(errors).toEqual([]);
+      expect(emitted).toHaveLength(position === 'initial' ? 1 : 2);
+      const emittedLifecycle = emitted[position === 'initial' ? 0 : 1];
+      expect(emittedLifecycle).toMatchObject({ provider_metadata: 'bounded metadata' });
+      expect(emittedLifecycle).not.toHaveProperty('provider_private');
     },
   );
 

--- a/tests/lib/ResponseStream.test.ts
+++ b/tests/lib/ResponseStream.test.ts
@@ -732,6 +732,128 @@ describe('.stream()', () => {
   });
 
   it.each(
+    (['create', 'replay'] as const).flatMap((mode) =>
+      (['initial', 'subsequent'] as const).flatMap((position) =>
+        (['self cycle', 'multi-node cycle', 'unbounded chain'] as const).map((chain) => ({
+          mode,
+          position,
+          chain,
+        })),
+      ),
+    ),
+  )(
+    'rejects an $position $chain lifecycle prototype chain during $mode',
+    async ({ mode, position, chain }) => {
+      const privateMessage = 'synthetic-private-unbounded-prototype-secret';
+      const stopUnsafeFixture = vi.fn(() => {
+        throw new Error(privateMessage);
+      });
+      const inspectPrototype = vi.fn(() => {
+        if (inspectPrototype.mock.calls.length > 512) {
+          stopUnsafeFixture();
+        }
+      });
+      const cyclicPrototype: { root?: ResponseStreamEvent } = {};
+      const createPrototype = (cycleDepth = 2): object =>
+        new Proxy(Object.create(null) as object, {
+          getPrototypeOf() {
+            inspectPrototype();
+            if (chain === 'multi-node cycle' && cycleDepth === 1) {
+              return cyclicPrototype.root ?? null;
+            }
+            return createPrototype(cycleDepth - 1);
+          },
+        });
+
+      const lifecycle: ResponseStreamEvent = new Proxy(
+        {
+          type: position === 'initial' ? ('response.created' as const) : ('response.completed' as const),
+          sequence_number: position === 'initial' ? 0 : 1,
+          response: makeResponse(),
+        },
+        {
+          getPrototypeOf() {
+            inspectPrototype();
+            return chain === 'self cycle' ? (cyclicPrototype.root ?? null) : createPrototype();
+          },
+        },
+      );
+      cyclicPrototype.root = lifecycle;
+      const events: ResponseStreamEvent[] =
+        position === 'initial'
+          ? [lifecycle]
+          : [{ type: 'response.created', sequence_number: 0, response: makeResponse() }, lifecycle];
+      const transport = {
+        controller: new AbortController(),
+        async *[Symbol.asyncIterator]() {
+          yield* events;
+        },
+      };
+      const client = {
+        responses: { create: vi.fn(async () => transport), retrieve: vi.fn(async () => transport) },
+      } as unknown as OpenAI;
+      const stream =
+        mode === 'replay'
+          ? ResponseStream.createResponse(client, { response_id: 'resp_123', starting_after: -1 })
+          : ResponseStream.createResponse(client, {
+              model: 'gpt-test',
+              input: 'reject malformed prototypes',
+            });
+      const emitted = vi.fn();
+      const errors: OpenAIError[] = [];
+      stream.on('event', emitted);
+      stream.on('error', (error) => errors.push(error));
+
+      await expect(stream.finalResponse()).rejects.toThrow(
+        'Response event does not match the active response.',
+      );
+
+      expect(stopUnsafeFixture).not.toHaveBeenCalled();
+      const expectedPrototypeReads = { 'self cycle': 2, 'multi-node cycle': 6, 'unbounded chain': 128 };
+      expect(inspectPrototype).toHaveBeenCalledTimes(expectedPrototypeReads[chain]);
+      expect(emitted).toHaveBeenCalledTimes(position === 'initial' ? 0 : 1);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(OpenAIError);
+      expect(errors[0]?.message).not.toContain(privateMessage);
+      expect(errors[0]).not.toHaveProperty('cause');
+    },
+  );
+
+  it('preserves metadata from ordinary multi-level lifecycle prototype chains', async () => {
+    const providerPrototype = Object.assign(
+      Object.create({ provider_region: 'synthetic-region' }) as object,
+      {
+        provider_metadata: 'inherited metadata',
+      },
+    );
+    const lifecycle = Object.assign(Object.create(providerPrototype) as object, {
+      type: 'response.created' as const,
+      sequence_number: 0,
+      response: makeResponse(),
+    });
+
+    const transport = {
+      controller: new AbortController(),
+      async *[Symbol.asyncIterator]() {
+        yield lifecycle;
+      },
+    };
+    const client = { responses: { create: vi.fn(async () => transport) } } as unknown as OpenAI;
+    const stream = ResponseStream.createResponse(client, { model: 'gpt-test', input: 'normal prototypes' });
+    const emitted = vi.fn();
+    stream.on('response.created', emitted);
+
+    await expect(stream.finalResponse()).resolves.toMatchObject({ id: 'resp_123' });
+
+    expect(emitted).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider_metadata: 'inherited metadata',
+        provider_region: 'synthetic-region',
+      }),
+    );
+  });
+
+  it.each(
     (['initial', 'subsequent'] as const).flatMap((position) =>
       (['own keys', 'descriptor', 'prototype'] as const).map((trap) => ({ position, trap })),
     ),

--- a/tests/lib/ResponseStream.test.ts
+++ b/tests/lib/ResponseStream.test.ts
@@ -437,16 +437,69 @@ describe('.stream()', () => {
     expect(Object.isFrozen(lifecycle)).toBe(true);
   });
 
-  it.each(['initial', 'subsequent'] as const)(
-    'rejects an %s lifecycle response ID accessor before exposing private payloads or events',
-    async (position) => {
+  it.each(
+    (['initial', 'subsequent'] as const).flatMap((position) =>
+      (
+        [
+          'missing',
+          'inherited',
+          'polluted prototype',
+          'throwing accessor',
+          'non-enumerable',
+          'undefined',
+          'null',
+          'number',
+          'boolean',
+          'object',
+          'symbol',
+        ] as const
+      ).map((kind) => ({ position, kind })),
+    ),
+  )(
+    'rejects an $position lifecycle response with a $kind ID before exposing private payloads or events',
+    async ({ position, kind }) => {
       const response = makeResponse();
-      const readID = vi.fn(() => 'resp_123');
+      const readID = vi.fn(() => {
+        throw new Error('synthetic-private-stream-id');
+      });
       const readOutput = vi.fn(() => {
         throw new Error('synthetic-private-stream-output');
       });
-      Object.defineProperty(response, 'id', { configurable: true, enumerable: true, get: readID });
       Object.defineProperty(response, 'output', { configurable: true, enumerable: true, get: readOutput });
+
+      if (kind === 'missing' || kind === 'inherited' || kind === 'polluted prototype') {
+        Reflect.deleteProperty(response, 'id');
+        if (kind !== 'missing') {
+          const prototype = kind === 'inherited' ? { id: 'resp_123' } : Object.create(Object.prototype);
+          if (kind === 'polluted prototype') {
+            Object.defineProperty(prototype, 'id', {
+              configurable: true,
+              enumerable: true,
+              value: 'resp_123',
+            });
+          }
+          Object.setPrototypeOf(response, prototype);
+        }
+      } else if (kind === 'throwing accessor') {
+        Object.defineProperty(response, 'id', { configurable: true, enumerable: true, get: readID });
+      } else if (kind === 'non-enumerable') {
+        Object.defineProperty(response, 'id', { configurable: true, enumerable: false, value: 'resp_123' });
+      } else {
+        const invalidIDs = {
+          undefined,
+          null: null,
+          number: 123,
+          boolean: false,
+          object: {},
+          symbol: Symbol('invalid stream response ID'),
+        };
+        Object.defineProperty(response, 'id', {
+          configurable: true,
+          enumerable: true,
+          value: invalidIDs[kind],
+        });
+      }
+
       const lifecycle = {
         type: position === 'initial' ? ('response.created' as const) : ('response.completed' as const),
         sequence_number: position === 'initial' ? 0 : 1,
@@ -482,6 +535,58 @@ describe('.stream()', () => {
       expect(errors).toHaveLength(1);
       expect(errors[0]).toBeInstanceOf(OpenAIError);
       expect(errors[0]?.message).not.toContain('synthetic-private-stream-output');
+    },
+  );
+
+  it.each(['changed', 'deleted', 'throwing accessor'] as const)(
+    'retains its canonical response identity when a listener leaves the emitted snapshot ID %s',
+    async (mutation) => {
+      const foreign = makeResponse({ id: 'resp_foreign' });
+      const readOutput = vi.fn(() => {
+        throw new Error('synthetic-private-foreign-stream-output');
+      });
+      Object.defineProperty(foreign, 'output', { configurable: true, enumerable: true, get: readOutput });
+      const events: ResponseStreamEvent[] = [
+        { type: 'response.created', sequence_number: 0, response: makeResponse() },
+        { type: 'response.in_progress', sequence_number: 1, response: makeResponse() },
+        { type: 'response.completed', sequence_number: 2, response: foreign },
+      ];
+      const transport = {
+        controller: new AbortController(),
+        async *[Symbol.asyncIterator]() {
+          yield* events;
+        },
+      };
+      const client = { responses: { create: vi.fn(async () => transport) } } as unknown as OpenAI;
+      const stream = ResponseStream.createResponse(client, {
+        model: 'gpt-test',
+        input: 'preserve canonical response identity',
+      });
+      const emitted: ResponseStreamEvent[] = [];
+      const readID = vi.fn(() => {
+        throw new Error('synthetic-private-mutated-stream-id');
+      });
+      stream.on('event', (event) => {
+        emitted.push(event);
+        if (event.type !== 'response.created') {
+          return;
+        }
+        if (mutation === 'changed') {
+          event.response.id = 'resp_foreign';
+        } else if (mutation === 'deleted') {
+          Reflect.deleteProperty(event.response, 'id');
+        } else {
+          Object.defineProperty(event.response, 'id', { configurable: true, enumerable: true, get: readID });
+        }
+      });
+
+      await expect(stream.finalResponse()).rejects.toThrow(
+        'Response event does not match the active response.',
+      );
+
+      expect(emitted.map((event) => event.type)).toEqual(['response.created', 'response.in_progress']);
+      expect(readID).not.toHaveBeenCalled();
+      expect(readOutput).not.toHaveBeenCalled();
     },
   );
 

--- a/tests/lib/ResponseStream.test.ts
+++ b/tests/lib/ResponseStream.test.ts
@@ -74,6 +74,112 @@ describe('.stream()', () => {
     expect(final.id).toBe('resp_123');
   });
 
+  it('does not detach lifecycle responses discarded while replaying prior events', async () => {
+    const output = {
+      id: 'msg_123',
+      type: 'message' as const,
+      role: 'assistant' as const,
+      status: 'in_progress' as const,
+      content: [{ type: 'output_text' as const, annotations: [], text: 'replayed' }],
+    };
+    const created = makeResponse({
+      metadata: { stage: 'created' },
+      output: [output],
+      output_text: 'replayed',
+    });
+    const inProgress = makeResponse({
+      metadata: { stage: 'replayed' },
+      output: [output],
+      output_text: 'replayed',
+    });
+    const completed = makeResponse({
+      status: 'completed',
+      metadata: { stage: 'completed' },
+      output: [
+        {
+          ...output,
+          status: 'completed',
+          content: [{ type: 'output_text', annotations: [], text: 'replayed live' }],
+        },
+      ],
+      output_text: 'replayed live',
+    });
+    const readCreated = vi.fn(() => created);
+    const readInProgress = vi.fn(() => inProgress);
+    const inspectReplayMetadata = vi.fn((target: object) => Reflect.ownKeys(target));
+    const replayLifecycle = (
+      type: 'response.created' | 'response.in_progress',
+      sequenceNumber: number,
+      readResponse: () => Response,
+    ): ResponseStreamEvent =>
+      new Proxy(
+        {
+          type,
+          sequence_number: sequenceNumber,
+          get response() {
+            return readResponse();
+          },
+        },
+        {
+          ownKeys(target) {
+            return inspectReplayMetadata(target);
+          },
+        },
+      );
+    const events: ResponseStreamEvent[] = [
+      replayLifecycle('response.created', 0, readCreated),
+      replayLifecycle('response.in_progress', 1, readInProgress),
+      {
+        type: 'response.output_text.delta',
+        sequence_number: 2,
+        item_id: 'msg_123',
+        output_index: 0,
+        content_index: 0,
+        delta: ' live',
+        logprobs: [],
+      },
+      { type: 'response.completed', sequence_number: 3, response: completed },
+    ];
+    const transport = {
+      controller: new AbortController(),
+      async *[Symbol.asyncIterator]() {
+        yield* events;
+      },
+    };
+    const client = { responses: { retrieve: vi.fn(async () => transport) } } as unknown as OpenAI;
+    const clone = vi.spyOn(globalThis, 'structuredClone');
+
+    try {
+      const stream = ResponseStream.createResponse(client, { response_id: 'resp_123', starting_after: 1 });
+      const emitted: ResponseStreamEvent[] = [];
+      const snapshots: string[] = [];
+      const replayed = vi.fn();
+      stream.on('event', (event) => emitted.push(event));
+      stream.on('response.created', replayed);
+      stream.on('response.in_progress', replayed);
+      stream.on('response.output_text.delta', (event) => snapshots.push(event.snapshot));
+
+      await expect(stream.finalResponse()).resolves.toMatchObject({
+        id: 'resp_123',
+        metadata: { stage: 'completed' },
+        output_text: 'replayed live',
+      });
+
+      expect(readCreated).toHaveBeenCalledTimes(1);
+      expect(readInProgress).toHaveBeenCalledTimes(1);
+      expect(inspectReplayMetadata).not.toHaveBeenCalled();
+      expect(clone).toHaveBeenCalledTimes(4);
+      expect(clone.mock.calls[0]?.[0]).toBe(created);
+      expect(clone.mock.calls[1]?.[0]).toBe(inProgress);
+      expect(clone.mock.calls[2]?.[0]).toBe(completed);
+      expect(replayed).not.toHaveBeenCalled();
+      expect(snapshots).toEqual(['replayed live']);
+      expect(emitted.map((event) => event.sequence_number)).toEqual([2, 3]);
+    } finally {
+      clone.mockRestore();
+    }
+  });
+
   it('creates a response stream from a readable stream', async () => {
     const events: ResponseStreamEvent[] = [
       {
@@ -344,7 +450,7 @@ describe('.stream()', () => {
     'response.failed',
     'response.incomplete',
   ] as const)(
-    'emits the exact validated %s response when a transport getter changes identity',
+    'emits the validated %s response when a transport getter changes its identity and raw event type',
     async (type) => {
       const matching = makeResponse({ metadata: { source: 'validated' } });
       const foreign = makeResponse({ id: 'resp_foreign', metadata: { source: 'private foreign response' } });
@@ -353,7 +459,9 @@ describe('.stream()', () => {
         type,
         sequence_number: type === 'response.created' ? 0 : 1,
         get response() {
-          return readResponse();
+          const response = readResponse();
+          lifecycle.type = 'error';
+          return response;
         },
         provider_metadata: 'preserved',
       } as ResponseStreamEvent;
@@ -392,6 +500,8 @@ describe('.stream()', () => {
       expect(rawLifecycleResponses[0]).not.toBe(matching);
       expect(rawLifecycleResponses[0]).toMatchObject({ id: 'resp_123', metadata: { source: 'validated' } });
       expect(emittedEvents[0]).toMatchObject({ type, provider_metadata: 'preserved' });
+      expect(Object.getOwnPropertyDescriptor(emittedEvents[0] ?? {}, 'type')?.value).toBe(type);
+      expect(lifecycle.type).toBe('error');
       expect(final.id).toBe('resp_123');
     },
   );
@@ -435,6 +545,68 @@ describe('.stream()', () => {
     expect(raw).not.toBe(lifecycle);
     expect(raw && 'response' in raw ? raw.response : undefined).not.toBe(response);
     expect(Object.isFrozen(lifecycle)).toBe(true);
+  });
+
+  it.each(
+    (['initial', 'subsequent'] as const).flatMap((position) =>
+      (['own keys', 'descriptor', 'prototype'] as const).map((trap) => ({ position, trap })),
+    ),
+  )('redacts $position lifecycle event metadata failures from its $trap trap', async ({ position, trap }) => {
+    const privateMessage = `synthetic-private-lifecycle-${trap}-secret`;
+    const lifecycle = new Proxy(
+      {
+        type: position === 'initial' ? ('response.created' as const) : ('response.completed' as const),
+        sequence_number: position === 'initial' ? 0 : 1,
+        response: makeResponse(),
+        provider_metadata: 'preserved when valid',
+      },
+      {
+        ownKeys(target) {
+          if (trap === 'own keys') {
+            throw new Error(privateMessage);
+          }
+          return Reflect.ownKeys(target);
+        },
+        getOwnPropertyDescriptor(target, property) {
+          if (trap === 'descriptor' && property === 'provider_metadata') {
+            throw new Error(privateMessage);
+          }
+          return Reflect.getOwnPropertyDescriptor(target, property);
+        },
+        getPrototypeOf(target) {
+          if (trap === 'prototype') {
+            throw new Error(privateMessage);
+          }
+          return Reflect.getPrototypeOf(target);
+        },
+      },
+    );
+    const events: ResponseStreamEvent[] =
+      position === 'initial'
+        ? [lifecycle]
+        : [{ type: 'response.created', sequence_number: 0, response: makeResponse() }, lifecycle];
+    const transport = {
+      controller: new AbortController(),
+      async *[Symbol.asyncIterator]() {
+        yield* events;
+      },
+    };
+    const client = { responses: { create: vi.fn(async () => transport) } } as unknown as OpenAI;
+    const stream = ResponseStream.createResponse(client, { model: 'gpt-test', input: 'redact metadata' });
+    const emitted = vi.fn();
+    const errors: OpenAIError[] = [];
+    stream.on('event', emitted);
+    stream.on('error', (error) => errors.push(error));
+
+    await expect(stream.finalResponse()).rejects.toThrow(
+      'Response event does not match the active response.',
+    );
+
+    expect(emitted).toHaveBeenCalledTimes(position === 'initial' ? 0 : 1);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(OpenAIError);
+    expect(errors[0]?.message).not.toContain(privateMessage);
+    expect(errors[0]).not.toHaveProperty('cause');
   });
 
   it.each(

--- a/tests/lib/ResponseStream.test.ts
+++ b/tests/lib/ResponseStream.test.ts
@@ -5,6 +5,47 @@ import { ResponseStream } from 'openai/lib/responses/ResponseStream';
 import type { Response, ResponseStreamEvent } from 'openai/resources/responses/responses';
 import { makeStreamSnapshotRequest } from '../utils/mock-snapshots';
 
+class ProviderLifecycleEvent {
+  readonly type: 'response.created' | 'response.in_progress' | 'response.completed';
+  #sequenceNumber: number;
+  #response: Response;
+  #metadata: string;
+  #readMetadata: (value: string) => string;
+  #failingProperty: 'sequence_number' | 'provider_metadata' | undefined;
+
+  constructor(
+    type: 'response.created' | 'response.in_progress' | 'response.completed',
+    sequenceNumber: number,
+    readMetadata: (value: string) => string = (value) => value,
+    failingProperty?: 'sequence_number' | 'provider_metadata',
+  ) {
+    this.type = type;
+    this.#sequenceNumber = sequenceNumber;
+    this.#response = makeResponse({ status: type === 'response.completed' ? 'completed' : 'in_progress' });
+    this.#metadata = `provider-${sequenceNumber}`;
+    this.#readMetadata = readMetadata;
+    this.#failingProperty = failingProperty;
+  }
+
+  get sequence_number(): number {
+    if (this.#failingProperty === 'sequence_number') {
+      throw new Error('synthetic-private-inherited-sequence_number-secret');
+    }
+    return this.#sequenceNumber;
+  }
+
+  get response(): Response {
+    return this.#response;
+  }
+
+  get provider_metadata(): string {
+    if (this.#failingProperty === 'provider_metadata') {
+      throw new Error('synthetic-private-inherited-provider_metadata-secret');
+    }
+    return this.#readMetadata(this.#metadata);
+  }
+}
+
 describe('.stream()', () => {
   it('replays prior events when resuming by ID so snapshots stay complete', async () => {
     const requests: string[] = [];
@@ -440,6 +481,149 @@ describe('.stream()', () => {
     expect(emitted).toHaveBeenCalledWith(
       expect.objectContaining({ output_index: 0, content_index: 0, snapshot: 'first!' }),
     );
+  });
+
+  it.each(
+    (
+      [
+        'response.created',
+        'response.queued',
+        'response.in_progress',
+        'response.completed',
+        'response.failed',
+        'response.incomplete',
+      ] as const
+    ).flatMap((type) =>
+      (['error', 'response.output_text.delta', 'response.queued'] as const).map((mutatedType) => ({
+        type,
+        mutatedType:
+          type === 'response.queued' && mutatedType === 'response.queued'
+            ? ('response.completed' as const)
+            : mutatedType,
+      })),
+    ),
+  )(
+    'keeps the validated $type route when a generic listener changes its type to $mutatedType',
+    async ({ type, mutatedType }) => {
+      const lifecycle = {
+        type,
+        sequence_number: type === 'response.created' ? 0 : 1,
+        response: makeResponse(),
+      } as ResponseStreamEvent;
+      const events: ResponseStreamEvent[] =
+        type === 'response.created'
+          ? [lifecycle]
+          : [{ type: 'response.created', sequence_number: 0, response: makeResponse() }, lifecycle];
+      const stream = ResponseStream.fromReadableStream(readableStreamFromEvents(events));
+      const typed = vi.fn();
+      const misrouted = vi.fn();
+      stream.on('event', (event) => {
+        if (event.type === type && event.sequence_number === lifecycle.sequence_number) {
+          Reflect.set(event, 'type', mutatedType);
+        }
+      });
+      stream.on(type, typed);
+      stream.on('error', misrouted);
+      if (mutatedType === 'response.output_text.delta') {
+        stream.on(mutatedType, misrouted);
+      } else if (mutatedType === 'response.queued' || mutatedType === 'response.completed') {
+        stream.on(mutatedType, misrouted);
+      }
+
+      await expect(stream.finalResponse()).resolves.toMatchObject({ id: 'resp_123' });
+
+      expect(typed).toHaveBeenCalledTimes(1);
+      expect(typed).toHaveBeenCalledWith(expect.objectContaining({ type: mutatedType }));
+      expect(misrouted).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['create', 'replay'] as const)(
+    'materializes private inherited lifecycle metadata and sequence numbers through %s',
+    async (mode) => {
+      const readMetadata = vi.fn((value: string) => value);
+
+      const events: ResponseStreamEvent[] = [
+        new ProviderLifecycleEvent('response.created', 0, readMetadata),
+        new ProviderLifecycleEvent('response.in_progress', 1, readMetadata),
+        new ProviderLifecycleEvent('response.completed', 2, readMetadata),
+      ];
+      const transport = {
+        controller: new AbortController(),
+        async *[Symbol.asyncIterator]() {
+          yield* events;
+        },
+      };
+      const client = {
+        responses: { create: vi.fn(async () => transport), retrieve: vi.fn(async () => transport) },
+      } as unknown as OpenAI;
+      const stream =
+        mode === 'replay'
+          ? ResponseStream.createResponse(client, { response_id: 'resp_123', starting_after: 0 })
+          : ResponseStream.createResponse(client, { model: 'gpt-test', input: 'private lifecycle metadata' });
+      const emitted: ResponseStreamEvent[] = [];
+      const typed: ResponseStreamEvent[] = [];
+      stream.on('event', (event) => {
+        expect(Reflect.get(event, 'provider_metadata')).toBe(`provider-${event.sequence_number}`);
+        emitted.push(event);
+      });
+      stream.on('response.created', (event) => typed.push(event));
+      stream.on('response.in_progress', (event) => typed.push(event));
+      stream.on('response.completed', (event) => typed.push(event));
+
+      await expect(stream.finalResponse()).resolves.toMatchObject({ id: 'resp_123', status: 'completed' });
+
+      const expectedSequences = mode === 'replay' ? [1, 2] : [0, 1, 2];
+      expect(emitted.map((event) => event.sequence_number)).toEqual(expectedSequences);
+      expect(typed).toEqual(emitted);
+      expect(readMetadata).toHaveBeenCalledTimes(expectedSequences.length);
+      for (const event of emitted) {
+        expect(Object.getPrototypeOf(event)).toBe(Object.prototype);
+        expect(event).not.toBeInstanceOf(ProviderLifecycleEvent);
+        expect(Object.getOwnPropertyDescriptor(event, 'provider_metadata')).toMatchObject({
+          value: `provider-${event.sequence_number}`,
+        });
+        expect(Object.getOwnPropertyDescriptor(event, 'sequence_number')).toMatchObject({
+          value: event.sequence_number,
+        });
+      }
+    },
+  );
+
+  it.each(
+    (['create', 'replay'] as const).flatMap((mode) =>
+      (['sequence_number', 'provider_metadata'] as const).map((property) => ({ mode, property })),
+    ),
+  )('redacts inherited $property accessor failures during $mode', async ({ mode, property }) => {
+    const privateMessage = `synthetic-private-inherited-${property}-secret`;
+
+    const transport = {
+      controller: new AbortController(),
+      async *[Symbol.asyncIterator]() {
+        yield new ProviderLifecycleEvent('response.created', 0, undefined, property);
+      },
+    };
+    const client = {
+      responses: { create: vi.fn(async () => transport), retrieve: vi.fn(async () => transport) },
+    } as unknown as OpenAI;
+    const stream =
+      mode === 'replay'
+        ? ResponseStream.createResponse(client, { response_id: 'resp_123', starting_after: -1 })
+        : ResponseStream.createResponse(client, { model: 'gpt-test', input: 'redact inherited metadata' });
+    const emitted = vi.fn();
+    const errors: OpenAIError[] = [];
+    stream.on('event', emitted);
+    stream.on('error', (error) => errors.push(error));
+
+    await expect(stream.finalResponse()).rejects.toThrow(
+      'Response event does not match the active response.',
+    );
+
+    expect(emitted).not.toHaveBeenCalled();
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(OpenAIError);
+    expect(errors[0]?.message).not.toContain(privateMessage);
+    expect(errors[0]).not.toHaveProperty('cause');
   });
 
   it.each([

--- a/tests/lib/response-stream-lifecycle-dispatch-security.test.ts
+++ b/tests/lib/response-stream-lifecycle-dispatch-security.test.ts
@@ -1,0 +1,431 @@
+import { vi } from 'vitest';
+import OpenAI, { OpenAIError } from 'openai';
+import type { Response, ResponseStreamEvent } from 'openai/resources/responses/responses';
+
+type LifecycleType = 'response.created' | 'response.completed';
+type StreamMode = 'create' | 'replay';
+
+function makeResponse(overrides: Partial<Response> = {}): Response {
+  return {
+    id: 'resp_lifecycle',
+    object: 'response',
+    created_at: 1,
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    metadata: null,
+    model: 'gpt-test',
+    output: [],
+    output_text: '',
+    parallel_tool_calls: false,
+    status: 'in_progress',
+    temperature: null,
+    tool_choice: 'auto',
+    tools: [],
+    top_p: null,
+    ...overrides,
+  } as Response;
+}
+
+function startStream(events: ResponseStreamEvent[], mode: StreamMode = 'create') {
+  const client = new OpenAI({ apiKey: 'synthetic-lifecycle-api-key' });
+  const transport = {
+    controller: new AbortController(),
+    async *[Symbol.asyncIterator]() {
+      yield* events;
+    },
+  };
+
+  Object.defineProperties(client.responses, {
+    create: { value: vi.fn(async () => transport) },
+    retrieve: { value: vi.fn(async () => transport) },
+  });
+
+  return mode === 'replay'
+    ? client.responses.stream({ response_id: 'resp_lifecycle', starting_after: -1 })
+    : client.responses.stream({ model: 'gpt-test', input: 'synthetic lifecycle dispatch' });
+}
+
+function lifecycleEvent(
+  type: LifecycleType,
+  sequenceNumber: number,
+  response = makeResponse({ status: type === 'response.completed' ? 'completed' : 'in_progress' }),
+): Extract<ResponseStreamEvent, { type: LifecycleType }> {
+  return { type, sequence_number: sequenceNumber, response };
+}
+
+describe('public Responses lifecycle dispatch boundary', () => {
+  it.each(['response.created', 'response.completed'] as const)(
+    'pins the validated %s discriminator when an extensible transport proxy omits its own key',
+    async (type) => {
+      const sequenceNumber = type === 'response.created' ? 0 : 7;
+      const target = lifecycleEvent(type, sequenceNumber);
+      const lifecycle = new Proxy(target, {
+        ownKeys(current) {
+          return Reflect.ownKeys(current).filter((key) => key !== 'type');
+        },
+      });
+      const stream = startStream(
+        type === 'response.created' ? [lifecycle] : [lifecycleEvent('response.created', 0), lifecycle],
+      );
+      const generic = vi.fn();
+      const typed = vi.fn();
+      stream.on('event', (event) => {
+        if (event.sequence_number === sequenceNumber) {
+          generic(event);
+        }
+      });
+      stream.on(type, typed);
+      const iteration = (async () => {
+        const observed: ResponseStreamEvent[] = [];
+        for await (const event of stream) {
+          observed.push(event);
+        }
+        return observed;
+      })();
+
+      const [final, iterated] = await Promise.all([stream.finalResponse(), iteration]);
+
+      expect(final.id).toBe('resp_lifecycle');
+      expect(generic).toHaveBeenCalledTimes(1);
+      expect(typed).toHaveBeenCalledTimes(1);
+      const emitted = typed.mock.calls[0]?.[0] as ResponseStreamEvent;
+      expect(generic).toHaveBeenCalledWith(emitted);
+      expect(iterated.find((event) => event.sequence_number === sequenceNumber)).toBe(emitted);
+      expect(Object.getOwnPropertyDescriptor(emitted, 'type')).toMatchObject({ value: type });
+      expect(emitted.type).toBe(type);
+    },
+  );
+
+  it.each(['own', 'inherited'] as const)(
+    'captures the original lifecycle cursor before %s metadata mutates it',
+    async (location) => {
+      let mutateSequence: () => void;
+      const readMetadata = vi.fn(() => {
+        mutateSequence();
+        return 'validated provider metadata';
+      });
+      let lifecycle: ResponseStreamEvent;
+
+      if (location === 'own') {
+        const event = {
+          type: 'response.completed' as const,
+          get provider_metadata() {
+            return readMetadata();
+          },
+          sequence_number: 7,
+          response: makeResponse({ status: 'completed' }),
+        };
+        mutateSequence = () => {
+          event.sequence_number = 41;
+        };
+        lifecycle = event;
+      } else {
+        const sequenceOwner = { sequence_number: 7 };
+        const metadataOwner = Object.create(sequenceOwner) as object;
+        Object.defineProperty(metadataOwner, 'provider_metadata', {
+          configurable: true,
+          enumerable: true,
+          get: readMetadata,
+        });
+        mutateSequence = () => {
+          sequenceOwner.sequence_number = 41;
+        };
+        lifecycle = Object.assign(Object.create(metadataOwner) as object, {
+          type: 'response.completed' as const,
+          response: makeResponse({ status: 'completed' }),
+        }) as ResponseStreamEvent;
+      }
+
+      const stream = startStream([lifecycleEvent('response.created', 0), lifecycle]);
+      const generic: ResponseStreamEvent[] = [];
+      const typed: ResponseStreamEvent[] = [];
+      stream.on('event', (event) => generic.push(event));
+      stream.on('response.completed', (event) => typed.push(event));
+      const iteration = (async () => {
+        const observed: ResponseStreamEvent[] = [];
+        for await (const event of stream) {
+          observed.push(event);
+        }
+        return observed;
+      })();
+
+      const [final, iterated] = await Promise.all([stream.finalResponse(), iteration]);
+
+      expect(final.status).toBe('completed');
+      expect(readMetadata).toHaveBeenCalledTimes(1);
+      expect(lifecycle.sequence_number).toBe(41);
+      expect(generic.map((event) => event.sequence_number)).toEqual([0, 7]);
+      expect(typed.map((event) => event.sequence_number)).toEqual([7]);
+      expect(iterated.map((event) => event.sequence_number)).toEqual([0, 7]);
+      expect(generic[1]).toBe(typed[0]);
+      expect(iterated[1]).toBe(typed[0]);
+      expect(Reflect.get(typed[0] ?? {}, 'provider_metadata')).toBe('validated provider metadata');
+    },
+  );
+
+  it.each(['create', 'replay'] as const)(
+    'clones large %s responses only for accumulation when lifecycle metadata has no consumers',
+    async (mode) => {
+      const largeText = 'synthetic lifecycle response payload '.repeat(65_536);
+      const output = {
+        id: 'msg_lifecycle',
+        type: 'message' as const,
+        role: 'assistant' as const,
+        status: 'completed' as const,
+        content: [{ type: 'output_text' as const, annotations: [], text: largeText }],
+      };
+      const created = makeResponse({ output: [output], output_text: largeText });
+      const completed = makeResponse({ output: [output], output_text: largeText, status: 'completed' });
+      const inspectMetadata = vi.fn((target: object) => Reflect.ownKeys(target));
+      const readMetadata = vi.fn(() => {
+        throw new Error('synthetic-private-unobserved-provider-metadata');
+      });
+      const unobserved = (type: LifecycleType, sequenceNumber: number, response: Response) =>
+        new Proxy(
+          {
+            ...lifecycleEvent(type, sequenceNumber, response),
+            get provider_metadata(): string {
+              return readMetadata();
+            },
+          },
+          {
+            ownKeys(target) {
+              return inspectMetadata(target);
+            },
+          },
+        );
+      const clone = vi.spyOn(globalThis, 'structuredClone');
+
+      try {
+        const stream = startStream(
+          [unobserved('response.created', 0, created), unobserved('response.completed', 1, completed)],
+          mode,
+        );
+        stream.on('response.output_text.delta', vi.fn());
+        stream.on('error', vi.fn());
+
+        const final = await stream.finalResponse();
+
+        expect(final.id).toBe('resp_lifecycle');
+        expect(final.status).toBe('completed');
+        expect(final.output_text).toHaveLength(largeText.length);
+        expect(inspectMetadata).not.toHaveBeenCalled();
+        expect(readMetadata).not.toHaveBeenCalled();
+        expect(clone).toHaveBeenCalledTimes(2);
+        expect(clone.mock.calls[0]?.[0]).toBe(created);
+        expect(clone.mock.calls[1]?.[0]).toBe(completed);
+      } finally {
+        clone.mockRestore();
+      }
+    },
+  );
+
+  it.each([
+    'generic listener',
+    'typed listener',
+    'async iterator',
+    'generic event iterator',
+    'typed event iterator',
+    'emitted promise',
+    'once listener',
+  ] as const)('materializes a lifecycle event exactly once for an active %s', async (consumer) => {
+    const response = makeResponse();
+    const readMetadata = vi.fn(() => 'observable provider metadata');
+    const event = {
+      ...lifecycleEvent('response.created', 7, response),
+      get provider_metadata() {
+        return readMetadata();
+      },
+    };
+    const clone = vi.spyOn(globalThis, 'structuredClone');
+
+    try {
+      const stream = startStream([event]);
+      let observed: Promise<ResponseStreamEvent> | undefined;
+      const listener = vi.fn<(event: ResponseStreamEvent) => void>();
+
+      switch (consumer) {
+        case 'generic listener': {
+          stream.on('event', listener);
+          break;
+        }
+        case 'typed listener': {
+          stream.on('response.created', listener);
+          break;
+        }
+        case 'async iterator': {
+          observed = stream[Symbol.asyncIterator]()
+            .next()
+            .then(({ value }) => value);
+          break;
+        }
+        case 'generic event iterator': {
+          observed = stream
+            .events('event')
+            .next()
+            .then(({ value }) => value[0]);
+          break;
+        }
+        case 'typed event iterator': {
+          observed = stream
+            .events('response.created')
+            .next()
+            .then(({ value }) => value[0]);
+          break;
+        }
+        case 'emitted promise': {
+          observed = stream.emitted('response.created');
+          break;
+        }
+        case 'once listener': {
+          stream.once('response.created', listener);
+          break;
+        }
+        default: {
+          throw new Error(`Unsupported lifecycle consumer: ${consumer}`);
+        }
+      }
+
+      const final = await stream.finalResponse();
+      const emitted = observed ? await observed : listener.mock.calls[0]?.[0];
+      if (!emitted) {
+        throw new Error('Expected an observed lifecycle event.');
+      }
+
+      expect(final.id).toBe('resp_lifecycle');
+      expect(emitted.type).toBe('response.created');
+      expect(emitted.sequence_number).toBe(7);
+      expect(Reflect.get(emitted, 'provider_metadata')).toBe('observable provider metadata');
+      expect('response' in emitted && emitted.response).not.toBe(response);
+      expect(readMetadata).toHaveBeenCalledTimes(1);
+      expect(clone).toHaveBeenCalledTimes(2);
+    } finally {
+      clone.mockRestore();
+    }
+  });
+
+  it.each(['generic', 'typed'] as const)(
+    'does not materialize metadata after its only %s lifecycle listener is removed',
+    async (channel) => {
+      const readMetadata = vi.fn(() => {
+        throw new Error('synthetic-private-removed-listener-metadata');
+      });
+      const event = {
+        ...lifecycleEvent('response.created', 0),
+        get provider_metadata(): string {
+          return readMetadata();
+        },
+      };
+      const stream = startStream([event]);
+      const listener = vi.fn();
+
+      if (channel === 'generic') {
+        stream.on('event', listener);
+        stream.off('event', listener);
+      } else {
+        stream.on('response.created', listener);
+        stream.off('response.created', listener);
+      }
+
+      await expect(stream.finalResponse()).resolves.toMatchObject({ id: 'resp_lifecycle' });
+
+      expect(listener).not.toHaveBeenCalled();
+      expect(readMetadata).not.toHaveBeenCalled();
+    },
+  );
+
+  it('stops materializing later lifecycle events after a one-time generic consumer is removed', async () => {
+    const readMetadata = vi.fn(() => {
+      throw new Error('synthetic-private-expired-consumer-metadata');
+    });
+    const completed = {
+      ...lifecycleEvent('response.completed', 1),
+      get provider_metadata(): string {
+        return readMetadata();
+      },
+    };
+    const clone = vi.spyOn(globalThis, 'structuredClone');
+
+    try {
+      const stream = startStream([lifecycleEvent('response.created', 0), completed]);
+      const observed = vi.fn();
+      stream.once('event', observed);
+
+      await expect(stream.finalResponse()).resolves.toMatchObject({ status: 'completed' });
+
+      expect(observed).toHaveBeenCalledTimes(1);
+      expect(readMetadata).not.toHaveBeenCalled();
+      expect(clone).toHaveBeenCalledTimes(3);
+    } finally {
+      clone.mockRestore();
+    }
+  });
+
+  it('materializes lifecycle events for typed consumers registered during connection or generic dispatch', async () => {
+    const readMetadata = vi.fn(() => 'dynamically observed metadata');
+    const event = {
+      ...lifecycleEvent('response.created', 0),
+      get provider_metadata() {
+        return readMetadata();
+      },
+    };
+    const stream = startStream([event]);
+    const connected = vi.fn();
+    const duringGeneric = vi.fn();
+    stream.on('connect', () => stream.on('response.created', connected));
+    stream.on('event', () => stream.on('response.created', duringGeneric));
+
+    await expect(stream.finalResponse()).resolves.toMatchObject({ id: 'resp_lifecycle' });
+
+    expect(readMetadata).toHaveBeenCalledTimes(1);
+    expect(connected).toHaveBeenCalledTimes(1);
+    expect(duringGeneric).toHaveBeenCalledTimes(1);
+    expect(connected.mock.calls[0]?.[0]).toBe(duringGeneric.mock.calls[0]?.[0]);
+  });
+
+  it.each(['generic', 'typed', 'iterator'] as const)(
+    'redacts throwing lifecycle metadata when an active %s consumer requires materialization',
+    async (consumer) => {
+      const privateMessage = 'synthetic-private-observed-provider-metadata';
+      const readMetadata = vi.fn(() => {
+        throw new Error(privateMessage);
+      });
+      const event = {
+        ...lifecycleEvent('response.created', 0),
+        get provider_metadata(): string {
+          return readMetadata();
+        },
+      };
+      const stream = startStream([event]);
+      const errors: OpenAIError[] = [];
+      stream.on('error', (error) => errors.push(error));
+      let iteration: Promise<unknown> = Promise.resolve();
+
+      if (consumer === 'generic') {
+        stream.on('event', vi.fn());
+      } else if (consumer === 'typed') {
+        stream.on('response.created', vi.fn());
+      } else {
+        iteration = (async () => {
+          try {
+            return await stream[Symbol.asyncIterator]().next();
+          } catch (error: unknown) {
+            return error;
+          }
+        })();
+      }
+
+      await expect(stream.finalResponse()).rejects.toThrow(
+        'Response event does not match the active response.',
+      );
+      await iteration;
+
+      expect(readMetadata).toHaveBeenCalledTimes(1);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(OpenAIError);
+      expect(errors[0]?.message).not.toContain(privateMessage);
+      expect(errors[0]).not.toHaveProperty('cause');
+    },
+  );
+});


### PR DESCRIPTION
## Summary

- Keep response snapshots bound to the same response across every lifecycle event.
- Reject foreign or malformed response identities before exposing data or updating stream state.
- Cover all six lifecycle events, hostile getters, and the public streaming API.

## Test plan

- Node 22.23.0 and 26.7.0: 6,556 handwritten and 556 generated tests per runtime.
- Lint, strict type checking, CommonJS/ESM builds, and published TypeScript 4.9/6 checks.
- Package lint and an actually packed, installed public CommonJS/ESM consumer.