### PR TITLE
test: execute webpack browser bundle without live credentials

### DIFF
--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -418,6 +418,7 @@ const projectRunners = {
 
     await run('npm', ['run', 'tsc']);
     await run('npm', ['run', 'build']);
+    await run('npm', ['run', 'test:bundle']);
 
     if (state.live) {
       await run('npm', ['run', 'test:ci']);

--- a/ecosystem-tests/ts-browser-webpack/package.json
+++ b/ecosystem-tests/ts-browser-webpack/package.json
@@ -8,6 +8,7 @@
     "serve": "webpack serve",
     "build": "webpack",
     "test": "ts-node src/test.ts",
+    "test:bundle": "ts-node src/test-bundle.ts",
     "test:ci": "start-server-and-test serve http://localhost:8080 test"
   },
   "devDependencies": {

--- a/ecosystem-tests/ts-browser-webpack/src/index.ts
+++ b/ecosystem-tests/ts-browser-webpack/src/index.ts
@@ -227,4 +227,21 @@ describe('toFile', () => {
   });
 });
 
-runTests();
+const bundleOnly = (
+  globalThis as typeof globalThis & { __OPENAI_ECOSYSTEM_TEST_BUNDLE_ONLY__?: boolean }
+).__OPENAI_ECOSYSTEM_TEST_BUNDLE_ONLY__;
+
+if (bundleOnly) {
+  try {
+    const unprotectedClient = new OpenAI({ apiKey });
+    throw new Error(`Unexpected unprotected browser client: ${unprotectedClient.constructor.name}`);
+  } catch (error) {
+    if (!(error instanceof Error) || !error.message.includes('running in a browser-like environment')) {
+      throw error;
+    }
+  }
+
+  document.querySelector('#running')?.remove();
+} else {
+  runTests();
+}

--- a/ecosystem-tests/ts-browser-webpack/src/test-bundle.ts
+++ b/ecosystem-tests/ts-browser-webpack/src/test-bundle.ts
@@ -1,0 +1,56 @@
+import { once } from 'node:events';
+import { pathToFileURL } from 'node:url';
+import { launch } from 'puppeteer';
+
+(async () => {
+  const browser = await launch({ args: ['--no-sandbox'] });
+
+  try {
+    const page = await browser.newPage();
+
+    await page.setRequestInterception(true);
+    page.on('request', async (request) => {
+      if (new URL(request.url()).protocol === 'file:') {
+        await request.continue();
+        return;
+      }
+
+      await request.abort();
+    });
+
+    await page.evaluateOnNewDocument(() => {
+      Object.defineProperty(globalThis, '__OPENAI_ECOSYSTEM_TEST_API_KEY__', {
+        value: 'synthetic-browser-webpack-test-key',
+        configurable: false,
+        enumerable: false,
+        writable: false,
+      });
+      Object.defineProperty(globalThis, '__OPENAI_ECOSYSTEM_TEST_BUNDLE_ONLY__', {
+        value: true,
+        configurable: false,
+        enumerable: false,
+        writable: false,
+      });
+    });
+
+    const bundleURL = pathToFileURL('dist/index.html').href;
+    await Promise.race([
+      (async () => {
+        await page.goto(bundleURL);
+        await page.waitForSelector('#running', { hidden: true, timeout: 15_000 });
+      })(),
+      (async () => {
+        const [error] = await once(page, 'pageerror');
+        throw error instanceof Error ? error : new Error(String(error));
+      })(),
+      (async () => {
+        const [request] = await once(page, 'requestfailed');
+        throw new Error(`Unexpected network request: ${request.url()}`);
+      })(),
+    ]);
+
+    console.log('Webpack bundle executed in Chrome without live credentials or network requests');
+  } finally {
+    await browser.close();
+  }
+})();


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Execute the existing `ts-browser-webpack` fixture's actual webpack output in headless Chrome during the normal credential-free ecosystem run.
- Fail immediately on bundle/module evaluation errors, block all non-file network requests, and assert that browser credentials remain disabled by default.
- Preserve the existing live browser suite, webpack/module configuration, dependencies, workflows, and SDK production code.

## Verification

- `pnpm install --frozen-lockfile`
- `./scripts/test tests/ecosystem-browser-credential-security.test.ts tests/ecosystem-cli.test.ts` (24 tests)
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `env -u OPENAI_API_KEY PUPPETEER_EXECUTABLE_PATH=<installed-headless-chrome> PUPPETEER_SKIP_DOWNLOAD=true pnpm tsn ecosystem-tests/cli.ts ts-browser-webpack --verbose`
- Confirmed that an injected webpack evaluation error and an injected outbound request each fail the real-browser regression.

## Additional context & links

Follow-up to #2494. The production direct-browser-import fix is tracked separately in #2495 and is intentionally not included or required for this independently passing webpack regression.
