### PR TITLE
fix: preserve CommonJS constructor inheritance

### DIFF
--- a/ecosystem-tests/node-js/test.js
+++ b/ecosystem-tests/node-js/test.js
@@ -1,8 +1,77 @@
-const openaiKey = "a valid OpenAI key"
+const assert = require('node:assert/strict');
 const OpenAI = require('openai');
 
-console.log(OpenAI)
+const requests = [];
+const options = {
+  apiKey: 'synthetic-test-key',
+  baseURL: 'https://example.test/v1',
+  defaultQuery: { caller: 'present' },
+  fetch: (url) => {
+    requests.push(new URL(url));
+    return Promise.resolve(
+      Response.json({ id: 'synthetic-model', object: 'model', created: 0, owned_by: 'test' }),
+    );
+  },
+};
 
-const openai = new OpenAI({
-	apiKey: openaiKey,
-});
+class DerivedClient extends OpenAI {
+  marker() {
+    return this.baseURL;
+  }
+
+  defaultQuery() {
+    return { ...super.defaultQuery(), from_subclass: 'true' };
+  }
+}
+
+// oxlint-disable-next-line max-classes-per-file -- Verify constructor forwarding through two inheritance levels.
+class GrandchildClient extends DerivedClient {}
+
+void (async () => {
+  try {
+    assert.equal(typeof OpenAI, 'function');
+    assert.equal(OpenAI.OpenAI, OpenAI.default);
+    assert.equal(OpenAI.APIError, OpenAI.default.APIError);
+    assert.equal(OpenAI.toFile, OpenAI.default.toFile);
+
+    // Preserve construction with and without `new`, including the existing export aliases.
+    for (const client of [new OpenAI(options), OpenAI(options), new OpenAI.default(options)]) {
+      assert.ok(client instanceof OpenAI.default);
+      assert.ok(client instanceof OpenAI, 'the CommonJS constructor should recognize its instances');
+      assert.equal(client.apiKey, options.apiKey);
+    }
+    assert.equal(OpenAI.DEFAULT_TIMEOUT, OpenAI.default.DEFAULT_TIMEOUT);
+    assert.equal(DerivedClient.DEFAULT_TIMEOUT, OpenAI.default.DEFAULT_TIMEOUT);
+
+    const derived = new DerivedClient(options);
+    const cloned = derived.withOptions({ maxRetries: 0 });
+    const grandchild = new GrandchildClient(options);
+    const clients = [derived, cloned, grandchild];
+    for (const client of clients) {
+      assert.ok(client instanceof OpenAI);
+      assert.ok(client instanceof OpenAI.default);
+      assert.ok(client instanceof DerivedClient);
+      assert.equal(client.marker(), options.baseURL);
+    }
+    const models = await Promise.all(clients.map((client) => client.models.retrieve('synthetic-model')));
+    for (const model of models) {
+      assert.equal(model.id, 'synthetic-model');
+    }
+    assert.equal(derived.constructor, DerivedClient);
+    assert.equal(cloned.constructor, DerivedClient);
+    assert.ok(grandchild instanceof GrandchildClient);
+    assert.equal(grandchild.constructor, GrandchildClient);
+    assert.equal(requests.length, 3);
+    for (const url of requests) {
+      assert.equal(url.origin, 'https://example.test');
+      assert.equal(url.pathname, '/v1/models/synthetic-model');
+      assert.equal(url.searchParams.get('caller'), 'present');
+      assert.equal(url.searchParams.get('from_subclass'), 'true');
+    }
+
+    console.log('CommonJS constructor compatibility checks passed.');
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  }
+})();

--- a/scripts/utils/fix-index-exports.cjs
+++ b/scripts/utils/fix-index-exports.cjs
@@ -9,8 +9,16 @@ const before = fs.readFileSync(indexJs, 'utf-8');
 const after = before.replace(
   /^(\s*Object\.defineProperty\s*\(exports,\s*["']__esModule["'].+)$/m,
   `exports = module.exports = function (...args) {
-    return new exports.default(...args)
+    return Reflect.construct(exports.default, args, new.target || exports.default)
   }
   $1`.replaceAll(/^ {2}/gm, ''),
 );
-fs.writeFileSync(indexJs, after, 'utf-8');
+// Retain the callable CommonJS export while sharing the SDK class's inheritance.
+fs.writeFileSync(
+  indexJs,
+  `${after}
+Object.setPrototypeOf(exports, exports.default);
+exports.prototype = exports.default.prototype;
+`,
+  'utf-8',
+);


### PR DESCRIPTION
## Summary

Fix constructor inheritance for the callable CommonJS entrypoint returned by `require('openai')`.

The handwritten packaging wrapper currently returns `new exports.default(...)` regardless of the constructor being invoked. As a result, `new DerivedClient(...)` silently returns a base-client instance: subclass methods and protected overrides disappear, `withOptions()` loses the subclass, and even `new OpenAI(...) instanceof OpenAI` is false.

The wrapper now forwards `new.target` through `Reflect.construct()` and shares the SDK class's instance and static prototype chains. Calling `OpenAI(options)` without `new` still works. Existing named/default exports, own export names, module paths, and ESM output are unchanged.

Only two handwritten files change: the CommonJS packaging helper and the existing plain-Node ecosystem fixture. No generated SDK source, declaration, export-map, dependency, or custom-code-budget changes are included.

## Regression

Replace the Node.js fixture's construction-only smoke check with assertions against the actual packed and installed public package:

- construction with and without `new`, plus named/default aliases;
- `instanceof`, instance methods, and static inheritance through two subclass levels;
- subclass-preserving `withOptions()` cloning;
- real SDK requests through an overridden `defaultQuery()` method, with caller query settings preserved.

The canonical ecosystem runner freshly built, packed, and installed main, then failed the new `instanceof` assertion. Repeating the same command after the fix passes. The transport is a local synthetic fetch implementation; no live credentials or API calls are used.

## Validation

- `pnpm exec ts-node -T ecosystem-tests/cli.ts node-js`: passed after failing on main.
- The installed-package constructor regression passed on Node **22.0.0**, **24.20.0**, and **26.7.0**.
- `pnpm exec ts-node -T ecosystem-tests/cli.ts node-ts-cjs node-ts4.5-jest28`: passed, including TypeScript 5.9/Jest 29 and TypeScript 4.5.5/Jest 28.
- `pnpm exec ts-node -T scripts/test-packed-package.ts`: passed CommonJS/ESM imports, ES2020 browser bundling, TypeScript 4.9/6 checks, optional-integration checks, and 1,286 source maps.
- `CI=true ./scripts/test`: 7,009 handwritten and 556 generated tests passed; 12 snapshots passed, with existing generated skips unchanged.
- `pnpm lint`, `pnpm exec tsc --noEmit`, and fresh builds: passed. The changed ecosystem fixture was also checked explicitly with the pinned formatter.

## Adversarial self-review

Reviewed constructor forwarding, callable compatibility, subclass hooks, cloning, nested inheritance, export identity, static members, and module initialization twice. Prototype targets are the already-loaded SDK class, not caller-controlled options. The SDK constructor and its authentication/browser checks still execute normally, and the existing public aliases remain intact. No wrapper cache, proxy abstraction, or alternate client implementation is introduced.
