### PR TITLE
fix(audio): use ALSA card identifiers when recording

### DIFF
--- a/src/helpers/audio.ts
+++ b/src/helpers/audio.ts
@@ -103,7 +103,7 @@ type RecordAudioOptions = {
   /** Stops recording when aborted; successful termination returns the captured audio. */
   signal?: AbortSignal;
 
-  /** Zero-based audio-input device number passed to FFmpeg; defaults to `0`. */
+  /** Zero-based audio-input index (ALSA card number on Linux); defaults to `0`. */
   device?: number;
 
   /** Positive recording duration in milliseconds; nonpositive values disable the timeout. */
@@ -223,7 +223,7 @@ function nodejsRecordAudio({ signal, device, timeout }: RecordAudioOptions = {})
           '-f',
           provider,
           '-i',
-          `:${device ?? 0}`, // default audio input device; adjust as needed
+          provider === 'alsa' ? `hw:${device ?? 0}` : `:${device ?? 0}`,
           '-ar',
           DEFAULT_SAMPLE_RATE.toString(),
           '-ac',

--- a/tests/helpers/audio-recording-device.test.ts
+++ b/tests/helpers/audio-recording-device.test.ts
@@ -1,0 +1,53 @@
+import { ChildProcess, spawn } from 'node:child_process';
+import type * as ChildProcessModule from 'node:child_process';
+import { PassThrough } from 'node:stream';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { recordAudio } from 'openai/helpers/audio';
+
+const runtime = vi.hoisted(() => ({ platform: 'linux' }));
+vi.mock('node:process', () => ({
+  get platform() {
+    return runtime.platform;
+  },
+  versions: process.versions,
+}));
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof ChildProcessModule>()),
+  spawn: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.mocked(spawn).mockReset();
+});
+
+describe.each([
+  { platform: 'linux', provider: 'alsa', prefix: 'hw:' },
+  { platform: 'darwin', provider: 'avfoundation', prefix: ':' },
+  { platform: 'win32', provider: 'dshow', prefix: ':' },
+])('recordAudio device arguments on $platform', ({ platform, provider, prefix }) => {
+  test.each([undefined, 0, 3])('uses the provider-specific input for device %s', async (device) => {
+    runtime.platform = platform;
+    const output = Buffer.from('synthetic audio');
+    const ffmpeg = Object.assign(new ChildProcess(), {
+      stdout: new PassThrough(),
+      kill: vi.fn(),
+    });
+    vi.mocked(spawn).mockReturnValue(ffmpeg);
+
+    const recording = recordAudio(device === undefined ? {} : { device });
+    ffmpeg.stdout.end(output);
+    ffmpeg.emit('close', 0);
+
+    const file = await recording;
+    expect(vi.mocked(spawn).mock.calls).toEqual([
+      [
+        'ffmpeg',
+        ['-f', provider, '-i', `${prefix}${device ?? 0}`, '-ar', '24000', '-ac', '1', '-f', 'wav', 'pipe:1'],
+        { stdio: ['ignore', 'pipe', 'ignore'] },
+      ],
+    ]);
+    expect(file.name).toBe('audio.wav');
+    expect(file.type).toBe('audio/wav');
+    expect(Buffer.from(await file.arrayBuffer())).toEqual(output);
+  });
+});

--- a/tests/helpers/audio-recording.test.ts
+++ b/tests/helpers/audio-recording.test.ts
@@ -8,6 +8,7 @@ import { playAudio, recordAudio } from 'openai/helpers/audio';
 vi.mock('node:child_process', () => ({ spawn: vi.fn() }));
 
 const spawnMock = spawn as MockedFunction<typeof spawn>;
+const devicePrefix = ['darwin', 'win32', 'cygwin'].includes(process.platform) ? '' : 'hw';
 
 function mockFfmpeg() {
   const ffmpeg = Object.assign(new EventEmitter(), {
@@ -59,7 +60,7 @@ describe('recordAudio', () => {
     expect(Buffer.from(await file.arrayBuffer()).toString()).toBe('first second');
     expect(spawnMock).toHaveBeenCalledWith(
       'ffmpeg',
-      expect.arrayContaining(['-i', ':0', '-ar', '24000', '-ac', '1', '-f', 'wav', 'pipe:1']),
+      expect.arrayContaining(['-i', `${devicePrefix}:0`, '-ar', '24000', '-ac', '1', '-f', 'wav', 'pipe:1']),
       { stdio: ['ignore', 'pipe', 'ignore'] },
     );
   });
@@ -73,7 +74,7 @@ describe('recordAudio', () => {
 
     expect(spawnMock).toHaveBeenCalledWith(
       'ffmpeg',
-      expect.arrayContaining(['-i', ':3']),
+      expect.arrayContaining(['-i', `${devicePrefix}:3`]),
       expect.any(Object),
     );
   });


### PR DESCRIPTION
## Summary

`recordAudio()` selects FFmpeg's ALSA input format on Linux but passes device names such as `:0` and `:3`. That is AVFoundation's audio-only syntax; ALSA uses card identifiers such as `hw:0` and `hw:3` ([FFmpeg ALSA documentation](https://ffmpeg.org/ffmpeg-devices.html#alsa)).

Use the `hw:` prefix only when the selected provider is `alsa`, and clarify the Linux card-number meaning in the option's JSDoc. The default and explicit `0` are preserved with `??`. Other providers, argument order, WAV output, sample rate, channel count, timeout/cancellation handling, and playback are unchanged.

## Regression coverage

Add a nine-case public-helper matrix covering Linux, macOS, and Windows argument selection with an omitted device, explicit `0`, and explicit `3`. It checks the complete spawn argument vector and returned file metadata/content. Update the existing host-dependent recording assertions without removing their lifecycle coverage.

The [test-only commit](https://github.com/openai/openai-node/commit/4ae0131c3bc422f4b057a8d45e9ce80d9a5a23c1) reproduced five Linux failures and 42 passing controls locally before the production change. Afterward, all 47 audio tests pass.

## Native verification

A separate Linux proof used FFmpeg 6.1.1 and an isolated ALSA configuration containing only a [null PCM source](https://www.alsa-project.org/alsa-doc/alsa-lib/pcm_plugins.html), which generates zero samples without microphone access.

- Before the fix, the public helper rejected for devices `0` and `3`; native FFmpeg rejected `:0`/`:3` while accepting the corresponding `hw:` control inputs.
- After the fix, **18 public-helper cases pass** across built CJS/ESM modules on exact Node **22.0.0, 24.20.0, and 26.7.0**, each covering omitted/`0`/`3`.
- Every case completed naturally and returned a nonempty RIFF/WAVE file named `audio.wav`, with one channel at 24 kHz.
- The test adapter validates and forwards the SDK's arguments unchanged, adding only a one-frame output bound. A negative control verifies that an altered input is rejected before FFmpeg starts.

This validates argument syntax and helper integration, not physical microphone compatibility.

## Validation and scope

[CI on `607c9233`](https://github.com/openai/openai-node/actions/runs/33561912527) passes **7,018 handwritten tests, 556 generated tests, and 12 generated snapshots on each of Node 22, 24, and 26**. Existing skips are unchanged. All 14 non-live ecosystem fixtures, canonical lint, build, published-source TypeScript 4.9/6 checks, package validation, and benchmarks pass. Packed CJS/ESM/browser/source-map checks pass on the Node 22/24 CI lines.

Adversarial self-review and an independent closing review found no remaining candidate issues.

One production expression, one JSDoc clarification, and focused tests. All three paths are handwritten and absent from the verified public generated reference `65094c1637432c123c310d03e0cda1e7e6f1c997`. No generated code, public types, dependencies, provider mappings, workflows, or custom-code budgets change. This is separate from #2548's playback-input detection fix.
