### PR TITLE
fix: keep formatter inputs on LF across Git checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Keep formatter inputs consistent across platforms and core.autocrlf settings.
+* text=auto eol=lf

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,6 +27,21 @@ The repository's pnpm scripts use Bash. On Windows, install [Git for Windows](ht
 and run the development commands from Git Bash, where `bash` is available on `PATH`. If you run pnpm from
 PowerShell instead, add the Git for Windows `bin` directory that contains `bash.exe` to `PATH` first.
 
+The repository keeps formatter inputs on LF through `.gitattributes`. Git does not rewrite unchanged files
+when an existing `core.autocrlf=true` checkout first pulls that rule. If `git ls-files --eol AGENTS.md`
+still reports `w/crlf` and `pnpm lint` reports widespread formatting failures, first make sure
+`git status --short` is empty, then run:
+
+```sh
+$ pnpm format
+$ git add -u
+$ git status --short
+```
+
+The format command rewrites the existing checkout to LF. Because the checkout was clean, `git add -u`
+only refreshes equivalent tracked content after line-ending normalization. The final status command should
+remain empty; inspect any reported changes instead of discarding them.
+
 To set up the repository, run:
 
 ```sh

--- a/tests/oxlint-config.test.ts
+++ b/tests/oxlint-config.test.ts
@@ -42,6 +42,7 @@ test('formats an existing CRLF checkout after the LF policy is pulled', () => {
     runGit(['config', 'user.email', 'line-endings@example.com']);
     runGit(['config', 'user.name', 'Line Endings Test']);
     runGit(['config', 'core.autocrlf', 'true']);
+    runGit(['config', 'core.safecrlf', 'false']);
 
     writeFileSync(fixturePath, 'export const value = 1;\n');
     runGit(['add', 'fixture.ts']);

--- a/tests/oxlint-config.test.ts
+++ b/tests/oxlint-config.test.ts
@@ -25,6 +25,60 @@ test('keeps formatter inputs on LF across Git checkout configurations', () => {
   expect(checked.stdout.trim().split(/\r?\n/u)).toEqual(paths.map((filePath) => `${filePath}: eol: lf`));
 });
 
+test('formats an existing CRLF checkout after the LF policy is pulled', () => {
+  const fixtureRoot = mkdtempSync(path.join(tmpdir(), 'openai-node-line-endings-'));
+  const fixturePath = path.join(fixtureRoot, 'fixture.ts');
+  const runGit = (args: string[]) => {
+    const result = spawnSync('git', args, { cwd: fixtureRoot, encoding: 'utf-8' });
+
+    if (result.status !== 0) {
+      throw new Error(result.stderr);
+    }
+    return result.stdout.trim();
+  };
+
+  try {
+    runGit(['init', '--quiet']);
+    runGit(['config', 'user.email', 'line-endings@example.com']);
+    runGit(['config', 'user.name', 'Line Endings Test']);
+    runGit(['config', 'core.autocrlf', 'true']);
+
+    writeFileSync(fixturePath, 'export const value = 1;\n');
+    runGit(['add', 'fixture.ts']);
+    runGit(['commit', '--quiet', '-m', 'parent']);
+    const parent = runGit(['rev-parse', 'HEAD']);
+
+    rmSync(fixturePath);
+    runGit(['checkout', '--', 'fixture.ts']);
+    expect(readFileSync(fixturePath, 'utf-8')).toContain('\r\n');
+
+    copyFileSync(path.join(repoRoot, '.gitattributes'), path.join(fixtureRoot, '.gitattributes'));
+    runGit(['add', '.gitattributes']);
+    runGit(['commit', '--quiet', '-m', 'add LF policy']);
+    const policy = runGit(['rev-parse', 'HEAD']);
+
+    runGit(['checkout', '--quiet', '--detach', parent]);
+    runGit(['checkout', '--quiet', '--detach', policy]);
+    expect(readFileSync(fixturePath, 'utf-8')).toContain('\r\n');
+    expect(runGit(['status', '--porcelain'])).toBe('');
+
+    const formatted = spawnSync(
+      process.execPath,
+      [oxfmt, '--config', path.join(repoRoot, 'oxfmt.config.ts'), fixturePath],
+      { cwd: fixtureRoot, encoding: 'utf-8' },
+    );
+
+    if (formatted.status !== 0) {
+      throw new Error(formatted.stderr);
+    }
+    expect(readFileSync(fixturePath, 'utf-8')).not.toContain('\r\n');
+    runGit(['add', '-u']);
+    expect(runGit(['status', '--porcelain'])).toBe('');
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
 test('inherits Ultracite native plugins and enforces their rules', () => {
   const printed = spawnSync(process.execPath, [oxlint, '--print-config', 'src/internal/uploads.ts'], {
     cwd: repoRoot,

--- a/tests/oxlint-config.test.ts
+++ b/tests/oxlint-config.test.ts
@@ -14,6 +14,17 @@ function spawnPnpmScript(script: 'format' | 'lint') {
   return spawnSync(command, args, { cwd: repoRoot, encoding: 'utf-8' });
 }
 
+test('keeps formatter inputs on LF across Git checkout configurations', () => {
+  const paths = ['AGENTS.md', '.github/workflows/ci.yml', 'package.json', 'src/index.ts'];
+  const checked = spawnSync('git', ['check-attr', 'eol', '--', ...paths], {
+    cwd: repoRoot,
+    encoding: 'utf-8',
+  });
+
+  expect(checked.status).toBe(0);
+  expect(checked.stdout.trim().split(/\r?\n/u)).toEqual(paths.map((filePath) => `${filePath}: eol: lf`));
+});
+
 test('inherits Ultracite native plugins and enforces their rules', () => {
   const printed = spawnSync(process.execPath, [oxlint, '--print-config', 'src/internal/uploads.ts'], {
     cwd: repoRoot,


### PR DESCRIPTION
## Problem

On Windows, a normal Git configuration with `core.autocrlf=true` checks this repository's tracked LF files out as CRLF because the repository does not declare an end-of-line policy. Oxfmt then rejects the checkout before Oxlint runs:

- `git ls-files --eol AGENTS.md package.json src/index.ts` reported `i/lf w/crlf attr/`
- `pnpm lint` reported formatting issues in all 737 matched files

This makes a clean Windows checkout fail the documented lint command without any source changes.

## Root cause

The formatter expects LF input, but there was no `.gitattributes` rule to override a contributor's global Git line-ending conversion.

## Fix

- Add a repository-wide `text=auto eol=lf` rule so text files remain LF while Git continues to detect binary files.
- Add a focused policy regression test that checks the effective Git `eol` attribute for representative Markdown, workflow YAML, JSON, and TypeScript inputs.

## Tests

Passed:

- Regression test before the fix: failed with `eol: unspecified` for all representative files
- `./scripts/test tests/oxlint-config.test.ts` (10/10)
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm exec tsc`
- `pnpm lint` (737 files)
- Fresh clone with `core.autocrlf=true`: representative files reported `i/lf w/lf attr/text=auto eol=lf`

The complete `./scripts/test` suite was also attempted on Windows: 6,941 tests passed and 69 unrelated tests failed in existing Unix-permission/symlink, temporary-process cleanup, Bash-path, and timing-sensitive fixtures. The generated-only follow-up was blocked by the local OpenAPI metadata mismatch and the Windows environment not providing `lsof`. No failure was in the changed policy test.

## Compatibility / Risk

Low risk. This changes no SDK runtime code, public API, generated output, dependency, or package metadata. `text=auto` keeps binary detection intact; only tracked text checkout line endings are made deterministic across platforms.