### PR TITLE
fix(embeddings): preserve numeric output with body overrides

### DIFF
--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -34,16 +34,16 @@ export function createEmbedding(
     ...options,
     __security: { bearerAuth: true },
   };
-  const shouldDecode = !hasUserProvidedEncodingFormat && requestOptions.body === optimizedBody;
+  const hasBodyOverride = requestOptions.body !== optimizedBody;
   const response: APIPromise<CreateEmbeddingResponse> = client.post('/embeddings', requestOptions);
 
-  // Only decode the optimized body we supplied, not a caller's body override.
-  if (!shouldDecode) {
+  // Explicit encodings return the original response promise unchanged.
+  if (hasUserProvidedEncodingFormat) {
     return response;
   }
 
-  // The default request uses base64 on the wire, but returns the API's default
-  // numeric embedding representation to the caller.
+  // Preserve numeric output for default requests, including body overrides that
+  // change the encoding used on the wire.
   loggerFor(client).debug('embeddings/decoding base64 embeddings from base64');
 
   return response._thenUnwrap((data) => {
@@ -54,8 +54,12 @@ export function createEmbedding(
       for (let index = 0; index < length; index += 1) {
         if (index in embeddings) {
           const embeddingBase64Obj = embeddings[index] as Embedding;
-          const embeddingBase64Str = embeddingBase64Obj.embedding as unknown as string;
-          embeddingBase64Obj.embedding = toFloat32Array(embeddingBase64Str);
+          const { embedding } = embeddingBase64Obj;
+          // A body override can request float embeddings or omit the format.
+          if (hasBodyOverride && Array.isArray(embedding)) {
+            continue;
+          }
+          embeddingBase64Obj.embedding = toFloat32Array(embedding as unknown as string);
         }
       }
     }

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -28,17 +28,17 @@ export function createEmbedding(
     loggerFor(client).debug('embeddings/user defined encoding_format:', body.encoding_format);
   }
 
-  const response: APIPromise<CreateEmbeddingResponse> = client.post('/embeddings', {
-    body: {
-      ...body,
-      encoding_format: encodingFormat,
-    },
+  const optimizedBody = { ...body, encoding_format: encodingFormat };
+  const requestOptions: RequestOptions = {
+    body: optimizedBody,
     ...options,
     __security: { bearerAuth: true },
-  });
+  };
+  const shouldDecode = !hasUserProvidedEncodingFormat && requestOptions.body === optimizedBody;
+  const response: APIPromise<CreateEmbeddingResponse> = client.post('/embeddings', requestOptions);
 
-  // Explicit encodings return the original response promise unchanged.
-  if (hasUserProvidedEncodingFormat) {
+  // Only decode the optimized body we supplied, not a caller's body override.
+  if (!shouldDecode) {
     return response;
   }
 

--- a/tests/lib/embeddings-request.test.ts
+++ b/tests/lib/embeddings-request.test.ts
@@ -4,6 +4,7 @@ import { APIPromise } from 'openai/api-promise';
 import type { Fetch } from 'openai/internal/builtin-types';
 import type { RequestOptions } from 'openai/internal/request-options';
 import type { PromiseOrValue } from 'openai/internal/types';
+import { compareType } from '../utils/typing';
 
 const vector = [1.25, -2.5];
 const encodedVector = Buffer.from(new Float32Array(vector).buffer).toString('base64');
@@ -144,7 +145,7 @@ describe('embedding request compatibility', () => {
   });
 
   test.each([undefined, 'float', 'base64'] as const)(
-    'preserves a request-body override with %s encoding',
+    'preserves numeric output for a request-body override with %s encoding',
     async (format) => {
       const body = Object.freeze({ ...request });
       const overrideBody = Object.freeze({
@@ -177,9 +178,11 @@ describe('embedding request compatibility', () => {
         data: [{ embedding: expectedEmbedding }],
       });
       const response = await promise;
-      expect(response.data[0]?.embedding).toEqual(expectedEmbedding);
+      compareType<(typeof response.data)[number]['embedding'], number[]>(true);
+      expect(response.data[0]?.embedding.map((value) => value * 2)).toEqual([2.5, -5]);
+      expect(response.data[0]?.embedding).toEqual(vector);
       const dataAndResponse = await promise.withResponse();
-      expect(promise).toBe(call?.response);
+      expect(promise).not.toBe(call?.response);
       expect(dataAndResponse.data).toBe(response);
       expect(dataAndResponse.response).toBe(rawResponse);
       expect(dataAndResponse.request_id).toBe('req_embeddings');

--- a/tests/lib/embeddings-request.test.ts
+++ b/tests/lib/embeddings-request.test.ts
@@ -143,6 +143,57 @@ describe('embedding request compatibility', () => {
     expect(options).toEqual(originalOptions);
   });
 
+  test.each([undefined, 'float', 'base64'] as const)(
+    'preserves a request-body override with %s encoding',
+    async (format) => {
+      const body = Object.freeze({ ...request });
+      const overrideBody = Object.freeze({
+        ...request,
+        input: 'overridden',
+        ...(format === undefined ? {} : { encoding_format: format }),
+      });
+      const expectedEmbedding = format === 'base64' ? encodedVector : vector;
+      const headers = Object.freeze({ 'X-Custom': 'kept' });
+      let bodyReads = 0;
+      const options = Object.freeze<RequestOptions>({
+        get body() {
+          bodyReads += 1;
+          return overrideBody;
+        },
+        headers,
+        __security: { adminAPIKeyAuth: true },
+      });
+      const fetch = vi.fn<Fetch>(async (_url, init) => {
+        expect(JSON.parse(String(init?.body))).toEqual(overrideBody);
+        expect(new Headers(init?.headers).get('X-Custom')).toBe('kept');
+        return embeddingResponse(expectedEmbedding);
+      });
+      const client = new RecordingClient({ apiKey: 'test-key', fetch });
+      const promise = client.embeddings.create(body, options);
+      const [call] = client.requests;
+      const rawResponse = await promise.asResponse();
+
+      expect(await rawResponse.clone().json()).toMatchObject({
+        data: [{ embedding: expectedEmbedding }],
+      });
+      const response = await promise;
+      expect(response.data[0]?.embedding).toEqual(expectedEmbedding);
+      const dataAndResponse = await promise.withResponse();
+      expect(promise).toBe(call?.response);
+      expect(dataAndResponse.data).toBe(response);
+      expect(dataAndResponse.response).toBe(rawResponse);
+      expect(dataAndResponse.request_id).toBe('req_embeddings');
+      expect(await call?.response.asResponse()).toBe(rawResponse);
+      const sentOptions = await call?.options;
+      expect(sentOptions?.body).toBe(overrideBody);
+      expect(sentOptions?.headers).toBe(headers);
+      expect(sentOptions?.__security).toEqual({ bearerAuth: true });
+      expect(bodyReads).toBe(1);
+      expect(body).toEqual(request);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    },
+  );
+
   test('preserves response identity and sparse entries from custom parsers', async () => {
     const client = new OpenAI({ apiKey: 'test-key' });
     const entries: OpenAI.Embedding[] = [];


### PR DESCRIPTION
When primary embeddings parameters omit `encoding_format`, a supported `RequestOptions.body` override can return numeric vectors that the SDK incorrectly decodes as base64, turning `[1.25, -2.5]` into `[]`.

Preserve the existing numeric SDK result for default-format calls: leave numeric override embeddings intact and continue decoding base64 override responses. Explicit primary encodings retain their existing behavior. The helper keeps request-option precedence, single getter evaluation, and raw/parsed response accessors.

The three override regressions cover omitted, float, and base64 wire encodings, exact `number[]` inference, a working `.map()` call, immutable caller objects, headers/security precedence, one fetch, and response identity. Only the handwritten helper and its existing test file change.

Validation:

- The reported base64-override `.map()` regression fails before the fix; all 20 embeddings tests pass afterward.
- `pnpm lint`, `pnpm exec tsc --noEmit`, and `pnpm build` pass with Node 24.20.0 and the frozen dependency lockfile.
- Canonical `./scripts/test` passes using a separately managed local Steady server: 7,012 handwritten tests, 556 generated tests, and 12 snapshots; existing generated skips remain.
- Packed npm checks pass for CommonJS, ESM, ES2020 browser bundling, TypeScript consumers, and 1,286 source maps.
- Built CJS/ESM entrypoints pass 48 mock-fetch cases across Node 22.0.0, 24.20.0, and 26.7.0.
- Independent review found no additional correctness or parsing issues.