### PR TITLE
fix(uploads): reject zero batch upload concurrency

### DIFF
--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -203,6 +203,8 @@ if (batch.status !== 'completed' || batch.file_counts.failed > 0 || batch.file_c
 }
 ```
 
+A zero `maxConcurrency` is rejected before any upload or batch-creation request.
+
 Use `vectorStores.files.createAndPoll` or
 `vectorStores.fileBatches.createAndPoll` when files have already been uploaded
 and you only need to attach and process their IDs. These polling helpers accept

--- a/src/lib/vector-store-upload.ts
+++ b/src/lib/vector-store-upload.ts
@@ -8,7 +8,8 @@ type UploadOptions = RequestOptions & { pollIntervalMs?: number; maxConcurrency?
 
 /**
  * Uploads files with a shared iterator, then creates and polls the batch. Every
- * worker settles before upload failures are propagated.
+ * worker settles before upload failures are propagated. Zero concurrency is
+ * rejected before any upload or batch-creation request.
  *
  * @internal
  */
@@ -28,6 +29,9 @@ export async function uploadAndPollVectorStoreFileBatch(
 
   const configuredConcurrency = options?.maxConcurrency ?? 5;
   const concurrencyLimit = Math.min(configuredConcurrency, files.length);
+  if (concurrencyLimit === 0) {
+    throw new RangeError('maxConcurrency must be greater than 0');
+  }
   const fileIterator = files.values();
   const allFileIds = [...fileIds];
 

--- a/tests/lib/vector-store-upload.test.ts
+++ b/tests/lib/vector-store-upload.test.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest';
 
 import OpenAI from 'openai';
+import type { Fetch } from 'openai/internal/builtin-types';
 import type { Uploadable } from 'openai/uploads';
 import type { VectorStoreFileBatch } from 'openai/resources/vector-stores/file-batches';
 
@@ -90,22 +91,26 @@ describe('vector-store batch upload orchestration', () => {
     expect(active).toBe(0);
   });
 
-  test('preserves zero concurrency and copies existing identifiers', async () => {
-    const client = createClient();
-    const upload = vi.spyOn(client.files, 'create');
-    const createAndPoll = vi
-      .spyOn(client.vectorStores.fileBatches, 'createAndPoll')
-      .mockResolvedValue(completed);
-    const fileIds = ['existing'];
-    const options = { maxConcurrency: 0 };
+  test.each([
+    { name: 'zero with existing IDs', limit: 0, fileIds: ['existing'] },
+    { name: 'negative zero with existing IDs', limit: -0, fileIds: ['existing'] },
+    { name: 'zero without existing IDs', limit: 0, fileIds: undefined },
+  ])('rejects $name before any request', async ({ limit, fileIds }) => {
+    const fetch = vi.fn<Fetch>(async () => Response.json(completed));
+    const client = new OpenAI({ apiKey: 'test-key', baseURL: 'https://example.com/v1/', fetch });
+    const originalFileIds = fileIds === undefined ? undefined : [...fileIds];
+    const options = { maxConcurrency: limit };
 
-    await expect(
-      client.vectorStores.fileBatches.uploadAndPoll('vs_123', { files: createFiles(1), fileIds }, options),
-    ).resolves.toBe(completed);
-    expect(upload).not.toHaveBeenCalled();
-    expect(createAndPoll).toHaveBeenCalledWith('vs_123', { file_ids: ['existing'] }, options);
-    expect(createAndPoll.mock.calls[0]?.[1].file_ids).not.toBe(fileIds);
-    expect(fileIds).toEqual(['existing']);
+    const result = client.vectorStores.fileBatches.uploadAndPoll(
+      'vs_123',
+      { files: createFiles(1), ...(fileIds === undefined ? {} : { fileIds }) },
+      options,
+    );
+
+    await expect(result).rejects.toBeInstanceOf(RangeError);
+    await expect(result).rejects.toThrow('maxConcurrency must be greater than 0');
+    expect(fetch).not.toHaveBeenCalled();
+    expect(fileIds).toEqual(originalFileIds);
   });
 
   test.each([-1, Number.NaN, 1.5, Number.NEGATIVE_INFINITY])(


### PR DESCRIPTION
## Summary

Reject zero `maxConcurrency` in `vectorStores.fileBatches.uploadAndPoll` before any upload or batch-creation request.

Previously, zero created no workers, so every supplied new file was silently skipped. If the caller also supplied existing `fileIds`, the helper could create and return a successful batch containing only those existing files. Without existing IDs, it submitted an empty batch instead.

The fix is a three-line guard in the handwritten upload orchestrator. It rejects with `RangeError: maxConcurrency must be greater than 0`, including for negative zero. Valid upload concurrency, default/null behavior, file-count capping, completion-order IDs, caller options, and the existing native errors for other invalid numeric limits are unchanged.

## Scope and regression coverage

- Three handwritten files only: the guard, focused regression tests, and upload documentation. No generated/upstream code, dependencies, or exported signatures change.
- Replace the old zero-concurrency compatibility expectation, which encoded the skipped-upload behavior, with public SDK regressions using the actual fetch boundary.
- Cover zero and negative zero with existing IDs, plus zero when IDs are omitted. All cases reject without any request or identifier mutation.
- Existing positive concurrency, upload ordering, error propagation, and cancellation coverage remains intact.

## Validation

- Before the fix: both initial public-entrypoint regressions failed because the promise resolved to a completed batch.
- After the fix and coverage tightening: **73 focused upload/cancellation tests passed**.
- Full `CI=true ./scripts/test`: **7,011 handwritten tests and 556 generated tests passed**; 2 existing generated tests skipped.
- `pnpm exec tsc`, `pnpm lint`, and `pnpm build` passed.
- Built CommonJS and ESM packages: **8 public upload smoke cases passed on Node 22.0.0**, checking zero rejection and successful uploads with concurrency 1 and Infinity.
- Completed two adversarial self-review passes for security, compatibility, numeric edge cases, async failure behavior, mutation/side effects, and missing regressions. Tightened the omitted-ID case and verified its exact optional-property typing before publication.