### PR TITLE
fix(streaming): honor cancellation while decoding SSE responses

### DIFF
--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -334,6 +334,128 @@ export class Stream<Item> implements AsyncIterable<Item> {
   }
 }
 
+function createAbortableSSESource(body: NonNullable<Response['body']>, signal: AbortSignal) {
+  const reader = typeof body.getReader === 'function' ? body.getReader() : undefined;
+  const source = reader
+    ? {
+        next: () => reader.read(),
+        return: () => reader.cancel(),
+      }
+    : ReadableStreamToAsyncIterable<Bytes>(body)[Symbol.asyncIterator]();
+  const ended: IteratorResult<Bytes> = { value: undefined, done: true };
+  let closed = false;
+  let canceled = false;
+  let cancellation: Promise<unknown> | undefined;
+  let interrupt: (() => void) | undefined;
+
+  const waitForAbort = () =>
+    // oxlint-disable-next-line promise/avoid-new -- AbortSignal callbacks need a portable Promise bridge.
+    new Promise<void>((resolve) => {
+      interrupt = resolve;
+    });
+
+  const cancel = () => {
+    if (canceled || closed) {
+      return cancellation;
+    }
+    canceled = true;
+    try {
+      cancellation = Promise.resolve(source.return?.());
+    } catch (error) {
+      cancellation = Promise.reject(error);
+    }
+    cancellation.catch(() => undefined);
+    return cancellation;
+  };
+  const abort = () => {
+    queueMicrotask(() => {
+      interrupt?.();
+      cancel();
+    });
+  };
+  const iterator: AsyncIterableIterator<Bytes> = {
+    async next() {
+      if (signal.aborted) {
+        return ended;
+      }
+      const aborted = waitForAbort().then(() => ended);
+      try {
+        const result = await Promise.race([source.next(), aborted]);
+        if (signal.aborted) {
+          return ended;
+        }
+        if (result.done) {
+          closed = true;
+          return ended;
+        }
+        return { value: result.value, done: false };
+      } catch (error) {
+        if (signal.aborted && (isAbortError(error) || error === signal.reason)) {
+          return ended;
+        }
+        throw error;
+      } finally {
+        interrupt = undefined;
+      }
+    },
+    async return() {
+      const pending = cancel();
+      if (pending && !signal.aborted) {
+        const aborted = waitForAbort();
+        try {
+          if (!signal.aborted) {
+            await Promise.race([pending, aborted]);
+          }
+        } finally {
+          interrupt = undefined;
+        }
+      }
+      return ended;
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  };
+
+  return {
+    iterator,
+    start() {
+      signal.addEventListener('abort', abort, { once: true });
+      if (signal.aborted) {
+        abort();
+      }
+    },
+    async cleanup(failed: boolean) {
+      let cleanupError: unknown;
+      try {
+        signal.removeEventListener('abort', abort);
+      } catch (error) {
+        cleanupError = error;
+      }
+      if (!closed) {
+        const pending = cancel();
+        if (pending && !failed && !signal.aborted) {
+          try {
+            await pending;
+          } catch (error) {
+            cleanupError ??= error;
+          }
+        }
+      }
+      if (reader) {
+        try {
+          reader.releaseLock();
+        } catch (error) {
+          cleanupError ??= error;
+        }
+      }
+      if (cleanupError !== undefined && !failed && !signal.aborted) {
+        throw cleanupError;
+      }
+    },
+  };
+}
+
 /**
  * Decodes complete SSE records from a response and aborts when its body is absent.
  * Complete events are decoded on demand without imposing a line or event size limit.
@@ -359,22 +481,45 @@ export async function* _iterSSEMessages(
 
   const sseDecoder = new SSEDecoder();
   const lineDecoder = new LineDecoder();
+  const { signal } = controller;
+  const source = createAbortableSSESource(response.body, signal);
+  let failed = false;
 
-  const iter = ReadableStreamToAsyncIterable<Bytes>(response.body);
-  for await (const sseChunk of iterSSEChunks(iter)) {
-    for (const line of lineDecoder.decode(sseChunk)) {
+  try {
+    source.start();
+    for await (const sseChunk of iterSSEChunks(source.iterator)) {
+      if (signal.aborted) {
+        return;
+      }
+      for (const line of lineDecoder.decode(sseChunk)) {
+        if (signal.aborted) {
+          return;
+        }
+        const sse = sseDecoder.decode(line);
+        if (sse) {
+          yield sse;
+        }
+      }
+    }
+    if (signal.aborted) {
+      return;
+    }
+    for (const line of lineDecoder.flush()) {
+      if (signal.aborted) {
+        return;
+      }
       const sse = sseDecoder.decode(line);
       if (sse) {
         yield sse;
       }
     }
-  }
-
-  for (const line of lineDecoder.flush()) {
-    const sse = sseDecoder.decode(line);
-    if (sse) {
-      yield sse;
+  } catch (error) {
+    failed = true;
+    if (!signal.aborted || (!isAbortError(error) && error !== signal.reason)) {
+      throw error;
     }
+  } finally {
+    await source.cleanup(failed);
   }
 }
 

--- a/tests/lib/streaming-core.test.ts
+++ b/tests/lib/streaming-core.test.ts
@@ -1,5 +1,6 @@
 import { vi } from 'vitest';
-import { APIError, OpenAIError } from 'openai/core/error';
+import OpenAI from 'openai';
+import { APIError, APIUserAbortError, OpenAIError } from 'openai/core/error';
 import { Stream, _iterSSEMessages } from 'openai/core/streaming';
 import * as lineDecoders from 'openai/internal/decoders/line';
 import { ReadableStreamFrom } from 'openai/internal/shims';
@@ -18,12 +19,104 @@ async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
   return result;
 }
 
+function settlesSoon<T>(promise: Promise<T>): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  // oxlint-disable-next-line promise/avoid-new -- Bound regression fixtures that intentionally never settle.
+  const expired = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => reject(new Error('Aborted SSE stream did not settle')), 1500);
+  });
+  return Promise.race([promise, expired]).finally(() => clearTimeout(timeout));
+}
+
 describe('Stream.fromSSEResponse', () => {
   test('parses data events and ignores events after the completion sentinel', async () => {
     const response = responseForSSE('data: {"id":1}\n\ndata: {"id":2}\n\ndata: [DONE]\n\ndata: not-json\n\n');
     const stream = Stream.fromSSEResponse<{ id: number }>(response, new AbortController());
 
     await expect(collect(stream)).resolves.toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  test.each(['before', 'registration', 'buffered'])('hides data after %s abort', async (stage) => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({
+      start(source) {
+        source.enqueue(encoder.encode('data: {"id":1}\n\ndata: {"private":"never expose"}\n\n'));
+      },
+      cancel,
+    });
+    const controller = new AbortController();
+    const reason = new Error('private abort reason');
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener');
+    if (stage === 'registration') {
+      const addListener = controller.signal.addEventListener.bind(controller.signal);
+      vi.spyOn(controller.signal, 'addEventListener').mockImplementation((...args) => {
+        controller.abort(reason);
+        addListener(...args);
+      });
+    }
+    const iterator = Stream.fromSSEResponse(new Response(body), controller)[Symbol.asyncIterator]();
+    if (stage === 'buffered') {
+      await expect(iterator.next()).resolves.toEqual({ value: { id: 1 }, done: false });
+    }
+    if (stage !== 'registration') {
+      controller.abort(reason);
+    }
+
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+    expect(cancel).toHaveBeenCalledWith(undefined);
+    expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function));
+    expect(body.locked).toBe(false);
+  });
+
+  test.each([
+    ['rejects', () => Promise.reject(new Error('private cancellation failure'))],
+    ['never resolves', () => Promise.race([])],
+  ])('settles an aborted pending response read when source cancellation %s', async (_, cancellation) => {
+    const cancel = vi.fn(cancellation);
+    const body = new ReadableStream<Uint8Array>({ cancel });
+    const controller = new AbortController();
+    const iterator = Stream.fromSSEResponse(new Response(body), controller)[Symbol.asyncIterator]();
+    const pending = settlesSoon(iterator.next());
+    await vi.waitFor(() => expect(body.locked).toBe(true));
+    controller.abort(new Error('private abort reason'));
+
+    await expect(pending).resolves.toEqual({ value: undefined, done: true });
+    expect(cancel.mock.calls).toEqual([[undefined]]);
+    expect(body.locked).toBe(false);
+  });
+
+  test.each(['raw', 'helper'])('settles public %s Responses aborts', async (kind) => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({ cancel });
+    const client = new OpenAI({
+      apiKey: 'test-key',
+      fetch: async () => new Response(body, { headers: { 'content-type': 'text/event-stream' } }),
+    });
+    const caller = new AbortController();
+    const onabort = vi.fn();
+    // oxlint-disable-next-line unicorn/prefer-add-event-listener -- Existing caller handlers must survive streaming.
+    caller.signal.onabort = onabort;
+    const params = { model: 'gpt-4o', input: 'hello' };
+    const completion: Promise<unknown> =
+      kind === 'raw'
+        ? client.responses
+            .create({ ...params, stream: true }, { signal: caller.signal })
+            .then((stream) => stream[Symbol.asyncIterator]().next())
+        : client.responses.stream(params, { signal: caller.signal }).finalResponse();
+    const assertion =
+      kind === 'raw'
+        ? expect(settlesSoon(completion)).resolves.toEqual({ value: undefined, done: true })
+        : expect(settlesSoon(completion)).rejects.toBeInstanceOf(APIUserAbortError);
+    const reason = new Error('private caller abort reason');
+
+    await vi.waitFor(() => expect(body.locked).toBe(true));
+    caller.abort(reason);
+
+    await assertion;
+    expect(caller.signal.reason).toBe(reason);
+    expect(caller.signal.onabort).toBe(onabort);
+    expect(cancel).toHaveBeenCalledWith(undefined);
+    expect(body.locked).toBe(false);
   });
 
   test('finishes at the completion sentinel without waiting for the response body to close', async () => {
@@ -301,6 +394,62 @@ describe('_iterSSEMessages', () => {
       'Attempted to iterate over a response with no body',
     );
     expect(controller.signal.aborted).toBe(true);
+  });
+
+  test.each([
+    ['rejects', () => Promise.reject(new Error('private iterable cancellation failure'))],
+    [
+      'throws',
+      () => {
+        throw new Error('private iterable cancellation failure');
+      },
+    ],
+    ['never resolves', () => Promise.race<IteratorResult<Uint8Array>>([])],
+  ])('settles an aborted async-only response when iterator cancellation %s', async (_, cancellation) => {
+    const returned = vi.fn(cancellation);
+    const source: AsyncIterableIterator<Uint8Array> = {
+      next: vi
+        .fn()
+        .mockResolvedValueOnce({ value: encoder.encode('data: {"id":1}\n\n'), done: false })
+        .mockImplementation(() => Promise.race<IteratorResult<Uint8Array>>([])),
+      return: returned,
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+    const body = new ReadableStream<Uint8Array>();
+    const response = new Response(body);
+    Object.defineProperties(body, {
+      getReader: { value: undefined },
+      [Symbol.asyncIterator]: { value: () => source },
+    });
+    const controller = new AbortController();
+    const events = _iterSSEMessages(response, controller);
+    await expect(events.next()).resolves.toMatchObject({ value: { data: '{"id":1}' }, done: false });
+    const pending = settlesSoon(events.next());
+
+    await vi.waitFor(() => expect(source.next).toHaveBeenCalledTimes(2));
+    controller.abort(new Error('private iterable abort reason'));
+
+    await expect(pending).resolves.toEqual({ value: undefined, done: true });
+    expect(returned.mock.calls).toEqual([[]]);
+  });
+
+  test('preserves a primary reader failure when cancellation and lock release also fail', async () => {
+    const primary = new Error('original response read failure');
+    const body = new ReadableStream<Uint8Array>();
+    const response = new Response(body);
+    const reader = body.getReader();
+    Object.defineProperty(body, 'getReader', { value: () => reader });
+    vi.spyOn(reader, 'read').mockRejectedValue(primary);
+    const cancel = vi.spyOn(reader, 'cancel').mockRejectedValue(new Error('secondary cancellation failure'));
+    const release = vi.spyOn(reader, 'releaseLock').mockImplementation(() => {
+      throw new Error('secondary lock-release failure');
+    });
+
+    await expect(collect(_iterSSEMessages(response, new AbortController()))).rejects.toBe(primary);
+    expect(cancel.mock.calls).toEqual([[]]);
+    expect(release).toHaveBeenCalledTimes(1);
   });
 
   test('ignores comments and handles CRLF-delimited multiline data', async () => {


### PR DESCRIPTION
## Summary

- Honor pre-aborted and in-flight cancellation while decoding streamed SSE responses, suppress buffered events after abort, and promptly settle pending reads.
- Cancel owned readers exactly once, preserve async-iterable response bodies and independent transport failures, and retain existing completion, signal-reason, and streaming-helper contracts.
- Cover raw Responses streams, typed helpers, hostile cancellation cleanup, and abort/error races in the existing handwritten streaming suite.

## Validation

- Node.js 22.23.0 and 26.7.0: complete handwritten suites (158 files, 6,840 tests) and generated suites (82 files, 556 tests).
- Canonical lint, strict TypeScript, release build, published TypeScript 4.9/current, publint, and package type analysis on both runtimes.
- Packed and installed the actual npm artifact and exercised CommonJS and ESM consumers on both runtimes.