### PR TITLE
ci: gate npm publication on release-sha CI

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -163,6 +163,48 @@ jobs:
             exit "${version_status}"
           fi
 
+  release-ci:
+    name: check release CI before publication
+    if: needs.publication-check.outputs.should_publish == 'true'
+    needs: publication-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    permissions:
+      actions: read
+
+    steps:
+      - name: Wait for CI on the immutable release commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ needs.publication-check.outputs.release_sha }}
+        run: |
+          run_id=''
+          for attempt in {1..30}; do
+            run_id="$(gh api --method GET \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+              -f event=push \
+              -f head_sha="${RELEASE_SHA}" \
+              -f per_page=100 \
+              --jq '.workflow_runs | map(select(.head_branch == "main")) | first | .id // empty')"
+            if [[ -n "${run_id}" ]]; then
+              break
+            fi
+            sleep 2
+          done
+
+          if [[ -z "${run_id}" ]]; then
+            echo "::error::No CI push workflow found for release commit ${RELEASE_SHA}."
+            exit 1
+          fi
+
+          run_sha="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" --jq '.head_sha')"
+          if [[ "${run_sha}" != "${RELEASE_SHA}" ]]; then
+            echo "::error::CI run ${run_id} targets ${run_sha}, expected ${RELEASE_SHA}."
+            exit 1
+          fi
+
+          gh run watch "${run_id}" --repo "${GITHUB_REPOSITORY}" --exit-status
+
   browser-compatibility:
     name: check browser compatibility before publication
     if: needs.publication-check.outputs.should_publish == 'true'
@@ -290,6 +332,7 @@ jobs:
     if: needs.publication-check.outputs.should_publish == 'true'
     needs:
       - publication-check
+      - release-ci
       - browser-compatibility
       - build-package
     runs-on: ubuntu-latest

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -171,6 +171,7 @@ jobs:
     timeout-minutes: 35
     permissions:
       actions: read
+      checks: read
 
     steps:
       - name: Wait for CI on the immutable release commit


### PR DESCRIPTION
## Summary

Adds an explicit CI gate to npm publication for the immutable release commit, addressing the remaining release-safety gap in #2509.

## Change

- add a `release-ci` job after publication state is resolved;
- locate the `CI` push workflow for the exact `release_sha` on `main`;
- fail closed if no matching CI run exists or if the run points at a different commit;
- wait for that CI run and require a successful conclusion with `gh run watch --exit-status`;
- make the final `publish` job depend on the release CI gate;
- leave package build and browser compatibility checks running in parallel.

## Why

The release workflow currently verifies the release tag and package commit, then gates publication on its own browser/package checks, but it does not require the repository's normal `CI` workflow to have passed for that exact release SHA. This means a failing release-relevant main-branch check can race with npm publication.

The new gate binds publication to the immutable commit being released rather than merely to the latest `main` state.

## Scope

Workflow-only change. Normal PR/main CI is unchanged, and non-release pushes do not run the gate.

Addresses #2509
