### PR TITLE
chore: raise custom-code budget to 4,000 lines

### DIFF
--- a/.castiron-ratchet.json
+++ b/.castiron-ratchet.json
@@ -1,4 +1,4 @@
 {
   "schema_version": 1,
-  "max_custom_patch_lines": 3000
+  "max_custom_patch_lines": 4000
 }


### PR DESCRIPTION
Raise the custom-code budget from 3,000 to 4,000 to unblock SDK generation. Main currently uses 2,983 lines; the current generation candidate uses 3,497, leaving 503 lines under the new limit.

These remaining customizations are technical debt. We do not have time to address that debt at the moment, so this raises the budget to unblock the work and defers the underlying cleanup.

Usage was 1,770 when the original budget landed in #2446. The increase on main came from:

- Reporter and test changes: +696 lines in #2447 and #2464.
- X.509 client integration: +513 lines in #2472, #2473 and #2479.
- Webhook verification wiring: +4 lines in #2475.

Only `.castiron-ratchet.json` changes.
