### PR TITLE
fix: clean up failed mock-server startups

### DIFF
--- a/scripts/mock
+++ b/scripts/mock
@@ -34,12 +34,21 @@ if [ "$1" == "--daemon" ]; then
   ./node_modules/.bin/steady --version
 
   ./node_modules/.bin/steady --host 127.0.0.1 -p 4010 --validator-query-array-format=brackets --validator-form-array-format=brackets --validator-query-object-format=brackets --validator-form-object-format=brackets "$URL" &> .stdy.log &
+  steady_pid=$!
+
+  cleanup_steady() {
+    if kill -0 "$steady_pid" 2>/dev/null; then
+      kill "$steady_pid" 2>/dev/null || true
+    fi
+    wait "$steady_pid" 2>/dev/null || true
+  }
+  trap cleanup_steady EXIT
 
   # Wait for server to come online via health endpoint (max 30s)
   echo -n "Waiting for server"
   attempts=0
   while ! curl --silent --fail "http://127.0.0.1:4010/_x-steady/health" >/dev/null 2>&1; do
-    if ! kill -0 $! 2>/dev/null; then
+    if ! kill -0 "$steady_pid" 2>/dev/null; then
       echo
       cat .stdy.log
       exit 1
@@ -55,6 +64,7 @@ if [ "$1" == "--daemon" ]; then
     sleep 0.1
   done
 
+  trap - EXIT
   echo
 else
   ./node_modules/.bin/steady --host 127.0.0.1 -p 4010 --validator-query-array-format=brackets --validator-form-array-format=brackets --validator-query-object-format=brackets --validator-form-object-format=brackets "$URL"

--- a/tests/mock-launcher.test.ts
+++ b/tests/mock-launcher.test.ts
@@ -27,6 +27,31 @@ function writeExecutable(filename: string, source: string) {
   writeFileSync(filename, `#!/usr/bin/env node\n${source}\n`, { mode: 0o755 });
 }
 
+function writeShellExecutable(filename: string, source: string) {
+  writeFileSync(filename, `#!/usr/bin/env bash\n${source}\n`, { mode: 0o755 });
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ESRCH') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function readPid(filename: string): number | undefined {
+  if (!existsSync(filename)) {
+    return undefined;
+  }
+
+  const pid = Number(readFileSync(filename, 'utf-8'));
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : undefined;
+}
+
 describe('Steady mock launcher', () => {
   test.each([
     ['foreground', false],
@@ -37,7 +62,9 @@ describe('Steady mock launcher', () => {
     const executableDirectory = path.join(fixture, 'executables');
     const observationsFile = path.join(fixture, 'steady.jsonl');
     const pnpmInvocation = path.join(fixture, 'pnpm-invoked');
+    const steadyPidFile = path.join(fixture, 'steady.pid');
     const url = 'fixtures/spec with spaces; $(touch shell-injection).yml';
+    let steadyPid: number | undefined;
 
     try {
       mkdirSync(path.join(checkout, 'scripts'), { recursive: true });
@@ -53,7 +80,11 @@ describe('Steady mock launcher', () => {
           'const observation = { args, cwd: process.cwd(), node: process.version };',
           "fs.appendFileSync(process.env.STEADY_OBSERVATIONS, JSON.stringify(observation) + '\\n');",
           "if (args[0] === '--version') process.stdout.write('0.22.2\\n');",
-          "else if (process.env.STEADY_DAEMON === 'true') setTimeout(() => {}, 500);",
+          "else if (process.env.STEADY_DAEMON === 'true') {",
+          '  fs.writeFileSync(process.env.STEADY_PID_FILE, String(process.pid));',
+          "  process.on('SIGTERM', () => process.exit(0));",
+          '  setInterval(() => {}, 1000);',
+          '}',
         ].join('\n'),
       );
       writeExecutable(
@@ -84,11 +115,15 @@ describe('Steady mock launcher', () => {
             PATH: `${executableDirectory}${path.delimiter}${path.dirname(process.execPath)}${path.delimiter}${process.env['PATH']}`,
             STEADY_DAEMON: String(daemon),
             STEADY_OBSERVATIONS: observationsFile,
+            STEADY_PID_FILE: steadyPidFile,
             PNPM_INVOCATION: pnpmInvocation,
           },
           timeout: 5000,
         },
       );
+      if (daemon) {
+        steadyPid = readPid(steadyPidFile);
+      }
 
       expect(result.error).toBeUndefined();
       expect(result.status).toBe(0);
@@ -107,8 +142,122 @@ describe('Steady mock launcher', () => {
       );
       if (daemon) {
         expect(result.stdout).toContain('Waiting for server');
+        expect(steadyPid).toBeDefined();
+        if (steadyPid !== undefined) {
+          expect(isProcessRunning(steadyPid)).toBe(true);
+        }
       }
     } finally {
+      steadyPid ??= readPid(steadyPidFile);
+      if (steadyPid !== undefined && isProcessRunning(steadyPid)) {
+        process.kill(steadyPid, 'SIGTERM');
+      }
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  test('preserves the startup failure after the daemon exits early', () => {
+    const fixture = mkdtempSync(path.join(tmpdir(), 'openai-node-mock-launcher-exit-'));
+    const checkout = path.join(fixture, 'checkout');
+    const executableDirectory = path.join(fixture, 'executables');
+
+    try {
+      mkdirSync(path.join(checkout, 'scripts'), { recursive: true });
+      mkdirSync(path.join(checkout, 'node_modules/.bin'), { recursive: true });
+      mkdirSync(executableDirectory);
+      writeFileSync(path.join(checkout, 'scripts/mock'), readFileSync(path.join(root, 'scripts/mock')));
+
+      writeShellExecutable(
+        path.join(checkout, 'node_modules/.bin/steady'),
+        `if [[ "\${1-}" == "--version" ]]; then
+  echo "0.22.2"
+  exit 0
+fi
+echo "synthetic startup failure" >&2
+exit 23`,
+      );
+      writeShellExecutable(
+        path.join(executableDirectory, 'curl'),
+        `while [[ ! -s .stdy.log ]]; do
+  :
+done
+exit 1`,
+      );
+
+      const result = spawnSync('bash', [path.join(checkout, 'scripts/mock'), 'synthetic.yml', '--daemon'], {
+        cwd: fixture,
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          PATH: `${executableDirectory}${path.delimiter}${path.dirname(process.execPath)}${path.delimiter}${process.env['PATH']}`,
+        },
+        timeout: 5000,
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain('synthetic startup failure');
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  test('terminates the daemon if it times out before becoming healthy', () => {
+    const fixture = mkdtempSync(path.join(tmpdir(), 'openai-node-mock-launcher-timeout-'));
+    const checkout = path.join(fixture, 'checkout');
+    const executableDirectory = path.join(fixture, 'executables');
+    const steadyPidFile = path.join(fixture, 'steady.pid');
+    let steadyPid: number | undefined;
+
+    try {
+      mkdirSync(path.join(checkout, 'scripts'), { recursive: true });
+      mkdirSync(path.join(checkout, 'node_modules/.bin'), { recursive: true });
+      mkdirSync(executableDirectory);
+      writeFileSync(path.join(checkout, 'scripts/mock'), readFileSync(path.join(root, 'scripts/mock')));
+
+      writeExecutable(
+        path.join(checkout, 'node_modules/.bin/steady'),
+        [
+          "const fs = require('node:fs');",
+          "if (process.argv[2] === '--version') { console.log('0.22.2'); process.exit(0); }",
+          'fs.writeFileSync(process.env.STEADY_PID_FILE, String(process.pid));',
+          "process.on('SIGTERM', () => process.exit(0));",
+          'setInterval(() => {}, 1000);',
+        ].join('\n'),
+      );
+      writeShellExecutable(
+        path.join(executableDirectory, 'curl'),
+        `while [[ ! -s "$STEADY_PID_FILE" ]]; do
+  :
+done
+exit 1`,
+      );
+      writeShellExecutable(path.join(executableDirectory, 'sleep'), 'exit 0');
+
+      const result = spawnSync('bash', [path.join(checkout, 'scripts/mock'), 'synthetic.yml', '--daemon'], {
+        cwd: fixture,
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          PATH: `${executableDirectory}${path.delimiter}${path.dirname(process.execPath)}${path.delimiter}${process.env['PATH']}`,
+          STEADY_PID_FILE: steadyPidFile,
+        },
+        timeout: 15_000,
+      });
+      steadyPid = readPid(steadyPidFile);
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain('Timed out waiting for Steady server to start');
+      expect(steadyPid).toBeDefined();
+      if (steadyPid !== undefined) {
+        expect(isProcessRunning(steadyPid)).toBe(false);
+      }
+    } finally {
+      steadyPid ??= readPid(steadyPidFile);
+      if (steadyPid !== undefined && isProcessRunning(steadyPid)) {
+        process.kill(steadyPid, 'SIGTERM');
+      }
       rmSync(fixture, { recursive: true, force: true });
     }
   });

--- a/tests/mock-launcher.test.ts
+++ b/tests/mock-launcher.test.ts
@@ -78,10 +78,12 @@ describe('Steady mock launcher', () => {
           "const fs = require('node:fs');",
           'const args = process.argv.slice(2);',
           'const observation = { args, cwd: process.cwd(), node: process.version };',
+          "if (args[0] !== '--version' && process.env.STEADY_DAEMON === 'true') {",
+          '  fs.writeFileSync(process.env.STEADY_PID_FILE, String(process.pid));',
+          '}',
           "fs.appendFileSync(process.env.STEADY_OBSERVATIONS, JSON.stringify(observation) + '\\n');",
           "if (args[0] === '--version') process.stdout.write('0.22.2\\n');",
           "else if (process.env.STEADY_DAEMON === 'true') {",
-          '  fs.writeFileSync(process.env.STEADY_PID_FILE, String(process.pid));',
           "  process.on('SIGTERM', () => process.exit(0));",
           '  setInterval(() => {}, 1000);',
           '}',
@@ -100,7 +102,8 @@ describe('Steady mock launcher', () => {
         [
           "const fs = require('node:fs');",
           "const observations = fs.existsSync(process.env.STEADY_OBSERVATIONS) ? fs.readFileSync(process.env.STEADY_OBSERVATIONS, 'utf8').trim().split('\\n') : [];",
-          "process.exit(observations.some((line) => JSON.parse(line).args[0] !== '--version') ? 0 : 1);",
+          "const daemonStarted = observations.some((line) => JSON.parse(line).args[0] !== '--version');",
+          'process.exit(daemonStarted && fs.existsSync(process.env.STEADY_PID_FILE) ? 0 : 1);',
         ].join('\n'),
       );
 
@@ -176,13 +179,7 @@ fi
 echo "synthetic startup failure" >&2
 exit 23`,
       );
-      writeShellExecutable(
-        path.join(executableDirectory, 'curl'),
-        `while [[ ! -s .stdy.log ]]; do
-  :
-done
-exit 1`,
-      );
+      writeShellExecutable(path.join(executableDirectory, 'curl'), 'exit 1');
 
       const result = spawnSync('bash', [path.join(checkout, 'scripts/mock'), 'synthetic.yml', '--daemon'], {
         cwd: fixture,
@@ -227,12 +224,21 @@ exit 1`,
       );
       writeShellExecutable(
         path.join(executableDirectory, 'curl'),
-        `while [[ ! -s "$STEADY_PID_FILE" ]]; do
+        `attempts=0
+while [[ ! -s "$STEADY_PID_FILE" && "$attempts" -lt 1000 ]]; do
+  attempts=$((attempts + 1))
   :
 done
 exit 1`,
       );
       writeShellExecutable(path.join(executableDirectory, 'sleep'), 'exit 0');
+
+      const curlWithoutPid = spawnSync('bash', [path.join(executableDirectory, 'curl')], {
+        env: { ...process.env, STEADY_PID_FILE: steadyPidFile },
+        timeout: 1000,
+      });
+      expect(curlWithoutPid.error).toBeUndefined();
+      expect(curlWithoutPid.status).toBe(1);
 
       const result = spawnSync('bash', [path.join(checkout, 'scripts/mock'), 'synthetic.yml', '--daemon'], {
         cwd: fixture,


### PR DESCRIPTION
## Summary

Clean up the owned Steady process when `scripts/mock --daemon` fails during startup.

Previously, a live process whose health endpoint never became ready survived the launcher's 300-attempt timeout. The script exited with status 1 but left the mock server running.

The daemon branch now captures its child PID immediately and installs an EXIT trap that terminates and waits for that exact child. Cleanup commands cannot replace the original failure status. The trap is removed immediately after health succeeds, before the final output, so a healthy daemon remains running.

Foreground execution, command/spec arguments, health probes, polling intervals, and successful startup behavior are unchanged. Cleanup retains the locked server's normal SIGTERM behavior; this does not add process-group killing, port-wide discovery, or shutdown escalation.

## Regression coverage

The existing tests invoke the actual Bash launcher with isolated synthetic Steady and health-check executables:

- Foreground execution remains synchronous and uses the locked local binary.
- A healthy daemon remains alive after the launcher exits, then the test cleans up its exact PID.
- An early child exit preserves failure status and startup-log output.
- A live but unhealthy child is terminated and reaped when startup times out.

The timeout regression failed against unchanged main while the two original launcher controls passed. Final fixtures publish the child PID before readiness, use bounded failing probes, verify the missing-PID probe terminates, and recover cleanup ownership in `finally`. The preflight invokes Bash explicitly for compatibility with the existing launcher tests.

## Validation

- Final focused tests: 4/4 on Node 22.0.0, 24.20.0, and 26.7.0.
- [Complete CI on the exact final commit](https://github.com/openai/openai-node/actions/runs/33547284347): 7,011 handwritten tests across 163 files, 556 generated tests across 82 suites, and 12 snapshots pass on the Node 22, 24, and 26 matrix. Existing generated skips are unchanged.
- Lint, TypeScript, build, packed-package checks, offline ecosystem tests, and performance benchmarks pass.
- Bash syntax, diff checks, executable mode, and byte-for-byte comparison of the published files with the locally tested files pass.

The isolated local environment exposed a PID-namespace mismatch in the separate `scripts/test` cleanup: generated assertions passed but that wrapper exited nonzero. No workaround was committed; the complete unchanged test entrypoint and cleanup pass in GitHub CI.

Repeated adversarial self-review and independent final review found no remaining actionable issue. Only the handwritten `scripts/mock` and `tests/mock-launcher.test.ts` change; no SDK implementation, generated code, dependencies, or custom-code-budget settings change.
