### PR TITLE
fix(polling): treat a cancelled vector store file as terminal

### DIFF
--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -173,12 +173,10 @@ if (file.status !== 'completed') {
 }
 ```
 
-The helper returns files with `completed` or `failed` status; inspect `status`
-and `last_error` before assuming ingestion succeeded. It does not currently
-return for a `cancelled` file, so use an abort signal or retrieve the file
-directly when cancellation is possible. Vector-store polling uses the interval
-suggested by the API, or five seconds when none is provided; `pollIntervalMs`
-overrides that interval.
+The helper returns files with `completed`, `cancelled`, or `failed` status;
+inspect `status` and `last_error` before assuming ingestion succeeded.
+Vector-store polling uses the interval suggested by the API, or five seconds
+when none is provided; `pollIntervalMs` overrides that interval.
 
 ### Upload multiple files
 

--- a/src/lib/vector-store-polling.ts
+++ b/src/lib/vector-store-polling.ts
@@ -6,8 +6,8 @@ import { pollWithResponse } from './polling';
 type PollOptions = RequestOptions & { pollIntervalMs?: number };
 
 /**
- * Polls an attached file through the resource's retrieve method. Failed files are
- * returned to the caller, and cancelled files retain their existing retry behavior.
+ * Polls an attached file through the resource's retrieve method until it completes,
+ * fails, or is cancelled. Retrieval errors are propagated unchanged.
  *
  * @internal
  */
@@ -20,7 +20,7 @@ export function pollVectorStoreFile(
   return pollWithResponse(
     (headers) => resource.retrieve(fileID, { vector_store_id: vectorStoreID }, { ...options, headers }),
     ['in_progress'],
-    ['failed', 'completed'],
+    ['failed', 'cancelled', 'completed'],
     options,
   );
 }

--- a/tests/lib/vector-store-polling.test.ts
+++ b/tests/lib/vector-store-polling.test.ts
@@ -83,22 +83,23 @@ describe.each([
     expect(mockedSleep).not.toHaveBeenCalled();
   });
 
-  test('preserves the distinct cancelled status behavior', async () => {
+  test('stops polling a resource that stays cancelled', async () => {
     let count = 0;
     const client = new OpenAI({
       apiKey: 'test-key',
+      maxRetries: 0,
       fetch: async () => {
         count += 1;
-        return Response.json({ id, status: count === 1 ? 'cancelled' : 'completed' });
+        if (count > 10) {
+          throw new Error(`poll re-requested the ${name} after ${count - 1} cancelled responses`);
+        }
+        return Response.json({ id, status: 'cancelled' });
       },
     });
     const resource = name === 'file' ? client.vectorStores.files : client.vectorStores.fileBatches;
 
-    await expect(resource.poll('vs_123', id)).resolves.toMatchObject({
-      id,
-      status: name === 'file' ? 'completed' : 'cancelled',
-    });
-    expect(count).toBe(name === 'file' ? 2 : 1);
+    await expect(resource.poll('vs_123', id)).resolves.toMatchObject({ id, status: 'cancelled' });
+    expect(count).toBe(1);
     expect(mockedSleep).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
`vectorStores.files.poll` never returns for a `cancelled` file, and re-requests it with no delay between calls.

`vector-store-polling.ts:23` lists `['failed', 'completed']` as terminal, but `VectorStoreFile.status` is `'in_progress' | 'completed' | 'cancelled' | 'failed'`. `pollWithResponse` sleeps only for intermediate statuses and returns only for terminal ones, so `cancelled` falls through both branches of the `while (true)` loop and the next request goes out immediately.

`pollVectorStoreFileBatch` in the same file already lists `cancelled` as terminal, and `openai-python`'s `poll_vector_store_file` returns on it too, so this is the file disagreeing with itself.

Reachability is narrow and worth stating: there is no per-file cancel endpoint, so a file reaches `cancelled` only via `fileBatches.cancel`, and the hang needs someone to then poll one of those files through the single-file helper.

Two things you would otherwise find yourself. `docs/uploads.md` said the helper "does not currently return for a `cancelled` file, so use an abort signal" - I have updated that paragraph, and I am flagging it because it means this changes documented behaviour rather than fixing an oversight. It also did not mention the tight request loop, which is the part I would want fixed.

The existing `preserves the distinct cancelled status behavior` test encoded the divergence directly (`name === 'file' ? 'completed' : 'cancelled'`), so it is replaced rather than extended; the new test asserts both helpers stop after one request and fails on the tenth re-request.

Happy to drop the doc edit or narrow this to the loop alone if you would rather keep the current return semantics.
