### PR TITLE
fix(uploads): accept cross-realm ArrayBuffers

### DIFF
--- a/ecosystem-tests/browser-direct-import/public/index.js
+++ b/ecosystem-tests/browser-direct-import/public/index.js
@@ -22,7 +22,13 @@ async function runTests() {
     pre.textContent = JSON.stringify(results, null, 2);
   }
   for (const { path, run, timeout } of tests) {
-    if (!live && path[0] !== 'browser API-key protection remains enabled by default') {
+    if (
+      !live &&
+      ![
+        'browser API-key protection remains enabled by default',
+        'toFile accepts ArrayBuffers from another realm',
+      ].includes(path[0])
+    ) {
       continue;
     }
     console.log('running', ...path);
@@ -133,6 +139,27 @@ it('browser API-key protection remains enabled by default', () => {
     !browserError.message.includes('dangerouslyAllowBrowser')
   ) {
     throw new Error('Expected API-key use to be disabled in browsers by default.');
+  }
+});
+
+it('toFile accepts ArrayBuffers from another realm', async () => {
+  const frame = document.createElement('iframe');
+  document.body.append(frame);
+  try {
+    const { contentWindow } = frame;
+    if (!contentWindow) {throw new Error('The iframe did not create a window');}
+    const foreign = /** @type {Window & typeof globalThis} */ (contentWindow);
+    const { buffer } = new foreign.Uint8Array([0, 1, 127, 255]);
+    expect(buffer instanceof ArrayBuffer).toEqual(false);
+
+    const file = await toFile(buffer, 'foreign.bin');
+    expect(file.name).toEqual('foreign.bin');
+    expect([...new Uint8Array(await file.arrayBuffer())].join(',')).toEqual('0,1,127,255');
+
+    const empty = await toFile(new foreign.ArrayBuffer(0), 'empty.bin');
+    expect(empty.size).toEqual(0);
+  } finally {
+    frame.remove();
   }
 });
 

--- a/src/internal/to-file.ts
+++ b/src/internal/to-file.ts
@@ -1,5 +1,5 @@
 import type { BlobPart } from './uploads';
-import { getName, makeFile, isAsyncIterable, checkFileSupport } from './uploads';
+import { getName, makeFile, isAsyncIterable, isArrayBuffer, checkFileSupport } from './uploads';
 import type { FilePropertyBag } from './builtin-types';
 
 /** Text, binary content, or a Blob-compatible value accepted inside a file stream. */
@@ -176,7 +176,7 @@ async function getBytes(value: BlobLikePart | AsyncIterable<BlobLikePart>): Prom
   if (
     typeof value === 'string' ||
     ArrayBuffer.isView(value) || // includes Uint8Array, Buffer, etc.
-    value instanceof ArrayBuffer
+    isArrayBuffer(value)
   ) {
     parts.push(value);
   } else if (isBlobLike(value)) {

--- a/src/internal/uploads.ts
+++ b/src/internal/uploads.ts
@@ -196,6 +196,17 @@ function normalizeFilenamePath(value: string): string {
   return normalized;
 }
 
+const arrayBufferByteLengthGetter = Object.getOwnPropertyDescriptor(ArrayBuffer.prototype, 'byteLength')?.get;
+
+/** Recognizes native ArrayBuffers across realms without trusting their prototype or string tag. */
+export function isArrayBuffer(value: unknown): value is ArrayBuffer {
+  try {
+    return arrayBufferByteLengthGetter?.call(value) !== undefined;
+  } catch {
+    return false;
+  }
+}
+
 /** Identifies objects that expose a callable `Symbol.asyncIterator` method. */
 export const isAsyncIterable = (value: any): value is AsyncIterable<any> =>
   value != null && typeof value === 'object' && typeof value[Symbol.asyncIterator] === 'function';
@@ -538,7 +549,7 @@ async function* iterateBytes(value: unknown): AsyncGenerator<Uint8Array> {
     yield encodeUTF8(value);
   } else if (ArrayBuffer.isView(value)) {
     yield new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
-  } else if (value instanceof ArrayBuffer) {
+  } else if (isArrayBuffer(value)) {
     yield new Uint8Array(value);
   } else if (value instanceof Response) {
     yield* iterateBytes(value.body || (await value.blob()));

--- a/tests/internal/uploads-cross-realm.test.ts
+++ b/tests/internal/uploads-cross-realm.test.ts
@@ -1,0 +1,144 @@
+import { runInNewContext } from 'node:vm';
+import OpenAI, { toFile, toStreamingFile } from 'openai';
+import type { Fetch } from 'openai/internal/builtin-types';
+
+interface BufferCase {
+  name: string;
+  make: () => ArrayBuffer | Uint8Array | DataView;
+  expected: number[];
+}
+
+const cases: BufferCase[] = [
+  {
+    name: 'foreign ArrayBuffer',
+    make: () => runInNewContext('new Uint8Array([0, 1, 127, 255]).buffer') as ArrayBuffer,
+    expected: [0, 1, 127, 255],
+  },
+  {
+    name: 'empty foreign ArrayBuffer',
+    make: () => runInNewContext('new ArrayBuffer(0)') as ArrayBuffer,
+    expected: [],
+  },
+  {
+    name: 'native ArrayBuffer',
+    make: () => new Uint8Array([0, 1, 127, 255]).buffer,
+    expected: [0, 1, 127, 255],
+  },
+  {
+    name: 'foreign typed-array slice',
+    make: () =>
+      runInNewContext('new Uint8Array(new Uint8Array([0, 1, 127, 255]).buffer, 1, 2)') as Uint8Array,
+    expected: [1, 127],
+  },
+  {
+    name: 'foreign DataView slice',
+    make: () => runInNewContext('new DataView(new Uint8Array([0, 1, 127, 255]).buffer, 1, 2)') as DataView,
+    expected: [1, 127],
+  },
+];
+
+function uploadClient() {
+  const files: File[] = [];
+  const transport: Fetch = async (_input, init) => {
+    const form = await new Response(init?.body, { headers: new Headers(init?.headers) }).formData();
+    const file = form.get('file');
+    if (!(file instanceof File)) {
+      throw new Error('Expected a multipart file');
+    }
+    expect(form.get('purpose')).toBe('assistants');
+    files.push(file);
+    return Response.json({ id: 'file_test', object: 'file' });
+  };
+  return {
+    files,
+    client: new OpenAI({
+      apiKey: 'synthetic-test-key',
+      baseURL: 'https://example.test',
+      fetch: Object.assign(transport, { Response }),
+      maxRetries: 0,
+    }),
+  };
+}
+
+describe.each(cases)('$name upload bytes', ({ make, expected }) => {
+  test.each(['direct', 'chunked'])('buffers %s input with toFile', async (mode) => {
+    const value = make();
+    const chunks = {
+      async *[Symbol.asyncIterator]() {
+        yield value;
+      },
+    };
+    const file = await toFile(mode === 'direct' ? value : chunks, 'bytes.bin', {
+      type: 'application/octet-stream',
+      lastModified: 123,
+    });
+
+    expect(file.name).toBe('bytes.bin');
+    expect(file.type).toBe('application/octet-stream');
+    expect(file.lastModified).toBe(123);
+    expect([...new Uint8Array(await file.arrayBuffer())]).toEqual(expected);
+  });
+
+  test.each(['wrapped', 'iterable', 'readable'] as const)(
+    'streams %s input through files.create',
+    async (mode) => {
+      const value = make();
+      const chunks = {
+        name: 'bytes.bin',
+        async *[Symbol.asyncIterator]() {
+          yield value;
+        },
+      };
+      const inputs = {
+        wrapped: () => toStreamingFile(chunks, 'bytes.bin'),
+        iterable: () => chunks,
+        readable: () =>
+          Object.assign(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(value);
+                controller.close();
+              },
+            }),
+            { name: 'bytes.bin' },
+          ),
+      };
+      const { client, files } = uploadClient();
+      const input = inputs[mode]();
+      await expect(client.files.create({ file: input, purpose: 'assistants' })).resolves.toHaveProperty(
+        'id',
+        'file_test',
+      );
+
+      expect(files).toHaveLength(1);
+      const [uploaded] = files;
+      if (!uploaded) {
+        throw new Error('The transport did not receive an uploaded file');
+      }
+      expect(uploaded.name).toBe('bytes.bin');
+      expect([...new Uint8Array(await uploaded.arrayBuffer())]).toEqual(expected);
+    },
+  );
+});
+
+test.each([
+  { name: 'a string-tag lookalike', value: { byteLength: 4, [Symbol.toStringTag]: 'ArrayBuffer' } },
+  { name: 'a SharedArrayBuffer', value: new SharedArrayBuffer(4) },
+])('does not accept $name as an ArrayBuffer', async ({ value }) => {
+  // @ts-expect-error Neither input is a supported ArrayBuffer upload part.
+  await expect(toFile(value, 'invalid.bin')).rejects.toThrow('Unexpected data type');
+
+  const chunks = {
+    async *[Symbol.asyncIterator]() {
+      yield value;
+    },
+  };
+  const { client, files } = uploadClient();
+  // @ts-expect-error Invalid chunks are deliberately supplied to the public streaming boundary.
+  const file = toStreamingFile(chunks, 'invalid.bin');
+  await expect(client.files.create({ file, purpose: 'assistants' })).rejects.toHaveProperty(
+    'cause.message',
+    expect.stringContaining('Invalid streaming file chunk'),
+  );
+  expect(files).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary

- Fix `toFile()` and streaming multipart uploads rejecting native `ArrayBuffer` values created in another JavaScript realm (for example, an iframe or Node VM context).
- Share a small native-brand check between the buffered and streaming paths. The captured `ArrayBuffer.prototype.byteLength` getter recognizes real buffers across realms without trusting `Symbol.toStringTag` or accepting `SharedArrayBuffer` as an `ArrayBuffer`.
- Add 27 public-boundary regression/control cases and an offline browser test using an actual iframe. No generated files, dependencies, upload metadata rules, or public API signatures change.

## Reproduction and behavior

Before this change, a VM-created `new Uint8Array([0, 1, 127, 255]).buffer` is accepted by the native `File` constructor but rejected by `toFile()` with `Unexpected data type: object; constructor: ArrayBuffer`. Supplying the same buffer as a streamed file chunk makes `files.create()` fail with an `Invalid streaming file chunk` cause.

The two upload paths used `instanceof ArrayBuffer`, which only recognizes the current realm's prototype. Ten new foreign-buffer cases fail on the base revision while the 17 existing-behavior controls pass; all 27 pass with the fix.

Coverage includes nonempty and empty foreign buffers, native buffers, foreign typed-array and DataView slices, direct and async-chunked `toFile()`, `toStreamingFile()`, raw async iterables, and readable streams. Streaming tests inspect the actual multipart bytes at a synthetic `fetch` boundary. Invalid string-tag lookalikes and `SharedArrayBuffer` inputs remain rejected.

## Validation

- `CI=true ./scripts/test`: 7,036 handwritten tests and 556 generated tests passed (two existing generated skips; 12 snapshots passed).
- Four focused upload suites: 134 tests passed.
- `pnpm lint`, `pnpm exec tsc --noEmit`, and `pnpm build` passed.
- Existing packed-package `browser-direct-import` workflow ran offline: fixture type-check, native browser ESM imports, API-key protection, and iframe buffer regression all passed. Re-ran its type-check and browser tests after the final lint-only fixture edit.
- Built CJS and ESM public entrypoints: 27 upload cases per format passed on Node 22.0.0, 24.20.0, and 26.7.0 (162 checks total).
- Published upload declarations passed strict TypeScript 4.5.5 CJS and 4.9.5 CJS/ESM consumers; distributed source passed TypeScript 4.9.5.

Adversarial review covered native-brand spoofing, empty buffers, byte-range preservation, metadata compatibility, module/runtime compatibility, and the unchanged browser credential guard. Tests are offline and use synthetic credentials. All four changed paths are absent from the pinned generated snapshot; current open PRs have no overlapping upload fix.
