### PR TITLE
fix(audio): prefer readable inputs over body metadata

### DIFF
--- a/src/helpers/audio.ts
+++ b/src/helpers/audio.ts
@@ -24,8 +24,17 @@ const recordingProviders: Record<NodeJS.Platform, string> = {
 };
 
 function isResponse(stream: NodeJS.ReadableStream | Response | File): stream is Response {
-  // Node readable streams can also carry unrelated body metadata.
-  return !('pipe' in stream && typeof stream.pipe === 'function') && (stream as any).body !== undefined;
+  // Readables have event and flow-control methods, even after they have ended.
+  const nodeReadable =
+    'pipe' in stream &&
+    typeof stream.pipe === 'function' &&
+    'on' in stream &&
+    typeof stream.on === 'function' &&
+    'pause' in stream &&
+    typeof stream.pause === 'function' &&
+    'resume' in stream &&
+    typeof stream.resume === 'function';
+  return !nodeReadable && 'body' in stream && stream.body !== undefined;
 }
 
 function isFile(stream: NodeJS.ReadableStream | Response | File): stream is File {

--- a/src/helpers/audio.ts
+++ b/src/helpers/audio.ts
@@ -24,7 +24,8 @@ const recordingProviders: Record<NodeJS.Platform, string> = {
 };
 
 function isResponse(stream: NodeJS.ReadableStream | Response | File): stream is Response {
-  return (stream as any).body !== undefined;
+  // Node readable streams can also carry unrelated body metadata.
+  return !('pipe' in stream && typeof stream.pipe === 'function') && (stream as any).body !== undefined;
 }
 
 function isFile(stream: NodeJS.ReadableStream | Response | File): stream is File {

--- a/tests/helpers/audio-recording.test.ts
+++ b/tests/helpers/audio-recording.test.ts
@@ -404,6 +404,23 @@ describe('playAudio input and process errors', () => {
     expect(Buffer.concat(chunks).toString()).toBe('node audio');
   });
 
+  test.each([
+    { name: 'null', body: null },
+    { name: 'Buffer', body: Buffer.from('body metadata') },
+    { name: 'another readable', body: Readable.from(['body metadata']) },
+  ])('plays the outer Node readable with $name body metadata', async ({ body }) => {
+    const { chunks } = mockFfplay();
+    const source = Object.assign(Readable.from(['node audio']), { body });
+
+    await playAudio(source);
+
+    expect(Buffer.concat(chunks).toString()).toBe('node audio');
+    expect(source.body).toBe(body);
+    if (body instanceof Readable) {
+      expect(body.readableEnded).toBe(false);
+    }
+  });
+
   test('drains ffplay output without changing its spawn arguments', async () => {
     const { ffplay } = mockFfplay();
 

--- a/tests/helpers/audio-recording.test.ts
+++ b/tests/helpers/audio-recording.test.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import type { MockedFunction } from 'vitest';
 import { spawn } from 'node:child_process';
-import { EventEmitter, getEventListeners } from 'node:events';
+import { EventEmitter, getEventListeners, once } from 'node:events';
 import { PassThrough, Readable, Writable } from 'node:stream';
 import { playAudio, recordAudio } from 'openai/helpers/audio';
 
@@ -388,6 +388,17 @@ describe('recordAudio', () => {
 });
 
 describe('playAudio input and process errors', () => {
+  test('plays a Response body even when the response has a callable pipe property', async () => {
+    const { chunks } = mockFfplay();
+    const pipe = vi.fn();
+    const response = Object.assign(new Response('response audio'), { pipe });
+
+    await playAudio(response);
+
+    expect(Buffer.concat(chunks).toString()).toBe('response audio');
+    expect(pipe).not.toHaveBeenCalled();
+  });
+
   test('plays File inputs through their readable stream', async () => {
     const { chunks } = mockFfplay();
 
@@ -419,6 +430,19 @@ describe('playAudio input and process errors', () => {
     if (body instanceof Readable) {
       expect(body.readableEnded).toBe(false);
     }
+  });
+
+  test('keeps ended Node readable inputs on the stream path despite body metadata', async () => {
+    const { chunks } = mockFfplay();
+    const source = Object.assign(Readable.from([]), { body: null });
+    const ended = once(source, 'end');
+    source.resume();
+    await ended;
+
+    await playAudio(source);
+
+    expect(Buffer.concat(chunks).length).toBe(0);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
   });
 
   test('drains ffplay output without changing its spawn arguments', async () => {


### PR DESCRIPTION
## Summary

Preserve the documented Node-readable input path in `playAudio()` when the readable carries an unrelated `body` field.

The response discriminator previously treated any non-`undefined` `body` as a fetch response. A valid Node readable decorated with `body: null` or Buffer metadata was rejected before `ffplay` started. If that metadata was itself readable, the helper played the metadata bytes instead of the input stream.

The discriminator now recognizes the outer readable event/flow protocol (`pipe`, `on`, `pause`, and `resume`) before treating a `body` field as a response. A Response with an unrelated `pipe` method still follows its response body, and ended Node readables retain their stream path. Native Response inputs, the existing response-like Node-body path, File inputs, process arguments, and error handling are otherwise unchanged. No generated files, dependencies, exported types, or custom-code budget settings change.

## Regression coverage

The existing public-subpath audio suite now covers Node readables with null, Buffer, and readable-stream body metadata. It verifies that the outer stream's audio reaches `ffplay`, metadata identity is preserved, and readable metadata remains unconsumed.

All three metadata regressions fail before the fix: two reject and one captures the wrong bytes. The review follow-up also reproduces and fixes a Response carrying a callable `pipe` property, with an already-ended readable as a control. All 46 focused playback/recording tests pass, including the existing Response, File, process-error, source-error, and cancellation controls.

## Verification

- `./scripts/test tests/helpers/audio.test.ts tests/helpers/audio-recording.test.ts` — 46 tests passed.
- `pnpm lint` — passed.
- `pnpm exec tsc --noEmit` — passed.
- `pnpm build` — CommonJS and ESM passed.
- Public built-SDK CJS/ESM matrix on Node 22.0.0, 24.20.0, and 26.7.0: 48 baseline cases confirmed the metadata failures and unchanged controls; all 72 final cases produced the expected bytes or expected missing-body rejection. Final coverage includes native and response-like inputs with extra `pipe` methods, bodyless Responses with that metadata, and ended Node readables. A local `ffplay` fixture captured stdin and process invocation counts; no live API, audio hardware, or real credentials were used.
- An independent scratch build/pack/install check also confirmed the null/Buffer regressions and existing input controls through the actual packed public subpath on all three runtimes and both module formats.
- Emitted `helpers/audio.d.ts` and `helpers/audio.d.mts` are byte-for-byte identical to the baseline packed declarations.
- `CI=true ./scripts/test` — 7,014 handwritten tests across 163 files and 556 generated tests across 82 suites passed, plus all 12 snapshots; the existing two generated test skips and one skipped suite are unchanged.

Two adversarial review passes checked protocol precedence, inherited Node stream methods, unchanged Response/File handling and process lifecycle, metadata preservation, unchanged public declarations, and supported runtime behavior. The fix adds no new parser, retained state, or fallback abstraction.
