### PR TITLE
fix(auth): validate Azure metadata access token values

### DIFF
--- a/src/auth/subject-token-providers.ts
+++ b/src/auth/subject-token-providers.ts
@@ -149,6 +149,15 @@ function isMalformedAzureJSONError(error: unknown): boolean {
   }
 }
 
+function readAzureAccessToken(data: unknown): string {
+  const token =
+    typeof data === 'object' && data !== null && 'access_token' in data ? data.access_token : undefined;
+  if (typeof token !== 'string' || token.trim().length === 0) {
+    throw new SubjectTokenProviderError("IMDS response missing 'access_token' field", 'azure-imds');
+  }
+  return token;
+}
+
 /** Reads the UTF-8 contents of a Kubernetes service-account token file. */
 type ReadFile = (path: string) => Promise<string>;
 
@@ -316,9 +325,9 @@ export function azureManagedIdentityTokenProvider(
           );
         }
 
-        let data: { access_token?: string };
+        let data: unknown;
         try {
-          data = (await response.json()) as { access_token?: string };
+          data = await response.json();
         } catch (error) {
           if (isMalformedAzureJSONError(error)) {
             throw new SyntaxError('IMDS response contains invalid JSON');
@@ -326,11 +335,7 @@ export function azureManagedIdentityTokenProvider(
           throw error;
         }
 
-        if (!data.access_token) {
-          throw new SubjectTokenProviderError("IMDS response missing 'access_token' field", 'azure-imds');
-        }
-
-        return data.access_token;
+        return readAzureAccessToken(data);
       } catch (error) {
         if (error instanceof SubjectTokenProviderError) {
           throw error;

--- a/src/auth/subject-token-providers.ts
+++ b/src/auth/subject-token-providers.ts
@@ -3,6 +3,7 @@ import type { SubjectTokenProvider } from './types';
 import type { Fetch } from '../internal/builtin-types';
 import * as Shims from '../internal/shims';
 import { SubjectTokenProviderError } from '../core/error';
+import { hasOwn, isObj } from '../internal/utils/values';
 
 const DEFAULT_RESOURCE = 'https://management.azure.com/';
 const DEFAULT_AZURE_API_VERSION = '2018-02-01';
@@ -150,8 +151,7 @@ function isMalformedAzureJSONError(error: unknown): boolean {
 }
 
 function readAzureAccessToken(data: unknown): string {
-  const token =
-    typeof data === 'object' && data !== null && 'access_token' in data ? data.access_token : undefined;
+  const token = isObj(data) && hasOwn(data, 'access_token') ? data['access_token'] : undefined;
   if (typeof token !== 'string' || token.trim().length === 0) {
     throw new SubjectTokenProviderError("IMDS response missing 'access_token' field", 'azure-imds');
   }

--- a/tests/auth/azure-imds-success-response-privacy.test.ts
+++ b/tests/auth/azure-imds-success-response-privacy.test.ts
@@ -847,12 +847,76 @@ describe('Azure IMDS successful-response JSON privacy', () => {
     expect(failure.cause).toBeUndefined();
   });
 
-  it('preserves successful Azure subject-token responses', async () => {
-    const provider = azureManagedIdentityTokenProvider(undefined, {
-      fetch: async () => Response.json({ access_token: VALID_SUBJECT_TOKEN }),
+  it.each([
+    { name: 'numeric token', body: { access_token: 42 } },
+    { name: 'boolean token', body: { access_token: true } },
+    { name: 'object token', body: { access_token: { value: 'not-a-token' } } },
+    { name: 'array token', body: { access_token: ['not-a-token'] } },
+    { name: 'empty token', body: { access_token: '' } },
+    { name: 'blank token', body: { access_token: ' \t\r\n ' } },
+    { name: 'null response', body: null },
+  ])('rejects $name with a typed error and releases its timer', async ({ body }) => {
+    vi.useFakeTimers();
+    const response = Response.json(body);
+    const provider = azureManagedIdentityTokenProvider(undefined, { fetch: async () => response });
+    const result = provider.getToken();
+
+    await expect(result).rejects.toBeInstanceOf(SubjectTokenProviderError);
+    await expect(result).rejects.toMatchObject({
+      message: "IMDS response missing 'access_token' field",
+      provider: 'azure-imds',
     });
+    expect(response.bodyUsed).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it.each([VALID_SUBJECT_TOKEN, ` ${VALID_SUBJECT_TOKEN} `])(
+    'preserves nonempty Azure token text without rewriting it: %j',
+    async (token) => {
+      const provider = azureManagedIdentityTokenProvider(undefined, {
+        fetch: async () => Response.json({ access_token: token }),
+      });
+
+      await expect(provider.getToken()).resolves.toBe(token);
+    },
+  );
+
+  it.each([false, true])('reads a custom parsed token only once (inherited: %s)', async (inherited) => {
+    const readToken = vi.fn<() => unknown>().mockReturnValueOnce(VALID_SUBJECT_TOKEN).mockReturnValue(42);
+    const data = Object.defineProperty({}, 'access_token', { get: readToken });
+    const response = new Response(null);
+    vi.spyOn(response, 'json').mockResolvedValue(inherited ? Object.create(data) : data);
+    const provider = azureManagedIdentityTokenProvider(undefined, { fetch: async () => response });
 
     await expect(provider.getToken()).resolves.toBe(VALID_SUBJECT_TOKEN);
+    expect(readToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects malformed token values before exchange and allows a subsequent valid request', async () => {
+    const [privateValue] = PRIVATE_VALUES;
+    const metadataFetch = vi.fn(async () => Response.json({ access_token: { private_value: privateValue } }));
+    const apiFetch = vi
+      .fn(async () => new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(Response.json({ access_token: 'valid-openai-access-token', expires_in: 3600 }))
+      .mockResolvedValueOnce(Response.json({ object: 'list', data: [] }));
+    const client = createWorkloadClient(
+      azureManagedIdentityTokenProvider(undefined, { fetch: metadataFetch }),
+      apiFetch,
+    );
+
+    const failure = await client.models.list().catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(SubjectTokenProviderError);
+    expect(inspect(failure, { depth: null })).not.toContain(privateValue);
+    expect(metadataFetch).toHaveBeenCalledTimes(1);
+    expect(apiFetch).not.toHaveBeenCalled();
+
+    metadataFetch.mockResolvedValueOnce(Response.json({ access_token: VALID_SUBJECT_TOKEN }));
+
+    const result = await client.models.list();
+    expect(result.data).toEqual([]);
+    expect(metadataFetch).toHaveBeenCalledTimes(2);
+    expect(apiFetch).toHaveBeenCalledTimes(2);
   });
 
   it('shares concurrent public failures and allows a subsequent valid workload exchange', async () => {

--- a/tests/auth/azure-imds-success-response-privacy.test.ts
+++ b/tests/auth/azure-imds-success-response-privacy.test.ts
@@ -881,15 +881,42 @@ describe('Azure IMDS successful-response JSON privacy', () => {
     },
   );
 
-  it.each([false, true])('reads a custom parsed token only once (inherited: %s)', async (inherited) => {
+  it('reads an own custom parsed token only once', async () => {
     const readToken = vi.fn<() => unknown>().mockReturnValueOnce(VALID_SUBJECT_TOKEN).mockReturnValue(42);
     const data = Object.defineProperty({}, 'access_token', { get: readToken });
     const response = new Response(null);
-    vi.spyOn(response, 'json').mockResolvedValue(inherited ? Object.create(data) : data);
+    vi.spyOn(response, 'json').mockResolvedValue(data);
     const provider = azureManagedIdentityTokenProvider(undefined, { fetch: async () => response });
 
     await expect(provider.getToken()).resolves.toBe(VALID_SUBJECT_TOKEN);
     expect(readToken).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['data', 'accessor'] as const)('rejects inherited token %s before exchange', async (shape) => {
+    vi.useFakeTimers();
+    const readToken = vi.fn(() => VALID_SUBJECT_TOKEN);
+    const prototype = Object.defineProperty(
+      {},
+      'access_token',
+      shape === 'data' ? { value: VALID_SUBJECT_TOKEN } : { get: readToken },
+    );
+    const response = new Response(null);
+    vi.spyOn(response, 'json').mockResolvedValue(Object.create(prototype));
+    const apiFetch = vi.fn(async () => new Response(null, { status: 204 }));
+    const client = createWorkloadClient(
+      azureManagedIdentityTokenProvider(undefined, { fetch: async () => response }),
+      apiFetch,
+    );
+
+    const result = client.models.list();
+    await expect(result).rejects.toBeInstanceOf(SubjectTokenProviderError);
+    await expect(result).rejects.toMatchObject({
+      message: "IMDS response missing 'access_token' field",
+      provider: 'azure-imds',
+    });
+    expect(readToken).not.toHaveBeenCalled();
+    expect(apiFetch).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it('rejects malformed token values before exchange and allows a subsequent valid request', async () => {


### PR DESCRIPTION
## Summary

Validate the `access_token` value in successful Azure IMDS responses before returning it from `azureManagedIdentityTokenProvider().getToken()`.

The provider previously checked only truthiness. For example, `{ "access_token": 42 }` returned the number `42` from an API declared as `Promise<string>`. Truthy booleans, objects, arrays, and whitespace-only strings also passed through and could reach the workload-identity exchange before failing there.

A small private validator now requires an own `access_token` property containing a nonblank string and reads its value once, using the existing object-record and own-property helpers. Invalid values use the existing `SubjectTokenProviderError` and missing-token message without retaining the malformed value. Nonblank token text is returned verbatim; this does not parse JWTs or rewrite token contents.

## Scope and compatibility

- Two handwritten files only; no generated/upstream code, dependencies, endpoints, headers, or public signatures change.
- Existing JSON-error sanitization, rejected-response cleanup, metadata timeouts, and other subject-token providers are unchanged.
- Validation is isolated from the request method to keep the existing complexity limit intact without adding lint exceptions.

## Regressions and adversarial review

- Public provider tests cover invalid token values, a null JSON body, consumed response bodies, and cleared timeout handles.
- Positive cases preserve ordinary and space-padded nonblank strings exactly.
- Own custom JSON-result accessors are read once so validation and return use the same value. Inherited token data and accessors are rejected before the workload exchange, without invoking inherited getters.
- A public `client.models.list()` regression verifies malformed tokens never reach the exchange fetch, diagnostics do not retain the synthetic private value, and a subsequent valid request recovers.
- Completed two adversarial passes for authentication boundaries, error privacy, cleanup, compatibility, getter behavior, and missing coverage; repeated the review and validation after tightening the own-property guard.

## Validation

- Before the fix: **7 focused regressions failed**, including a built-package reproduction returning a numeric token.
- Review follow-up: both inherited-token regressions failed against the initial PR head before the own-property check.
- **243 focused provider, privacy, lifecycle, and workload-authentication tests passed**.
- Final `CI=true ./scripts/test`: **7,021 handwritten tests and 556 generated tests passed**; 2 existing generated tests skipped.
- `pnpm exec tsc`, `pnpm lint`, and `pnpm build` passed.
- **20 built CommonJS/ESM Azure provider and client-recovery checks passed on Node 22.0.0**.
- Published source typechecked on **TypeScript 4.9.5**.