### PR TITLE
fix(pagination): follow next cursors through empty pages

### DIFF
--- a/src/core/pagination.ts
+++ b/src/core/pagination.ts
@@ -309,7 +309,7 @@ export class NextCursorPage<Item> extends AbstractPage<Item> implements NextCurs
       return false;
     }
 
-    return super.hasNextPage();
+    return this.nextPageRequestOptions() != null;
   }
 
   nextPageRequestOptions(): PageRequestOptions | null {

--- a/tests/lib/next-cursor-pagination.test.ts
+++ b/tests/lib/next-cursor-pagination.test.ts
@@ -1,0 +1,126 @@
+import { once } from 'node:events';
+import { createServer, type IncomingHttpHeaders } from 'node:http';
+import OpenAI from 'openai';
+import type { NextCursorPageResponse } from 'openai/core/pagination';
+import type { Group } from 'openai/resources/admin/organization/groups/groups';
+
+const firstGroup: Group = {
+  id: 'group_first',
+  created_at: 0,
+  group_type: 'group',
+  is_scim_managed: false,
+  name: 'First group',
+};
+const secondGroup: Group = { ...firstGroup, id: 'group_second', name: 'Second group' };
+
+const cases: Array<{ name: string; pages: NextCursorPageResponse<Group>[] }> = [
+  {
+    name: 'empty first page with a continuation cursor',
+    pages: [
+      { data: [], has_more: true, next: 'cursor:one/+=' },
+      { data: [firstGroup], has_more: false, next: null },
+    ],
+  },
+  {
+    name: 'empty intermediate page with a continuation cursor',
+    pages: [
+      { data: [firstGroup], has_more: true, next: 'cursor:one/+=' },
+      { data: [], has_more: true, next: 'cursor:two/+=' },
+      { data: [secondGroup], has_more: false, next: null },
+    ],
+  },
+  {
+    name: 'ordinary populated pages',
+    pages: [
+      { data: [firstGroup], has_more: true, next: 'cursor:one/+=' },
+      { data: [secondGroup], has_more: false, next: null },
+    ],
+  },
+  {
+    name: 'terminal empty page',
+    pages: [{ data: [], has_more: false, next: null }],
+  },
+];
+
+describe.each(['items', 'pages'] as const)('NextCursorPage %s iteration', (mode) => {
+  test.each(cases)('$name', async ({ pages }) => {
+    const requests: Array<{ method: string | undefined; url: URL; headers: IncomingHttpHeaders }> = [];
+    const server = createServer((request, response) => {
+      const url = new URL(request.url!, 'http://127.0.0.1');
+      requests.push({ method: request.method, url, headers: request.headers });
+      const pageIndex = pages.findIndex(
+        (_, index) =>
+          url.searchParams.get('after') === (index === 0 ? null : pages[index - 1]!.next),
+      );
+      if (pageIndex === -1 || requests.length > pages.length) {
+        response.writeHead(400, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({ error: { message: 'Unexpected pagination request' } }));
+        return;
+      }
+
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify(pages[pageIndex]));
+    });
+
+    try {
+      const listening = once(server, 'listening');
+      server.listen(0, '127.0.0.1');
+      await listening;
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Expected a TCP server address');
+      }
+
+      const client = new OpenAI({
+        apiKey: 'synthetic-api-key',
+        adminAPIKey: 'synthetic-admin-key',
+        organization: null,
+        project: null,
+        baseURL: `http://127.0.0.1:${address.port}/v1`,
+        maxRetries: 0,
+        timeout: 5000,
+        logLevel: 'off',
+      });
+      const result = client.admin.organization.groups.list(
+        { limit: 1, order: 'asc' },
+        { headers: { 'x-pagination-test': 'synthetic' } },
+      );
+      const items: Group[] = [];
+      const receivedPages: Group[][] = [];
+      if (mode === 'items') {
+        for await (const group of result) {
+          items.push(group);
+        }
+      } else {
+        for await (const page of (await result).iterPages()) {
+          receivedPages.push(page.data);
+          items.push(...page.data);
+        }
+      }
+
+      expect(requests).toHaveLength(pages.length);
+      expect(items).toEqual(pages.flatMap((page) => page.data));
+      if (mode === 'pages') {
+        expect(receivedPages).toEqual(pages.map((page) => page.data));
+      }
+      for (const [index, request] of requests.entries()) {
+        expect(request.method).toBe('GET');
+        expect(request.url.pathname).toBe('/v1/organization/groups');
+        expect(Object.fromEntries(request.url.searchParams)).toEqual({
+          limit: '1',
+          order: 'asc',
+          ...(index === 0 ? {} : { after: pages[index - 1]!.next }),
+        });
+        expect(request.headers.authorization).toBe('Bearer synthetic-admin-key');
+        expect(request.headers['x-pagination-test']).toBe('synthetic');
+      }
+    } finally {
+      if (server.listening) {
+        const closed = once(server, 'close');
+        server.close();
+        server.closeAllConnections();
+        await closed;
+      }
+    }
+  });
+});

--- a/tests/lib/next-cursor-pagination.test.ts
+++ b/tests/lib/next-cursor-pagination.test.ts
@@ -1,5 +1,6 @@
 import { once } from 'node:events';
-import { createServer, type IncomingHttpHeaders } from 'node:http';
+import { createServer } from 'node:http';
+import type { IncomingHttpHeaders } from 'node:http';
 import OpenAI from 'openai';
 import type { NextCursorPageResponse } from 'openai/core/pagination';
 import type { Group } from 'openai/resources/admin/organization/groups/groups';
@@ -13,7 +14,7 @@ const firstGroup: Group = {
 };
 const secondGroup: Group = { ...firstGroup, id: 'group_second', name: 'Second group' };
 
-const cases: Array<{ name: string; pages: NextCursorPageResponse<Group>[] }> = [
+const cases: { name: string; pages: NextCursorPageResponse<Group>[] }[] = [
   {
     name: 'empty first page with a continuation cursor',
     pages: [
@@ -44,13 +45,12 @@ const cases: Array<{ name: string; pages: NextCursorPageResponse<Group>[] }> = [
 
 describe.each(['items', 'pages'] as const)('NextCursorPage %s iteration', (mode) => {
   test.each(cases)('$name', async ({ pages }) => {
-    const requests: Array<{ method: string | undefined; url: URL; headers: IncomingHttpHeaders }> = [];
+    const requests: { method: string | undefined; url: URL; headers: IncomingHttpHeaders }[] = [];
     const server = createServer((request, response) => {
-      const url = new URL(request.url!, 'http://127.0.0.1');
+      const url = new URL(request.url ?? '/', 'http://127.0.0.1');
       requests.push({ method: request.method, url, headers: request.headers });
       const pageIndex = pages.findIndex(
-        (_, index) =>
-          url.searchParams.get('after') === (index === 0 ? null : pages[index - 1]!.next),
+        (_, index) => url.searchParams.get('after') === (index === 0 ? null : pages[index - 1]?.next),
       );
       if (pageIndex === -1 || requests.length > pages.length) {
         response.writeHead(400, { 'content-type': 'application/json' });
@@ -92,7 +92,8 @@ describe.each(['items', 'pages'] as const)('NextCursorPage %s iteration', (mode)
           items.push(group);
         }
       } else {
-        for await (const page of (await result).iterPages()) {
+        const firstPage = await result;
+        for await (const page of firstPage.iterPages()) {
           receivedPages.push(page.data);
           items.push(...page.data);
         }
@@ -109,7 +110,7 @@ describe.each(['items', 'pages'] as const)('NextCursorPage %s iteration', (mode)
         expect(Object.fromEntries(request.url.searchParams)).toEqual({
           limit: '1',
           order: 'asc',
-          ...(index === 0 ? {} : { after: pages[index - 1]!.next }),
+          ...(index === 0 ? {} : { after: pages[index - 1]?.next }),
         });
         expect(request.headers.authorization).toBe('Bearer synthetic-admin-key');
         expect(request.headers['x-pagination-test']).toBe('synthetic');


### PR DESCRIPTION
## Summary

`NextCursorPage` has an explicit server-provided `next` cursor, but its `hasNextPage()` delegates to the base implementation, which rejects every empty data array before checking continuation metadata. An empty first or intermediate page can therefore silently stop both item auto-iteration and `iterPages()`, omitting subsequent results.

After the existing `has_more === false` guard, consult `nextPageRequestOptions()` directly. Missing/empty cursors still stop pagination. Other pagination classes are unchanged.

## Regression coverage

Add eight real loopback-HTTP cases through `client.admin.organization.groups.list()`: empty first page, empty intermediate page, ordinary populated pages, and terminal empty page, each exercised through item and page iteration.

The tests use a positive page limit and distinct opaque cursors, and verify yielded items/pages, exact request counts, cursor encoding, retained query parameters, admin authentication, and request headers. Unknown/repeated unexpected requests fail within the synthetic fixture; retries are disabled and servers/connections close in `finally`.

## Validation

- **Before the fix:** the [test-only commit](https://github.com/openai/openai-node/commit/3c37675e9e53fc1242efba044d8b87e0e326211c) produces exactly four regression failures and four passing controls on Node 22, 24, and 26 ([CI run](https://github.com/openai/openai-node/actions/runs/33555440586)). The formatted final test also reproduced the same four failures locally before the production change.
- **After the fix:** [CI on `96b30860`](https://github.com/openai/openai-node/actions/runs/33556279606) passes all 7,017 handwritten tests, 556 generated tests, and 12 generated snapshots on each of Node 22, 24, and 26. Existing skipped tests are unchanged.
- All 20 focused pagination tests pass locally, together with the complete handwritten suite, canonical lint, TypeScript checking, and package build.
- The installed npm tarball passes **16 CJS/ESM cases and 32 native loopback HTTP requests on exact Node 22.0.0**, covering both iteration modes and all four page shapes. This check ran locally without optional peers.
- CI also passes published-source checks with TypeScript 4.9 and 6, package/export checks, ecosystem tests, and benchmarks.

Adversarial self-review covered termination guards, subclass dispatch, cursor/query encoding, request-option and authentication preservation, response ordering, and fixture cleanup. An independent closing review found no actionable bypasses or regressions.

## Scope

One production line plus one focused test file. Both paths are absent from the current verified public generated tree (`65094c1637432c123c310d03e0cda1e7e6f1c997`). No generated resources, public types, dependencies, workflow files, custom-code budgets, or pagination limits change.
