### PR TITLE
chore: restore monthly Node version review

### DIFF
--- a/.github/workflows/node-version-review.yml
+++ b/.github/workflows/node-version-review.yml
@@ -50,7 +50,7 @@ jobs:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt-file: .github/codex/prompts/node-version-review.md
           codex-version: '0.144.6'
-          codex-args: '["--search","--ephemeral"]'
+          codex-args: '["--config","web_search=\"live\"","--ephemeral"]'
           permission-profile: ':workspace'
           safety-strategy: drop-sudo
 


### PR DESCRIPTION
## Summary

Replace the removed Codex CLI --search flag with the pinned 0.144.6 CLI supported web_search="live" configuration.

Both scheduled monthly review runs failed before the prompt executed because codex exec rejected --search as an unexpected argument.

## Verification

- Parsed the workflow codex-args JSON and confirmed the intended argv.
- Ran the exact official Codex 0.144.6 binary with the corrected arguments; it entered startup instead of failing argument parsing.
- Ran git diff --check.
- Ran ./scripts/lint.
- Completed two clean adversarial-review rounds with two fresh reviewers per round.