### PR TITLE
fix(examples): cancel Edge streams when requests abort

### DIFF
--- a/examples/chat-completions/stream-to-client-next.ts
+++ b/examples/chat-completions/stream-to-client-next.ts
@@ -124,11 +124,14 @@ export default async function handler(request: Request): Promise<Response> {
   }
 
   const openai = new OpenAI();
-  const stream = openai.chat.completions.stream({
-    model: 'gpt-3.5-turbo',
-    stream: true,
-    messages: [{ role: 'user', content: prompt }],
-  });
+  const stream = openai.chat.completions.stream(
+    {
+      model: 'gpt-3.5-turbo',
+      stream: true,
+      messages: [{ role: 'user', content: prompt }],
+    },
+    { signal: request.signal },
+  );
 
   return new Response(stream.toReadableStream());
 }

--- a/tests/lib/next-streaming-example-cancellation.test.ts
+++ b/tests/lib/next-streaming-example-cancellation.test.ts
@@ -1,0 +1,172 @@
+import { getEventListeners } from 'node:events';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { APIUserAbortError } from 'openai';
+import handler from '../../examples/chat-completions/stream-to-client-next';
+
+const token = 'synthetic-auth-token-0123456789abcdef';
+const encoder = new TextEncoder();
+const content = {
+  id: 'chatcmpl-example',
+  object: 'chat.completion.chunk',
+  created: 1,
+  model: 'gpt-test',
+  choices: [{ index: 0, delta: { role: 'assistant', content: 'safe response' }, finish_reason: null }],
+};
+const finished = {
+  ...content,
+  choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+};
+
+function request(signal: AbortSignal): Request {
+  return new Request('https://example.test/api/chat', {
+    method: 'POST',
+    body: 'A synthetic prompt',
+    headers: { authorization: `Bearer ${token}` },
+    signal,
+  });
+}
+
+function completeResponse(): Response {
+  return new Response(
+    `data: ${JSON.stringify(content)}\n\ndata: ${JSON.stringify(finished)}\n\ndata: [DONE]\n\n`,
+    { headers: { 'Content-Type': 'text/event-stream' } },
+  );
+}
+
+async function readOutcome(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<unknown> {
+  try {
+    return await reader.read();
+  } catch (error) {
+    return error;
+  }
+}
+
+beforeEach(() => {
+  vi.stubEnv('OPENAI_API_KEY', 'synthetic-test-key');
+  vi.stubEnv('OPENAI_BASE_URL', 'https://example.test/v1');
+  vi.stubEnv('OPENAI_EXAMPLE_AUTH_TOKEN', token);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe('Next Edge streaming example cancellation through the public SDK', () => {
+  test('does not start an upstream request when the caller is already aborted', async () => {
+    const transport = vi.fn<typeof fetch>(async () => completeResponse());
+    vi.stubGlobal('fetch', transport);
+    const caller = new AbortController();
+    caller.abort();
+
+    const response = await handler(request(caller.signal));
+
+    await expect(response.text()).rejects.toBeInstanceOf(APIUserAbortError);
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  test('cancels an upstream request that has not returned response headers', async () => {
+    let upstreamSignal: AbortSignal | null | undefined;
+    const transport = vi.fn<typeof fetch>(async (_input, options) => {
+      upstreamSignal = options?.signal;
+      if (!upstreamSignal) {
+        throw new Error('Expected an upstream abort signal');
+      }
+      const signal = upstreamSignal;
+      // oxlint-disable-next-line promise/avoid-new -- Model a pending fetch that rejects when its signal aborts.
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      });
+    });
+    vi.stubGlobal('fetch', transport);
+    const caller = new AbortController();
+    const input = request(caller.signal);
+    const response = await handler(input);
+    if (!response.body) {
+      throw new Error('The example did not return a response body');
+    }
+    const reader = response.body.getReader();
+    const pending = readOutcome(reader);
+
+    try {
+      await vi.waitFor(() => expect(transport).toHaveBeenCalledOnce());
+      caller.abort(new Error('caller disconnected'));
+
+      await vi.waitFor(() => expect(upstreamSignal?.aborted).toBe(true));
+      expect(await pending).toBeInstanceOf(APIUserAbortError);
+      expect(transport).toHaveBeenCalledOnce();
+      expect(getEventListeners(input.signal, 'abort')).toHaveLength(0);
+    } finally {
+      await reader.cancel().catch(() => {});
+      reader.releaseLock();
+    }
+  });
+
+  test('cancels the upstream body after streaming has begun', async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(content)}\n\n`));
+      },
+      cancel,
+    });
+    let upstreamSignal: AbortSignal | null | undefined;
+    const transport = vi.fn<typeof fetch>(async (_input, options) => {
+      upstreamSignal = options?.signal;
+      return new Response(body, { headers: { 'Content-Type': 'text/event-stream' } });
+    });
+    vi.stubGlobal('fetch', transport);
+    const caller = new AbortController();
+    const input = request(caller.signal);
+    const response = await handler(input);
+    if (!response.body) {
+      throw new Error('The example did not return a response body');
+    }
+    const reader = response.body.getReader();
+
+    try {
+      const first = await reader.read();
+      expect(new TextDecoder().decode(first.value)).toBe(`${JSON.stringify(content)}\n`);
+      const pending = readOutcome(reader);
+      caller.abort();
+
+      await vi.waitFor(() => expect(upstreamSignal?.aborted).toBe(true));
+      expect(await pending).toBeInstanceOf(APIUserAbortError);
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(body.locked).toBe(false);
+      expect(transport).toHaveBeenCalledOnce();
+      expect(getEventListeners(input.signal, 'abort')).toHaveLength(0);
+    } finally {
+      await reader.cancel().catch(() => {});
+      reader.releaseLock();
+    }
+  });
+
+  test('preserves a completed response and removes the incoming abort listener', async () => {
+    let upstreamSignal: AbortSignal | null | undefined;
+    const transport = vi.fn<typeof fetch>(async (input, options) => {
+      expect(String(input)).toBe('https://example.test/v1/chat/completions');
+      expect(JSON.parse(String(options?.body))).toEqual({
+        model: 'gpt-3.5-turbo',
+        stream: true,
+        messages: [{ role: 'user', content: 'A synthetic prompt' }],
+      });
+      upstreamSignal = options?.signal;
+      return completeResponse();
+    });
+    vi.stubGlobal('fetch', transport);
+    const caller = new AbortController();
+    const input = request(caller.signal);
+    const response = await handler(input);
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(`${JSON.stringify(content)}\n${JSON.stringify(finished)}\n`);
+    expect(transport).toHaveBeenCalledOnce();
+    expect(upstreamSignal?.aborted).toBe(false);
+    expect(getEventListeners(input.signal, 'abort')).toHaveLength(0);
+
+    caller.abort();
+    expect(upstreamSignal?.aborted).toBe(false);
+  });
+});

--- a/tests/lib/next-streaming-example-security.test.ts
+++ b/tests/lib/next-streaming-example-security.test.ts
@@ -222,16 +222,20 @@ describe('Next Edge streaming example request boundaries', () => {
   });
 
   test('accepts an authenticated command-line request with no browser-origin headers', async () => {
-    const response = await invoke(request());
+    const input = request();
+    const response = await invoke(input);
 
     expect(response.status).toBe(200);
     expect(await response.text()).toBe('{"content":"safe"}\n');
     expect(openai.constructor).toHaveBeenCalledOnce();
-    expect(openai.createStream).toHaveBeenCalledWith({
-      model: 'gpt-3.5-turbo',
-      stream: true,
-      messages: [{ role: 'user', content: 'Tell me why dogs are better than cats' }],
-    });
+    expect(openai.createStream).toHaveBeenCalledWith(
+      {
+        model: 'gpt-3.5-turbo',
+        stream: true,
+        messages: [{ role: 'user', content: 'Tell me why dogs are better than cats' }],
+      },
+      { signal: input.signal },
+    );
   });
 
   test('accepts an authenticated browser request from the configured trusted origin', async () => {
@@ -244,13 +248,15 @@ describe('Next Edge streaming example request boundaries', () => {
 
   test('preserves an authenticated body at exactly the 64 KiB UTF-8 boundary', async () => {
     const body = '🐕'.repeat(maximumPromptBytes / 4);
-    const response = await invoke(request({ body }));
+    const input = request({ body });
+    const response = await invoke(input);
 
     expect(response.status).toBe(200);
     expect(openai.createStream).toHaveBeenCalledWith(
       expect.objectContaining({
         messages: [{ role: 'user', content: body }],
       }),
+      { signal: input.signal },
     );
   });
 });


### PR DESCRIPTION
## Summary

- Pass the incoming `Request.signal` to the SDK stream in the Next.js Edge streaming example.
- Stop upstream work when an authenticated caller aborts, including before response headers arrive and after streaming starts.
- Keep the existing Pages Router handler, authorization/origin checks, prompt limits, request parameters, and response encoding unchanged. No SDK source, public types, dependencies, or generated files change.

## Reproduction

The example previously created its SDK stream without the incoming abort signal. Running the actual handler with the public SDK and an offline synthetic transport showed `request.signal.aborted === true` while the upstream signal remained un-aborted and the upstream body was not canceled.

The fix delegates cancellation to the SDK's existing signal handling rather than adding new listeners or lifecycle logic to the example. The same reproduction now aborts the upstream signal, cancels its body exactly once, releases the reader, and surfaces `APIUserAbortError` to the downstream reader.

## Regression coverage

Four tests exercise the actual example handler with the public SDK, standard Web `Request`/`Response` objects, and synthetic `fetch` responses:

- Already-aborted requests never reach the upstream transport.
- Cancellation propagates while upstream response headers are pending, without retries.
- Cancellation after the first SSE chunk closes the upstream body once and releases its reader and incoming abort listener.
- Normal completion preserves request parameters and response bytes; a later caller abort has no effect.

The three cancellation cases fail on unchanged main; the normal-completion control passes. Existing authorization tests now also assert that the exact incoming signal is forwarded.

## Validation

- `CI=true ./scripts/test`: 7,013 handwritten tests and 556 generated tests passed (two existing generated skips; 12 snapshots passed).
- Three focused example security/cancellation suites: 61 tests passed.
- `pnpm lint`, `pnpm exec tsc --noEmit`, and `pnpm build` passed.
- Standalone actual-handler reproduction passed with built CJS and ESM SDK entrypoints on Node 22.0.0, 24.20.0, and 26.7.0.

Adversarial review covered pre-aborted requests, cancellation before/after headers, custom abort reasons, reader/listener cleanup, retry behavior, normal completion, and the unchanged authentication boundary. All testing was offline; this does not claim a deployed Next.js end-to-end test. The three changed paths are absent from the pinned generated snapshot, and current open PRs have no overlapping fix.
