### PR TITLE
fix(examples): keep tracking fine-tuning file validation

### DIFF
--- a/examples/fine-tuning/fine-tuning.ts
+++ b/examples/fine-tuning/fine-tuning.ts
@@ -49,7 +49,11 @@ async function main() {
 
   const events: Record<string, FineTuningJobEvent> = {};
 
-  while (fineTune.status === 'running' || fineTune.status === 'queued') {
+  while (
+    fineTune.status === 'validating_files' ||
+    fineTune.status === 'queued' ||
+    fineTune.status === 'running'
+  ) {
     fineTune = await client.fineTuning.jobs.retrieve(fineTune.id);
     console.log(`${fineTune.status}`);
 

--- a/tests/lib/fine-tuning-example.test.ts
+++ b/tests/lib/fine-tuning-example.test.ts
@@ -1,0 +1,146 @@
+import fs from 'node:fs';
+import { runInNewContext } from 'node:vm';
+import ts from 'typescript';
+import { vi } from 'vitest';
+import OpenAI from 'openai';
+import type { Fetch } from 'openai/internal/builtin-types';
+import type { FileObject } from 'openai/resources/files';
+import type { FineTuningJob } from 'openai/resources/fine-tuning';
+
+type Status = FineTuningJob['status'];
+const filename = 'examples/fine-tuning/fine-tuning.ts';
+const source = ts.transpileModule(fs.readFileSync(filename, 'utf-8'), {
+  compilerOptions: {
+    module: ts.ModuleKind.CommonJS,
+    target: ts.ScriptTarget.ES2020,
+    esModuleInterop: true,
+  },
+  fileName: filename,
+}).outputText;
+
+async function runExample(initialStatus: Status, followingStatuses: Status[]) {
+  const requests: string[] = [];
+  const waits: number[] = [];
+  const log = vi.fn();
+  const error = vi.fn();
+  const exit = vi.fn();
+  let statusIndex = 0;
+  const file: FileObject = {
+    id: 'file_test',
+    object: 'file',
+    bytes: 1,
+    created_at: 0,
+    filename: 'training.jsonl',
+    purpose: 'fine-tune',
+    status: 'processed',
+  };
+  const job = (status: Status): FineTuningJob => ({
+    id: 'ftjob_test',
+    object: 'fine_tuning.job',
+    created_at: 0,
+    error: null,
+    fine_tuned_model: null,
+    finished_at: null,
+    hyperparameters: { n_epochs: 'auto' },
+    model: 'gpt-3.5-turbo',
+    organization_id: 'org_test',
+    result_files: [],
+    seed: 1,
+    status,
+    trained_tokens: null,
+    training_file: file.id,
+    validation_file: null,
+  });
+  const fetch: Fetch = async (input, init) => {
+    const url = new URL(String(input));
+    const request = `${init?.method} ${url.pathname}`;
+    requests.push(request);
+    if (request === 'POST /files') {
+      // Consume the real example's streaming multipart body before completing its upload.
+      await new Response(init?.body).arrayBuffer();
+      return Response.json(file);
+    }
+    if (request === 'GET /files/file_test') {
+      return Response.json(file);
+    }
+    if (request === 'POST /fine_tuning/jobs') {
+      return Response.json(job(initialStatus));
+    }
+    if (request === 'GET /fine_tuning/jobs/ftjob_test') {
+      const status = followingStatuses[statusIndex];
+      statusIndex += 1;
+      if (status === undefined) {
+        throw new Error('The example polled past its terminal status');
+      }
+      return Response.json(job(status));
+    }
+    if (request === 'GET /fine_tuning/jobs/ftjob_test/events') {
+      expect(url.searchParams.get('limit')).toBe('100');
+      return Response.json({ object: 'list', data: [], has_more: false });
+    }
+    throw new Error(`Unexpected example request: ${request}`);
+  };
+  class OfflineOpenAI extends OpenAI {
+    constructor() {
+      super({ apiKey: 'synthetic-test-key', baseURL: 'https://example.test', fetch, maxRetries: 0 });
+    }
+  }
+
+  await runInNewContext(
+    source,
+    {
+      exports: {},
+      require(specifier: string) {
+        if (specifier === 'openai') {
+          return { __esModule: true, default: OfflineOpenAI };
+        }
+        if (specifier === 'node:fs') {
+          return fs;
+        }
+        throw new Error(`Unexpected example import: ${specifier}`);
+      },
+      console: { log, error },
+      process: { exit },
+      setTimeout(callback: () => void, milliseconds: number) {
+        waits.push(milliseconds);
+        // oxlint-disable-next-line promise/prefer-await-to-callbacks -- Preserve the VM timer callback contract without real five-second waits.
+        callback();
+        return 0;
+      },
+    },
+    { filename },
+  );
+
+  expect(error).not.toHaveBeenCalled();
+  expect(exit).not.toHaveBeenCalled();
+  expect(requests.filter((request) => request === 'POST /fine_tuning/jobs')).toHaveLength(1);
+  expect(requests.filter((request) => request === 'GET /fine_tuning/jobs/ftjob_test')).toHaveLength(
+    followingStatuses.length,
+  );
+  expect(requests.filter((request) => request === 'GET /fine_tuning/jobs/ftjob_test/events')).toHaveLength(
+    followingStatuses.length,
+  );
+  expect(waits).toEqual(followingStatuses.map(() => 5000));
+  for (const status of followingStatuses) {
+    expect(log).toHaveBeenCalledWith(status);
+  }
+}
+
+test('tracks a newly created job through file validation, queueing, and training', async () => {
+  await runExample('validating_files', ['validating_files', 'queued', 'running', 'succeeded']);
+});
+
+test.each<Status>(['queued', 'running'])('continues tracking an initially %s job', async (status) => {
+  await runExample(status, ['running', 'succeeded']);
+});
+
+test.each<Status>(['succeeded', 'failed', 'cancelled'])(
+  'does not poll an initially %s job',
+  async (status) => {
+    await runExample(status, []);
+  },
+);
+
+test.each<Status>(['failed', 'cancelled'])('stops when validation ends with %s', async (status) => {
+  await runExample('validating_files', [status]);
+});


### PR DESCRIPTION
## Summary

Include `validating_files` in the fine-tuning example's existing polling condition. It is a nonterminal status in the public `FineTuningJob` contract, alongside `queued` and `running`.

Previously, a create response in `validating_files` caused the example to exit successfully without retrieving the job again or fetching any progress events. The example now keeps tracking until the job succeeds, fails, or is cancelled.

The production change is one condition in `examples/fine-tuning/fine-tuning.ts`. Request parameters, model selection, file handling, event reporting, polling interval, and terminal-state behavior are unchanged. No SDK runtime or generated code changes.

## Reproduction and regressions

Executed the actual example with the public SDK and an injected synthetic fetch transport. The real training-file stream was consumed as multipart data, while every API request was handled offline; no live fine-tuning job was created.

- Before: an initial `validating_files` response produced **zero job polls and zero event requests**, with no error.
- After: the same reproduction followed `queued` → `running` → `succeeded`, making **three job polls and three event requests**.
- Eight regressions cover repeated validation, queueing/training, all three terminal statuses, initially queued/running jobs, and failure/cancellation during validation. The three validation cases failed on the base; the five existing-behavior controls passed. All eight pass with the change.
- The tests run the transpiled example itself rather than a copied polling loop, preserve its timer callback behavior without real five-second waits, and assert that only one fine-tuning job is created.

## Validation

- `pnpm exec tsc --noEmit` and `pnpm lint` pass.
- Complete `CI=true ./scripts/test`: **7,017 handwritten tests and 556 generated tests pass**, with 2 existing generated skips and all 12 snapshots passing.
- `pnpm build` passes for both module formats.
- The actual-example reproduction passes on **Node 22.0.0, 24.20.0, and 26.7.0** using the built public SDK and the offline fetch transport.

## Adversarial self-review and scope

Checked the complete six-status public contract: validation, queueing, and running continue; succeeded, failed, and cancelled stop. Verified repeated validation does not terminate early, terminal transitions do not issue another job poll, the existing five-second interval is retained, and event polling and single-job creation stay unchanged. The regression transport cannot make live API requests.

Both changed files are handwritten and absent from the pinned generated snapshot. No open PR overlaps this example. No new polling helper, state machine, dependency, timeout policy, API surface, or credential handling is introduced.