### PR TITLE
fix(examples): report image-streaming failures

### DIFF
--- a/examples/images/image-stream.ts
+++ b/examples/images/image-stream.ts
@@ -51,4 +51,5 @@ const main = async () => {
 
 main().catch((error) => {
   console.error('Error generating image:', error);
+  process.exitCode = 1;
 });

--- a/tests/lib/image-streaming-example.test.ts
+++ b/tests/lib/image-streaming-example.test.ts
@@ -1,0 +1,156 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdir, mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const root = process.cwd();
+const partialImage = Buffer.from('synthetic partial image');
+const finalImage = Buffer.from('synthetic final image');
+const failure = { message: 'synthetic image failure', type: 'invalid_request_error', code: 'image_failure' };
+
+async function runExample(directory: string, baseURL: string) {
+  const child = spawn(
+    process.execPath,
+    [
+      path.join(root, 'node_modules/ts-node/dist/bin.js'),
+      '-r',
+      path.join(root, 'node_modules/tsconfig-paths/register.js'),
+      path.join(root, 'examples/images/image-stream.ts'),
+    ],
+    {
+      cwd: directory,
+      env: {
+        PATH: process.env['PATH'],
+        SystemRoot: process.env['SystemRoot'],
+        OPENAI_API_KEY: 'synthetic-image-example-key',
+        OPENAI_BASE_URL: baseURL,
+        OPENAI_LOG: 'off',
+        NO_PROXY: '127.0.0.1',
+        no_proxy: '127.0.0.1',
+        DISABLE_V8_COMPILE_CACHE: '1',
+        TS_NODE_PROJECT: path.join(root, 'tsconfig.json'),
+        TS_NODE_TRANSPILE_ONLY: 'true',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 15_000,
+    },
+  );
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf-8').on('data', (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.setEncoding('utf-8').on('data', (chunk: string) => {
+    stderr += chunk;
+  });
+  try {
+    const [code, signal] = await once(child, 'close');
+    return { code, signal, stdout, stderr };
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill();
+    }
+  }
+}
+
+describe('image-streaming executable example', () => {
+  test.each(['HTTP rejection', 'SSE error', 'output write failure', 'success'] as const)(
+    'reports the process result for %s',
+    async (scenario) => {
+      const directory = await mkdtemp(path.join(tmpdir(), 'openai-image-stream-example-'));
+      const requests: {
+        method: string | undefined;
+        url: string | undefined;
+        authorization: string | undefined;
+      }[] = [];
+      const server = createServer((request, response) => {
+        request.resume();
+        requests.push({
+          method: request.method,
+          url: request.url,
+          authorization: request.headers.authorization,
+        });
+        if (scenario === 'HTTP rejection') {
+          response.writeHead(400, { 'content-type': 'application/json', connection: 'close' });
+          response.end(JSON.stringify({ error: failure }));
+          return;
+        }
+
+        response.writeHead(200, { 'content-type': 'text/event-stream', connection: 'close' });
+        response.write(
+          `data: ${JSON.stringify({
+            type: 'image_generation.partial_image',
+            partial_image_index: 0,
+            b64_json: partialImage.toString('base64'),
+          })}\n\n`,
+        );
+        response.end(
+          scenario === 'SSE error'
+            ? `event: error\ndata: ${JSON.stringify({ error: failure })}\n\n`
+            : `data: ${JSON.stringify({
+                type: 'image_generation.completed',
+                b64_json: finalImage.toString('base64'),
+              })}\n\n`,
+        );
+      });
+
+      try {
+        if (scenario === 'output write failure') {
+          await mkdir(path.join(directory, 'final_image.png'));
+        }
+        server.listen(0, '127.0.0.1');
+        await once(server, 'listening');
+        const address = server.address();
+        if (!address || typeof address === 'string') {
+          throw new Error('Expected a loopback HTTP address');
+        }
+        const result = await runExample(directory, `http://127.0.0.1:${address.port}/v1`);
+
+        expect(result.signal).toBeNull();
+        expect(requests).toEqual([
+          {
+            method: 'POST',
+            url: '/v1/images/generations',
+            authorization: 'Bearer synthetic-image-example-key',
+          },
+        ]);
+        if (scenario === 'HTTP rejection') {
+          expect(await readdir(directory)).toEqual([]);
+        } else {
+          expect(await readFile(path.join(directory, 'partial_1.png'))).toEqual(partialImage);
+        }
+        if (scenario === 'success') {
+          expect(await readFile(path.join(directory, 'final_image.png'))).toEqual(finalImage);
+          expect(result.stdout).toContain('Saved to:');
+          expect(result.stderr).toBe('');
+          expect(result.code).toBe(0);
+        } else {
+          expect(result.stderr).toContain('Error generating image:');
+          expect(result.stderr).toContain(
+            scenario === 'output write failure' ? 'final_image.png' : failure.message,
+          );
+          if (scenario === 'output write failure') {
+            const output = await stat(path.join(directory, 'final_image.png'));
+            expect(output.isDirectory()).toBe(true);
+          } else if (scenario === 'SSE error') {
+            expect(await readdir(directory)).toEqual(['partial_1.png']);
+          }
+          expect(result.code).toBe(1);
+        }
+      } finally {
+        try {
+          if (server.listening) {
+            const closed = once(server, 'close');
+            server.close();
+            server.closeAllConnections();
+            await closed;
+          }
+        } finally {
+          await rm(directory, { recursive: true, force: true });
+        }
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Summary

The image-streaming example catches request, stream, and filesystem failures but only logs them. It therefore exits successfully even when no final image can be produced, misleading shell scripts and CI that invoke it.

Set `process.exitCode = 1` in the existing catch handler, matching the non-streaming picture example. This preserves the diagnostic and allows normal stream/socket cleanup instead of forcing an immediate exit.

## Regression coverage

Four real child-process cases run the actual executable example against a synthetic loopback HTTP server:

- HTTP 400 rejection.
- A named SSE error after a partial image has been saved.
- A final-image write failure, induced portably by creating a directory at the output filename.
- Successful partial and final saves.

The tests assert exact exit status, request endpoint/authentication, scenario-specific diagnostics, and saved bytes. Each child has an isolated environment and temporary working directory; child processes, connections, and temporary output are cleaned up.

The [test-only commit](https://github.com/openai/openai-node/commit/b179d29853566504267ded161953e38326c1a5d6) reproduced three `0`-instead-of-`1` failures and one passing success control locally before the fix. The final candidate passes all four cases.

## Validation

- [CI on `8208d2ef`](https://github.com/openai/openai-node/actions/runs/33559828865): **7,013 handwritten tests, 556 generated tests, and 12 generated snapshots pass on each of Node 22, 24, and 26**. Existing skipped tests are unchanged.
- All 14 non-live ecosystem fixtures pass. Canonical lint, build, published-source TypeScript 4.9/6 checks, package/export validation, and benchmarks pass.
- Packed-package CJS, ESM, browser-bundling, and source-map checks pass on the supported Node 22/24 CI lines.
- Local full handwritten suite, canonical lint, TypeScript checking, and build pass.
- Independent focused execution passes on Node 24.20.0 and 26.7.0. A separate direct execution on **exact Node 22.0.0** passes all four native HTTP/file cases with exit statuses `1/1/1/0`, without requiring the newer pnpm tooling to run on that runtime.

Adversarial self-review and an independent closing review found no actionable issues in error coverage, compatibility, environment isolation, or cleanup.

## Scope

One production line plus one focused test file. Both paths are handwritten and absent from the verified public generated reference `65094c1637432c123c310d03e0cda1e7e6f1c997`. No SDK source, public API, dependencies, workflows, generated files, or custom-code budgets change.
