### PR TITLE
fix(uploads): detect multipart bodies from own properties only

### DIFF
--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -348,7 +348,8 @@ const hasStreamingUploadableValue = (value: unknown): boolean => {
     return value.some(hasStreamingUploadableValue);
   }
   if (value && typeof value === 'object' && !isBlob(value) && !(value instanceof Response)) {
-    for (const k in value) {
+    // Own properties only, matching what form encoding serializes; inherited values are never encoded.
+    for (const k of Object.keys(value)) {
       if (hasStreamingUploadableValue((value as Record<string, unknown>)[k])) {
         return true;
       }
@@ -365,7 +366,8 @@ const hasUploadableValue = (value: unknown): boolean => {
     return value.some(hasUploadableValue);
   }
   if (value && typeof value === 'object') {
-    for (const k in value) {
+    // Own properties only, matching what form encoding serializes; inherited values are never encoded.
+    for (const k of Object.keys(value)) {
       if (hasUploadableValue((value as any)[k])) {
         return true;
       }

--- a/tests/internal/uploads-branches.test.ts
+++ b/tests/internal/uploads-branches.test.ts
@@ -140,6 +140,46 @@ describe('buffered multipart forms', () => {
     await expect(maybeMultipartFormRequestOptions(options, fetch)).resolves.toBe(options);
   });
 
+  test('ignores uploadable values inherited from a body prototype', async () => {
+    let inheritedReads = 0;
+    const prototype = Object.create(null);
+    Object.defineProperty(prototype, 'file', {
+      enumerable: true,
+      get() {
+        inheritedReads += 1;
+        return new File(['prototype bytes'], 'prototype.txt');
+      },
+    });
+    const options = { body: Object.assign(Object.create(prototype), { file_id: 'file_123' }) };
+
+    await expect(maybeMultipartFormRequestOptions(options, fetch)).resolves.toBe(options);
+    expect(inheritedReads).toBe(0);
+  });
+
+  test('selects buffered encoding from own values when a prototype holds a streaming value', async () => {
+    let inheritedReads = 0;
+    const prototype = Object.create(null);
+    Object.defineProperty(prototype, 'stream', {
+      enumerable: true,
+      get() {
+        inheritedReads += 1;
+        return (async function* prototypeChunks() {
+          yield 'prototype chunk';
+        })();
+      },
+    });
+    const upload = new File(['file contents'], 'input.jsonl');
+    const options = await maybeMultipartFormRequestOptions(
+      { body: Object.assign(Object.create(prototype), { upload }) },
+      fetch,
+    );
+
+    expect(options.body).toBeInstanceOf(FormData);
+    expect((options.body as FormData).get('upload')).toBeInstanceOf(File);
+    expect((options.body as FormData).get('stream')).toBeNull();
+    expect(inheritedReads).toBe(0);
+  });
+
   test('creates buffered multipart forms for nested File values', async () => {
     const upload = new File(['file contents'], 'input.jsonl', { type: 'application/jsonl' });
     const options = await maybeMultipartFormRequestOptions(


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

`hasUploadableValue` and `hasStreamingUploadableValue` walk candidate request bodies with `for...in`, which includes inherited enumerable properties and triggers their getters. Every serializer is own-property-only: `createForm` and the streaming encoder iterate `Object.entries`, the generated multipart encoding checks `hasOwnProperty`, and the JSON path is `JSON.stringify`. So detection and serialization can disagree about what a body contains. A body whose only `File` sits on its prototype chain flips the request to `multipart/form-data` while the form omits the value that caused the flip (reproduced with `containers.files.create`: an own `file_id` plus a prototype `file` getter sent multipart containing only `file_id`, with the foreign getter fired twice), and an inherited async iterable can flip buffered encoding to the lazy streaming path. Under the old walk, an inherited uploadable could never reach the wire under any encoding; it could only corrupt the content-type choice and fire getters the caller never exposed as own data.

This change makes both walkers iterate `Object.keys`, so detection matches what every encoder actually serializes. Two regressions land beside the existing "leaves requests without uploadable values unchanged" test: an inherited `File` no longer flips the request (and its getter is never read), and an own `File` plus an inherited streaming value selects buffered `FormData` encoding with the inherited value absent from the form.

The two remaining `for...in` walks in `src/` are intentionally untouched: `isEmptyObj` in `internal/utils/values.ts` is correct as written because inherited enumerable properties genuinely make an object non-empty (its vendored twin documents exactly that intent), and the vendored `zod-to-json-schema` utility is excluded from repository policy.

Verified locally (Node 24.18.0): both regressions fail on `main` and pass with this change; the uploads suite passes 61/61; lint, build, and the full test suite pass (158 files).

## Additional context & links

Found while auditing the multipart detection path; the fix aligns detection with the ownership contract every serializer in the module already follows.
