### PR TITLE
ci: open release PRs ready for review

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -79,17 +79,6 @@ jobs:
           manifest-file: .release-please-manifest.json
           target-branch: main
 
-      - name: Re-draft the updated release PR
-        if: steps.release.outputs.prs_created == 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          RELEASE_PR_JSON: ${{ steps.release.outputs.pr }}
-        run: |
-          RELEASE_PR="$(jq -er '.number' <<< "${RELEASE_PR_JSON}")"
-          if [[ "$(gh pr view "${RELEASE_PR}" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq '.isDraft')" == 'false' ]]; then
-            gh pr ready "${RELEASE_PR}" --repo "${GITHUB_REPOSITORY}" --undo
-          fi
-
   publication-check:
     name: check publication state
     if: >-

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,6 @@
   "prerelease": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
-  "draft-pull-request": true,
   "pull-request-header": "Automated Release PR",
   "pull-request-title-pattern": "release: ${version}",
   "changelog-sections": [


### PR DESCRIPTION
## Summary

Align release PRs with the other SDKs, including [openai-python](https://github.com/openai/openai-python/blob/main/release-please-config.json), by opening them ready for review and keeping them ready after automated updates. Maintainers should not need to manually mark each release PR ready or repeat that step when new changes land.

The draft behavior was introduced in #2048 so a maintainer's `ready_for_review` action could trigger CI when Release Please used `GITHUB_TOKEN`. Since #2068, the workflow uses the `openai-sdks` GitHub App token, which triggers normal CI on release-branch pushes, so that workaround is no longer needed.

Remove the draft setting and the step that returns updated release PRs to draft. Release version validation, CI triggers, permissions, and publishing safeguards remain unchanged.
