### PR TITLE
fix: support Jest 28 CommonJS package imports

### DIFF
--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -25,6 +25,13 @@ async function defaultNodeRunner() {
   }
 }
 
+async function commonJSEcosystemRunner() {
+  await defaultNodeRunner();
+  if (!state.live) {
+    await run('npm', ['test', '--', '--runInBand', 'tests/import.test.ts']);
+  }
+}
+
 async function writeCloudflareCredentialFile(
   file: Awaited<ReturnType<typeof fs.open>>,
   contents: Buffer,
@@ -402,10 +409,10 @@ async function withCloudflareCredentials(apiKey: string, runLiveTest: () => Prom
 }
 
 const projectRunners = {
-  'node-ts-cjs': defaultNodeRunner,
-  'node-ts-cjs-web': defaultNodeRunner,
-  'node-ts-cjs-auto': defaultNodeRunner,
-  'node-ts4.5-jest28': defaultNodeRunner,
+  'node-ts-cjs': commonJSEcosystemRunner,
+  'node-ts-cjs-web': commonJSEcosystemRunner,
+  'node-ts-cjs-auto': commonJSEcosystemRunner,
+  'node-ts4.5-jest28': commonJSEcosystemRunner,
   'node-ts-esm': defaultNodeRunner,
   'node-ts-esm-web': defaultNodeRunner,
   'node-ts-esm-auto': defaultNodeRunner,

--- a/ecosystem-tests/node-ts-cjs-auto/tests/import.test.ts
+++ b/ecosystem-tests/node-ts-cjs-auto/tests/import.test.ts
@@ -1,0 +1,6 @@
+import OpenAI from 'openai';
+
+test('loads the CommonJS entrypoint through Jest 28', () => {
+  expect(typeof OpenAI).toBe('function');
+  expect(() => new OpenAI({ apiKey: 'test', dangerouslyAllowBrowser: true })).not.toThrow();
+});

--- a/ecosystem-tests/node-ts-cjs-web/tests/import.test.ts
+++ b/ecosystem-tests/node-ts-cjs-web/tests/import.test.ts
@@ -1,0 +1,9 @@
+/**
+ * @jest-environment jest-fixed-jsdom
+ */
+import OpenAI from 'openai';
+
+test('loads the CommonJS entrypoint with browser export conditions', () => {
+  expect(typeof OpenAI).toBe('function');
+  expect(() => new OpenAI({ apiKey: 'test', dangerouslyAllowBrowser: true })).not.toThrow();
+});

--- a/ecosystem-tests/node-ts-cjs/tests/import.test.ts
+++ b/ecosystem-tests/node-ts-cjs/tests/import.test.ts
@@ -1,0 +1,9 @@
+/**
+ * @jest-environment jest-fixed-jsdom
+ */
+import OpenAI from 'openai';
+
+test('loads the CommonJS entrypoint with browser export conditions', () => {
+  expect(typeof OpenAI).toBe('function');
+  expect(() => new OpenAI({ apiKey: 'test', dangerouslyAllowBrowser: true })).not.toThrow();
+});

--- a/ecosystem-tests/node-ts4.5-jest28/tests/import.test.ts
+++ b/ecosystem-tests/node-ts4.5-jest28/tests/import.test.ts
@@ -1,0 +1,6 @@
+import OpenAI from 'openai';
+
+test('loads the CommonJS entrypoint through Jest 28', () => {
+  expect(typeof OpenAI).toBe('function');
+  expect(() => new OpenAI({ apiKey: 'test', dangerouslyAllowBrowser: true })).not.toThrow();
+});

--- a/scripts/utils/postprocess-files.cjs
+++ b/scripts/utils/postprocess-files.cjs
@@ -17,6 +17,23 @@ async function* walk(dir) {
   }
 }
 
+// Jest 28 does not resolve package imports from CommonJS modules, so keep emitted
+// CJS on the same relative private state module used by the ESM wrapper.
+function rewriteX509TransportStateImport(file, code) {
+  if (!file.endsWith('.mjs') && !file.endsWith('.js')) {
+    return;
+  }
+
+  const isModule = file.endsWith('.mjs');
+  const statePath = path.join(distDir, 'internal/auth', `x509-transport-state.${isModule ? 'mjs' : 'js'}`);
+  const relativeStatePath = path.relative(path.dirname(file), statePath).split(path.sep).join('/');
+  const stateSpecifier = relativeStatePath.startsWith('.') ? relativeStatePath : `./${relativeStatePath}`;
+
+  return isModule
+    ? code.replaceAll(/from (['"])#x509-transport-state\1/g, `from '${stateSpecifier}'`)
+    : code.replaceAll(/require\((['"])#x509-transport-state\1\)/g, `require('${stateSpecifier}')`);
+}
+
 async function postprocess() {
   const stateDirectory = path.join(distDir, 'internal/auth');
   const canonicalState = await fs.promises.readFile(
@@ -37,20 +54,16 @@ async function postprocess() {
   await fs.promises.writeFile(path.join(stateDirectory, 'x509-transport-state.js'), browserCompatibleState);
 
   for await (const file of walk(distDir)) {
-    if (!/(\.d)?[cm]?ts$|\.mjs$/.test(file)) {
+    if (!/(\.d)?[cm]?ts$|\.m?js$/.test(file)) {
       continue;
     }
 
     const code = await fs.promises.readFile(file, 'utf-8');
 
-    if (file.endsWith('.mjs')) {
-      const statePath = path.join(distDir, 'internal/auth/x509-transport-state.mjs');
-      const relativeStatePath = path.relative(path.dirname(file), statePath).split(path.sep).join('/');
-      const stateSpecifier = relativeStatePath.startsWith('.') ? relativeStatePath : `./${relativeStatePath}`;
-      const transformed = code.replaceAll(/from (['"])#x509-transport-state\1/g, `from '${stateSpecifier}'`);
-
-      if (transformed !== code) {
-        await fs.promises.writeFile(file, transformed, 'utf-8');
+    const rewrittenStateImport = rewriteX509TransportStateImport(file, code);
+    if (rewrittenStateImport !== undefined) {
+      if (rewrittenStateImport !== code) {
+        await fs.promises.writeFile(file, rewrittenStateImport, 'utf-8');
       }
       continue;
     }


### PR DESCRIPTION
## Problem

After #2507 fixes the CommonJS + browser-condition Jest failure, the main-only examples job still has two CommonJS fixtures that fail under Jest 28:

```
Cannot find module '#x509-transport-state'
```

Jest 28 does not resolve the package `imports` alias from the emitted CommonJS modules.

## Fix

- Rewrite emitted CommonJS `require('#x509-transport-state')` calls to relative `.js` state-module paths during package postprocessing.
- Keep the existing ESM rewrite and shared guarded X.509 state module behavior unchanged.
- Add import-only tests for all four CommonJS ecosystem fixtures.
- Run those deterministic import checks in the credential-free ecosystem runner so PR CI covers Jest 28 and Jest/jsdom without live API credentials.

## Verification

Passed locally:

- `pnpm tsn ecosystem-tests/cli.ts node-ts4.5-jest28 --verbose --retry=0` (failed before the fix, passed after)
- `pnpm tsn ecosystem-tests/cli.ts node-ts-cjs node-ts-cjs-web node-ts-cjs-auto node-ts4.5-jest28 --verbose --parallel --jobs=4 --retry=0`
- `./scripts/test tests/ecosystem-cli.test.ts tests/ecosystem-browser-credential-security.test.ts` (26 tests)
- `node --experimental-strip-types scripts/test-packed-package.ts`
- `pnpm lint`
- `pnpm exec tsc`

Also attempted the complete credential-free ecosystem matrix. All relevant Node/CommonJS fixtures passed; the local run could not complete Bun (binary unavailable), Deno (sandboxed cache permissions), or browser-direct/webpack checks (Chrome launch unavailable). These are local environment limitations, not failures in the changed paths.

Follow-up to #2507 and #2509.