### PR TITLE
perf(bedrock): avoid copying repeated query values

### DIFF
--- a/src/providers/bedrock/aws.ts
+++ b/src/providers/bedrock/aws.ts
@@ -115,7 +115,7 @@ function requestTarget(parsedURL: URL): { path: string; query: Record<string, st
     } else if (typeof existing === 'string') {
       query[name] = [existing, value];
     } else {
-      query[name] = [...existing, value];
+      existing.push(value);
     }
   }
   return { path: parsedURL.pathname, query };

--- a/tests/lib/bedrock-provider-query-safety.test.ts
+++ b/tests/lib/bedrock-provider-query-safety.test.ts
@@ -61,6 +61,55 @@ function firstSignedRequest(calls: Parameters<SignatureV4['sign']>[]) {
 }
 
 describe('Bedrock SigV4 query parameter safety', () => {
+  test.each(endpointCases)(
+    'signs repeated query values without repeatedly traversing earlier values for $endpoint',
+    async ({ endpoint, signingService }) => {
+      const marker = 'synthetic-repeated-query-value';
+      const values = Object.freeze(Array.from({ length: 256 }, (_, index) => `${marker}-${index}`));
+      const extraValues = Object.freeze(['', 'one two', 'snowman☃', 'a+b']);
+      const sign = vi.spyOn(SignatureV4.prototype, 'sign');
+      const fetch = mockFetch();
+      const client = new OpenAI({ provider: staticProvider(endpoint), fetch, maxRetries: 0 });
+      const originalIterator = Array.prototype[Symbol.iterator];
+      let visitedValues = 0;
+      // oxlint-disable-next-line no-extend-native -- Count real traversal work; a Vitest iterator spy recursively invokes itself.
+      Array.prototype[Symbol.iterator] = function* countArrayValues(
+        this: unknown[],
+      ): Generator<unknown, undefined, unknown> {
+        for (const value of originalIterator.call(this)) {
+          if (typeof value === 'string' && value.startsWith(marker)) {
+            visitedValues += 1;
+          }
+          yield value;
+        }
+      };
+
+      try {
+        await client.get('/models', { query: { tag: values, extra: extraValues } });
+      } finally {
+        // oxlint-disable-next-line no-extend-native -- Restore the native iterator even when the request fails.
+        Array.prototype[Symbol.iterator] = originalIterator;
+      }
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(sign).toHaveBeenCalledTimes(1);
+      const signedRequest = firstSignedRequest(sign.mock.calls);
+      expect(signedRequest.query).toEqual({ 'tag[]': values, 'extra[]': extraValues });
+      const [request] = fetch.mock.calls;
+      if (!request) {
+        throw new Error('Expected the signed request to be sent.');
+      }
+      const [url, init] = request;
+      expect(new URL(String(url)).searchParams.getAll('tag[]')).toEqual(values);
+      expect(new URL(String(url)).searchParams.getAll('extra[]')).toEqual(extraValues);
+      expect(new Headers(init?.headers).get('authorization')).toContain(
+        `/us-east-1/${signingService}/aws4_request`,
+      );
+      // Count work rather than elapsed time so repeated array copies fail deterministically.
+      expect(visitedValues).toBeLessThanOrEqual(values.length * 4);
+    },
+  );
+
   test.each(
     endpointCases.flatMap(({ endpoint, signingService }) =>
       inheritedQueryNames.map((queryName) => ({ endpoint, signingService, queryName })),


### PR DESCRIPTION
## Summary

Avoid repeatedly copying earlier values while grouping duplicate query parameters for Bedrock SigV4 signing. After the second value, `requestTarget()` currently replaces the accumulated array with `[...existing, value]` on every iteration. Appending to that request-local array preserves the exact signing input while removing quadratic copying from this grouping step.

The production change is one line in handwritten code. There are no generated-file, dependency, authentication-policy, public-type, endpoint, or custom-code-budget changes.

## Regression and compatibility

- Exercise `new OpenAI({ provider: bedrock(...) }).get(...)` with the real query serializer and AWS signer for both Mantle and Runtime.
- Count repeated-value iteration instead of using a timing threshold. With 256 values, the regression observes **33,151 visits before** the fix and **512 after** it. Both new cases fail on main; all 26 existing query-safety cases pass there.
- Preserve frozen caller arrays, value order, empty values, spaces, Unicode, and literal plus signs. Existing inherited-name and `__proto__` query checks remain unchanged.
- The complexity claim applies to the SDK's query-grouping step; the AWS library's canonicalization is unchanged.

## Validation

- `./scripts/test tests/lib/bedrock-provider-query-safety.test.ts`: 28 passed.
- `CI=true ./scripts/test`: 7,011 handwritten tests and 556 generated tests passed; 12 snapshots passed. The existing generated skips are unchanged.
- `pnpm lint`, `pnpm exec tsc --noEmit`, and `pnpm build`: passed.
- Built CommonJS and ESM entrypoints on Node **22.0.0**, **24.20.0**, and **26.7.0**: 48 public-client cases passed, covering both endpoints and zero, one, two, and 256 repeated values. The smoke check independently reconstructs each dispatched URL's query and verifies the resulting signature.

## Adversarial self-review

Reviewed ownership, query-key handling, serialization, frozen inputs, inter-request isolation, and signing compatibility twice. The array is created within `requestTarget()` and cannot alias caller input or a previous request. The null-prototype record and unsafe-key rejection are untouched. No new parsing rules, retained state, limits, or fallback authentication behavior are introduced.
