### PR TITLE
fix: preserve package selection in parallel ecosystem tests

### DIFF
--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -844,7 +844,7 @@ async function main() {
                       ...(args.live ? ['--live'] : []),
                       ...(args.verbose ? ['--verbose'] : []),
                       ...(args.deploy ? ['--deploy'] : []),
-                      ...(args.fromNpm ? ['--from-npm'] : []),
+                      ...(args.fromNpm ? [`--from-npm=${args.fromNpm}`] : []),
                     ],
                     {
                       stdio: 'pipe',

--- a/tests/ecosystem-cli.test.ts
+++ b/tests/ecosystem-cli.test.ts
@@ -170,6 +170,73 @@ describe('ecosystem test CLI', () => {
   });
 
   test.each([
+    { name: 'sequential', options: [], packageOption: '--fromNpm' },
+    { name: 'explicit worker count', options: ['--jobs=2'], packageOption: '--fromNpm' },
+    { name: 'parallel', options: ['--parallel'], packageOption: '--from-npm' },
+  ])('installs the selected local package in $name mode', ({ options, packageOption }) => {
+    const fixture = mkdtempSync(path.join(tmpdir(), 'openai-node-ecosystem-cli-'));
+    const dependency = path.join(fixture, 'selected package = fixture');
+    const projects = ['node-js', 'cloudflare-worker'];
+    const version = '0.0.0-selected-fixture';
+
+    try {
+      mkdirSync(dependency);
+      writeFileSync(path.join(dependency, 'package.json'), JSON.stringify({ name: 'openai', version }));
+      writeFileSync(
+        path.join(fixture, 'package.json'),
+        JSON.stringify({
+          private: true,
+          packageManager: JSON.parse(readFileSync(path.join(root, 'package.json'), 'utf-8')).packageManager,
+          scripts: { tsn: 'node tsn.cjs' },
+        }),
+      );
+      writeFileSync(
+        path.join(fixture, 'tsn.cjs'),
+        `require(${JSON.stringify(path.join(root, 'node_modules/ts-node/dist/bin.js'))}).main();\n`,
+      );
+
+      for (const name of projects) {
+        const project = path.join(fixture, 'ecosystem-tests', name);
+        mkdirSync(project, { recursive: true });
+        writeFileSync(
+          path.join(project, 'package.json'),
+          JSON.stringify({ private: true, scripts: { tsc: 'node test.js' } }),
+        );
+        writeFileSync(
+          path.join(project, 'test.js'),
+          [
+            "const fs = require('node:fs');",
+            "const { version } = require('openai/package.json');",
+            "fs.writeFileSync('installed-version.txt', version);",
+          ].join('\n'),
+        );
+      }
+
+      const result = runCli(
+        [...projects, `${packageOption}=${dependency}`, '--noCleanup', ...options],
+        fixture,
+        {
+          npm_config_audit: 'false',
+          npm_config_fund: 'false',
+          npm_config_offline: 'true',
+          npm_config_package_lock: 'false',
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(0);
+      for (const project of projects) {
+        expect(
+          readFileSync(path.join(fixture, 'ecosystem-tests', project, 'installed-version.txt'), 'utf-8'),
+        ).toBe(version);
+      }
+      expect(existsSync(path.join(fixture, '.pack'))).toBe(false);
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
     {
       projectName: 'node-ts-cjs',
       option: '--live',


### PR DESCRIPTION
## Problem

The ecosystem CLI loses the value of `--fromNpm` when it starts parallel workers: it forwards only `--from-npm`. The parent deliberately skips building a local tarball when a package is selected, but each worker sees an empty selection and falls back to `.pack/openai.tgz`.

As a result, using `--fromNpm` with `--parallel` or `--jobs=2` fails when there is no local tarball, or can test a stale local tarball instead of the requested package.

## Fix

Forward the selected package as one `--from-npm=<value>` argument. This is a one-line runner change; no SDK runtime, generated code, dependencies, workflow permissions, or release policy change.

Added one table-driven integration regression covering:
- Sequential execution as an unchanged control.
- Both explicit worker counts and `--parallel`.
- Both `--fromNpm` and `--from-npm` spellings.
- A local package path containing spaces and `=`, with each real worker installing and executing the selected package.

The fixtures use local, synthetic packages and offline npm installation; no API credentials or live API requests are needed.

## Validation

Using Node.js 24.20.0 and the repository-pinned pnpm 11.5.1:
- Before the fix: sequential regression passed; both worker-mode regressions failed.
- `./scripts/test tests/ecosystem-cli.test.ts`: 23 passed.
- `pnpm install --frozen-lockfile`: passed.
- `pnpm exec tsc`: passed.
- `pnpm lint`: passed.
- `pnpm build`: passed.
- `./scripts/test`: 7,012 handwritten tests and 556 generated tests passed; 2 existing generated tests skipped.
- `git diff --check`: passed.

## Adversarial self-review

Reviewed argument boundaries, shell metacharacter handling, credential isolation, option aliases, sequential/parallel behavior, and test portability. Tightened the fixture to use the repository's pinned package manager, then repeated the review and full validation. The value remains a single argv element, and existing live/deploy gates and install/type-check credential filtering are unchanged.

Both changed files are absent from the pinned public generated snapshot (`65094c1637432c123c310d03e0cda1e7e6f1c997`). Open PRs were checked for overlapping work.