### PR TITLE
ci: gate npm publication on browser-compatible imports

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -174,10 +174,86 @@ jobs:
             exit "${version_status}"
           fi
 
+  browser-compatibility:
+    name: check browser compatibility before publication
+    if: needs.publication-check.outputs.should_publish == 'true'
+    needs: publication-check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ needs.publication-check.outputs.release_sha }}
+          persist-credentials: false
+
+      - name: Verify release commit
+        env:
+          RELEASE_SHA: ${{ needs.publication-check.outputs.release_sha }}
+        run: |
+          [[ "$(git rev-parse HEAD)" == "${RELEASE_SHA}" ]]
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - name: Set up Node
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Pack the immutable release artifact
+        run: |
+          pnpm build
+          package_tarball="$(npm pack ./dist --ignore-scripts --silent --pack-destination "${RUNNER_TEMP}")"
+          package_root="$(mktemp -d "${RUNNER_TEMP}/openai-browser-package.XXXXXX")"
+          tar -xzf "${RUNNER_TEMP}/${package_tarball}" -C "${package_root}"
+          echo "BROWSER_PACKAGE_ROOT=${package_root}/package" >> "${GITHUB_ENV}"
+
+      - name: Check native-browser imports from the packed artifact
+        run: |
+          node --experimental-vm-modules --input-type=module <<'NODE'
+          import assert from 'node:assert/strict';
+          import { readFile, realpath } from 'node:fs/promises';
+          import { join, sep } from 'node:path';
+          import { fileURLToPath, pathToFileURL } from 'node:url';
+          import { SourceTextModule } from 'node:vm';
+
+          const packageRoot = await realpath(process.env.BROWSER_PACKAGE_ROOT);
+          const modules = new Map();
+
+          async function load(url) {
+            let module = modules.get(url.href);
+            if (!module) {
+              const path = await realpath(fileURLToPath(url));
+              assert(path.startsWith(`${packageRoot}${sep}`), `Module escapes packed artifact: ${path}`);
+              module = new SourceTextModule(await readFile(path, 'utf8'), { identifier: url.href });
+              modules.set(url.href, module);
+            }
+            return module;
+          }
+
+          const entrypoint = await load(pathToFileURL(join(packageRoot, 'index.mjs')));
+          await entrypoint.link((specifier, parent) => {
+            assert(
+              specifier.startsWith('./') || specifier.startsWith('../') || specifier.startsWith('/'),
+              `Native browsers cannot resolve module specifier ${JSON.stringify(specifier)} from ${parent.identifier}`,
+            );
+            return load(new URL(specifier, parent.identifier));
+          });
+
+          console.log(`Native-browser entrypoint linked ${modules.size} packed modules.`);
+          NODE
+
   publish:
     name: publish
     if: needs.publication-check.outputs.should_publish == 'true'
-    needs: publication-check
+    needs:
+      - publication-check
+      - browser-compatibility
     runs-on: ubuntu-latest
     concurrency:
       group: publish-npm-${{ needs.publication-check.outputs.release_sha }}


### PR DESCRIPTION
## Summary
- add a release-only, read-only browser-compatibility job between immutable release validation and protected npm publication
- build and `npm pack` the exact verified release commit, then link the packed native-browser ESM graph and reject browser-unresolvable package specifiers or imports outside the artifact
- preserve SHA-pinned actions, frozen dependency installation, protected release/publish environments, immutable commit binding, and OIDC-only npm publishing

## Dependency and rollout
- follow-up to #2494; the production fix is independently tracked in #2495 and is intentionally not included here
- the current `main` artifact correctly fails this guard on `#x509-transport-state`; merge #2495 before activating this fail-closed publication gate
- a temporary, local-only simulation of the production fix successfully linked all 173 packed SDK modules

## Verification
- `pnpm build`
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `node --experimental-strip-types scripts/check-node-version-policy.ts`
- executed the exact workflow scripts against the current packed artifact (expected failure on `#x509-transport-state`) and a temporary repaired artifact (173 modules linked)
- checked valid relative imports, rejected bare/private specifiers and package-root escapes, and asserted workflow ordering, immutable SHA binding, action pinning, least privilege, protected environments, and OIDC isolation
- two consecutive clean adversarial-review rounds with two independent fresh-context, read-only reviewers per round
