### PR TITLE
fix: publish Castiron checks for behind-main pull requests

### DIFF
--- a/.github/workflows/castiron-custom-code-comment.yml
+++ b/.github/workflows/castiron-custom-code-comment.yml
@@ -165,7 +165,8 @@ jobs:
               const current = [];
               for (const number of numbers) {
                 const {data: pr} = await github.rest.pulls.get({...context.repo, pull_number: number});
-                if (pr.number === number && pr.state === 'open' && pr.head.sha === head && pr.base.sha === base &&
+                if (pr.number === number && pr.state === 'open' && pr.head.sha === head &&
+                    /^[0-9a-f]{40}$/.test(pr.base.sha) &&
                     pr.head.repo?.full_name === source.full_name && pr.base.ref === 'main' &&
                     pr.base.repo.full_name === upstream) current.push(pr);
               }

--- a/scripts/castiron/CUSTOM_CODE.md
+++ b/scripts/castiron/CUSTOM_CODE.md
@@ -39,8 +39,9 @@ The custom-code workflow pair separates candidate execution from trusted checks:
   on `pull_request` with read-only permissions.
 - `castiron-custom-code-comment.yml` handles `workflow_run` from **main**. Its
   read-only compute job runs main's reporter against candidate Git objects in a
-  new bare repository, then reuses that verified report to check main's budget.
-  It never checks out, imports, installs, or executes candidate code.
+  new bare repository. It reuses that verified report when its base is current,
+  or recomputes against current main when the PR is behind. It never checks out,
+  imports, installs, or executes candidate code.
 - An unprivileged `merge_group` job in the first workflow only signals that a candidate
   needs checking. A `workflow_run` handler whose **workflow definition is on
   main** then uses the same trusted checkout. It ignores the signal's conclusion
@@ -72,7 +73,8 @@ and [merge-queue behavior](https://docs.github.com/en/repositories/configuring-b
 The trusted run summary reports additions, deletions, total, mixed-file count,
 headroom, largest patches, and exact policy/candidate/generated revisions. The
 existing custom-code comment remains unchanged, including when the budget fails.
-The trusted compute job reuses its own report, never the candidate's artifacts.
+The trusted compute job reuses its own report only when its base is current and
+never uses the candidate's artifacts.
 The checker, policy, and workflows are maintained in the SDK and preserved
 through the normal three-way merge during generation.
 

--- a/scripts/castiron/custom_code_budget.py
+++ b/scripts/castiron/custom_code_budget.py
@@ -299,9 +299,12 @@ def github_evaluate(
     ):
         raise ValueError("unexpected or superseded source workflow run")
     head = report.require_sha(run["head_sha"])
+    pull_base = None
     if run["event"] == "pull_request":
-        if report.associated_pull_request(repository, run, base_ref=branch, base_sha=main) is None:
+        pull = report.associated_pull_request(repository, run, base_ref=branch)
+        if pull is None:
             raise ValueError("source run must identify exactly one current PR targeting main")
+        pull_base = pull["base"]["sha"]
     elif run["event"] == "merge_group":
         if not run["head_branch"].startswith(f"gh-readonly-queue/{branch}/"):
             raise ValueError("queue signal does not target main")
@@ -320,11 +323,14 @@ def github_evaluate(
         if run["event"] != "pull_request":
             raise ValueError("only PR runs can reuse the trusted report")
         measured = json.loads((trusted_report_dir / "report.json").read_text())
-        if measured["target_base_sha"] != main or measured["head_sha"] != head:
+        if measured["target_base_sha"] != pull_base or measured["head_sha"] != head:
             raise ValueError("trusted report is stale; rerun against current main")
         if report.git(repo, "rev-parse", "--is-bare-repository").strip() != b"true":
             raise ValueError("trusted report must use a bare object store")
-        measurement = (measured, (trusted_report_dir / "custom-code.patch").read_bytes())
+        if pull_base == main:
+            measurement = (measured, (trusted_report_dir / "custom-code.patch").read_bytes())
+        else:
+            report.git(repo, "fetch", "--quiet", "--no-tags", "origin", main)
     else:
         if repo.exists():
             raise ValueError("Git object directory must be fresh")

--- a/scripts/castiron/test_custom_code_budget.py
+++ b/scripts/castiron/test_custom_code_budget.py
@@ -312,6 +312,8 @@ class StatusPublisherTests(unittest.TestCase):
         event_name: str = "pull_request",
         head_changed: bool = False,
         base_changed: bool = False,
+        pull_base_behind: bool = False,
+        main_advanced: bool = False,
         no_result: bool = False,
         failed_budget: bool = False,
         head_repository: str = "openai/example",
@@ -352,6 +354,7 @@ class StatusPublisherTests(unittest.TestCase):
             "run": run,
             "associations": associations,
             "association_repository": head_repository,
+            "main_sha": "d" * 40 if main_advanced else ("c" * 40 if base_changed else base),
             "current": {
                 "state": "open",
                 "head": {
@@ -359,7 +362,7 @@ class StatusPublisherTests(unittest.TestCase):
                     "repo": {"full_name": pull_repository or head_repository},
                 },
                 "base": {
-                    "sha": "c" * 40 if base_changed else base,
+                    "sha": "c" * 40 if base_changed or pull_base_behind else base,
                     "ref": "main",
                     "repo": {"full_name": "openai/example"},
                 },
@@ -384,7 +387,7 @@ class StatusPublisherTests(unittest.TestCase):
             rest: {
               pulls: {get: async options => ({data: {...data.current, number: options.pull_number}})},
               actions: {getWorkflowRun: async () => ({data: data.run})},
-              git: {getRef: async () => ({data: {object: {sha: data.current.base.sha}}})},
+              git: {getRef: async () => ({data: {object: {sha: data.main_sha}}})},
               repos: {
                 listPullRequestsAssociatedWithCommit: async () => {},
                 createCommitStatus: async value => published.push(value),
@@ -497,6 +500,27 @@ class StatusPublisherTests(unittest.TestCase):
 
     def test_stale_pr_head_is_not_published(self) -> None:
         self.assertEqual(self.publish(head_changed=True), [])
+
+    def test_behind_main_pr_publishes_current_main_results(self) -> None:
+        results = self.publish(pull_base_behind=True)
+        self.assertEqual(
+            [result["context"] for result in results],
+            ["Castiron / budget-only change", "Castiron / custom-code budget"],
+        )
+        self.assertTrue(
+            all(result["sha"] == "b" * 40 and result["state"] == "success" for result in results)
+        )
+
+    def test_behind_main_pr_fails_closed_if_main_advances_after_evaluation(self) -> None:
+        results = self.publish(pull_base_behind=True, main_advanced=True)
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(result["state"] == "failure" for result in results))
+        self.assertTrue(
+            all(
+                "base changed; rerun against current main" in result["description"]
+                for result in results
+            )
+        )
 
     def test_stale_base_and_missing_evaluation_cannot_publish_success(self) -> None:
         for event in ("pull_request", "merge_group"):
@@ -708,6 +732,70 @@ class GitHubBudgetTests(unittest.TestCase):
                         )
                         git.assert_called_once_with(repo, "rev-parse", "--is-bare-repository")
 
+    def test_behind_main_pr_recomputes_report_against_current_main(self) -> None:
+        main, pull_base, head = "a" * 40, "c" * 40, "b" * 40
+        run = source_run(head)
+        event = {"repository": {"full_name": "openai/example"}, "workflow_run": run}
+        pull = {
+            "number": 3,
+            "state": "open",
+            "head": {"sha": head, "repo": {"full_name": "openai/example"}},
+            "base": {
+                "sha": pull_base,
+                "ref": "main",
+                "repo": {"full_name": "openai/example"},
+            },
+        }
+        for matches_pull in (True, False):
+            with self.subTest(matches_pull=matches_pull), tempfile.TemporaryDirectory() as temp:
+                trusted = Path(temp)
+                measured = {
+                    "target_base_sha": pull_base if matches_pull else main,
+                    "head_sha": head,
+                }
+                (trusted / "report.json").write_text(json.dumps(measured))
+                (trusted / "custom-code.patch").write_bytes(b"verified patch")
+                repo = trusted / "objects.git"
+                repo.mkdir()
+                with (
+                    mock.patch.object(
+                        budget.report,
+                        "api",
+                        side_effect=[
+                            {"default_branch": "main", "private": False},
+                            {"object": {"sha": main}},
+                            run,
+                            pull,
+                            [{"type": "merge_queue"}],
+                        ],
+                    ),
+                    mock.patch.object(budget.report, "git", return_value=b"true\n") as git,
+                    mock.patch.object(budget, "evaluate", return_value=({}, b"")) as evaluate,
+                ):
+                    if not matches_pull:
+                        with self.assertRaisesRegex(ValueError, "trusted report is stale"):
+                            budget.github_evaluate(repo, "openai/example", event, main, trusted)
+                        evaluate.assert_not_called()
+                        git.assert_not_called()
+                        continue
+
+                    budget.github_evaluate(repo, "openai/example", event, main, trusted)
+                    git.assert_has_calls(
+                        [
+                            mock.call(repo, "rev-parse", "--is-bare-repository"),
+                            mock.call(repo, "fetch", "--quiet", "--no-tags", "origin", main),
+                        ]
+                    )
+                    evaluate.assert_called_once_with(
+                        repo,
+                        main,
+                        head,
+                        public=True,
+                        fetch=True,
+                        pull_heads=None,
+                        measurement=None,
+                    )
+
     def test_queue_pagination(self) -> None:
         pages = [
             {
@@ -791,7 +879,7 @@ class GitHubBudgetTests(unittest.TestCase):
             )
 
     def test_stale_pull_and_wrong_target_fail_before_objects_created(self) -> None:
-        for kind in ("head", "source_repository", "base", "repository", "branch", "closed"):
+        for kind in ("head", "source_repository", "repository", "branch", "closed"):
             with self.subTest(kind=kind), tempfile.TemporaryDirectory() as temp:
                 base, head = "a" * 40, "b" * 40
                 event = {
@@ -808,8 +896,6 @@ class GitHubBudgetTests(unittest.TestCase):
                     pull["head"]["sha"] = "c" * 40
                 elif kind == "source_repository":
                     pull["head"]["repo"]["full_name"] = "someone-else/example"
-                elif kind == "base":
-                    pull["base"]["sha"] = "c" * 40
                 elif kind == "repository":
                     pull["base"]["repo"]["full_name"] = "wrong/repo"
                 elif kind == "branch":


### PR DESCRIPTION
## Summary

Fix Castiron's required budget statuses getting stuck in the expected state whenever an otherwise valid pull request is behind `main`.

- Authenticate the pull request by its exact head commit, source repository, upstream repository, and target branch instead of requiring its recorded base SHA to equal the latest `main` commit.
- Evaluate behind-main pull requests against the current trusted `main` policy by recomputing their report inside the existing trusted, bare Git object store; reuse an existing report only when its authenticated base is current.
- Publish both required statuses for valid behind-main pull requests and publish explicit failures if `main` changes between trusted evaluation and publication.
- Add executable regressions covering behind-main status publication, a `main` race, trusted recomputation, and rejection of a report bound to the wrong pull-request base.

This fixes the failure observed on #2468, #2478, and #2482, where the baseline workflow passed but `Castiron / budget-only change` and `Castiron / custom-code budget` were never published.

## Security

The trusted workflow still checks out and executes only current `main`, verifies the immutable candidate head and source repository, requires exactly one valid upstream pull request, evaluates the policy from current `main`, preserves merge-queue enforcement, and never executes candidate code or consumes candidate artifacts. Results are published only when their evaluated head and current policy revision still match; otherwise both required statuses fail closed.

## Verification

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/castiron -p 'test_custom_code*.py'`
- `ruff format --check scripts/castiron/custom_code_budget.py scripts/castiron/test_custom_code_budget.py`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/castiron-custom-code.yml .github/workflows/castiron-custom-code-comment.yml`
- `git diff --check`
