### PR TITLE
fix(polling): honor zero custom polling intervals

### DIFF
--- a/src/lib/polling.ts
+++ b/src/lib/polling.ts
@@ -92,8 +92,8 @@ function sleepUntilAborted(milliseconds: number, signal: AbortSignal): Promise<v
 
 /**
  * Repeatedly retrieves a lifecycle resource using the existing polling-helper
- * headers. Intermediate states wait for the explicit interval, server interval,
- * or five-second default; terminal states return the same parsed object.
+ * headers. Intermediate states wait for the explicit interval (including zero),
+ * the server interval, or five-second default; terminal states return the same parsed object.
  * The caller's signal interrupts intermediate waits, unknown states retry
  * immediately, and retrieval errors propagate unchanged.
  *
@@ -120,9 +120,10 @@ export async function pollWithResponse<T extends { status: string }>(
 
     if (intermediateStatuses.includes(status)) {
       let sleepInterval = 5000;
+      const pollIntervalMs = options?.pollIntervalMs;
 
-      if (options?.pollIntervalMs) {
-        sleepInterval = options.pollIntervalMs;
+      if (pollIntervalMs || pollIntervalMs === 0) {
+        sleepInterval = pollIntervalMs;
       } else {
         const headerInterval = response.headers.get('openai-poll-after-ms');
         if (headerInterval) {

--- a/tests/lib/assistant-run-polling.test.ts
+++ b/tests/lib/assistant-run-polling.test.ts
@@ -21,7 +21,8 @@ afterEach(() => {
 
 describe('assistant run polling compatibility', () => {
   test.each([
-    { label: 'zero explicit interval', interval: 0, header: '17', expected: 17 },
+    { label: 'zero explicit interval', interval: 0, header: '17', expected: 0 },
+    { label: 'zero interval without a server interval', interval: 0, header: '', expected: 0 },
     { label: 'negative explicit interval', interval: -2, header: '17', expected: -2 },
     { label: 'NaN explicit interval', interval: Number.NaN, header: '0x10', expected: 16 },
     { label: 'numeric header prefix', interval: undefined, header: '12ms', expected: 12 },

--- a/tests/lib/polling-abort-security.test.ts
+++ b/tests/lib/polling-abort-security.test.ts
@@ -226,6 +226,24 @@ afterEach(() => {
 });
 
 describe.each(directMethods)('%s public cancellation', (_name, requests, invoke) => {
+  test.each([
+    { name: 'default interval', header: undefined },
+    { name: 'server interval', header: '9000' },
+  ])('honors a zero interval over the $name and releases its abort listener', async ({ header }) => {
+    const controller = new AbortController();
+    const { client, fetch } = createClient(header);
+    const pending = observe(invoke(client, { signal: controller.signal, pollIntervalMs: 0 }));
+
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(requestCount(fetch)).toBe(requests + 1);
+    await expect(Promise.race([pending, Promise.resolve('still polling')])).resolves.toMatchObject({
+      completed: { status: 'completed' },
+    });
+    expect(getEventListeners(controller.signal, 'abort')).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   test('promptly cancels the documented caller signal without another request', async () => {
     const controller = new AbortController();
     const { client, fetch } = createClient();

--- a/tests/lib/vector-store-polling.test.ts
+++ b/tests/lib/vector-store-polling.test.ts
@@ -23,7 +23,8 @@ describe.each([
   { name: 'batch', id: 'batch_123', segment: 'file_batches' },
 ] as const)('vector store $name polling compatibility', ({ name, id, segment }) => {
   test.each([
-    { label: 'zero explicit interval', interval: 0, header: '17', expected: 17 },
+    { label: 'zero explicit interval', interval: 0, header: '17', expected: 0 },
+    { label: 'zero interval without a server interval', interval: 0, header: '', expected: 0 },
     { label: 'negative explicit interval', interval: -2, header: '17', expected: -2 },
     { label: 'NaN explicit interval', interval: Number.NaN, header: '0x10', expected: 16 },
     { label: 'numeric header prefix', interval: undefined, header: '12ms', expected: 12 },


### PR DESCRIPTION
## Summary

Honor an explicitly configured `pollIntervalMs: 0` in the shared handwritten polling helper.

The helper already sends `X-Stainless-Custom-Poll-Interval: 0`, but its truthiness check discards zero when selecting the local delay. As a result, assistant-run, vector-store-file, and vector-store-file-batch polling wait for the server's interval or the five-second default despite the explicit override.

The fix reads the interval once per iteration and accepts zero alongside the previously accepted values. It preserves existing `NaN` fallback, negative intervals, header parsing/precedence, caller options, status handling, and cancellation behavior. Zero still uses the existing asynchronous sleep path.

## Scope and regression coverage

- Only four handwritten files change; no generated/upstream code, dependencies, exports, or release policy changes.
- Correct the existing zero-interval expectations and cover both server and default interval overrides through all three public poll methods.
- Add fake-timer public-entrypoint regressions with a real `AbortSignal`, asserting completion without the fallback wait and no retained listeners or timers.
- This does not change cancelled-file status handling, which is addressed separately by #2506.

## Validation

- Before the fix: **12 regression failures**, with the remaining 79 focused tests passing.
- After the fix: **91 focused polling/cancellation tests passed**.
- Full `CI=true ./scripts/test`: **7,018 handwritten tests and 556 generated tests passed**; 2 existing generated tests skipped.
- `pnpm exec tsc`, `pnpm lint`, and `pnpm build` passed.
- Built CommonJS and ESM packages: all **12 public polling smoke cases passed on Node 22.0.0**, covering each method with and without a caller signal.
- Completed two adversarial self-review passes covering security boundaries, compatibility, numeric edge cases, option/header preservation, timer/listener cleanup, and regression completeness. Clarified zero handling in the helper JSDoc; no further changes needed.