### PR TITLE
fix: load CommonJS under browser export conditions

### DIFF
--- a/scripts/test-packed-package.ts
+++ b/scripts/test-packed-package.ts
@@ -225,6 +225,38 @@ const packedPackagePath = require('node:path');
 
     const isolatedEnvironment = { ...process.env };
     delete isolatedEnvironment['NODE_PATH'];
+    const browserConditionTest = path.join(temporaryDirectory, 'browser-condition.test.cjs');
+    fs.writeFileSync(
+      browserConditionTest,
+      [
+        "const OpenAI = require('openai');",
+        "test('loads the CommonJS entrypoint with browser export conditions', () => {",
+        "  expect(typeof OpenAI).toBe('function');",
+        "  expect(() => new OpenAI({ apiKey: 'test', dangerouslyAllowBrowser: true })).not.toThrow();",
+        '});',
+      ].join('\n'),
+    );
+    const browserConditionConfig = path.join(temporaryDirectory, 'jest-browser-condition.config.cjs');
+    fs.writeFileSync(
+      browserConditionConfig,
+      `module.exports = ${JSON.stringify({
+        testEnvironment: 'node',
+        testEnvironmentOptions: { customExportConditions: ['browser'] },
+        testMatch: ['<rootDir>/browser-condition.test.cjs'],
+        transform: {},
+      })};\n`,
+    );
+    const jestPackage = require.resolve('jest/package.json');
+    run(
+      process.execPath,
+      [
+        path.join(path.dirname(jestPackage), 'bin/jest.js'),
+        '--config',
+        browserConditionConfig,
+        '--runInBand',
+      ],
+      { env: isolatedEnvironment },
+    );
     const browserConsumer = path.join(temporaryDirectory, 'browser-consumer.mjs');
     fs.writeFileSync(browserConsumer, "import OpenAI from 'openai';\nexport default OpenAI;\n");
     const browserConfig = path.join(temporaryDirectory, 'browser.vite.config.mjs');

--- a/scripts/utils/make-dist-package-json.cjs
+++ b/scripts/utils/make-dist-package-json.cjs
@@ -23,7 +23,15 @@ if (pkgJson.imports?.['#x509-transport-state']) {
       continue;
     }
     if (condition === 'browser') {
-      state[condition] = './internal/auth/x509-transport-state.mjs';
+      state[condition] = {
+        import: './internal/auth/x509-transport-state.mjs',
+        require: './internal/auth/x509-transport-state.js',
+        default: './internal/auth/x509-transport-state.mjs',
+      };
+      continue;
+    }
+    if (condition === 'default') {
+      state[condition] = './internal/auth/x509-transport-state.js';
       continue;
     }
     state[condition] = state[condition]


### PR DESCRIPTION
## Problem

The `examples` job on current `main` / v7.8.0 fails in the CommonJS Jest/jsdom ecosystem fixtures after #2495. Jest resolves the private `#x509-transport-state` package import with the `browser` condition while executing the SDK's CommonJS entrypoint, then tries to parse `x509-transport-state-browser.mjs` as CommonJS:

```
SyntaxError: Unexpected token 'export'
```

This is reproducible in `ecosystem-tests/node-ts-cjs/tests/test-jsdom.ts` before any API request. The failing main run is https://github.com/openai/openai-node/actions/runs/33094963206.

## Root cause

The packed package maps both the `browser` condition and the unknown/default fallback for `#x509-transport-state` to ESM. Standards-compliant resolvers can distinguish nested `import` and `require` conditions, but Jest's package-import resolver falls back to the top-level `default` target in this case. A CommonJS consumer therefore receives an `.mjs` state module.

## Fix

- Emit nested browser targets: ESM imports keep the browser-compatible `.mjs` shim, while CommonJS requires use the guarded `.js` state module.
- Make the top-level default fallback use the guarded `.js` module for resolvers that do not honor the nested conditions.
- Add a packed-package Jest regression that loads the real CommonJS entrypoint with `browser` export conditions.

## Tests

Passed locally:

- `pnpm install --frozen-lockfile --registry=https://registry.npmjs.org/`
- `pnpm exec ultracite check scripts/test-packed-package.ts scripts/utils/make-dist-package-json.cjs`
- `node scripts/lint-generated.cjs --check`
- `pnpm exec tsc`
- `pnpm build`
- `./scripts/test tests/ecosystem-cli.test.ts tests/ecosystem-browser-credential-security.test.ts` (26 tests)
- Packed CommonJS Jest import with `customExportConditions: ['browser']`
- `node --conditions=browser` CommonJS and ESM package-entrypoint smoke tests
- Real Chrome native direct import without an import map; the credential-free browser protection check passed

`pnpm lint` was also attempted, but this Windows `core.autocrlf` checkout causes Oxfmt to report CRLF formatting on 737 otherwise unchanged files. The two changed files pass the targeted Ultracite check. The full packed-package script itself invokes `npm` through `execFileSync`, which is not executable by name on this Windows host; its newly added Jest regression was run directly and will run normally in Linux CI.

## Compatibility / Risk

The change only affects the generated package mapping for a private internal import. Public exports and runtime APIs are unchanged. Native browser ESM continues to use the `.mjs` shim, while CommonJS and legacy/unknown resolvers receive the existing guarded `.js` implementation. Node CommonJS, Node ESM, Jest/jsdom resolution, and the real native-browser import boundary were all checked.

Follow-up to #2494 and #2495.