### PR TITLE
fix: restore native browser ESM imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,8 @@
     "./internal/auth/x509-api-origin.mjs": null,
     "./internal/auth/x509-transport-state": null,
     "./internal/auth/x509-transport-state.cjs": null,
+    "./internal/auth/x509-transport-state.js": null,
+    "./internal/auth/x509-transport-state.mjs": null,
     "./internal/auth/x509-transport-state-browser": null,
     "./internal/auth/x509-transport-state-browser.js": null,
     "./internal/auth/x509-transport-state-browser.mjs": null,

--- a/scripts/build
+++ b/scripts/build
@@ -24,6 +24,7 @@ node scripts/utils/make-dist-package-json.cjs > dist/package.json
 
 # build to .js/.mjs/.d.ts files
 node -r ts-node/register/transpile-only scripts/_vendor/tsc-multi/src/cli.ts
+cp scripts/utils/x509-transport-state.mjs dist/internal/auth/x509-transport-state.mjs
 # we need to patch index.js so that `new module.exports()` works for cjs backwards
 # compat. No way to get that from index.ts because it would cause compile errors
 # when building .mjs

--- a/scripts/utils/make-dist-package-json.cjs
+++ b/scripts/utils/make-dist-package-json.cjs
@@ -22,9 +22,13 @@ if (pkgJson.imports?.['#x509-transport-state']) {
     if (condition === 'types') {
       continue;
     }
+    if (condition === 'browser') {
+      state[condition] = './internal/auth/x509-transport-state.mjs';
+      continue;
+    }
     state[condition] = state[condition]
       .replace(/^\.\/src\//, './')
-      .replace(/\.cts$/, '.cjs')
+      .replace(/\.cts$/, condition === 'node' ? '.js' : '.cjs')
       .replace(/\.ts$/, '.mjs');
   }
 }

--- a/scripts/utils/postprocess-files.cjs
+++ b/scripts/utils/postprocess-files.cjs
@@ -18,12 +18,42 @@ async function* walk(dir) {
 }
 
 async function postprocess() {
+  const stateDirectory = path.join(distDir, 'internal/auth');
+  const canonicalState = await fs.promises.readFile(
+    path.join(stateDirectory, 'x509-transport-state.cjs'),
+    'utf-8',
+  );
+  const strictDirective = '"use strict";';
+  const sourceMapComment = '//# sourceMappingURL=';
+  if (!canonicalState.startsWith(strictDirective) || !canonicalState.includes(sourceMapComment)) {
+    throw new Error('The generated X.509 transport state no longer has its expected CommonJS format.');
+  }
+  const browserCompatibleState = canonicalState
+    .replace(
+      strictDirective,
+      `${strictDirective} if (typeof module !== 'undefined' && module !== globalThis.module && typeof exports !== 'undefined' && module.exports === exports) {`,
+    )
+    .replace(sourceMapComment, `}\n${sourceMapComment}`);
+  await fs.promises.writeFile(path.join(stateDirectory, 'x509-transport-state.js'), browserCompatibleState);
+
   for await (const file of walk(distDir)) {
-    if (!/(\.d)?[cm]?ts$/.test(file)) {
+    if (!/(\.d)?[cm]?ts$|\.mjs$/.test(file)) {
       continue;
     }
 
     const code = await fs.promises.readFile(file, 'utf-8');
+
+    if (file.endsWith('.mjs')) {
+      const statePath = path.join(distDir, 'internal/auth/x509-transport-state.mjs');
+      const relativeStatePath = path.relative(path.dirname(file), statePath).split(path.sep).join('/');
+      const stateSpecifier = relativeStatePath.startsWith('.') ? relativeStatePath : `./${relativeStatePath}`;
+      const transformed = code.replaceAll(/from (['"])#x509-transport-state\1/g, `from '${stateSpecifier}'`);
+
+      if (transformed !== code) {
+        await fs.promises.writeFile(file, transformed, 'utf-8');
+      }
+      continue;
+    }
 
     // strip out lib="dom", types="node", and types="react" references; these
     // are needed at build time, but would pollute the user's TS environment

--- a/scripts/utils/x509-transport-state.mjs
+++ b/scripts/utils/x509-transport-state.mjs
@@ -1,0 +1,19 @@
+import * as browserState from './x509-transport-state-browser.mjs';
+import * as nodeState from './x509-transport-state.js';
+
+const state = typeof nodeState.findRegisteredX509Transport === 'function' ? nodeState : browserState;
+
+export const {
+  findRegisteredX509Transport,
+  rememberRegisteredX509Transport,
+  markTransientX509ConnectionError,
+  isTransientX509ConnectionError,
+  markRetryableX509IssuerError,
+  isRetryableX509IssuerError,
+  markApprovedX509Client,
+  isApprovedX509Client,
+  rememberX509OAuthError,
+  findX509OAuthError,
+  rememberX509Credential,
+  findX509Credential,
+} = state;


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fixes #2494.

- Rewrite emitted ESM references to the private X.509 state package import into browser-resolvable relative imports.
- Keep one private state registry across Node CommonJS and ESM consumers while allowing native browsers to load the SDK directly.
- Preserve browser credential protections, blocked internal package exports, and compatibility with browser `process`, `module`, and `exports` shims.

This is intentionally the production-only release fix. Expanded browser and bundler regression coverage will follow separately.

## Additional context & links

Verified locally:

- Real headless Chrome directly imports the built SDK without an import map and rejects browser API-key usage by default, including with browser `process`, `module`, and `exports` shims.
- Browser-targeted ES2020 bundling succeeds.
- Node 22.0.0 preserves both mixed CommonJS/ESM X.509 authentication combinations.
- Existing packed-package checks pass, including CommonJS, ESM, browser conditions, and optional dependencies.
- `pnpm build`, `pnpm lint`, `pnpm exec tsc`, and 196 focused authentication/browser-security tests pass.
- The complete existing test suite previously passed: 7,548 tests, with 2 skipped.
