### PR TITLE
fix(examples): support redirected streaming output

### DIFF
--- a/examples/chat-completions/function-call-stream-raw.ts
+++ b/examples/chat-completions/function-call-stream-raw.ts
@@ -144,6 +144,11 @@ function messageReducer(previous: ChatCompletionMessage, item: ChatCompletionChu
 function lineRewriter() {
   let lastMessageLength = 0;
   return function write(value: any) {
+    if (!process.stdout.isTTY) {
+      console.log(formatWithOptions({ colors: false, breakLength: Infinity }, value));
+      return;
+    }
+
     process.stdout.cursorTo(0);
     process.stdout.moveCursor(0, -Math.floor((lastMessageLength - 1) / process.stdout.columns));
     lastMessageLength = formatWithOptions({ colors: false, breakLength: Infinity }, value).length;

--- a/examples/chat-completions/function-call-stream-raw.ts
+++ b/examples/chat-completions/function-call-stream-raw.ts
@@ -99,6 +99,11 @@ async function main() {
     let message = {} as ChatCompletionMessage;
     for await (const chunk of stream) {
       message = messageReducer(message, chunk);
+      if (process.stdout.isTTY) {
+        writeLine(message);
+      }
+    }
+    if (!process.stdout.isTTY) {
       writeLine(message);
     }
     console.log();

--- a/examples/chat-completions/function-call-stream.ts
+++ b/examples/chat-completions/function-call-stream.ts
@@ -144,6 +144,11 @@ function messageReducer(previous: ChatCompletionMessage, item: ChatCompletionChu
 function lineRewriter() {
   let lastMessageLength = 0;
   return function write(value: any) {
+    if (!process.stdout.isTTY) {
+      console.log(formatWithOptions({ colors: false, breakLength: Infinity }, value));
+      return;
+    }
+
     process.stdout.cursorTo(0);
     process.stdout.moveCursor(0, -Math.floor((lastMessageLength - 1) / process.stdout.columns));
     lastMessageLength = formatWithOptions({ colors: false, breakLength: Infinity }, value).length;

--- a/examples/chat-completions/function-call-stream.ts
+++ b/examples/chat-completions/function-call-stream.ts
@@ -99,6 +99,11 @@ async function main() {
     let message = {} as ChatCompletionMessage;
     for await (const chunk of stream) {
       message = messageReducer(message, chunk);
+      if (process.stdout.isTTY) {
+        writeLine(message);
+      }
+    }
+    if (!process.stdout.isTTY) {
       writeLine(message);
     }
     console.log();

--- a/examples/chat-completions/tool-calls-stream.ts
+++ b/examples/chat-completions/tool-calls-stream.ts
@@ -133,10 +133,15 @@ async function main() {
     let message = {} as ChatCompletionMessage;
     for await (const chunk of stream) {
       message = messageReducer(message, chunk);
-      writeLine(message);
+      if (process.stdout.isTTY) {
+        writeLine(message);
+      }
 
       // Add a small delay so that the chunks coming in are noticeable
       await new Promise((resolve) => setTimeout(resolve, CHUNK_DELAY_MS));
+    }
+    if (!process.stdout.isTTY) {
+      writeLine(message);
     }
     console.log();
     messages.push(message);

--- a/examples/chat-completions/tool-calls-stream.ts
+++ b/examples/chat-completions/tool-calls-stream.ts
@@ -209,6 +209,11 @@ function messageReducer(previous: ChatCompletionMessage, item: ChatCompletionChu
 function lineRewriter() {
   let lastMessageLines = 0;
   return function write(value: any) {
+    if (!process.stdout.isTTY) {
+      console.log(formatWithOptions({ colors: false, breakLength: Infinity, depth: 4 }, value));
+      return;
+    }
+
     process.stdout.cursorTo(0);
     process.stdout.moveCursor(0, -lastMessageLines);
 

--- a/tests/lib/streaming-example-nontty.test.ts
+++ b/tests/lib/streaming-example-nontty.test.ts
@@ -1,0 +1,133 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { createServer } from 'node:http';
+import path from 'node:path';
+
+import type {
+  ChatCompletionChunk,
+  ChatCompletionCreateParamsStreaming,
+} from 'openai/resources/chat/completions';
+import { expect, test } from 'vitest';
+
+const examples = ['function-call-stream.ts', 'function-call-stream-raw.ts', 'tool-calls-stream.ts'] as const;
+
+test.each(examples)('%s completes a tool round trip with redirected stdout', async (filename) => {
+  const usesTools = filename === 'tool-calls-stream.ts';
+  const requests: ChatCompletionCreateParamsStreaming[] = [];
+  const server = createServer((request, response) => {
+    let body = '';
+    request.setEncoding('utf-8').on('data', (chunk: string) => {
+      body += chunk;
+    });
+    request.on('end', () => {
+      requests.push(JSON.parse(body) as ChatCompletionCreateParamsStreaming);
+      let deltas: ChatCompletionChunk.Choice.Delta[];
+      if (requests.length > 1) {
+        deltas = [{ role: 'assistant', content: 'Synthetic ' }, { content: 'recommendation.' }];
+      } else if (usesTools) {
+        deltas = [
+          {
+            role: 'assistant',
+            tool_calls: [
+              {
+                index: 0,
+                id: 'call_example',
+                type: 'function',
+                function: { name: 'list', arguments: '{"genre":' },
+              },
+            ],
+          },
+          { tool_calls: [{ index: 0, function: { arguments: '"historical"}' } }] },
+        ];
+      } else {
+        deltas = [
+          { role: 'assistant', function_call: { name: 'list', arguments: '{"genre":' } },
+          { function_call: { arguments: '"historical"}' } },
+        ];
+      }
+
+      response.writeHead(200, { 'Content-Type': 'text/event-stream' });
+      for (const delta of deltas) {
+        const chunk: ChatCompletionChunk = {
+          id: 'chatcmpl_example',
+          object: 'chat.completion.chunk',
+          created: 1,
+          model: 'gpt-3.5-turbo',
+          choices: [{ index: 0, delta, finish_reason: null }],
+        };
+        response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+      }
+      response.end('data: [DONE]\n\n');
+    });
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected a local TCP address');
+  }
+
+  const root = process.cwd();
+  const child = spawn(
+    process.execPath,
+    [
+      path.join(root, 'node_modules/ts-node/dist/bin.js'),
+      '-T',
+      '-r',
+      path.join(root, 'node_modules/tsconfig-paths/register.js'),
+      path.join(root, 'examples/chat-completions', filename),
+    ],
+    {
+      cwd: root,
+      env: {
+        OPENAI_API_KEY: 'synthetic-example-key',
+        OPENAI_BASE_URL: `http://127.0.0.1:${address.port}/v1`,
+        TS_NODE_PROJECT: path.join(root, 'tsconfig.json'),
+        DISABLE_V8_COMPILE_CACHE: '1',
+        SystemRoot: process.env['SystemRoot'],
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15_000,
+    },
+  );
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf-8').on('data', (data: string) => {
+    stdout += data;
+  });
+  child.stderr.setEncoding('utf-8').on('data', (data: string) => {
+    stderr += data;
+  });
+
+  try {
+    const [exitCode, signal] = await once(child, 'close');
+    expect(signal).toBeNull();
+    expect(stderr).toBe('');
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('Synthetic recommendation.');
+    expect(stdout).not.toContain('\u001B[');
+    expect(stdout).not.toContain('synthetic-example-key');
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.stream).toBe(true);
+    const messages = requests[1]?.messages;
+    expect(messages).toHaveLength(4);
+    const result = messages?.[3];
+    expect(result?.role).toBe(usesTools ? 'tool' : 'function');
+    expect(JSON.parse(String(result?.content))).toEqual([
+      { name: 'To Kill a Mockingbird', id: 'a1' },
+      { name: 'All the Light We Cannot See', id: 'a2' },
+      { name: 'Where the Crawdads Sing', id: 'a3' },
+    ]);
+    if (usesTools) {
+      expect(result).toHaveProperty('tool_call_id', 'call_example');
+    } else {
+      expect(result).toHaveProperty('name', 'list');
+    }
+  } finally {
+    child.kill();
+    const closed = once(server, 'close');
+    server.closeAllConnections();
+    server.close();
+    await closed;
+  }
+});

--- a/tests/lib/streaming-example-nontty.test.ts
+++ b/tests/lib/streaming-example-nontty.test.ts
@@ -105,6 +105,7 @@ test.each(examples)('%s completes a tool round trip with redirected stdout', asy
     expect(stderr).toBe('');
     expect(exitCode).toBe(0);
     expect(stdout).toContain('Synthetic recommendation.');
+    expect(stdout.match(/Synthetic /gu)).toHaveLength(1);
     expect(stdout).not.toContain('\u001B[');
     expect(stdout).not.toContain('synthetic-example-key');
     expect(requests).toHaveLength(2);


### PR DESCRIPTION
## Summary

Keep the three handwritten raw chat-streaming examples usable when stdout is piped or redirected to a file.

Their line rewriters unconditionally called `process.stdout.cursorTo()` and other terminal-only methods. On an ordinary pipe/file stream, the first API chunk instead raised `TypeError: process.stdout.cursorTo is not a function`, aborting the example before its function/tool call could complete.

Each example now emits one uncolored, newline-delimited completed message when stdout is not a TTY. It does not repeatedly format or append growing snapshots for redirected output. Interactive terminal rendering still updates after every chunk; request bodies, tool execution, stream timing, and the existing stream reducers are unchanged. No generated SDK files, dependencies, declarations, or custom-code budget settings change.

## Regression coverage

A table-driven test runs all three actual example CLIs through the documented `ts-node -T` / `tsconfig-paths` setup with stdout connected to a pipe. A local HTTP server supplies synthetic SSE chunks containing split function/tool arguments and a final assistant response. The test checks successful exit, the two-request tool round trip, exact function/tool results, final output, and absence of terminal controls. The final text prefix must occur exactly once, preventing repeated growing snapshots.

All three cases failed on the baseline with the cursor-method exception and pass with the fix. The review follow-up's one-prefix assertion also failed on the first PR head (the prefix appeared twice) and passes with completed-message-only output. The child environments use only a synthetic key and local API URL.

## Verification

- `pnpm lint` — passed.
- `pnpm exec tsc --noEmit` (TypeScript 6.0.3) — passed.
- `pnpm build` — CommonJS and ESM passed.
- Strict compilation of the three examples against built SDK declarations with TypeScript 4.5.5 and 4.9.5 — passed.
- Actual built-SDK smoke matrix: all three examples in CommonJS and ESM, each with pipe, file, and real pseudo-terminal stdout, on Node 22.0.0, 24.20.0, and 26.7.0 — 54 cases passed on the final follow-up. Tool request/results and final assistant text were checked; terminal control sequences appeared only in TTY mode, and redirected output contained the final text prefix only once.
- `CI=true ./scripts/test` — 7,012 handwritten tests across 164 files and 556 generated tests across 82 suites passed, plus all 12 snapshots; the existing two generated test skips and one skipped suite are unchanged.

Two adversarial self-review passes covered non-TTY stream capabilities, preservation of terminal rendering and tool execution, output formatting, supported runtime/compiler compatibility, isolated credentials, and child/server cleanup in the regression.
