### PR TITLE
fix(uploads): preserve explicit empty filenames

### DIFF
--- a/src/internal/to-file.ts
+++ b/src/internal/to-file.ts
@@ -106,7 +106,8 @@ export type ToFileInput =
  * filename and metadata are unchanged. Renamed native files reuse the original
  * file contents without buffering and retain their MIME type and modification
  * time unless explicitly overridden. Other filenames are inferred from response
- * URLs or input metadata when omitted, falling back to `unknown_file`. Responses,
+ * URLs or input metadata when omitted or null, falling back to `unknown_file`.
+ * An explicit empty filename is preserved. Responses,
  * native or compatible `Blob` values, and compatible non-native files supply
  * their MIME type unless `options.type` provides an explicit override.
  *
@@ -148,7 +149,7 @@ export async function toFile(
 
   if (isResponseLike(value)) {
     const blob = await value.blob();
-    name ||= getName(value);
+    name ??= getName(value);
 
     const responseOptions =
       options?.type === undefined && blob.type ? { ...options, type: blob.type } : options;
@@ -157,7 +158,7 @@ export async function toFile(
 
   const parts = await getBytes(value);
 
-  name ||= getName(value);
+  name ??= getName(value);
 
   if (options?.type === undefined) {
     const typedPart = parts.find(

--- a/tests/uploads.test.ts
+++ b/tests/uploads.test.ts
@@ -38,6 +38,62 @@ function mockResponse({ url, content }: { url: string; content?: Blob }): Respon
 }
 
 describe('toFile', () => {
+  describe.each([
+    {
+      kind: 'bytes',
+      make: () => new Uint8Array([1, 2]),
+      inferredName: 'unknown_file',
+    },
+    {
+      kind: 'named bytes',
+      make: () => Object.assign(new Uint8Array([1, 2]), { name: 'original.bin' }),
+      inferredName: 'original.bin',
+    },
+    {
+      kind: 'Blob',
+      make: () => new Blob([new Uint8Array([1, 2])]),
+      inferredName: 'unknown_file',
+    },
+    {
+      kind: 'Response',
+      make: () =>
+        mockResponse({
+          url: 'https://example.test/original.bin',
+          content: new Blob([new Uint8Array([1, 2])]),
+        }),
+      inferredName: 'original.bin',
+    },
+    {
+      kind: 'File',
+      make: () => new File([new Uint8Array([1, 2])], 'original.bin'),
+      inferredName: 'original.bin',
+    },
+    {
+      kind: 'compatible File',
+      make: foreignFileLike,
+      inferredName: 'foreign.jsonl',
+    },
+    {
+      kind: 'async iterable',
+      make: () => ({
+        name: 'original.bin',
+        async *[Symbol.asyncIterator]() {
+          yield new Uint8Array([1, 2]);
+        },
+      }),
+      inferredName: 'original.bin',
+    },
+  ])('$kind filename overrides', ({ make, inferredName }) => {
+    it.each(['', 'override.bin', undefined, null])('respects the %j filename', async (name) => {
+      const file = await toFile(make(), name, { type: 'application/octet-stream', lastModified: 7 });
+
+      expect(file.name).toBe(name ?? inferredName);
+      expect(file.type).toBe('application/octet-stream');
+      expect(file.lastModified).toBe(7);
+      expect([...new Uint8Array(await file.arrayBuffer())]).toEqual([1, 2]);
+    });
+  });
+
   it('throws a helpful error for mismatched types', async () => {
     await expect(
       // @ts-expect-error intentionally mismatched type


### PR DESCRIPTION
## Summary

- Preserve an explicitly supplied empty filename in `toFile()` for bytes, blobs, responses, and async iterables, matching its existing native and compatible `File` behavior.
- Use nullish filename fallback in the two affected branches. Omitted and `null` names still infer source metadata or fall back to `unknown_file`; explicit nonempty names remain unchanged.
- Document the behavior and add a 28-case matrix across seven input forms and four filename choices.

## Reproduction

Before this change, `(await toFile(new Uint8Array([1, 2]), '')).name` was `unknown_file`, while the same explicit name with an existing `File` was preserved as `''`. Named inputs and response URLs similarly overrode the explicit empty name with their inferred filename.

The two `||=` checks treated an empty string as omission. Switching them to `??=` makes filename selection consistent with the native-file branches and the helper's explicit-override contract. Five new empty-name cases fail on unchanged main; the other 23 matrix cases pass before and after the fix.

This changes only the name of the `File` returned by `toFile()`. Streaming-file nonempty-name validation and multipart filename/path rules are unchanged. The separate cross-realm upload PR (#2529) touches buffer recognition in different hunks of the same file; this PR does not depend on it or duplicate its fix.

## Validation

- `CI=true ./scripts/test`: 7,037 handwritten tests and 556 generated tests passed (two existing generated skips; 12 snapshots passed).
- Four focused upload/naming/security suites: 208 tests passed.
- `pnpm lint`, `pnpm exec tsc --noEmit`, and `pnpm build` passed.
- Built CJS and ESM entrypoints passed 28 filename cases each on Node 22.0.0, 24.20.0, and 26.7.0 (168 cases); root, static, core, and legacy helper exports agree.
- Published declarations passed a strict TypeScript 4.5.5 CJS consumer and a 4.9.5 ESM consumer; distributed source passed TypeScript 4.9.5.

Adversarial review covered nullish defaults, explicit overrides, native/compatible file behavior, bytes, MIME type, modification time, existing filename-safety rules, supported runtimes, and public entrypoint compatibility. No dependencies, exported signatures, generated files, or security gates change. Both changed paths are absent from the pinned generated snapshot, and no open PR addresses this filename-selection bug.
