### PR TITLE
fix(types): include missing parsed response stream events

### DIFF
--- a/src/lib/responses/EventTypes.ts
+++ b/src/lib/responses/EventTypes.ts
@@ -1,40 +1,7 @@
 import type {
-  ResponseAudioDeltaEvent,
-  ResponseAudioDoneEvent,
-  ResponseAudioTranscriptDeltaEvent,
-  ResponseAudioTranscriptDoneEvent,
-  ResponseCodeInterpreterCallCodeDeltaEvent,
-  ResponseCodeInterpreterCallCodeDoneEvent,
-  ResponseCodeInterpreterCallCompletedEvent,
-  ResponseCodeInterpreterCallInProgressEvent,
-  ResponseCodeInterpreterCallInterpretingEvent,
-  ResponseCompletedEvent,
-  ResponseContentPartAddedEvent,
-  ResponseContentPartDoneEvent,
-  ResponseCreatedEvent,
-  ResponseErrorEvent,
-  ResponseFailedEvent,
-  ResponseFileSearchCallCompletedEvent,
-  ResponseFileSearchCallInProgressEvent,
-  ResponseFileSearchCallSearchingEvent,
   ResponseFunctionCallArgumentsDeltaEvent as RawResponseFunctionCallArgumentsDeltaEvent,
-  ResponseFunctionCallArgumentsDoneEvent,
-  ResponseInProgressEvent,
-  ResponseOutputItemAddedEvent,
-  ResponseOutputItemDoneEvent,
-  ResponseRefusalDeltaEvent,
-  ResponseRefusalDoneEvent,
-  ResponseShellCallCommandAddedEvent,
-  ResponseShellCallCommandDeltaEvent,
-  ResponseShellCallCommandDoneEvent,
-  ResponseShellCallOutputContentDeltaEvent,
-  ResponseShellCallOutputContentDoneEvent,
+  ResponseStreamEvent,
   ResponseTextDeltaEvent as RawResponseTextDeltaEvent,
-  ResponseTextDoneEvent,
-  ResponseIncompleteEvent,
-  ResponseWebSearchCallCompletedEvent,
-  ResponseWebSearchCallInProgressEvent,
-  ResponseWebSearchCallSearchingEvent,
 } from '../../resources/responses/responses';
 
 /** A function-argument delta enhanced with the argument JSON accumulated so far. */
@@ -51,39 +18,6 @@ export type ResponseTextDeltaEvent = RawResponseTextDeltaEvent & {
 
 /** A Responses API event, with accumulated snapshots attached to text and argument deltas. */
 export type ParsedResponseStreamEvent =
-  | ResponseAudioDeltaEvent
-  | ResponseAudioDoneEvent
-  | ResponseAudioTranscriptDeltaEvent
-  | ResponseAudioTranscriptDoneEvent
-  | ResponseCodeInterpreterCallCodeDeltaEvent
-  | ResponseCodeInterpreterCallCodeDoneEvent
-  | ResponseCodeInterpreterCallCompletedEvent
-  | ResponseCodeInterpreterCallInProgressEvent
-  | ResponseCodeInterpreterCallInterpretingEvent
-  | ResponseCompletedEvent
-  | ResponseContentPartAddedEvent
-  | ResponseContentPartDoneEvent
-  | ResponseCreatedEvent
-  | ResponseErrorEvent
-  | ResponseFileSearchCallCompletedEvent
-  | ResponseFileSearchCallInProgressEvent
-  | ResponseFileSearchCallSearchingEvent
+  | Exclude<ResponseStreamEvent, RawResponseFunctionCallArgumentsDeltaEvent | RawResponseTextDeltaEvent>
   | ResponseFunctionCallArgumentsDeltaEvent
-  | ResponseFunctionCallArgumentsDoneEvent
-  | ResponseInProgressEvent
-  | ResponseFailedEvent
-  | ResponseIncompleteEvent
-  | ResponseOutputItemAddedEvent
-  | ResponseOutputItemDoneEvent
-  | ResponseRefusalDeltaEvent
-  | ResponseRefusalDoneEvent
-  | ResponseShellCallCommandAddedEvent
-  | ResponseShellCallCommandDeltaEvent
-  | ResponseShellCallCommandDoneEvent
-  | ResponseShellCallOutputContentDeltaEvent
-  | ResponseShellCallOutputContentDoneEvent
-  | ResponseTextDeltaEvent
-  | ResponseTextDoneEvent
-  | ResponseWebSearchCallCompletedEvent
-  | ResponseWebSearchCallInProgressEvent
-  | ResponseWebSearchCallSearchingEvent;
+  | ResponseTextDeltaEvent;

--- a/tests/lib/ResponseStream.test.ts
+++ b/tests/lib/ResponseStream.test.ts
@@ -1,9 +1,34 @@
-import { vi } from 'vitest';
+import { expectTypeOf, vi } from 'vitest';
 import OpenAI, { APIError, APIUserAbortError, OpenAIError } from 'openai';
 import { ReadableStreamFrom } from 'openai/internal/shims';
 import { ResponseStream } from 'openai/lib/responses/ResponseStream';
+import type {
+  ParsedResponseStreamEvent,
+  ResponseFunctionCallArgumentsDeltaEvent,
+  ResponseTextDeltaEvent,
+} from 'openai/lib/responses/EventTypes';
 import type { Response, ResponseStreamEvent } from 'openai/resources/responses/responses';
 import { makeStreamSnapshotRequest } from '../utils/mock-snapshots';
+
+test('parsed response events include every API event with unchanged non-delta shapes', () => {
+  type SnapshotDelta = ResponseTextDeltaEvent | ResponseFunctionCallArgumentsDeltaEvent;
+
+  expectTypeOf<ParsedResponseStreamEvent['type']>().toEqualTypeOf<ResponseStreamEvent['type']>();
+  expectTypeOf<Exclude<ParsedResponseStreamEvent, { type: SnapshotDelta['type'] }>>().toEqualTypeOf<
+    Exclude<ResponseStreamEvent, { type: SnapshotDelta['type'] }>
+  >();
+});
+
+test('parsed response deltas retain their required snapshots', () => {
+  expectTypeOf<ResponseTextDeltaEvent['snapshot']>().toEqualTypeOf<string>();
+  expectTypeOf<ResponseFunctionCallArgumentsDeltaEvent['snapshot']>().toEqualTypeOf<string>();
+  expectTypeOf<
+    Extract<ParsedResponseStreamEvent, { type: 'response.output_text.delta' }>
+  >().toEqualTypeOf<ResponseTextDeltaEvent>();
+  expectTypeOf<
+    Extract<ParsedResponseStreamEvent, { type: 'response.function_call_arguments.delta' }>
+  >().toEqualTypeOf<ResponseFunctionCallArgumentsDeltaEvent>();
+});
 
 describe('.stream()', () => {
   it('replays prior events when resuming by ID so snapshots stay complete', async () => {


### PR DESCRIPTION
## Summary

Derive `ParsedResponseStreamEvent` from the canonical `ResponseStreamEvent` union instead of maintaining a second event list.

The handwritten union had drifted to 36 variants while the API union has 58. It excluded valid reasoning, image-generation, MCP, queued-response, annotation, and custom-tool events. Consumers importing the parsed-event type could not assign those events or narrow them by their valid discriminators.

The replacement excludes the two raw deltas that receive SDK snapshots and substitutes their existing enriched types. All other event shapes come directly from the canonical API union, so future additions cannot silently drift out of this declaration.

## Scope and compatibility

- Two handwritten files only, with **41 fewer lines overall**. No generated/upstream code or dependencies change.
- This corrects the public type union; it does not change which events the runtime emits.
- Existing event shapes remain intact, and text/function-argument deltas still require a string `snapshot`.
- Consumers with exhaustive switches may now be prompted to handle valid event variants the old declaration omitted.

## Regression tests and adversarial review

- Added compile-time parity checks for every canonical event discriminator and every non-enriched event shape.
- Added exact enriched-delta checks, tightened during self-review with explicit required-string snapshot assertions.
- Completed two adversarial passes for security, declaration compatibility, event-shape preservation, snapshot requirements, module formats, and future schema additions.

## Validation

- The new parity assertions failed against the old source declaration.
- Isolated `.cts` and `.mts` consumers failed against the old published declarations, including image-generation narrowing, then passed after rebuilding.
- `pnpm exec tsc`, `pnpm lint`, and `pnpm build` passed.
- **149 focused response-stream/accumulator tests passed**.
- Full `CI=true ./scripts/test`: **7,011 handwritten tests and 556 generated tests passed**; 2 existing generated tests skipped.
- Published `.d.ts` and `.d.mts` consumers passed on **TypeScript 4.9.5 and 6.0.3**, including negative checks for missing snapshots.
- Published source navigation typechecked on TypeScript 4.9.5.
- CommonJS and ESM JavaScript emission is **byte-identical to the base**.