### PR TITLE
fix(streaming): surface server error frames and settle streams past throwing listeners

### DIFF
--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -20,7 +20,7 @@ import type {
 } from '../resources/beta/threads/runs/runs';
 import type { ReadableStream } from '../internal/shim-types';
 import { Stream } from '../streaming';
-import { APIUserAbortError, OpenAIError } from '../error';
+import { APIError, APIUserAbortError, OpenAIError } from '../error';
 import type {
   AssistantStreamEvent,
   MessageStreamEvent,
@@ -491,10 +491,7 @@ export class AssistantStream
       }
 
       case 'error': {
-        //This is included for completeness, but errors are processed in the SSE event processing so this should not occur
-        throw new Error(
-          'Encountered an error event in event processing - errors should be processed earlier',
-        );
+        throw new APIError(undefined, stableEvent.data, undefined, undefined);
       }
       default: {
         assertNever(stableEvent);

--- a/src/lib/ChatCompletionStream.ts
+++ b/src/lib/ChatCompletionStream.ts
@@ -1,5 +1,6 @@
 import { MalformedJSON, partialParse } from '../_vendor/partial-json-parser/parser';
 import {
+  APIError,
   APIUserAbortError,
   ContentFilterFinishReasonError,
   LengthFinishReasonError,
@@ -1771,6 +1772,10 @@ export class ChatCompletionStream<ParsedT = null>
     );
     let chatId;
     for await (const item of stream) {
+      if ('error' in item && typeof item.error === 'object' && item.error !== null) {
+        throw new APIError(undefined, item.error, undefined, undefined);
+      }
+
       if (isChatCompletionReadableStreamMessage(item)) {
         const message = getChatCompletionReadableStreamMessage(item);
         if (this.#currentChatCompletionSnapshot) {

--- a/src/lib/ChatCompletionStream.ts
+++ b/src/lib/ChatCompletionStream.ts
@@ -1772,7 +1772,7 @@ export class ChatCompletionStream<ParsedT = null>
     );
     let chatId;
     for await (const item of stream) {
-      if ('error' in item && typeof item.error === 'object' && item.error !== null) {
+      if ('error' in item && hasOwn(item, 'error') && typeof item.error === 'object' && item.error !== null) {
         throw new APIError(undefined, item.error, undefined, undefined);
       }
 

--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -1896,6 +1896,41 @@ export class EventStream<EventTypes extends BaseEvents> {
     return Boolean(this.#listeners[event]?.some((listener) => !listener.removed));
   }
 
+  #settleTerminalEvent<Event extends keyof EventTypes>(
+    event: Event,
+    args: EventParameters<EventTypes, Event>,
+    hasListeners: boolean,
+  ): void {
+    if (event === 'abort') {
+      const error = args[0] as APIUserAbortError;
+      if (!this.#catchingPromiseCreated && !hasListeners) {
+        Promise.reject(error);
+      }
+      this.#rejectConnectedPromise(error);
+      this.#rejectEndPromise(error);
+      this._emit('end');
+      return;
+    }
+
+    if (event === 'error') {
+      // NOTE: _emit('error', error) should only be called from #handleError().
+
+      const error = args[0] as OpenAIError;
+      if (!this.#catchingPromiseCreated && !hasListeners) {
+        // Trigger an unhandled rejection if the user hasn't registered any error handlers.
+        // If you are seeing stack traces here, make sure to handle errors via either:
+        // - runner.on('error', () => ...)
+        // - await runner.done()
+        // - await runner.finalChatCompletion()
+        // - etc.
+        Promise.reject(error);
+      }
+      this.#rejectConnectedPromise(error);
+      this.#rejectEndPromise(error);
+      this._emit('end');
+    }
+  }
+
   /** Dispatches a connection, failure, cancellation, or completion lifecycle event. */
   _emit<Event extends keyof BaseEvents>(event: Event, ...args: EventParameters<BaseEvents, Event>): void;
   /** Dispatches a typed stream event to all listeners registered for that event. */
@@ -1918,61 +1953,52 @@ export class EventStream<EventTypes extends BaseEvents> {
     }
 
     const listeners: EventListeners<EventTypes, Event> | undefined = this.#listeners[event];
-    if (listeners) {
-      this.#listeners[event] = listeners.filter((listener) => {
-        if (listener.once) {
-          listener.detached = true;
-        }
-        return !listener.once && !listener.removed;
-      }) as any;
-      this.#listenerDispatchDepth += 1;
-      try {
-        for (const registration of listeners as any) {
-          if (!registration.removed) {
-            registration.listener(...(args as any));
+    let dispatchError: unknown;
+    let dispatchThrew = false;
+    try {
+      if (listeners) {
+        this.#listeners[event] = listeners.filter((listener) => {
+          if (listener.once) {
+            listener.detached = true;
           }
-        }
-      } finally {
-        this.#listenerDispatchDepth -= 1;
-        if (this.#listenerDispatchDepth === 0) {
-          this.#cleanupEmittedListeners();
-          for (const check of this.#pendingBufferedEventChecks) {
-            this.#pendingBufferedEventChecks.delete(check);
-            if (!this.#ended) {
-              check();
+          return !listener.once && !listener.removed;
+        }) as any;
+        this.#listenerDispatchDepth += 1;
+        try {
+          for (const registration of listeners as any) {
+            if (!registration.removed) {
+              registration.listener(...(args as any));
+            }
+          }
+        } finally {
+          this.#listenerDispatchDepth -= 1;
+          if (this.#listenerDispatchDepth === 0) {
+            this.#cleanupEmittedListeners();
+            for (const check of this.#pendingBufferedEventChecks) {
+              this.#pendingBufferedEventChecks.delete(check);
+              if (!this.#ended) {
+                check();
+              }
             }
           }
         }
       }
+    } catch (error) {
+      dispatchError = error;
+      dispatchThrew = true;
     }
 
-    if (event === 'abort') {
-      const error = args[0] as APIUserAbortError;
-      if (!this.#catchingPromiseCreated && !listeners?.length) {
-        Promise.reject(error);
+    try {
+      this.#settleTerminalEvent(event, args, Boolean(listeners?.length));
+    } catch (error) {
+      if (!dispatchThrew) {
+        dispatchError = error;
+        dispatchThrew = true;
       }
-      this.#rejectConnectedPromise(error);
-      this.#rejectEndPromise(error);
-      this._emit('end');
-      return;
     }
 
-    if (event === 'error') {
-      // NOTE: _emit('error', error) should only be called from #handleError().
-
-      const error = args[0] as OpenAIError;
-      if (!this.#catchingPromiseCreated && !listeners?.length) {
-        // Trigger an unhandled rejection if the user hasn't registered any error handlers.
-        // If you are seeing stack traces here, make sure to handle errors via either:
-        // - runner.on('error', () => ...)
-        // - await runner.done()
-        // - await runner.finalChatCompletion()
-        // - etc.
-        Promise.reject(error);
-      }
-      this.#rejectConnectedPromise(error);
-      this.#rejectEndPromise(error);
-      this._emit('end');
+    if (dispatchThrew) {
+      throw dispatchError;
     }
   }
 

--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -1359,6 +1359,10 @@ export class EventStream<EventTypes extends BaseEvents> {
   #errored = false;
   #aborted = false;
   #catchingPromiseCreated = false;
+  // Terminal failure recorded during settlement, before `end` is emitted, so
+  // iterators can surface it even when a throwing user listener prevented
+  // their internal failure listeners from running.
+  #terminalFailure: { kind: 'error' | 'abort'; error: OpenAIError } | undefined;
 
   /** Creates an unstarted stream with independent connection and completion lifecycle promises. */
   constructor() {
@@ -1790,8 +1794,24 @@ export class EventStream<EventTypes extends BaseEvents> {
         rejectReader();
       }
     };
+    // A throwing user listener registered before this iterator stops dispatch
+    // before onFailure runs; adopt the failure the stream recorded during
+    // settlement so terminal errors are never converted into clean completion.
+    const adoptTerminalFailure = () => {
+      if (failure) {
+        return;
+      }
+      const terminal = this.#terminalFailure;
+      if (!terminal) {
+        return;
+      }
+      if (terminal.kind === 'error' ? rejectOnError : rejectOnAbort) {
+        failure = terminal.error;
+      }
+    };
     const onEnd = () => {
       ended = true;
+      adoptTerminalFailure();
       cleanup();
       if (!pushQueue.length) {
         rejectReader();
@@ -1826,6 +1846,9 @@ export class EventStream<EventTypes extends BaseEvents> {
           return Promise.resolve({ value, done: false });
         }
 
+        if (ended || this.ended) {
+          adoptTerminalFailure();
+        }
         if (failure && !failureDelivered) {
           failureDelivered = true;
           return Promise.reject(failure);
@@ -1841,6 +1864,9 @@ export class EventStream<EventTypes extends BaseEvents> {
       },
       return: () => {
         ended = true;
+        // The consumer walked away; terminal failures recorded later must not
+        // resurface through this iterator.
+        failureDelivered = true;
         while (bufferedEventSizes.length) {
           deactivateBufferedEvent(bufferedEventSizes.dequeue()!);
         }
@@ -1903,6 +1929,7 @@ export class EventStream<EventTypes extends BaseEvents> {
   ): void {
     if (event === 'abort') {
       const error = args[0] as APIUserAbortError;
+      this.#terminalFailure ??= { kind: 'abort', error };
       if (!this.#catchingPromiseCreated && !hasListeners) {
         Promise.reject(error);
       }
@@ -1916,6 +1943,7 @@ export class EventStream<EventTypes extends BaseEvents> {
       // NOTE: _emit('error', error) should only be called from #handleError().
 
       const error = args[0] as OpenAIError;
+      this.#terminalFailure ??= { kind: 'error', error };
       if (!this.#catchingPromiseCreated && !hasListeners) {
         // Trigger an unhandled rejection if the user hasn't registered any error handlers.
         // If you are seeing stack traces here, make sure to handle errors via either:

--- a/tests/lib/AssistantStream.test.ts
+++ b/tests/lib/AssistantStream.test.ts
@@ -1,7 +1,8 @@
 import { vi } from 'vitest';
-import { APIUserAbortError, OpenAIError } from 'openai/core/error';
+import { APIError, APIUserAbortError, OpenAIError } from 'openai/core/error';
 import { AssistantStream } from 'openai/lib/AssistantStream';
 import type { AssistantStreamEvent } from 'openai/resources/beta/assistants';
+import { Stream } from 'openai/streaming';
 import { assistantStream, completedRun } from './assistant-stream-test-utils';
 
 type Event = Record<string, any>;
@@ -1225,6 +1226,47 @@ describe('AssistantStream run-step lifecycle', () => {
 });
 
 describe('AssistantStream factories and async iteration', () => {
+  test('surfaces a server error event from a readable stream as an APIError', async () => {
+    const errorBody = {
+      message: 'upstream exploded',
+      type: 'server_error',
+      code: 'server_error',
+      param: 'thread_id',
+    };
+    const readable = new Stream(async function* errorEvents() {
+      yield { event: 'error' as const, data: errorBody };
+    }, new AbortController()).toReadableStream();
+
+    const runner = AssistantStream.fromReadableStream(readable);
+    const failure = await runner.done().then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(APIError);
+    expect(failure).toMatchObject({
+      message: 'upstream exploded',
+      code: 'server_error',
+      param: 'thread_id',
+      type: 'server_error',
+      error: errorBody,
+    });
+  });
+
+  test('surfaces an error event with malformed data as an APIError instead of crashing', async () => {
+    const readable = new Stream(async function* errorEvents() {
+      yield { event: 'error' as const, data: null as any };
+    }, new AbortController()).toReadableStream();
+
+    const runner = AssistantStream.fromReadableStream(readable);
+    const failure = await runner.done().then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(APIError);
+  });
+
   test('creates a run stream with helper metadata and preserves Headers instances', async () => {
     const runs = { create: vi.fn().mockResolvedValue(iterableEvents([completedRun()])) };
     const headers = new Headers({ 'x-custom': 'value' });
@@ -1459,9 +1501,21 @@ describe('AssistantStream factories and async iteration', () => {
     await expect(runner.finalRun()).resolves.toMatchObject({ id: 'run_123' });
   });
 
-  test('rejects unexpected streamed error events', async () => {
-    const runner = assistantStream([{ event: 'error', data: { message: 'unexpected' } }, completedRun()]);
+  test('surfaces streamed error events as APIError', async () => {
+    const error = {
+      message: 'unexpected',
+      type: 'server_error',
+      code: 'server_error',
+      param: 'thread_id',
+    };
+    const runner = assistantStream([{ event: 'error', data: error }, completedRun()]);
 
-    await expect(runner.done()).rejects.toThrow('Encountered an error event in event processing');
+    await expect(runner.done()).rejects.toMatchObject({
+      message: 'unexpected',
+      code: 'server_error',
+      param: 'thread_id',
+      type: 'server_error',
+      error,
+    });
   });
 });

--- a/tests/lib/ChatCompletionStream.test.ts
+++ b/tests/lib/ChatCompletionStream.test.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 import type OpenAI from 'openai';
-import { OpenAIError } from 'openai/error';
+import { APIError, OpenAIError } from 'openai/error';
 import { zodResponseFormat } from 'openai/helpers/zod';
 import { ChatCompletionStream } from 'openai/lib/ChatCompletionStream';
 import type { ChatCompletionSnapshot } from 'openai/lib/ChatCompletionStream';
@@ -1061,6 +1061,33 @@ describe('.stream()', () => {
     expect(collected).toHaveLength(chunks.length);
     expect(caught).toBeInstanceOf(OpenAIError);
     expect((caught as OpenAIError).message).toBe('network boom');
+  });
+
+  it('surfaces a server error frame from a readable stream as an APIError', async () => {
+    const errorBody = {
+      message: 'upstream exploded',
+      type: 'server_error',
+      code: 'server_error',
+      param: 'messages',
+    };
+    const readable = new Stream(async function* errorFrames() {
+      yield { error: errorBody };
+    }, new AbortController()).toReadableStream();
+
+    const stream = ChatCompletionStream.fromReadableStream(readable);
+    const failure = await stream.done().then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(APIError);
+    expect(failure).toMatchObject({
+      message: 'upstream exploded',
+      code: 'server_error',
+      param: 'messages',
+      type: 'server_error',
+      error: errorBody,
+    });
   });
 
   it('rejects a pending read exactly once when the stream errors while a reader is waiting', async () => {

--- a/tests/lib/ChatCompletionStream.test.ts
+++ b/tests/lib/ChatCompletionStream.test.ts
@@ -1090,6 +1090,39 @@ describe('.stream()', () => {
     });
   });
 
+  it('ignores an inherited error property when reading stream items', async () => {
+    // eslint-disable-next-line no-extend-native -- deliberately simulates prototype pollution; removed in finally
+    Object.defineProperty(Object.prototype, 'error', {
+      value: { message: 'polluted', type: 'server_error' },
+      configurable: true,
+      enumerable: false,
+      writable: true,
+    });
+    try {
+      const readable = new Stream(async function* chunks() {
+        yield {
+          id: 'chatcmpl-own',
+          object: 'chat.completion.chunk',
+          created: 0,
+          model: 'gpt-test',
+          choices: [{ index: 0, delta: { role: 'assistant', content: 'ok' }, finish_reason: null }],
+        };
+        yield {
+          id: 'chatcmpl-own',
+          object: 'chat.completion.chunk',
+          created: 0,
+          model: 'gpt-test',
+          choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+        };
+      }, new AbortController()).toReadableStream();
+
+      const stream = ChatCompletionStream.fromReadableStream(readable);
+      await expect(stream.finalContent()).resolves.toBe('ok');
+    } finally {
+      delete (Object.prototype as Record<string, unknown>)['error'];
+    }
+  });
+
   it('rejects a pending read exactly once when the stream errors while a reader is waiting', async () => {
     const chunks = [
       {

--- a/tests/lib/EventStream.test.ts
+++ b/tests/lib/EventStream.test.ts
@@ -48,8 +48,38 @@ class TestStream extends EventStream<TestEvents> {
     this._emit('abort', error);
   }
 
+  runFoo(value: string, index: number) {
+    this._run(async () => this._emit('foo', value, index));
+  }
+
   end() {
     this._emit('end');
+  }
+}
+
+function settledWithin(promise: Promise<unknown>, ticks = 50): Promise<'settled' | 'pending'> {
+  let settled = false;
+  void promise.then(
+    () => {
+      settled = true;
+    },
+    () => {
+      settled = true;
+    },
+  );
+  let chain: Promise<unknown> = Promise.resolve();
+  for (let i = 0; i < ticks; i += 1) {
+    chain = chain.then(() => null);
+  }
+  return chain.then(() => (settled ? 'settled' : 'pending'));
+}
+
+async function captureFailure(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+    return null;
+  } catch (error) {
+    return error;
   }
 }
 
@@ -85,6 +115,89 @@ describe('EventStream listeners', () => {
       expect(once).toHaveBeenCalledWith('first', 1);
     },
   );
+});
+
+describe('EventStream terminal lifecycle', () => {
+  test.each([
+    ['error', new OpenAIError('stream failed')],
+    ['abort', new APIUserAbortError()],
+  ] as const)(
+    'settles done after a throwing %s listener while preserving the listener failure',
+    async (event, terminalFailure) => {
+      const stream = new TestStream();
+      const listenerFailure = new Error('listener failed');
+      const endListener = vi.fn();
+      const doneFailure = captureFailure(stream.done());
+      stream.on(event, () => {
+        throw listenerFailure;
+      });
+      stream.on('end', endListener);
+
+      let thrown: unknown;
+      try {
+        if (event === 'error') {
+          stream.emitError(terminalFailure);
+        } else {
+          stream.emitAbort(terminalFailure);
+        }
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBe(listenerFailure);
+      expect(await settledWithin(doneFailure)).toBe('settled');
+      await expect(doneFailure).resolves.toBe(terminalFailure);
+      expect(stream.ended).toBe(true);
+      expect(endListener).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test('skips later error listeners after a throw yet still fires end', async () => {
+    const stream = new TestStream();
+    const listenerFailure = new Error('listener failed');
+    const terminalFailure = new OpenAIError('stream failed');
+    const laterErrorListener = vi.fn();
+    const endListener = vi.fn();
+    const doneFailure = captureFailure(stream.done());
+    stream.on('error', () => {
+      throw listenerFailure;
+    });
+    stream.on('error', laterErrorListener);
+    stream.on('end', endListener);
+
+    let thrown: unknown;
+    try {
+      stream.emitError(terminalFailure);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBe(listenerFailure);
+    expect(laterErrorListener).not.toHaveBeenCalled();
+    expect(endListener).toHaveBeenCalledTimes(1);
+    await expect(doneFailure).resolves.toBe(terminalFailure);
+    expect(stream.ended).toBe(true);
+  });
+
+  test('keeps later value listeners skipped while settling the failed run', async () => {
+    const stream = new TestStream();
+    const listenerFailure = new Error('listener failed');
+    const laterListener = vi.fn();
+    stream.on('foo', () => {
+      throw listenerFailure;
+    });
+    stream.on('foo', laterListener);
+
+    const doneFailure = captureFailure(stream.done());
+    stream.runFoo('payload', 1);
+
+    const failure = await doneFailure;
+    expect(failure).toBeInstanceOf(OpenAIError);
+    expect((failure as OpenAIError).message).toBe('listener failed');
+    expect((failure as Error & { cause?: unknown }).cause).toBe(listenerFailure);
+    expect(laterListener).not.toHaveBeenCalled();
+    expect(stream.ended).toBe(true);
+  });
 });
 
 describe('EventStream.emitted', () => {

--- a/tests/lib/EventStream.test.ts
+++ b/tests/lib/EventStream.test.ts
@@ -152,6 +152,47 @@ describe('EventStream terminal lifecycle', () => {
     },
   );
 
+  test('rejects a pending events() iterator when a throwing error listener starves its failure listener', async () => {
+    const stream = new TestStream();
+    const terminalFailure = new OpenAIError('stream failed');
+    stream.on('error', () => {
+      throw new Error('listener failed');
+    });
+    const iterator = stream.events('foo');
+    const pending = iterator.next();
+
+    expect(() => stream.emitError(terminalFailure)).toThrow('listener failed');
+    await expect(pending).rejects.toBe(terminalFailure);
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  test('drains buffered events then surfaces the terminal error past a throwing error listener', async () => {
+    const stream = new TestStream();
+    const terminalFailure = new OpenAIError('stream failed');
+    stream.on('error', () => {
+      throw new Error('listener failed');
+    });
+    const iterator = stream.events('foo');
+    stream.emitFoo('first', 1);
+    expect(() => stream.emitError(terminalFailure)).toThrow('listener failed');
+
+    await expect(iterator.next()).resolves.toEqual({ value: ['first', 1], done: false });
+    await expect(iterator.next()).rejects.toBe(terminalFailure);
+  });
+
+  test('rejects a pending events() iterator when a throwing abort listener starves its failure listener', async () => {
+    const stream = new TestStream();
+    const abortError = new APIUserAbortError();
+    stream.on('abort', () => {
+      throw new Error('listener failed');
+    });
+    const iterator = stream.events('foo');
+    const pending = iterator.next();
+
+    expect(() => stream.emitAbort(abortError)).toThrow('listener failed');
+    await expect(pending).rejects.toBe(abortError);
+  });
+
   test('skips later error listeners after a throw yet still fires end', async () => {
     const stream = new TestStream();
     const listenerFailure = new Error('listener failed');


### PR DESCRIPTION
`ChatCompletionStream.fromReadableStream()` turned a server error frame into `TypeError: chunk.choices is not iterable`, while `AssistantStream` returned a bare `Error` and a throwing `error` or `abort` listener could leave `done()` pending forever. This converts object-valued error frames in those helper paths to `APIError` with their server payload intact and settles terminal state before rethrowing the first listener failure; later listeners remain skipped, secondary `end` listener failures are suppressed, and the caller's catch runs after `end` listeners. `ResponseStream` already carries this contract, and #2047 is the existing cross-helper streaming precedent. I checked the red cases against the base, then ran `pnpm exec tsc`, lint, the three focused stream files with 391 tests passing, and the full suite with 6,999 handwritten and 556 generated tests passing. One otherwise-valid chunk with an extra top-level object-valued `error` key now fails with `APIError`; string error bodies remain unchanged, the check follows the function's existing property-detection style, and I can move the conversion into generic `Stream.fromReadableStream` if you prefer that broader central contract.
