### PR TITLE
fix(realtime): preserve base URL routing components

### DIFF
--- a/src/beta/realtime/internal-base.ts
+++ b/src/beta/realtime/internal-base.ts
@@ -186,8 +186,9 @@ export function buildRealtimeURL(
   const hasModel = !!config.model;
   const hasCallID = !!config.callID;
 
-  const path = '/realtime';
-  const url = new URL(baseURL + (baseURL.endsWith('/') ? path.slice(1) : path));
+  const url = new URL(baseURL);
+  url.pathname += url.pathname.endsWith('/') ? 'realtime' : '/realtime';
+  url.hash = '';
 
   if (hasModel === hasCallID) {
     throw new Error('Pass exactly one of `model` or `callID` when opening a Realtime WebSocket.');

--- a/src/realtime/internal-base.ts
+++ b/src/realtime/internal-base.ts
@@ -281,19 +281,17 @@ export function buildRealtimeURL(
     return url;
   }
 
-  let url: URL;
+  const url = new URL(baseURL);
   if (azure) {
-    url = new URL(baseURL);
     const basePath = url.pathname.replace(/\/+/g, '/').replace(/\/+$/, '');
     const versionedPath = basePath.endsWith('/v1') ? basePath : `${basePath}/v1`;
     url.pathname = `${versionedPath}/realtime`;
     url.search = '';
-    url.hash = '';
   } else {
-    const path = '/realtime';
-    url = new URL(baseURL + (baseURL.endsWith('/') ? path.slice(1) : path));
+    url.pathname += url.pathname.endsWith('/') ? 'realtime' : '/realtime';
   }
 
+  url.hash = '';
   url.protocol = 'wss';
   // Sideband control connections attach to an existing call via `call_id`.
   if (hasCallID) {

--- a/tests/realtime-websocket.test.ts
+++ b/tests/realtime-websocket.test.ts
@@ -91,8 +91,11 @@ function onRealtimeEvent(realtime: unknown, event: string, listener: Listener): 
   (realtime as { on: (event: string, listener: Listener) => unknown }).on(event, listener);
 }
 
-function createClient(apiKey: string | (() => Promise<string>) = 'test-key'): OpenAI {
-  return new OpenAI({ apiKey, baseURL: 'https://example.com/v1/' });
+function createClient(
+  apiKey: string | (() => Promise<string>) = 'test-key',
+  baseURL = 'https://example.com/v1/',
+): OpenAI {
+  return new OpenAI({ apiKey, baseURL });
 }
 
 function createAzureClient(
@@ -139,6 +142,28 @@ describe.each([
   { name: 'stable', Realtime: StableBrowserRealtime, beta: false },
   { name: 'beta', Realtime: BetaBrowserRealtime, beta: true },
 ])('$name browser realtime websocket', ({ Realtime, beta }) => {
+  test('preserves base URL routing queries when opening a model session', () => {
+    const client = createClient('test-key', 'https://example.com/v1?route=tenant#configuration');
+
+    const realtime = new Realtime({ model: 'gpt-realtime' }, client);
+
+    expect(lastBrowserSocket().url).toBe('wss://example.com/v1/realtime?route=tenant&model=gpt-realtime');
+    expect(realtime.url.toString()).toBe(lastBrowserSocket().url);
+    expect(lastBrowserSocket().protocols).toContain('openai-insecure-api-key.test-key');
+  });
+
+  test('preserves base URL routing queries when resolving sideband credentials', async () => {
+    const client = createClient(
+      async () => 'rotating-key',
+      'https://example.com/v1/?route=tenant&call_id=previous#configuration',
+    );
+
+    await Realtime.create(client, { callID: 'rtc_123' });
+
+    expect(lastBrowserSocket().url).toBe('wss://example.com/v1/realtime?route=tenant&call_id=rtc_123');
+    expect(lastBrowserSocket().protocols).toContain('openai-insecure-api-key.rotating-key');
+  });
+
   test('opens model and sideband sessions with the expected authentication protocols', () => {
     const client = createClient();
     const model = new Realtime({ model: 'gpt-realtime' }, client);
@@ -469,6 +494,32 @@ describe.each([
   { name: 'stable', Realtime: StableNodeRealtime, beta: false },
   { name: 'beta', Realtime: BetaNodeRealtime, beta: true },
 ])('$name Node realtime websocket', ({ Realtime, beta }) => {
+  test('preserves base URL routing queries when opening a model session', () => {
+    const client = createClient('test-key', 'https://example.com/v1?route=tenant#configuration');
+
+    const realtime = new Realtime({ model: 'gpt-realtime' }, client);
+
+    expect(lastNodeSocket().url.toString()).toBe(
+      'wss://example.com/v1/realtime?route=tenant&model=gpt-realtime',
+    );
+    expect(realtime.url.toString()).toBe(lastNodeSocket().url.toString());
+    expect(lastNodeSocket().options.headers).toMatchObject({ Authorization: 'Bearer test-key' });
+  });
+
+  test('preserves base URL routing queries when resolving sideband credentials', async () => {
+    const client = createClient(
+      async () => 'rotating-key',
+      'https://example.com/v1/?route=tenant&call_id=previous#configuration',
+    );
+
+    await Realtime.create(client, { callID: 'rtc_123' });
+
+    expect(lastNodeSocket().url.toString()).toBe(
+      'wss://example.com/v1/realtime?route=tenant&call_id=rtc_123',
+    );
+    expect(lastNodeSocket().options.headers).toMatchObject({ Authorization: 'Bearer rotating-key' });
+  });
+
   test('opens authenticated model and sideband sessions and preserves custom headers', () => {
     const client = createClient();
     const model = new Realtime(

--- a/tests/realtime.test.ts
+++ b/tests/realtime.test.ts
@@ -41,6 +41,29 @@ describe.each([
     );
   });
 
+  test.each([
+    ['https://example.com/custom/path?route=tenant', '/custom/path/realtime', ['tenant']],
+    ['https://example.com/custom/path/?route=tenant/', '/custom/path/realtime', ['tenant/']],
+    ['https://example.com?route=tenant', '/realtime', ['tenant']],
+    [
+      'https://example.com/custom%2Fpath/?route=first%2Ftenant&route=second#configuration',
+      '/custom%2Fpath/realtime',
+      ['first/tenant', 'second'],
+    ],
+    ['https://example.com/custom/path/#configuration', '/custom/path/realtime', []],
+    ['https://example.com/custom/path', '/custom/path/realtime', []],
+  ])('appends the endpoint to the pathname of %s', (baseURL, pathname, routes) => {
+    const client = new OpenAI({ apiKey: 'test-key', baseURL });
+    const url = buildRealtimeURL(client, { model: 'gpt-realtime' });
+
+    expect(url.origin).toBe('wss://example.com');
+    expect(url.pathname).toBe(pathname);
+    expect(url.searchParams.getAll('route')).toEqual(routes);
+    expect(url.searchParams.get('model')).toBe('gpt-realtime');
+    expect(url.hash).toBe('');
+    expect(client.baseURL).toBe(baseURL);
+  });
+
   test('preserves the legacy model string form', () => {
     expect(buildRealtimeURL(openAIClient, 'gpt-realtime').toString()).toBe(
       'wss://example.com/custom/path/realtime?model=gpt-realtime',
@@ -178,6 +201,17 @@ describe('stable realtime transcription', () => {
   test('uses transcription intent without a model for OpenAI connections', () => {
     expect(buildRealtimeURL(openAIClient, { intent: 'transcription' }).toString()).toBe(
       'wss://example.com/custom/path/realtime?intent=transcription',
+    );
+  });
+
+  test('preserves routing queries while replacing an existing transcription intent', () => {
+    const client = new OpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://example.com/custom/path?route=tenant&intent=previous',
+    });
+
+    expect(buildRealtimeURL(client, { intent: 'transcription' }).toString()).toBe(
+      'wss://example.com/custom/path/realtime?route=tenant&intent=transcription',
     );
   });
 


### PR DESCRIPTION
## Summary

Fix Realtime endpoint construction when a custom `baseURL` contains routing query parameters or a fragment.

- Append `realtime` to the parsed URL pathname in both stable and beta Realtime helpers.
- Preserve routing queries, repeated query values, and escaped path segments; remove fragments before opening the WebSocket.
- Keep the existing Azure GA path/query normalization, explicit session-parameter precedence, and custom `buildRealtimeURL` callback behavior unchanged.

## Reproduction

Given `baseURL: 'https://example.com/v1?route=tenant'`, string concatenation currently puts the endpoint suffix inside the routing parameter:

```text
Before: wss://example.com/v1?route=tenant%2Frealtime&model=gpt-realtime
After:  wss://example.com/v1/realtime?route=tenant&model=gpt-realtime
```

The old URL requests the wrong path and corrupts the routing value. A fragment in the base URL likewise absorbs the endpoint suffix and leaves a fragment on the WebSocket URL. Both public native-WebSocket and Node `ws` wrappers use these helpers.

## Regression coverage

Add 21 cases covering query-bearing base URLs with and without trailing slashes, root paths, encoded path segments, repeated routing parameters, fragments, transcription intent, and stable/beta public constructors and asynchronous sideband factories with rotating credentials. Nineteen cases fail before the fix; the two query-free controls already pass.

## Validation

- 178 focused Realtime tests passed.
- Full local suite: 7,030 handwritten tests, 556 generated tests, and 12 snapshots passed.
- Formatting, lint, root typechecking, build, and published source checks with TypeScript 4.9 and 6 passed.
- 84 offline checks through built public native-WebSocket exports passed across Node 22.0.0, 24.20.0, and 26.7.0, each in CommonJS and ESM. These capture actual constructor arguments with synthetic credentials; they do not make live API connections.
- [Full CI passed on this commit](https://github.com/openai/openai-node/actions/runs/33574064054): Node 22/24/26 test matrix, packed-package checks on Node 22/24, exact Node 22.0 X.509 compatibility fixture, all 14 ecosystem fixtures, build, lint, and performance benchmarks.
- Adversarial self-review and independent review covered security, compatibility, URL edge cases, and regression coverage; no unresolved findings.

Scope is four handwritten files only. Generated HTTP-client URL construction, dependencies, and CI policies are unchanged.
