### PR TITLE
fix(types): preserve runnable function tuple positions

### DIFF
--- a/ecosystem-tests/node-ts4.5-jest28/tests/import.test.ts
+++ b/ecosystem-tests/node-ts4.5-jest28/tests/import.test.ts
@@ -1,6 +1,31 @@
 import OpenAI from 'openai';
+import type { RunnableTools } from 'openai/lib/RunnableFunction';
 
 test('loads the CommonJS entrypoint through Jest 28', () => {
   expect(typeof OpenAI).toBe('function');
   expect(() => new OpenAI({ apiKey: 'test', dangerouslyAllowBrowser: true })).not.toThrow();
+});
+
+test('types fixed runnable tool tuples on TypeScript 4.5', () => {
+  const tools: RunnableTools<[{ city: string }, string]> = [
+    {
+      type: 'function',
+      function: {
+        function: (args) => args.city,
+        parse: (city) => ({ city }),
+        parameters: {},
+        description: 'Returns the parsed city',
+      },
+    },
+    {
+      type: 'function',
+      function: {
+        function: (args) => args.toUpperCase(),
+        parameters: {},
+        description: 'Returns the raw arguments',
+      },
+    },
+  ];
+
+  expect(tools.map((tool) => tool.type)).toEqual(['function', 'function']);
 });

--- a/src/lib/RunnableFunction.ts
+++ b/src/lib/RunnableFunction.ts
@@ -140,7 +140,7 @@ export type RunnableFunctions<FunctionsArgs extends BaseFunctionsArgs, ToolConte
 ] extends [FunctionsArgs]
   ? readonly RunnableFunction<any, ToolContext>[]
   : {
-      [Index in keyof FunctionsArgs]: Index extends number
+      [Index in keyof FunctionsArgs]: Index extends number | `${number}`
         ? RunnableFunction<FunctionsArgs[Index], ToolContext>
         : FunctionsArgs[Index];
     };
@@ -151,7 +151,7 @@ export type RunnableTools<FunctionsArgs extends BaseFunctionsArgs, ToolContext =
 ]
   ? readonly RunnableToolFunction<any, ToolContext>[]
   : {
-      [Index in keyof FunctionsArgs]: Index extends number
+      [Index in keyof FunctionsArgs]: Index extends number | `${number}`
         ? RunnableToolFunction<FunctionsArgs[Index], ToolContext>
         : FunctionsArgs[Index];
     };

--- a/src/lib/RunnableFunction.ts
+++ b/src/lib/RunnableFunction.ts
@@ -140,7 +140,7 @@ export type RunnableFunctions<FunctionsArgs extends BaseFunctionsArgs, ToolConte
 ] extends [FunctionsArgs]
   ? readonly RunnableFunction<any, ToolContext>[]
   : {
-      [Index in keyof FunctionsArgs]: Index extends number | `${number}`
+      [Index in keyof FunctionsArgs]: FunctionsArgs[Index] extends object | string
         ? RunnableFunction<FunctionsArgs[Index], ToolContext>
         : FunctionsArgs[Index];
     };
@@ -151,7 +151,7 @@ export type RunnableTools<FunctionsArgs extends BaseFunctionsArgs, ToolContext =
 ]
   ? readonly RunnableToolFunction<any, ToolContext>[]
   : {
-      [Index in keyof FunctionsArgs]: Index extends number | `${number}`
+      [Index in keyof FunctionsArgs]: FunctionsArgs[Index] extends object | string
         ? RunnableToolFunction<FunctionsArgs[Index], ToolContext>
         : FunctionsArgs[Index];
     };

--- a/tests/lib/runnable-function.test.ts
+++ b/tests/lib/runnable-function.test.ts
@@ -1,0 +1,69 @@
+import { expectTypeOf } from 'vitest';
+import type OpenAI from 'openai';
+import type {
+  ChatCompletionStreamingToolRunnerParams,
+  ChatCompletionToolRunnerParams,
+} from 'openai/resources/chat/completions';
+import type {
+  RunnableFunction,
+  RunnableFunctions,
+  RunnableToolFunction,
+  RunnableTools,
+} from 'openai/lib/RunnableFunction';
+
+interface ParsedArgs {
+  city: string;
+}
+interface Context {
+  requestId: string;
+}
+
+test('maps each fixed argument tuple position to its runnable function or tool', () => {
+  expectTypeOf<RunnableFunctions<[ParsedArgs, string], Context>>().toEqualTypeOf<
+    [RunnableFunction<ParsedArgs, Context>, RunnableFunction<string, Context>]
+  >();
+  expectTypeOf<RunnableTools<[ParsedArgs, string], Context>>().toEqualTypeOf<
+    [RunnableToolFunction<ParsedArgs, Context>, RunnableToolFunction<string, Context>]
+  >();
+});
+
+test('preserves readonly and variadic tuple shapes', () => {
+  expectTypeOf<RunnableFunctions<readonly [ParsedArgs, ...string[]]>>().toEqualTypeOf<
+    readonly [RunnableFunction<ParsedArgs>, ...RunnableFunction<string>[]]
+  >();
+  expectTypeOf<RunnableTools<readonly [ParsedArgs, ...string[]]>>().toEqualTypeOf<
+    readonly [RunnableToolFunction<ParsedArgs>, ...RunnableToolFunction<string>[]]
+  >();
+});
+
+test('preserves empty tuples and the existing unconstrained array fallback', () => {
+  expectTypeOf<RunnableFunctions<[]>>().toEqualTypeOf<[]>();
+  expectTypeOf<RunnableTools<[]>>().toEqualTypeOf<[]>();
+  expectTypeOf<RunnableFunctions<any[]>>().toEqualTypeOf<readonly RunnableFunction<any>[]>();
+  expectTypeOf<RunnableTools<any[]>>().toEqualTypeOf<readonly RunnableToolFunction<any>[]>();
+});
+
+function _typeTests(
+  client: OpenAI,
+  parsedTool: RunnableToolFunction<ParsedArgs, Context>,
+  rawTool: RunnableToolFunction<string, Context>,
+) {
+  const tools: RunnableTools<[ParsedArgs, string], Context> = [parsedTool, rawTool];
+  const request = {
+    model: 'gpt-4o',
+    messages: [],
+    tools,
+    toolContext: { requestId: 'req_synthetic' },
+  } satisfies ChatCompletionToolRunnerParams<[ParsedArgs, string], Context>;
+  const streamingRequest = {
+    ...request,
+    stream: true,
+  } satisfies ChatCompletionStreamingToolRunnerParams<[ParsedArgs, string], Context>;
+
+  client.chat.completions.runTools(request);
+  client.chat.completions.runTools(streamingRequest);
+
+  // @ts-expect-error The parsed-argument tool cannot occupy the raw-string position.
+  const reversed: RunnableTools<[ParsedArgs, string], Context> = [rawTool, parsedTool];
+  void reversed;
+}


### PR DESCRIPTION
## Summary

Fix the handwritten `RunnableFunctions` and `RunnableTools` tuple mappings.

The mappings checked `Index extends number`, but fixed tuple positions are string keys such as `"0"` and `"1"`. As a result, `RunnableTools<[{ city: string }, string]>` described raw argument values rather than two runnable tools, and valid typed tool tuples were rejected by the public `runTools()` entrypoints.

The fix narrows each tuple argument value directly instead of testing its index. This recognizes fixed tuple positions and lets older compilers prove the runnable argument constraint. The existing broad-array fallback stays unchanged.

## Scope and regressions

- Two production type-condition changes and two handwritten regression files; no generated/upstream edits or dependencies.
- Exact type checks cover fixed tuples, readonly/rest tuples, empty tuples, parsed versus raw argument positions, and callback context.
- Compile-time public-entrypoint regressions exercise both streaming and non-streaming `client.chat.completions.runTools()`; a reversed tuple remains rejected.
- A packed-package regression in the existing TypeScript 4.5/Jest 28 ecosystem fixture covers fixed tool tuples with inferred callbacks.
- Repeated adversarial review covered compatibility, inference, tuple order and shape, missing tests, and module/runtime behavior.
- No runtime logic or parser changes. CommonJS and ESM JavaScript are byte-identical to main.

## Validation

- The compiler reproductions failed before the fix, including tests against the old emitted CJS/ESM declarations on TypeScript 4.9.5.
- CI caught a TypeScript 4.5 declaration-checking regression in the initial numeric-string-key approach. Reproduced it locally and corrected it with direct argument-value narrowing.
- The exact `node-ts4.5-jest28` ecosystem fixture now passes on **TypeScript 4.5.5** with `skipLibCheck: false`, including both offline Jest tests. The same isolated fixture also passes strict declaration checking on TypeScript 4.9.5.
- Final `pnpm exec tsc`, `pnpm lint`, and `pnpm build` passed.
- Final `CI=true ./scripts/test`: **7,012 handwritten tests and 556 generated tests passed**, with 2 existing generated skips.
- **41 focused tuple and tool-runner tests passed**.
- Rebuilt `.d.ts` and `.d.mts` consumer fixtures passed on **TypeScript 4.9.5 and 6.0.3**; distributed source also passed on TypeScript 4.9.5.
- Built CJS/ESM runnable-function entrypoints passed an import/behavior smoke check on **Node 22.0.0**.