### PR TITLE
fix(examples): reuse completed background responses

### DIFF
--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -133,7 +133,7 @@ const initial = client.responses.stream({
 
 let responseId: string | undefined;
 let lastSequenceNumber = -1;
-let interrupted = false;
+let completed = false;
 
 for await (const event of initial) {
   lastSequenceNumber = event.sequence_number;
@@ -142,8 +142,11 @@ for await (const event of initial) {
     responseId = event.response.id;
   }
 
-  if (event.sequence_number === 10) {
-    interrupted = true;
+  if (event.type === 'response.completed') {
+    completed = true;
+  }
+
+  if (event.sequence_number === 10 && !completed) {
     break;
   }
 }
@@ -153,7 +156,7 @@ if (!responseId) {
 }
 
 let finalStream = initial;
-if (interrupted) {
+if (!completed) {
   finalStream = client.responses.stream({
     response_id: responseId,
     starting_after: lastSequenceNumber,
@@ -166,12 +169,12 @@ if (interrupted) {
   }
 }
 
-const completed = await finalStream.finalResponse();
-console.log(completed.output_text);
+const response = await finalStream.finalResponse();
+console.log(response.output_text);
 ```
 
-If the initial iteration completes without the deliberate interruption, reuse its final response without making
-another retrieval request.
+Reuse the initial response only after receiving `response.completed`. A clean end to the stream can still leave a
+background response queued or in progress, in which case retrieve it to continue streaming.
 
 `starting_after` suppresses events that the application has already handled. The helper still replays earlier events
 internally so snapshots and `finalResponse()` include the entire response. When resuming a response that used parsed

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -133,6 +133,7 @@ const initial = client.responses.stream({
 
 let responseId: string | undefined;
 let lastSequenceNumber = -1;
+let interrupted = false;
 
 for await (const event of initial) {
   lastSequenceNumber = event.sequence_number;
@@ -142,6 +143,7 @@ for await (const event of initial) {
   }
 
   if (event.sequence_number === 10) {
+    interrupted = true;
     break;
   }
 }
@@ -150,20 +152,26 @@ if (!responseId) {
   throw new Error('The response ID was not received.');
 }
 
-const resumed = client.responses.stream({
-  response_id: responseId,
-  starting_after: lastSequenceNumber,
-});
+let finalStream = initial;
+if (interrupted) {
+  finalStream = client.responses.stream({
+    response_id: responseId,
+    starting_after: lastSequenceNumber,
+  });
 
-for await (const event of resumed) {
-  if (event.type === 'response.output_text.delta') {
-    process.stdout.write(event.delta);
+  for await (const event of finalStream) {
+    if (event.type === 'response.output_text.delta') {
+      process.stdout.write(event.delta);
+    }
   }
 }
 
-const completed = await resumed.finalResponse();
+const completed = await finalStream.finalResponse();
 console.log(completed.output_text);
 ```
+
+If the initial iteration completes without the deliberate interruption, reuse its final response without making
+another retrieval request.
 
 `starting_after` suppresses events that the application has already handled. The helper still replays earlier events
 internally so snapshots and `finalResponse()` include the entire response. When resuming a response that used parsed

--- a/examples/responses/stream_background.ts
+++ b/examples/responses/stream_background.ts
@@ -12,6 +12,7 @@ async function main() {
   });
 
   let id: string | null = null;
+  let interrupted = false;
 
   for await (const event of runner) {
     if (event.type === 'response.created') {
@@ -20,8 +21,14 @@ async function main() {
 
     console.log('event', event);
     if (event.sequence_number === 10) {
+      interrupted = true;
       break;
     }
+  }
+
+  if (!interrupted) {
+    console.log(await runner.finalResponse());
+    return;
   }
 
   console.log('Interrupted. Continuing...');

--- a/examples/responses/stream_background.ts
+++ b/examples/responses/stream_background.ts
@@ -12,7 +12,7 @@ async function main() {
   });
 
   let id: string | null = null;
-  let interrupted = false;
+  let completed = false;
 
   for await (const event of runner) {
     if (event.type === 'response.created') {
@@ -20,13 +20,16 @@ async function main() {
     }
 
     console.log('event', event);
-    if (event.sequence_number === 10) {
-      interrupted = true;
+    if (event.type === 'response.completed') {
+      completed = true;
+    }
+    if (event.sequence_number === 10 && !completed) {
       break;
     }
   }
 
-  if (!interrupted) {
+  // A clean EOF alone does not mean the background response has completed.
+  if (completed) {
     console.log(await runner.finalResponse());
     return;
   }

--- a/tests/lib/background-streaming-example.test.ts
+++ b/tests/lib/background-streaming-example.test.ts
@@ -1,0 +1,167 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { createServer } from 'node:http';
+import path from 'node:path';
+
+import type { Response, ResponseStreamEvent } from 'openai/resources/responses/responses';
+import { expect, test } from 'vitest';
+
+function responseEvents(chunks: readonly string[]): ResponseStreamEvent[] {
+  const response: Response = {
+    id: 'resp_background_example',
+    object: 'response',
+    created_at: 1,
+    model: 'gpt-4o-2024-08-06',
+    output: [],
+    output_text: '',
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    metadata: null,
+    parallel_tool_calls: false,
+    temperature: null,
+    tool_choice: 'auto',
+    tools: [],
+    top_p: null,
+    status: 'in_progress',
+    background: true,
+  };
+  const events: ResponseStreamEvent[] = [
+    { type: 'response.created', sequence_number: 0, response },
+    {
+      type: 'response.output_item.added',
+      sequence_number: 1,
+      output_index: 0,
+      item: { id: 'msg_example', type: 'message', role: 'assistant', status: 'in_progress', content: [] },
+    },
+    {
+      type: 'response.content_part.added',
+      sequence_number: 2,
+      item_id: 'msg_example',
+      output_index: 0,
+      content_index: 0,
+      part: { type: 'output_text', annotations: [], text: '' },
+    },
+  ];
+  for (const delta of chunks) {
+    events.push({
+      type: 'response.output_text.delta',
+      sequence_number: events.length,
+      item_id: 'msg_example',
+      output_index: 0,
+      content_index: 0,
+      delta,
+      logprobs: [],
+    });
+  }
+  const text = chunks.join('');
+  events.push({
+    type: 'response.completed',
+    sequence_number: events.length,
+    response: {
+      ...response,
+      status: 'completed',
+      output_text: text,
+      output: [
+        {
+          id: 'msg_example',
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', annotations: [], text }],
+        },
+      ],
+    },
+  });
+  return events;
+}
+
+test.each([false, true])('background example completes (interrupted: %s)', async (interrupted) => {
+  const chunks = interrupted
+    ? ['Synthetic ', 'background ', 'response ', 'resumed ', 'after ', 'the ', 'demo ', 'break.']
+    : ['Synthetic completion.'];
+  const events = responseEvents(chunks);
+  const body = `${events.map((event) => `data: ${JSON.stringify(event)}`).join('\n\n')}\n\ndata: [DONE]\n\n`;
+  const requests: { method: string | undefined; url: string | undefined; body: unknown }[] = [];
+  const server = createServer((request, response) => {
+    let requestBody = '';
+    request.setEncoding('utf-8').on('data', (chunk: string) => {
+      requestBody += chunk;
+    });
+    request.on('end', () => {
+      requests.push({
+        method: request.method,
+        url: request.url,
+        body: requestBody ? JSON.parse(requestBody) : null,
+      });
+      response.writeHead(200, { 'content-type': 'text/event-stream' });
+      response.end(body);
+    });
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected a local TCP address');
+  }
+
+  const root = process.cwd();
+  const child = spawn(
+    process.execPath,
+    [
+      path.join(root, 'node_modules/ts-node/dist/bin.js'),
+      '-T',
+      '-r',
+      path.join(root, 'node_modules/tsconfig-paths/register.js'),
+      path.join(root, 'examples/responses/stream_background.ts'),
+    ],
+    {
+      cwd: root,
+      env: {
+        OPENAI_API_KEY: 'synthetic-example-key',
+        OPENAI_BASE_URL: `http://127.0.0.1:${address.port}/v1`,
+        TS_NODE_PROJECT: path.join(root, 'tsconfig.json'),
+        DISABLE_V8_COMPILE_CACHE: '1',
+        SystemRoot: process.env['SystemRoot'],
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15_000,
+    },
+  );
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf-8').on('data', (data: string) => {
+    stdout += data;
+  });
+  child.stderr.setEncoding('utf-8').on('data', (data: string) => {
+    stderr += data;
+  });
+
+  try {
+    const [exitCode, signal] = await once(child, 'close');
+    expect(signal).toBeNull();
+    expect(stderr).toBe('');
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(chunks.join(''));
+    expect(stdout.includes('Interrupted. Continuing...')).toBe(interrupted);
+    expect(stdout).not.toContain('synthetic-example-key');
+    expect(requests).toHaveLength(interrupted ? 2 : 1);
+    expect(requests[0]).toMatchObject({
+      method: 'POST',
+      url: '/v1/responses',
+      body: { background: true, stream: true },
+    });
+    if (interrupted) {
+      expect(requests[1]).toMatchObject({
+        method: 'GET',
+        url: '/v1/responses/resp_background_example?stream=true',
+      });
+    }
+  } finally {
+    child.kill();
+    const closed = once(server, 'close');
+    server.closeAllConnections();
+    server.close();
+    await closed;
+  }
+});

--- a/tests/lib/background-streaming-example.test.ts
+++ b/tests/lib/background-streaming-example.test.ts
@@ -76,12 +76,40 @@ function responseEvents(chunks: readonly string[]): ResponseStreamEvent[] {
   return events;
 }
 
-test.each([false, true])('background example completes (interrupted: %s)', async (interrupted) => {
-  const chunks = interrupted
-    ? ['Synthetic ', 'background ', 'response ', 'resumed ', 'after ', 'the ', 'demo ', 'break.']
-    : ['Synthetic completion.'];
+const scenarios = [
+  {
+    name: 'completion before the cutoff',
+    chunks: ['Synthetic completion.'],
+    resumed: false,
+    partial: false,
+  },
+  {
+    name: 'completion at the cutoff',
+    chunks: ['Synthetic ', 'response ', 'completed ', 'exactly ', 'at ', 'the ', 'cutoff.'],
+    resumed: false,
+    partial: false,
+  },
+  {
+    name: 'explicit interruption',
+    chunks: ['Synthetic ', 'background ', 'response ', 'resumed ', 'after ', 'the ', 'demo ', 'break.'],
+    resumed: true,
+    partial: false,
+  },
+  {
+    name: 'clean EOF before completion',
+    chunks: ['Synthetic completion.'],
+    resumed: true,
+    partial: true,
+  },
+] as const;
+
+test.each(scenarios)('background example: $name', async ({ chunks, resumed, partial }) => {
   const events = responseEvents(chunks);
   const body = `${events.map((event) => `data: ${JSON.stringify(event)}`).join('\n\n')}\n\ndata: [DONE]\n\n`;
+  const partialBody = `${events
+    .slice(0, -1)
+    .map((event) => `data: ${JSON.stringify(event)}`)
+    .join('\n\n')}\n\n`;
   const requests: { method: string | undefined; url: string | undefined; body: unknown }[] = [];
   const server = createServer((request, response) => {
     let requestBody = '';
@@ -95,7 +123,7 @@ test.each([false, true])('background example completes (interrupted: %s)', async
         body: requestBody ? JSON.parse(requestBody) : null,
       });
       response.writeHead(200, { 'content-type': 'text/event-stream' });
-      response.end(body);
+      response.end(partial && requests.length === 1 ? partialBody : body);
     });
   });
   server.listen(0, '127.0.0.1');
@@ -143,15 +171,15 @@ test.each([false, true])('background example completes (interrupted: %s)', async
     expect(stderr).toBe('');
     expect(exitCode).toBe(0);
     expect(stdout).toContain(chunks.join(''));
-    expect(stdout.includes('Interrupted. Continuing...')).toBe(interrupted);
+    expect(stdout.includes('Interrupted. Continuing...')).toBe(resumed);
     expect(stdout).not.toContain('synthetic-example-key');
-    expect(requests).toHaveLength(interrupted ? 2 : 1);
+    expect(requests).toHaveLength(resumed ? 2 : 1);
     expect(requests[0]).toMatchObject({
       method: 'POST',
       url: '/v1/responses',
       body: { background: true, stream: true },
     });
-    if (interrupted) {
+    if (resumed) {
       expect(requests[1]).toMatchObject({
         method: 'GET',
         url: '/v1/responses/resp_background_example?stream=true',


### PR DESCRIPTION
## Summary

Avoid retrieving a background response again when its initial stream has already delivered `response.completed`.

The executable background-streaming example previously always printed `Interrupted. Continuing...` and opened a retrieval stream, even when the initial response completed before the demo cutoff. The example and canonical streaming guide now track the completion event and reuse the initial final response in that case.

Completion is checked before the sequence-10 cutoff, so a completed response at that boundary is not aborted. A clean EOF alone is not treated as completion: queued/in-progress snapshots still follow the existing retrieval path. Deliberate midstream interruption and existing error propagation are preserved.

No SDK implementation, generated file, public API, dependency, authentication, cursor, or custom-code-budget changes are included.

## Public CLI regressions

The tests spawn the actual TypeScript example through its documented `ts-node`/`tsconfig-paths` runtime. An ephemeral localhost HTTP server supplies typed synthetic SSE events; the public OpenAI client and response helper are not mocked.

| Initial stream | Expected requests |
| --- | --- |
| Completes before the cutoff | One POST |
| Completes exactly at sequence 10 | One POST |
| Reaches sequence 10 before completion | POST plus full-replay GET |
| Ends cleanly before completion | POST plus full-replay GET |

Every case checks successful exit, complete final text, the correct interruption message, request method/path/settings, and credential isolation. Child processes and servers are cleaned up in `finally`.

## Verification

- The original completion regression failed on Node 22, 24, and 26, while the deliberate-interruption control and all other handwritten tests passed ([baseline run](https://github.com/openai/openai-node/actions/runs/33541299993)).
- Expanded review regressions exposed partial-EOF and exact-cutoff defects in the initial candidate on all three Node lines ([edge-case run](https://github.com/openai/openai-node/actions/runs/33542230773)). The final change uses observed completion as its single decision point.
- Complete suites pass on Node 22, 24, and 26: 7,013 handwritten tests across 164 files, 556 generated tests across 82 suites, and 12 snapshots. Existing generated skips are unchanged ([final validation](https://github.com/openai/openai-node/actions/runs/33542576612)).
- Lint and TypeScript checks, CJS/ESM build, packed-package checks, offline ecosystem tests, and performance benchmarks pass.
- The example's executable file mode is preserved. All credentials, payloads, and HTTP requests used for these regressions are synthetic; no live OpenAI API calls are required.

Repeated adversarial self-review and independent final review found no remaining actionable issue in the scoped change. Only `examples/responses/stream_background.ts`, `docs/streaming.md`, and `tests/lib/background-streaming-example.test.ts` change.
