### PR TITLE
fix(types): preserve custom tool factory metadata

### DIFF
--- a/src/lib/ResponsesParser.ts
+++ b/src/lib/ResponsesParser.ts
@@ -220,9 +220,9 @@ export function makeParseableResponseTool<OptionsT extends ToolOptions>(
     /** Converts the raw JSON argument string into the function's typed argument value. */
     parser: (content: string) => OptionsT['arguments'];
     /** Optional callback available to helpers that execute the parsed function. */
-    callback: ((args: any) => any) | undefined;
+    callback: ((args: OptionsT['arguments']) => any) | undefined;
   },
-): AutoParseableResponseTool<OptionsT['arguments']> {
+): AutoParseableResponseTool<OptionsT> {
   const obj = { ...tool };
 
   Object.defineProperties(obj, {
@@ -240,7 +240,7 @@ export function makeParseableResponseTool<OptionsT extends ToolOptions>(
     },
   });
 
-  return obj as AutoParseableResponseTool<OptionsT['arguments']>;
+  return obj as AutoParseableResponseTool<OptionsT>;
 }
 
 /** Returns whether a Responses API tool carries the SDK's argument-parser marker. */

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -214,19 +214,43 @@ export type AutoParseableTool<
   $parseRaw(args: string): OptionsT['arguments'];
 };
 
+/** Parser and optional callback supplied when creating a custom chat function tool. */
+type ToolParserOptions<OptionsT extends ToolOptions> = {
+  /** Converts the raw JSON argument string into the tool's typed argument value. */
+  parser: (content: string) => OptionsT['arguments'];
+  /** Optional callback invoked by a chat completion tool runner. */
+  callback: ((args: OptionsT['arguments']) => any) | undefined;
+};
+
+/** Creates a runnable function tool with a guaranteed execution callback. */
+export function makeParseableTool<OptionsT extends ToolOptions>(
+  tool: ChatCompletionFunctionTool,
+  options: ToolParserOptions<OptionsT> & {
+    /** Callback invoked with the parsed tool arguments. */
+    callback: (args: OptionsT['arguments']) => any;
+  },
+): AutoParseableTool<OptionsT, true>;
+
+/** Creates a parse-only function tool without an execution callback. */
+export function makeParseableTool<OptionsT extends ToolOptions>(
+  tool: ChatCompletionFunctionTool,
+  options: ToolParserOptions<OptionsT> & {
+    /** No execution callback is attached to this tool. */
+    callback: undefined;
+  },
+): AutoParseableTool<OptionsT, false>;
+
+/** Creates a function tool whose execution callback may be unavailable. */
+export function makeParseableTool<OptionsT extends ToolOptions>(
+  tool: ChatCompletionFunctionTool,
+  options: ToolParserOptions<OptionsT>,
+): AutoParseableTool<OptionsT, boolean>;
+
 /** Copies a function tool and attaches non-enumerable parsing and callback metadata. */
 export function makeParseableTool<OptionsT extends ToolOptions>(
   tool: ChatCompletionFunctionTool,
-  {
-    parser,
-    callback,
-  }: {
-    /** Converts the raw JSON argument string into the tool's typed argument value. */
-    parser: (content: string) => OptionsT['arguments'];
-    /** Optional callback invoked by a chat completion tool runner. */
-    callback: ((args: any) => any) | undefined;
-  },
-): AutoParseableTool<OptionsT['arguments']> {
+  { parser, callback }: ToolParserOptions<OptionsT>,
+): AutoParseableTool<OptionsT, boolean> {
   const obj = { ...tool };
 
   Object.defineProperties(obj, {
@@ -244,7 +268,7 @@ export function makeParseableTool<OptionsT extends ToolOptions>(
     },
   });
 
-  return obj as AutoParseableTool<OptionsT['arguments']>;
+  return obj as AutoParseableTool<OptionsT, boolean>;
 }
 
 /** Returns whether a Chat Completions tool carries the SDK's argument-parser marker. */

--- a/tests/lib/tool-factory-types.test.ts
+++ b/tests/lib/tool-factory-types.test.ts
@@ -1,0 +1,124 @@
+import type OpenAI from 'openai';
+import { makeParseableTool } from 'openai/lib/parser';
+import { makeParseableResponseTool } from 'openai/lib/ResponsesParser';
+import type { ChatCompletionFunctionTool } from 'openai/resources/chat/completions';
+import type { FunctionTool } from 'openai/resources/responses/responses';
+import { compareType } from '../utils/typing';
+
+interface Arguments {
+  city: string;
+}
+interface Metadata {
+  name: 'lookup';
+  arguments: Arguments;
+  function: (args: Arguments) => string;
+}
+
+const chatDefinition: ChatCompletionFunctionTool = {
+  type: 'function',
+  function: { name: 'lookup', parameters: {}, strict: true },
+};
+const responseDefinition: FunctionTool = {
+  type: 'function',
+  name: 'lookup',
+  parameters: {},
+  strict: true,
+};
+const parser = (raw: string): Arguments => ({ city: raw });
+const callback = (args: Arguments) => args.city;
+const wrongCallback = (args: { count: number }) => args.count;
+
+function makeOptionalTool(optionalCallback?: typeof callback) {
+  return makeParseableTool<Metadata>(chatDefinition, { parser, callback: optionalCallback });
+}
+
+test('preserves explicit parser, callback-argument, and name metadata in both factories', () => {
+  const chatTool = makeParseableTool<Metadata>(chatDefinition, { parser, callback });
+  const responseTool = makeParseableResponseTool<Metadata>(responseDefinition, { parser, callback });
+
+  for (const [tool, definition] of [
+    [chatTool, chatDefinition],
+    [responseTool, responseDefinition],
+  ] as const) {
+    compareType<ReturnType<typeof tool.$parseRaw>, Arguments>(true);
+    compareType<typeof tool.__arguments, Arguments>(true);
+    compareType<typeof tool.__name, 'lookup'>(true);
+    compareType<Parameters<NonNullable<typeof tool.$callback>>[0], Arguments>(true);
+    expect(tool.$parseRaw('Paris').city).toBe('Paris');
+    expect(tool.$callback).toBe(callback);
+    expect(tool.$parseRaw).toBe(parser);
+    expect(Object.keys(tool)).toEqual(Object.keys(definition));
+    expect(JSON.stringify(tool)).toBe(JSON.stringify(definition));
+  }
+});
+
+test('derives runnable availability from the supplied callback, not argument properties', async () => {
+  const runnable = makeParseableTool<Metadata>(chatDefinition, { parser, callback });
+  const parseOnly = makeParseableTool<Metadata>(chatDefinition, { parser, callback: undefined });
+  const optional = makeOptionalTool();
+  const withoutFunctionMetadata = makeParseableTool<Omit<Metadata, 'function'>>(chatDefinition, {
+    parser,
+    callback,
+  });
+  const asyncRunnable = makeParseableTool<Metadata>(chatDefinition, {
+    parser,
+    callback: async (args) => args.city,
+  });
+
+  compareType<typeof runnable.__hasFunction, true>(true);
+  compareType<typeof parseOnly.__hasFunction, false>(true);
+  compareType<typeof optional.__hasFunction, boolean>(true);
+  compareType<typeof withoutFunctionMetadata.__hasFunction, true>(true);
+  compareType<typeof asyncRunnable.__hasFunction, true>(true);
+  expect(parseOnly.$callback).toBeUndefined();
+  expect(optional.$callback).toBeUndefined();
+  await expect(asyncRunnable.$callback?.({ city: 'Paris' })).resolves.toBe('Paris');
+
+  // Compile-only public-entrypoint checks; no requests are started.
+  const checkRunnerTypes = (client: OpenAI) => {
+    const params = { model: 'gpt-test', messages: [] };
+    client.chat.completions.runTools({ ...params, tools: [runnable] });
+    client.chat.completions.runTools({ ...params, tools: [runnable], stream: true });
+    client.chat.completions.runTools({ ...params, tools: [withoutFunctionMetadata, asyncRunnable] });
+    // @ts-expect-error A missing callback cannot be executed.
+    client.chat.completions.runTools({ ...params, tools: [parseOnly] });
+    // @ts-expect-error Streaming runners also require a guaranteed callback.
+    client.chat.completions.runTools({ ...params, tools: [parseOnly], stream: true });
+    // @ts-expect-error A possibly absent callback cannot be executed.
+    client.chat.completions.runTools({ ...params, tools: [optional] });
+    // @ts-expect-error Streaming runners cannot execute a possibly absent callback either.
+    client.chat.completions.runTools({ ...params, tools: [optional], stream: true });
+    client.chat.completions.parse({ ...params, tools: [parseOnly] });
+    client.chat.completions.stream({ ...params, tools: [parseOnly] });
+    // @ts-expect-error The parser output does not contain a numeric city.
+    const wrongCity: number = runnable.$parseRaw('Paris').city;
+    void wrongCity;
+    // @ts-expect-error A callback must accept the parser's declared output.
+    makeParseableTool<Metadata>(chatDefinition, { parser, callback: wrongCallback });
+    // @ts-expect-error Responses callbacks must accept the same declared output.
+    makeParseableResponseTool<Metadata>(responseDefinition, { parser, callback: wrongCallback });
+  };
+  void checkRunnerTypes;
+});
+
+test('preserves non-object and nested argument shapes', () => {
+  function checkArguments<Args>(value: Args) {
+    interface Options {
+      name: 'lookup';
+      arguments: Args;
+    }
+    const props = { parser: (_raw: string) => value, callback: undefined };
+    const chatTool = makeParseableTool<Options>(chatDefinition, props);
+    const responseTool = makeParseableResponseTool<Options>(responseDefinition, props);
+
+    compareType<ReturnType<typeof chatTool.$parseRaw>, Args>(true);
+    compareType<ReturnType<typeof responseTool.$parseRaw>, Args>(true);
+    compareType<typeof chatTool.__hasFunction, false>(true);
+    expect(chatTool.$parseRaw('{}')).toBe(value);
+    expect(responseTool.$parseRaw('{}')).toBe(value);
+  }
+
+  checkArguments('raw result');
+  checkArguments(['one', 'two']);
+  checkArguments({ name: 42, arguments: 'nested', function: () => 'not the callback' });
+});


### PR DESCRIPTION
## Summary

- Pass the complete options metadata to `AutoParseableTool` and `AutoParseableResponseTool` instead of passing the parsed argument value type a second time.
- Preserve explicit parser-output, callback-argument, and function-name types in both public custom-tool factories.
- Derive Chat Completions runnable metadata from the supplied callback: a guaranteed callback is runnable, `undefined` is parse-only, and an optional callback remains unguaranteed. Callback parameters are checked against the parser's declared output.

## Reproduction

A custom factory call with metadata such as `{ name: 'lookup'; arguments: { city: string }; function: (args: { city: string }) => string }` currently returns a tool whose `$parseRaw()` result and name metadata are `unknown`. The argument object is incorrectly treated as another metadata object. A valid callback-backed Chat Completions tool is also incorrectly marked non-runnable and rejected by both public `runTools()` overloads.

A strict public-import consumer reproduced these errors before the change. The new compile-time regressions fail on the base and pass with the fix. They also ensure correcting the metadata cannot accidentally make a callback-free or optional-callback tool runnable, even if the declared metadata contains a function or the parsed argument object has its own `name`, `arguments`, and `function` properties.

## Validation

- Complete `CI=true ./scripts/test`: 7,012 handwritten tests and 556 generated tests pass (2 existing generated skips), with all 12 generated snapshots passing.
- Focused factory/parser suites: 46 tests pass.
- `pnpm exec tsc --noEmit`, `pnpm lint`, and `pnpm build` pass. CI's existing type-check step includes the new compile-time assertions.
- Strict emitted-declaration consumer passes TypeScript 4.5.5 (CommonJS), 4.9 (CommonJS/ESM), and 6 (CommonJS/ESM), all with `skipLibCheck: false`. TypeScript 4.9 also checks distributed source.
- Built CJS/ESM factory checks pass on Node 22.0.0, 24.20.0, and 26.7.0: 12 cases per runtime covering missing/sync/async callbacks, parser and callback identity, frozen definitions, non-enumerable metadata, and unchanged JSON serialization.
- Compared both factories' emitted CJS/ESM code with main using the pinned compilers to normalize comments/formatting; runtime code is unchanged.

## Adversarial self-review and scope

Reviewed the complete return-type invariant in both factories, not just the initially failing property access. Verified callback presence is determined by the actual callback argument rather than unrelated parser-output properties or a possibly inaccurate metadata declaration. Covered parse-only and optional tools in both runner modes, sync/async callbacks, metadata without a function field, string/array/nested parser outputs, and incompatible callback argument types. Rechecked the final diff after validation.

This is a types-only change in handwritten code. No runtime parser, schema conversion, request serialization, generated file, dependency, custom-code budget, or runtime policy changes. All three paths are absent from the pinned generated snapshot. Open-PR checks found no overlap; #2517 changes the Zod convenience helper, not these custom factories.