### PR TITLE
ci: require keyless ecosystem checks on release PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
   test_matrix:
     name: ${{ (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review') && 'test matrix' || 'test matrix (not run)' }}
     if: ${{ always() && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review') }}
-    needs: [test, benchmarks]
+    needs: [test, benchmarks, ecosystem_tests]
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -207,6 +207,7 @@ jobs:
         env:
           TEST_RESULT: ${{ needs.test.result }}
           BENCHMARKS_RESULT: ${{ needs.benchmarks.result }}
+          ECOSYSTEM_RESULT: ${{ needs.ecosystem_tests.result }}
         run: |
           if [ "$TEST_RESULT" != "success" ]; then
             echo "::error::Node.js test matrix result: $TEST_RESULT"
@@ -214,6 +215,10 @@ jobs:
           fi
           if [ "$BENCHMARKS_RESULT" != "success" ]; then
             echo "::error::Performance benchmarks result: $BENCHMARKS_RESULT"
+            exit 1
+          fi
+          if [ "$ECOSYSTEM_RESULT" != "success" ]; then
+            echo "::error::Ecosystem tests result: $ECOSYSTEM_RESULT"
             exit 1
           fi
 
@@ -311,11 +316,6 @@ jobs:
     name: ecosystem tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: >-
-      ${{
-        github.ref != 'refs/heads/release-please--branches--main--components--openai' &&
-        github.head_ref != 'release-please--branches--main--components--openai'
-      }}
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary

- Run the existing credential-free ecosystem/browser job on release-please branches as well as ordinary CI runs.
- Include ecosystem checks in the existing required `test_matrix` aggregate, failing it when the ecosystem job fails, is cancelled, or is skipped.
- Preserve read-only permissions, pinned actions, concurrent jobs, fork safety, and protected-main-only live API credentials.

This is an independently landable CI-only follow-up to #2494. The production browser-import fix is tracked separately in #2495 and is intentionally not included here.

## Verification

- `./scripts/test tests/ecosystem-cli.test.ts tests/ecosystem-browser-credential-security.test.ts` (24 tests passed)
- `./scripts/lint`
- Parsed the workflow and verified credential isolation, read-only permissions, pinned actions, release-branch execution, and required aggregate dependencies.
- Executed the aggregate script with ecosystem results `success`, `failure`, `cancelled`, and `skipped`; only `success` passes.
- Completed two consecutive clean adversarial-review rounds with two independent read-only reviewers per round.
