### PR TITLE
fix: preserve cross-realm error causes

### DIFF
--- a/src/internal/errors.ts
+++ b/src/internal/errors.ts
@@ -14,11 +14,12 @@ export const castToError = (err: any): Error => {
   if (typeof err === 'object' && err !== null) {
     try {
       if (Object.prototype.toString.call(err) === '[object Error]') {
+        const hasCause = 'cause' in err;
         // @ts-ignore - not all envs have native support for cause yet
-        const error = new Error(err.message, err.cause ? { cause: err.cause } : {});
+        const error = new Error(err.message, hasCause ? { cause: err.cause } : {});
         if (err.stack) error.stack = err.stack;
         // @ts-ignore - not all envs have native support for cause yet
-        if (err.cause && !error.cause) error.cause = err.cause;
+        if (hasCause && !Object.prototype.hasOwnProperty.call(error, 'cause')) error.cause = err.cause;
         if (err.name) error.name = err.name;
         return error;
       }

--- a/tests/lib/core-error.test.ts
+++ b/tests/lib/core-error.test.ts
@@ -1,3 +1,7 @@
+import { runInNewContext } from 'node:vm';
+import { vi } from 'vitest';
+
+import OpenAI from 'openai';
 import {
   APIConnectionError,
   APIConnectionTimeoutError,
@@ -18,6 +22,102 @@ import {
   SubjectTokenProviderError,
   UnprocessableEntityError,
 } from 'openai/core/error';
+
+describe('transport error causes', () => {
+  test.each([0, false, '', null, undefined, 'synthetic detail', { code: 'E_SYNTHETIC' }])(
+    'preserves a cross-realm Error cause of %s',
+    async (cause) => {
+      const failure = runInNewContext('new TypeError("synthetic transport failure", { cause })', {
+        cause,
+      }) as Error;
+      const fetch = vi.fn(async () => {
+        throw failure;
+      });
+      const client = new OpenAI({ apiKey: 'test-key', maxRetries: 0, fetch });
+
+      expect(failure).not.toBeInstanceOf(Error);
+      const requestError = await client.models.list().catch((error: unknown) => error);
+      expect(requestError).toBeInstanceOf(APIConnectionError);
+      const normalized = (requestError as APIConnectionError & { cause: Error }).cause;
+      expect(normalized).toBeInstanceOf(Error);
+      expect(normalized).not.toBe(failure);
+      expect(normalized.message).toBe(failure.message);
+      expect(normalized.name).toBe(failure.name);
+      expect(normalized.stack).toBe(failure.stack);
+      expect(Object.getOwnPropertyDescriptor(normalized, 'cause')).toEqual({
+        value: cause,
+        writable: true,
+        configurable: true,
+        enumerable: false,
+      });
+      expect(Object.getOwnPropertyDescriptor(normalized, 'cause')?.value).toBe(cause);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test.each([false, true])('preserves omitted causes (cross-realm: %s)', async (crossRealm) => {
+    const failure = crossRealm
+      ? (runInNewContext('new Error("synthetic transport failure")') as Error)
+      : new Error('synthetic transport failure');
+    const fetch = vi.fn(async () => {
+      throw failure;
+    });
+    const client = new OpenAI({ apiKey: 'test-key', maxRetries: 0, fetch });
+    const requestError = await client.models.list().catch((error: unknown) => error);
+
+    expect(requestError).toBeInstanceOf(APIConnectionError);
+    const normalized = (requestError as APIConnectionError & { cause: Error }).cause;
+    expect(Object.getOwnPropertyDescriptor(normalized, 'cause')).toBeUndefined();
+    if (!crossRealm) {
+      expect(normalized).toBe(failure);
+    }
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves cause presence when the Error constructor ignores cause options', () => {
+    const NativeError = Error;
+    function errorWithoutCauseOptions(message?: string) {
+      return new NativeError(message);
+    }
+    const options: { cause?: unknown }[] = [
+      { cause: 0 },
+      { cause: false },
+      { cause: '' },
+      { cause: null },
+      { cause: undefined },
+      {},
+    ];
+    const failures = options.map(
+      (causeOptions) =>
+        runInNewContext('new Error("synthetic transport failure", options)', {
+          options: causeOptions,
+        }) as Error,
+    );
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'Error');
+    if (!descriptor) {
+      throw new Error('Expected a global Error constructor');
+    }
+    let results: APIError[] = [];
+
+    try {
+      Object.defineProperty(globalThis, 'Error', { ...descriptor, value: errorWithoutCauseOptions });
+      results = failures.map((failure) => APIError.generate(undefined, failure, undefined, undefined));
+    } finally {
+      Object.defineProperty(globalThis, 'Error', descriptor);
+    }
+
+    expect(results).toHaveLength(options.length);
+    for (const [index, expected] of options.entries()) {
+      const result = results[index];
+      expect(result).toBeInstanceOf(APIConnectionError);
+      const normalized = (result as APIConnectionError & { cause: Error }).cause;
+      expect(Object.getOwnPropertyDescriptor(normalized, 'cause') !== undefined).toBe(
+        Object.getOwnPropertyDescriptor(expected, 'cause') !== undefined,
+      );
+      expect(Object.getOwnPropertyDescriptor(normalized, 'cause')?.value).toBe(expected.cause);
+    }
+  });
+});
 
 describe('APIError', () => {
   const headers = new Headers({ 'x-request-id': 'req_123' });


### PR DESCRIPTION
## Summary

Preserve valid falsy causes when normalizing a transport error from another JavaScript realm.

With the documented custom `fetch` option, throwing a genuine `node:vm` `TypeError` whose cause is `0`, `false`, `''`, `null`, or explicitly `undefined` produces an `APIConnectionError` whose reconstructed transport error has lost its own `cause` property. Truthy causes already survive. The handwritten `castToError` helper tests truthiness instead of presence.

Error causes may be any value: ECMAScript's [InstallErrorCause operation](https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-installerrorcause) distinguishes a present property from an omitted one.

## Change

- Capture whether the source error has a `cause` property and use that presence check when constructing the host-realm error.
- Keep the existing fallback for environments whose `Error` constructor ignores cause options, checking for an own property on the constructed error.
- Add request-level regressions using genuine foreign errors, the public `client.models.list()` method, and a synthetic throwing fetch.

The change preserves previously supported inherited source causes, omitted causes, same-realm error identity, foreign error messages/names/stacks, truthy cause identity, and the handling of thrown non-Errors. It does not change error branding, subclass reconstruction, retry policy, logging, authentication, or any exported types.

Only the handwritten `src/internal/errors.ts` and existing `tests/lib/core-error.test.ts` change. No generated files, dependencies, lockfiles, or budget rules change.

## Validation

- Six new regressions fail on main: five public-request cases lose the own cause descriptor, and the legacy-constructor fallback also drops falsy causes. All ten new cases pass after the fix.
- The focused error/client suites pass: 65 tests. The legacy-constructor test restores the exact global descriptor in `finally` before assertions.
- Complete `CI=true ./scripts/test`: 7,019 handwritten tests across 163 files, 556 generated tests across 82 suites, and 12 snapshots pass. Existing generated skips are unchanged.
- `pnpm lint`, `pnpm exec tsc --noEmit`, and `pnpm build` pass. The emitted error-helper `.d.ts` and `.d.mts` files are byte-identical to baseline.
- Actual built CJS and ESM checks pass on Node 22.0.0, 24.20.0, and 26.7.0: 324 cases through public SDK requests and `APIError.generate()`. The same baseline matrix confirms 96 affected cases plus unchanged local-error, omitted-cause, truthy-cause, and non-Error controls.
- An additional 168 checks cover own/inherited source causes and the native constructor versus a simulated constructor that ignores cause options. The latter is a compatibility fallback check, not a claim to have tested an additional runtime.

Independent reproduction and repeated adversarial self-review covered presence versus truthiness, metadata/identity preservation, inherited causes, fallback behavior, and unchanged sensitive-data handling. All requests, errors, and credentials used for verification are synthetic.
