### PR TITLE
test: exercise direct browser imports without credentials

### DIFF
--- a/ecosystem-tests/browser-direct-import/public/index.js
+++ b/ecosystem-tests/browser-direct-import/public/index.js
@@ -22,6 +22,9 @@ async function runTests() {
     pre.textContent = JSON.stringify(results, null, 2);
   }
   for (const { path, run, timeout } of tests) {
+    if (!live && path[0] !== 'browser API-key protection remains enabled by default') {
+      continue;
+    }
     console.log('running', ...path);
     try {
       await Promise.race([
@@ -110,8 +113,28 @@ const model = 'whisper-1';
 const apiKey = /** @type {typeof globalThis & { __OPENAI_ECOSYSTEM_TEST_API_KEY__?: string }} */ (
   globalThis
 ).__OPENAI_ECOSYSTEM_TEST_API_KEY__;
+const live = /** @type {typeof globalThis & { __OPENAI_ECOSYSTEM_TEST_LIVE__?: boolean }} */ (
+  globalThis
+).__OPENAI_ECOSYSTEM_TEST_LIVE__ === true;
 
 const client = new OpenAI({ apiKey, dangerouslyAllowBrowser: true });
+
+it('browser API-key protection remains enabled by default', () => {
+  let browserError;
+  try {
+    browserError = new OpenAI({ apiKey: 'synthetic-browser-api-key' });
+  } catch (error) {
+    browserError = error;
+  }
+
+  if (
+    !(browserError instanceof Error) ||
+    !browserError.message.includes('disabled by default') ||
+    !browserError.message.includes('dangerouslyAllowBrowser')
+  ) {
+    throw new Error('Expected API-key use to be disabled in browsers by default.');
+  }
+});
 
 async function typeTests() {
   // @ts-expect-error this should error if the `Uploadable` type was resolved correctly

--- a/ecosystem-tests/browser-direct-import/src/test.ts
+++ b/ecosystem-tests/browser-direct-import/src/test.ts
@@ -7,6 +7,22 @@ import { launch } from 'puppeteer';
   let page;
   try {
     page = await browser.newPage();
+    const live =
+      process.env.OPENAI_ECOSYSTEM_TEST_LIVE === undefined
+        ? Boolean(process.env.OPENAI_API_KEY)
+        : process.env.OPENAI_ECOSYSTEM_TEST_LIVE === 'true';
+    const apiKey = live ? process.env.OPENAI_API_KEY : 'synthetic-browser-api-key';
+
+    if (!apiKey) {throw new Error('missing process.env.OPENAI_API_KEY');}
+
+    const origin = 'http://localhost:8081';
+    let rejectBrowserFailure: (error: Error) => void;
+    const browserFailure = new Promise<never>((_resolve, reject) => {
+      rejectBrowserFailure = reject;
+    });
+    if (!live) {
+      await page.setRequestInterception(true);
+    }
     const debugEvent = (subj: string) => subj.padEnd('requestfailed'.length);
     page
       .on('console', (message) =>
@@ -18,21 +34,40 @@ import { launch } from 'puppeteer';
             .padEnd('warning'.length)} ${message.text()}`,
         ),
       )
-      .on('pageerror', (error) =>
-        console.error(`${debugEvent('pageerror')} ${error instanceof Error ? error.message : String(error)}`),
-      )
-      .on('response', (response) =>
-        console.error(`${debugEvent('response')} ${response.status()} ${response.url()}`),
-      )
-      .on('requestfailed', (request) =>
-        console.error(`${debugEvent('requestfailed')} ${request.failure()?.errorText} ${request.url()}`),
-      );
+      .on('pageerror', (error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`${debugEvent('pageerror')} ${message}`);
+        rejectBrowserFailure(new Error(`Browser direct import failed: ${message}`));
+      })
+      .on('request', async (request) => {
+        if (live) {
+          return;
+        }
+        try {
+          if (new URL(request.url()).origin !== origin) {
+            await request.abort();
+            rejectBrowserFailure(new Error(`Unexpected network request during browser import: ${request.url()}`));
+            return;
+          }
+          await request.continue();
+        } catch (error) {
+          rejectBrowserFailure(error instanceof Error ? error : new Error(String(error)));
+        }
+      })
+      .on('response', (response) => {
+        console.error(`${debugEvent('response')} ${response.status()} ${response.url()}`);
+        if (response.request().resourceType() === 'script' && !response.ok()) {
+          rejectBrowserFailure(new Error(`Browser module request failed: ${response.status()} ${response.url()}`));
+        }
+      })
+      .on('requestfailed', (request) => {
+        const message = `${request.failure()?.errorText} ${request.url()}`;
+        console.error(`${debugEvent('requestfailed')} ${message}`);
+        if (request.resourceType() === 'script') {
+          rejectBrowserFailure(new Error(`Browser module request failed: ${message}`));
+        }
+      });
 
-    const apiKey = process.env.OPENAI_API_KEY;
-
-    if (!apiKey) {throw new Error('missing process.env.OPENAI_API_KEY');}
-
-    const origin = 'http://localhost:8081';
     await page.evaluateOnNewDocument(
       (key, expectedOrigin) => {
         if (location.origin !== expectedOrigin) {
@@ -48,32 +83,43 @@ import { launch } from 'puppeteer';
       apiKey,
       origin,
     );
-    await page.goto(`${origin}/index.html`);
+    await page.evaluateOnNewDocument((isLive) => {
+      Object.defineProperty(globalThis, '__OPENAI_ECOSYSTEM_TEST_LIVE__', {
+        value: isLive,
+        configurable: false,
+        enumerable: false,
+        writable: false,
+      });
+    }, live);
 
-    await page.waitForSelector('#running', { timeout: 15_000 });
+    await Promise.race([
+      browserFailure,
+      (async () => {
+        await page.goto(`${origin}/index.html`);
+        await page.waitForSelector('#results', { timeout: 15_000 });
+        await page.waitForFunction(() => !document.querySelector('#running'), {
+          timeout: live ? 3 * 60_000 : 15_000,
+        });
 
-    const start = Date.now();
-    while ((await page.$('#running')) != null && Date.now() - start < 3 * 60_000) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+        let results;
+        const resultsEl = await page.$('#results');
+        if (resultsEl) {
+          const text = await page.evaluate((el) => el.textContent, resultsEl);
+          results = text ? JSON.parse(text) : undefined;
+        }
 
-    let results;
-    const resultsEl = await page.$('#results');
-    if (resultsEl) {
-      const text = await page.evaluate((el) => el.textContent, resultsEl);
-      results = text ? JSON.parse(text) : undefined;
-    }
-
-    if (!Array.isArray(results)) {
-      throw new TypeError(`failed to get test results from page`);
-    }
-    const failed = results.filter((r) => !r.passed);
-    if (failed.length) {
-      throw new Error(
-        `${failed.length} of ${results.length} tests failed: ${JSON.stringify(failed, null, 2)}`,
-      );
-    }
-    console.log(`${results.length} tests passed!`);
+        if (!Array.isArray(results)) {
+          throw new TypeError(`failed to get test results from page`);
+        }
+        const failed = results.filter((r) => !r.passed);
+        if (failed.length) {
+          throw new Error(
+            `${failed.length} of ${results.length} tests failed: ${JSON.stringify(failed, null, 2)}`,
+          );
+        }
+        console.log(`${results.length} tests passed!`);
+      })(),
+    ]);
   } catch (error) {
     if (page) {
       try {

--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -431,10 +431,9 @@ const projectRunners = {
     await fs.symlink('../node_modules', 'public/node_modules');
 
     await run('npm', ['run', 'tsc']);
-
-    if (state.live) {
-      await run('npm', ['run', 'test:ci']);
-    }
+    await run('npm', ['run', 'test:ci'], {
+      env: { OPENAI_ECOSYSTEM_TEST_LIVE: String(state.live) },
+    });
   },
   'vercel-edge': async () => {
     await installPackage();


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

- Run the existing `browser-direct-import` Puppeteer fixture in ordinary credential-free ecosystem checks against the actual packed and installed SDK, using its existing native browser ESM import of `index.mjs` without an import map.
- Fail promptly on browser page/module-loading errors, reject and abort every off-origin request in non-live mode, and verify that browser API-key protection remains enabled by default with a synthetic credential.
- Preserve the existing live browser fixture, direct credential-backed invocation, and immutable origin-scoped credential preload.

## Verification

- `pnpm build`
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `npm run tsc` in `ecosystem-tests/browser-direct-import`
- `./scripts/test tests/ecosystem-cli.test.ts tests/ecosystem-browser-credential-security.test.ts` (24 tests)
- Real headless Chrome against current `main`: fails immediately with `Failed to resolve module specifier "#x509-transport-state"` before any API request.
- Real headless Chrome with only an ignored installed-package simulation of the separate production fix: passes the credential-free native-import and default browser API-key-protection check.
- Three adversarial review rounds, including dedicated browser credential/network security review; the final two independent two-reviewer rounds were clean.

## Additional context & links

- Regression coverage for #2494.
- Depends on the independently reviewed production fix in #2495. Until #2495 merges into `main`, this new real-browser ecosystem regression intentionally exposes the existing failure; this PR does not include or stack on that production fix.
