### PR TITLE
test: cover webpack ESM and CommonJS package entrypoints

### DIFF
--- a/ecosystem-tests/ts-browser-webpack/webpack.config.js
+++ b/ecosystem-tests/ts-browser-webpack/webpack.config.js
@@ -5,7 +5,26 @@ const publicPath = path.resolve(__dirname, 'public');
 const srcPath = path.resolve(__dirname, 'src');
 const buildPath = path.resolve(__dirname, 'dist');
 
-module.exports = {
+const verifyOpenAIEntrypoint = (entrypoint) => ({
+  apply(compiler) {
+    compiler.hooks.afterCompile.tap('VerifyOpenAIEntrypoint', (compilation) => {
+      if (compilation.compiler !== compiler) {
+        return;
+      }
+
+      const expectedPath = path.join(path.dirname(require.resolve('openai')), entrypoint);
+      const includesEntrypoint = [...compilation.modules].some(({ resource }) => resource === expectedPath);
+
+      if (!includesEntrypoint) {
+        compilation.errors.push(new Error(`Expected webpack to bundle openai/${entrypoint}.`));
+      }
+    });
+  },
+});
+
+const commonJSConfig = {
+  name: 'commonjs',
+
   entry: path.join(srcPath, 'index.ts'),
 
   mode: 'development',
@@ -41,6 +60,7 @@ module.exports = {
       template: path.join(publicPath, 'index.html'),
       filename: 'index.html',
     }),
+    verifyOpenAIEntrypoint('index.js'),
   ],
 
   devServer: {
@@ -51,3 +71,46 @@ module.exports = {
     port: 8080,
   },
 };
+
+const esmConfig = {
+  ...commonJSConfig,
+
+  name: 'esm',
+
+  output: {
+    ...commonJSConfig.output,
+    filename: 'bundle.esm.js',
+  },
+
+  module: {
+    ...commonJSConfig.module,
+    rules: commonJSConfig.module.rules.map((rule) =>
+      rule.use === 'ts-loader'
+        ? {
+            ...rule,
+            use: {
+              loader: 'ts-loader',
+              options: {
+                compilerOptions: {
+                  module: 'esnext',
+                  moduleResolution: 'node',
+                },
+              },
+            },
+          }
+        : rule,
+    ),
+  },
+
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: path.join(publicPath, 'index.html'),
+      filename: 'index.esm.html',
+    }),
+    verifyOpenAIEntrypoint('index.mjs'),
+  ],
+
+  devServer: undefined,
+};
+
+module.exports = [commonJSConfig, esmConfig];


### PR DESCRIPTION
## Summary

- Run the existing browser-targeted webpack fixture as separate named CommonJS and ESM consumer configurations.
- Assert directly against each compiler's module graph that CommonJS bundles `openai/index.js` and ESM bundles `openai/index.mjs`.
- Preserve the existing CommonJS `bundle.js`, `index.html`, single development server, and credential-free ecosystem harness.

This independently landable follow-up to #2494 changes only the webpack fixture configuration. The native direct-browser production fix remains separate in #2495; webpack supports the package imports mapping, so both configurations already pass against current `main`.

## Verification

- `env OPENAI_API_KEY= PUPPETEER_SKIP_DOWNLOAD=true pnpm tsn ecosystem-tests/cli.ts ts-browser-webpack --verbose`
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `./scripts/test tests/ecosystem-browser-credential-security.test.ts tests/ecosystem-cli.test.ts` (24 passing tests)
- Independently built `npm run build -- --config-name commonjs` and `npm run build -- --config-name esm`.
- Confirmed forcing the ESM fixture back to CommonJS fails its `openai/index.mjs` module-graph assertion.
- Two consecutive clean adversarial-review rounds, with two independent fresh-context read-only reviewers per round.
