### PR TITLE
fix(runners): suppress content events for input history

### DIFF
--- a/src/lib/ChatCompletionRunner.ts
+++ b/src/lib/ChatCompletionRunner.ts
@@ -11,7 +11,7 @@ import type { AutoParseableTool } from '../lib/parser';
 
 /** Events emitted while executing a non-streaming chat completion tool run. */
 export interface ChatCompletionRunnerEvents extends AbstractChatCompletionRunnerEvents {
-  /** Called when an assistant message with nonempty text content is received. */
+  /** Called when a new assistant message with nonempty text is received; input history is not emitted. */
   content: (content: string) => void;
 }
 
@@ -95,7 +95,7 @@ export class ChatCompletionRunner<ParsedT = null> extends AbstractChatCompletion
     emit = true,
   ) {
     super._addMessage(message, emit);
-    if (isAssistantMessage(message) && message.content) {
+    if (emit && isAssistantMessage(message) && message.content) {
       this._emit('content', message.content as string);
     }
   }

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -660,6 +660,57 @@ describe('resource completions', () => {
       await runner.done();
     });
 
+    test.each([
+      { name: 'text in default mode', content: 'Earlier reply', stream: undefined },
+      { name: 'text with stream: false', content: 'Earlier reply', stream: false as const },
+      {
+        name: 'content parts',
+        content: [{ type: 'text' as const, text: 'Earlier reply' }],
+        stream: false as const,
+      },
+    ])('does not emit assistant $name from input history', async ({ content, stream }) => {
+      const { fetch, handleRequest } = mockChatCompletionFetch();
+      const openai = new OpenAI({ apiKey: 'test-key', baseURL: 'https://example.com/v1/', fetch });
+      const messages: ChatCompletionMessageParam[] = [
+        { role: 'user', content: 'Earlier question' },
+        { role: 'assistant', content },
+        { role: 'user', content: 'Continue' },
+      ];
+      const runner = openai.chat.completions.runTools({
+        messages,
+        model: 'gpt-4o-mini',
+        tools: [],
+        ...(stream === undefined ? {} : { stream }),
+      });
+      const listener = new RunnerListener(runner);
+
+      await handleRequest(async (request) => {
+        expect(request.messages).toEqual(messages);
+        return {
+          id: 'chatcmpl_123',
+          object: 'chat.completion',
+          created: 0,
+          model: 'gpt-4o-mini',
+          choices: [
+            {
+              index: 0,
+              finish_reason: 'stop',
+              logprobs: null,
+              message: { role: 'assistant', content: 'New reply', refusal: null },
+            },
+          ],
+        };
+      });
+      await runner.done();
+
+      expect(listener.contents).toEqual(['New reply']);
+      expect(listener.messages).toMatchObject([{ role: 'assistant', content: 'New reply' }]);
+      expect(runner.messages).toHaveLength(messages.length + 1);
+      expect(runner.messages.slice(0, messages.length)).toEqual(messages);
+      expect(runner.messages[1]).toBe(messages[1]);
+      await listener.sanityCheck();
+    });
+
     test('successful flow', async () => {
       const { fetch, handleRequest } = mockChatCompletionFetch();
 


### PR DESCRIPTION
## Summary

Make non-streaming `runTools()` honor the existing `emit = false` flag while loading input history.

`AbstractChatCompletionRunner` deliberately adds initial messages without emitting events. The `ChatCompletionRunner` override forwarded that flag to the base class but ignored it for `content` events. A conversation with an earlier assistant reply therefore emitted both the old reply and the new reply as fresh content, even though `message` events correctly contained only the new response.

Structured assistant history made this worse: a content-part array could reach a listener whose public parameter type is `string`.

The runtime fix is one condition: emit content only when `emit` is true. Input history remains in the request and runner state, and newly received assistant replies retain their existing events. This matches the documented content-event contract.

## Scope and regressions

- Two handwritten files only; no generated/upstream code, dependencies, public signatures, or streaming implementation changes.
- Add public-entrypoint regressions for text history in default and explicit `stream: false` modes, plus structured content-part history.
- Check unchanged request history, retained message identity, normal new-response events, and final-result/lifecycle behavior through the existing runner assertions.
- The existing streaming-error PR #2502 addresses different files and behavior.

## Validation

- Built-package reproduction before the fix: `content` received `["Earlier reply", "New reply"]` while `message` received only `["New reply"]`.
- Both initial regressions failed before the fix, including the array-valued history case.
- After coverage tightening: **79 focused runner/stream tests passed**.
- Full `CI=true ./scripts/test`: **7,012 handwritten tests and 556 generated tests passed**; 2 existing generated tests skipped.
- `pnpm exec tsc`, `pnpm lint`, and `pnpm build` passed.
- **8 built CommonJS/ESM public runner cases passed on Node 22.0.0**, covering both non-streaming forms and both history representations.
- Completed two adversarial self-review passes for security, compatibility, event ordering, callback argument types, history identity/mutation, and missing regression coverage. Added the explicit non-streaming case and clarified the event JSDoc; no further changes needed.