### PR TITLE
fix(azure): carry declared options through withOptions and fix deployment paths

### DIFF
--- a/src/azure.ts
+++ b/src/azure.ts
@@ -3,7 +3,7 @@ import type { NullableHeaders } from './internal/headers';
 import { buildHeaders } from './internal/headers';
 import * as Errors from './error';
 import type { FinalRequestOptions } from './internal/request-options';
-import { isObj, readEnv } from './internal/utils';
+import { hasOwn, isObj, readEnv } from './internal/utils';
 import { path } from './internal/utils/path';
 import { OpenAI } from './client';
 import type { ClientOptions } from './client';
@@ -162,8 +162,9 @@ export class AzureOpenAI extends OpenAI {
     };
 
     // The inherited base URL is always carried into the clone, so an `endpoint` override would
-    // otherwise collide with it; let the endpoint rebuild the base URL instead.
-    if (options.endpoint !== undefined && options.baseURL === undefined) {
+    // otherwise collide with it; let the endpoint rebuild the base URL instead. Both tests read
+    // own properties, so an option bag that passed neither field keeps the inherited base URL.
+    if (hasOwn(options, 'endpoint') && options.endpoint !== undefined && !hasOwn(options, 'baseURL')) {
       azureOptions.baseURL = undefined;
     }
 
@@ -236,7 +237,13 @@ export class AzureOpenAI extends OpenAI {
  * such as `/deployments-proxy/`, or a host like `deployments.example.com`.
  */
 function hasDeploymentPathSegment(baseURL: string): boolean {
-  return new URL(baseURL).pathname.split('/').includes('deployments');
+  try {
+    return new URL(baseURL).pathname.split('/').includes('deployments');
+  } catch {
+    // A base URL that is not an absolute URL has no path segments to read. Report none, the way
+    // the previous substring test did, and let joining the request path reject it as it did before.
+    return false;
+  }
 }
 
 const _deployments_endpoints = new Set([

--- a/src/azure.ts
+++ b/src/azure.ts
@@ -152,7 +152,22 @@ export class AzureOpenAI extends OpenAI {
 
   /** Clones this client with Azure options; OpenAI data residency remains unsupported. */
   override withOptions(options: Partial<AzureClientOptions>): this {
-    return super.withOptions(options);
+    // `OpenAI.withOptions` rebuilds the clone from `this._options`, which never holds the
+    // Azure-only construction options, so they are re-injected here the same way the Bedrock
+    // client re-injects its own subclass-only field.
+    const azureOptions: Partial<AzureClientOptions> = {
+      apiVersion: this.apiVersion,
+      deployment: this.deploymentName,
+      ...options,
+    };
+
+    // The inherited base URL is always carried into the clone, so an `endpoint` override would
+    // otherwise collide with it; let the endpoint rebuild the base URL instead.
+    if (options.endpoint !== undefined && options.baseURL === undefined) {
+      azureOptions.baseURL = undefined;
+    }
+
+    return super.withOptions(azureOptions);
   }
 
   /** Builds an Azure request and inserts its deployment into model-scoped endpoint paths. */
@@ -178,7 +193,7 @@ export class AzureOpenAI extends OpenAI {
         throw new Error('Expected request body to be an object');
       }
       const model = this.deploymentName || options.body['model'] || options.__metadata?.['model'];
-      if (model !== undefined && !this.baseURL.includes('/deployments')) {
+      if (model !== undefined && !hasDeploymentPathSegment(this.baseURL)) {
         options.path = path`/deployments/${model}` + options.path;
       }
     }
@@ -213,6 +228,15 @@ export class AzureOpenAI extends OpenAI {
     }
     return super.authHeaders(opts, security);
   }
+}
+
+/**
+ * Reports whether the base URL already routes through a `/deployments` path segment, so the
+ * deployment must not be inserted again. A substring test would also match an unrelated segment
+ * such as `/deployments-proxy/`, or a host like `deployments.example.com`.
+ */
+function hasDeploymentPathSegment(baseURL: string): boolean {
+  return new URL(baseURL).pathname.split('/').includes('deployments');
 }
 
 const _deployments_endpoints = new Set([

--- a/tests/lib/azure-deployment-path-safety.test.ts
+++ b/tests/lib/azure-deployment-path-safety.test.ts
@@ -138,6 +138,61 @@ describe('deployment path safety', () => {
     expect(req.headers.get('api-key')).toBe(apiKey);
   });
 
+  test('does not replace a deployment whose base URL path ends at the deployments segment', async () => {
+    const client = new AzureOpenAI({
+      baseURL: `${endpoint}/openai/deployments`,
+      apiKey,
+      apiVersion,
+      deployment: 'configured-deployment',
+    });
+
+    const { url } = await client.buildRequest({
+      method: 'post',
+      path: '/chat/completions',
+      body: { model: 'ignored-request-model', messages: [] },
+    });
+
+    expect(url).toBe(`${endpoint}/openai/deployments/chat/completions?api-version=${apiVersion}`);
+  });
+
+  test('inserts a deployment when deployments is only part of a base URL path segment', async () => {
+    const client = new AzureOpenAI({
+      baseURL: 'https://gateway.example.com/azure/deployments-proxy/openai',
+      apiKey,
+      apiVersion,
+      deployment: 'configured-deployment',
+    });
+
+    const { url } = await client.buildRequest({
+      method: 'post',
+      path: '/chat/completions',
+      body: { model: 'ignored-request-model', messages: [] },
+    });
+
+    expect(url).toBe(
+      `https://gateway.example.com/azure/deployments-proxy/openai/deployments/configured-deployment/chat/completions?api-version=${apiVersion}`,
+    );
+  });
+
+  test('inserts a deployment when deployments only appears in the base URL host', async () => {
+    const client = new AzureOpenAI({
+      baseURL: 'https://deployments.example.com/openai',
+      apiKey,
+      apiVersion,
+      deployment: 'configured-deployment',
+    });
+
+    const { url } = await client.buildRequest({
+      method: 'post',
+      path: '/chat/completions',
+      body: { model: 'ignored-request-model', messages: [] },
+    });
+
+    expect(url).toBe(
+      `https://deployments.example.com/openai/deployments/configured-deployment/chat/completions?api-version=${apiVersion}`,
+    );
+  });
+
   test('does not insert a deployment into non-POST requests', async () => {
     const { url } = await requestClient.buildRequest({
       method: 'get',

--- a/tests/lib/azure-deployment-path-safety.test.ts
+++ b/tests/lib/azure-deployment-path-safety.test.ts
@@ -24,6 +24,35 @@ describe('deployment path safety', () => {
     ['gpt-4o.prod_2024', 'gpt-4o.prod_2024'],
   ] as const;
 
+  // Base URLs `new URL()` cannot parse, paired with the scheme the request URL ends up with.
+  const unparseableBaseURLCases = [
+    ['https:', 'https'],
+    ['https:/', 'https'],
+    ['https://', 'https'],
+    ['https:///', 'https'],
+    ['https:////', 'https'],
+    ['https://///', 'https'],
+    ['http://', 'http'],
+    ['http:///', 'http'],
+    ['HTTPS://', 'https'],
+    ['HTTPS:///', 'https'],
+  ] as const;
+
+  // Base URLs a raw substring test reads as having no `/deployments`, but whose WHATWG
+  // normalization — backslash separators, and stripped tab, newline and carriage return
+  // characters — exposes a real `deployments` path segment. Paired with the normalized base
+  // URL the request is built against.
+  const normalizedDeploymentSegmentCases = [
+    ['https://azure.example.com/openai\\deployments', 'https://azure.example.com/openai/deployments'],
+    [
+      'https://azure.example.com/openai\\deployments\\existing-deployment',
+      'https://azure.example.com/openai/deployments/existing-deployment',
+    ],
+    ['https://azure.example.com/openai/deploy\tments', 'https://azure.example.com/openai/deployments'],
+    ['https://azure.example.com/openai/deploy\nments', 'https://azure.example.com/openai/deployments'],
+    ['https://azure.example.com/openai/deploy\rments', 'https://azure.example.com/openai/deployments'],
+  ] as const;
+
   const requestClient = new AzureOpenAI({ endpoint, apiKey, apiVersion, fetch: testFetch });
 
   test('keeps authenticated public chat requests inside the deployment route', async () => {
@@ -191,6 +220,71 @@ describe('deployment path safety', () => {
     expect(url).toBe(
       `https://deployments.example.com/openai/deployments/configured-deployment/chat/completions?api-version=${apiVersion}`,
     );
+  });
+
+  test.each(unparseableBaseURLCases)(
+    'inserts a deployment when the base URL %s is not a parseable absolute URL',
+    async (baseURL, scheme) => {
+      const client = new AzureOpenAI({
+        baseURL,
+        apiKey,
+        apiVersion,
+        deployment: 'configured-deployment',
+      });
+
+      const { url } = await client.buildRequest({
+        method: 'post',
+        path: '/chat/completions',
+        body: { model: 'ignored-request-model', messages: [] },
+      });
+
+      // Joining the request path supplies the authority these base URLs are missing, so the
+      // first joined segment becomes the host. That is what the client built before the
+      // segment test, which read the base URL as a substring and never parsed it.
+      expect(url).toBe(
+        `${scheme}://deployments/configured-deployment/chat/completions?api-version=${apiVersion}`,
+      );
+    },
+  );
+
+  test.each(normalizedDeploymentSegmentCases)(
+    'does not replace a deployment that the base URL %j only reveals once normalized',
+    async (baseURL, normalizedBaseURL) => {
+      expect(baseURL.includes('/deployments')).toBe(false);
+
+      const client = new AzureOpenAI({
+        baseURL,
+        apiKey,
+        apiVersion,
+        deployment: 'configured-deployment',
+      });
+
+      const { req, url } = await client.buildRequest({
+        method: 'post',
+        path: '/chat/completions',
+        body: { model: 'ignored-request-model', messages: [] },
+      });
+
+      expect(url).toBe(`${normalizedBaseURL}/chat/completions?api-version=${apiVersion}`);
+      expect(req.headers.get('api-key')).toBe(apiKey);
+    },
+  );
+
+  test('still rejects a relative base URL once the request path is joined', async () => {
+    const client = new AzureOpenAI({
+      baseURL: '/openai',
+      apiKey,
+      apiVersion,
+      deployment: 'configured-deployment',
+    });
+
+    await expect(
+      client.buildRequest({
+        method: 'post',
+        path: '/chat/completions',
+        body: { model: 'ignored-request-model', messages: [] },
+      }),
+    ).rejects.toThrow(TypeError);
   });
 
   test('does not insert a deployment into non-POST requests', async () => {

--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -461,6 +461,7 @@ describe('azure withOptions', () => {
     process.env = { ...env };
     delete process.env['OPENAI_API_VERSION'];
     delete process.env['OPENAI_BASE_URL'];
+    delete process.env['AZURE_OPENAI_ENDPOINT'];
   });
 
   afterEach(() => {
@@ -563,6 +564,80 @@ describe('azure withOptions', () => {
         endpoint: 'https://yetanother.example.com',
       }),
     ).toThrow(/baseURL and endpoint are mutually exclusive/);
+  });
+
+  test('keeps the inherited base URL for an option bag that only inherits an endpoint', () => {
+    const client = new AzureOpenAI({
+      endpoint: 'https://example.com',
+      apiKey: 'My API Key',
+      apiVersion,
+    });
+    const options: Partial<AzureClientOptions> = Object.create({
+      endpoint: 'https://another.example.com',
+    });
+    options.maxRetries = 0;
+
+    expect(client.withOptions(options).baseURL).toEqual('https://example.com/openai');
+  });
+
+  test('rebases onto an own endpoint for an option bag that only inherits a baseURL', () => {
+    const client = new AzureOpenAI({
+      endpoint: 'https://example.com',
+      apiKey: 'My API Key',
+      apiVersion,
+    });
+    const options: Partial<AzureClientOptions> = Object.create({
+      baseURL: 'https://inherited.example.com/openai',
+    });
+    options.endpoint = 'https://another.example.com';
+
+    expect(client.withOptions(options).baseURL).toEqual('https://another.example.com/openai');
+  });
+
+  test('keeps the inherited base URL when the clone passes an undefined endpoint', () => {
+    const client = new AzureOpenAI({
+      endpoint: 'https://example.com',
+      apiKey: 'My API Key',
+      apiVersion,
+    });
+
+    expect(client.withOptions({ endpoint: undefined }).baseURL).toEqual('https://example.com/openai');
+  });
+
+  test('rebases onto an endpoint paired with an explicitly undefined baseURL', () => {
+    const client = new AzureOpenAI({
+      endpoint: 'https://example.com',
+      apiKey: 'My API Key',
+      apiVersion,
+    });
+
+    expect(
+      client.withOptions({ baseURL: undefined, endpoint: 'https://another.example.com' }).baseURL,
+    ).toEqual('https://another.example.com/openai');
+  });
+
+  test('still rejects a clone whose only override is an undefined baseURL', () => {
+    const client = new AzureOpenAI({
+      endpoint: 'https://example.com',
+      apiKey: 'My API Key',
+      apiVersion,
+    });
+
+    expect(() => client.withOptions({ baseURL: undefined })).toThrow(
+      /Must provide one of the `baseURL` or `endpoint` arguments, or the `AZURE_OPENAI_ENDPOINT` environment variable/,
+    );
+  });
+
+  test('still rejects a clone whose only overrides are an undefined baseURL and endpoint', () => {
+    const client = new AzureOpenAI({
+      endpoint: 'https://example.com',
+      apiKey: 'My API Key',
+      apiVersion,
+    });
+
+    expect(() => client.withOptions({ endpoint: undefined, baseURL: undefined })).toThrow(
+      /Must provide one of the `baseURL` or `endpoint` arguments, or the `AZURE_OPENAI_ENDPOINT` environment variable/,
+    );
   });
 });
 

--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -452,6 +452,120 @@ describe('instantiate azure client', () => {
   });
 });
 
+describe('azure withOptions', () => {
+  const env = process.env;
+  const testFetch = async (url: RequestInfo): Promise<Response> =>
+    Response.json({ url }, { headers: { 'content-type': 'application/json' } });
+
+  beforeEach(() => {
+    process.env = { ...env };
+    delete process.env['OPENAI_API_VERSION'];
+    delete process.env['OPENAI_BASE_URL'];
+  });
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  test('keeps the api version when it is not in the environment', () => {
+    const client = new AzureOpenAI({
+      endpoint: 'https://example.com',
+      apiKey: 'My API Key',
+      apiVersion,
+    });
+
+    expect(client.withOptions({ maxRetries: 5 }).apiVersion).toEqual(apiVersion);
+  });
+
+  test('keeps the deployment', () => {
+    const client = new AzureOpenAI({
+      endpoint: 'https://example.com',
+      apiKey: 'My API Key',
+      apiVersion,
+      deployment,
+    });
+
+    expect(client.withOptions({ maxRetries: 5 }).deploymentName).toEqual(deployment);
+  });
+
+  test('keeps routing clone requests through the configured deployment', async () => {
+    const client = new AzureOpenAI({
+      endpoint: 'https://example.com',
+      apiKey: 'My API Key',
+      apiVersion,
+      deployment,
+      fetch: testFetch,
+    });
+
+    expect(
+      await client.withOptions({ maxRetries: 0 }).chat.completions.create({
+        model,
+        messages: [{ role: 'system', content: 'Hello' }],
+      }),
+    ).toMatchObject({
+      url: `https://example.com/openai/deployments/${deployment}/chat/completions?api-version=${apiVersion}`,
+    });
+  });
+
+  test('lets an explicit api version override the inherited one', async () => {
+    const overrideApiVersion = '2024-10-21';
+    const client = new AzureOpenAI({
+      endpoint: 'https://example.com',
+      apiKey: 'My API Key',
+      apiVersion,
+      deployment,
+      fetch: testFetch,
+    });
+    const clone = client.withOptions({ apiVersion: overrideApiVersion });
+
+    expect(clone.apiVersion).toEqual(overrideApiVersion);
+    expect(
+      await clone.chat.completions.create({ model, messages: [{ role: 'system', content: 'Hello' }] }),
+    ).toMatchObject({
+      url: `https://example.com/openai/deployments/${deployment}/chat/completions?api-version=${overrideApiVersion}`,
+    });
+  });
+
+  test('rebases the clone onto an endpoint override', () => {
+    const client = new AzureOpenAI({
+      endpoint: 'https://example.com',
+      apiKey: 'My API Key',
+      apiVersion,
+    });
+
+    expect(client.withOptions({ endpoint: 'https://another.example.com' }).baseURL).toEqual(
+      'https://another.example.com/openai',
+    );
+  });
+
+  test('keeps an explicit baseURL override', () => {
+    const client = new AzureOpenAI({
+      endpoint: 'https://example.com',
+      apiKey: 'My API Key',
+      apiVersion,
+    });
+
+    expect(client.withOptions({ baseURL: 'https://another.example.com/openai' }).baseURL).toEqual(
+      'https://another.example.com/openai',
+    );
+  });
+
+  test('still rejects a clone that sets both baseURL and endpoint', () => {
+    const client = new AzureOpenAI({
+      endpoint: 'https://example.com',
+      apiKey: 'My API Key',
+      apiVersion,
+    });
+
+    expect(() =>
+      client.withOptions({
+        baseURL: 'https://another.example.com',
+        endpoint: 'https://yetanother.example.com',
+      }),
+    ).toThrow(/baseURL and endpoint are mutually exclusive/);
+  });
+});
+
 describe('azure request building', () => {
   const client = new AzureOpenAI({ baseURL: 'https://example.com', apiKey: 'My API Key', apiVersion });
 


### PR DESCRIPTION
`AzureOpenAI` overrides `withOptions` only to re-type it: `apiVersion` and `deployment` are instance fields that `OpenAI.withOptions` cannot see when it rebuilds the clone, and the inherited `baseURL` is always carried across. So a clone throws `The OPENAI_API_VERSION environment variable is missing or empty` when that variable is unset, silently rebuilds the deployment segment from `body.model` when it is set — a client configured for `deployment-a` starts sending `/openai/deployments/request-model/chat/completions`, which 404s — and rejects `withOptions({ endpoint })` with `baseURL and endpoint are mutually exclusive`, though `endpoint` is declared on the `Partial<AzureClientOptions>` the override accepts. Separately, the deployment-path suppression was a substring test on the base URL, so a host like `deployments.example.com` or a gateway path like `/azure/deployments-proxy/openai` dropped the deployment segment and Azure answered 404 with nothing to show the SDK had dropped it.

Following `src/bedrock.ts`, which overrides `withOptions` to re-inject a subclass-only field the base clone cannot see, the Azure override now re-injects `apiVersion` and `deployment` ahead of the caller's options and clears the inherited `baseURL` only when the caller passed an `endpoint` and no explicit `baseURL`, so caller-supplied values still win and `{ deployment: undefined }` still clears. The suppression now tests `new URL(baseURL).pathname` for a `deployments` path segment, so `/openai/deployments/existing` and its trailing-slash form still suppress and only the false matches change. One residual stays: with `OPENAI_BASE_URL` set, `withOptions({ endpoint })` still throws `baseURL and endpoint are mutually exclusive`, exactly as `new AzureOpenAI({ endpoint })` does in that environment.

I added 10 regression tests across `tests/lib/azure.test.ts` and `tests/lib/azure-deployment-path-safety.test.ts` — nine red before the fix, the tenth a parity pin on the boundary case — then ran lint, `tsc --noEmit`, and the full suite, with 7019 handwritten and 556 generated tests passing.

`AzureClientOptions` declares a `workloadIdentity` member that the Azure credential guard never consults, and I've deliberately left it untouched here: wiring it up would federate an Azure-only client's calls through OpenAI's own token exchange at the hardcoded `https://auth.openai.com/oauth/token`, so whether Azure should accept it or declare it `?: never` alongside `provider`/`dataResidency`/`credential`/`x509Transport` is your call, not mine — flagging it rather than changing it.
