### PR TITLE
fix(format): preserve file-list scope

### DIFF
--- a/scripts/fast-format
+++ b/scripts/fast-format
@@ -28,12 +28,14 @@ echo "==> Fixing generated lint issues"
 node ./scripts/lint-generated.cjs --fix --file-list "$FILE_LIST"
 
 echo "==> Running oxlint --fix"
-LINT_FILES="$(grep -E '\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$' "$FILE_LIST" || true)"
+# Match the generated linter's line-based input, without letting xargs split paths.
+FILES="$(sed -e $'s/\r$//' -e '/^$/d' "$FILE_LIST")"
+LINT_FILES="$(printf '%s\n' "$FILES" | grep -E '\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$' || true)"
 if [ -n "$LINT_FILES" ]; then
-   echo "$LINT_FILES" | xargs ./node_modules/.bin/oxlint --fix --no-error-on-unmatched-pattern
+   printf '%s\n' "$LINT_FILES" | tr '\n' '\0' | xargs -0 ./node_modules/.bin/oxlint --fix --no-error-on-unmatched-pattern --
 fi
 
 echo "==> Running oxfmt --write"
-if [ -s "$FILE_LIST" ]; then
-   xargs ./node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern < "$FILE_LIST"
+if [ -n "$FILES" ]; then
+   printf '%s\n' "$FILES" | tr '\n' '\0' | xargs -0 ./node_modules/.bin/oxfmt --write --no-error-on-unmatched-pattern --
 fi

--- a/tests/fast-format-file-list.test.ts
+++ b/tests/fast-format-file-list.test.ts
@@ -1,0 +1,100 @@
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const source = 'export var value={a:1};\n';
+const formattedSource = 'export const value = { a: 1 };\n';
+const describeBash = process.platform === 'win32' ? describe.skip : describe;
+
+function withFormatFixture(run: (root: string) => void): void {
+  const root = mkdtempSync(path.join(tmpdir(), 'openai-node-fast-format-'));
+
+  try {
+    mkdirSync(path.join(root, 'scripts'));
+    for (const script of ['fast-format', 'lint-generated.cjs', 'generated-files.cjs']) {
+      copyFileSync(path.join(repoRoot, 'scripts', script), path.join(root, 'scripts', script));
+    }
+    symlinkSync(path.join(repoRoot, 'node_modules'), path.join(root, 'node_modules'), 'dir');
+    // The expected output requires both the lint fix and formatting to reach the listed file.
+    writeFileSync(path.join(root, '.oxlintrc.json'), JSON.stringify({ rules: { 'no-var': 'error' } }));
+    writeFileSync(path.join(root, 'unrelated.ts'), source);
+    run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function fastFormat(root: string, fileList: string): void {
+  writeFileSync(path.join(root, 'files.txt'), fileList);
+  const result = spawnSync('bash', [path.join(root, 'scripts/fast-format'), 'files.txt'], {
+    cwd: root,
+    encoding: 'utf-8',
+    timeout: 20_000,
+  });
+
+  expect(result.error).toBeUndefined();
+  expect({ status: result.status, output: result.status === 0 ? '' : result.stdout + result.stderr }).toEqual(
+    { status: 0, output: '' },
+  );
+  expect(readFileSync(path.join(root, 'unrelated.ts'), 'utf-8')).toBe(source);
+}
+
+describeBash('fast-format file lists', () => {
+  test.each(['', '\n\n', '\r\n\r\n'])('does not format unrelated files for an empty list %j', (list) => {
+    withFormatFixture((root) => fastFormat(root, list));
+  });
+
+  test.each(['selected.ts', 'with spaces.ts', "with'quote.ts", 'with"quote.ts', '-leading-dash.ts'])(
+    'formats the exact listed path %s',
+    (filename) => {
+      withFormatFixture((root) => {
+        writeFileSync(path.join(root, filename), source);
+
+        fastFormat(root, `${filename}\n`);
+
+        expect(readFileSync(path.join(root, filename), 'utf-8')).toBe(formattedSource);
+      });
+    },
+  );
+
+  test('ignores blank lines and accepts CRLF and a final path without a newline', () => {
+    withFormatFixture((root) => {
+      for (const filename of ['first file.ts', 'second.ts']) {
+        writeFileSync(path.join(root, filename), source);
+      }
+
+      fastFormat(root, '\r\nfirst file.ts\r\n\r\nsecond.ts');
+
+      for (const filename of ['first file.ts', 'second.ts']) {
+        expect(readFileSync(path.join(root, filename), 'utf-8')).toBe(formattedSource);
+      }
+    });
+  });
+
+  test('formats listed non-JavaScript files without linting them', () => {
+    withFormatFixture((root) => {
+      const json = '{"value":1}\n';
+      const filename = path.join(root, 'selected file.json');
+      writeFileSync(filename, json);
+
+      fastFormat(root, 'selected file.json\n');
+
+      expect(readFileSync(filename, 'utf-8')).not.toBe(json);
+      expect(JSON.parse(readFileSync(filename, 'utf-8'))).toEqual({ value: 1 });
+    });
+  });
+
+  test('does not format unrelated files when listed paths no longer exist', () => {
+    withFormatFixture((root) => fastFormat(root, 'deleted.ts\n'));
+  });
+});


### PR DESCRIPTION
## Problem

`scripts/fast-format` accepts one file path per line, but sends that input through whitespace- and quote-parsing `xargs`.

- A file containing only blank lines passes the existing nonempty-file check. Oxfmt is then invoked without any paths and formats the entire working directory, including unrelated files.
- Paths containing spaces are split and silently skipped; unmatched quotes cause the command to fail.

## Change

Normalize CRLF and empty lines, guard against an empty normalized selection, and pass NUL-delimited paths to both tools with an explicit end-of-options separator. Existing file-type selection, xargs batching, generated-file cleanup, and pipeline failure propagation remain intact.

The production change is six added and four removed lines in the handwritten shell script. No SDK runtime code, generated files, dependencies, or CI policies change.

## Regression coverage

Add 11 isolated cases that run the actual script with the repository's pinned Oxlint and Oxfmt. The fixtures require both the `var` → `const` lint fix and formatting to reach each selected file, while checking that an unlisted file remains byte-for-byte unchanged.

Coverage includes empty/LF/CRLF-only lists, ordinary and spaced paths, single and double quotes, leading dashes, blank lines mixed with CRLF, a final path without a newline, JSON-only selections, and deleted paths. The initial baseline reproducer had six failures and three passing controls before the fix.

## Validation

- Refreshed onto current main `3cf755ec`; range-diff confirmed the reviewed patch was unchanged.
- Full local suite: 7,020 handwritten tests, 556 generated tests, and 12 snapshots passed.
- Focused formatting/lint suites: 20 tests passed.
- Canonical lint, TypeScript checking, build, Bash syntax, and diff checks passed.
- [Full CI passed on this commit](https://github.com/openai/openai-node/actions/runs/33588967078): Node 22/24/26 tests, packed-package checks on Node 22/24, the exact Node 22.0 compatibility fixture, all 14 ecosystem fixtures, build, lint, and benchmarks.
- Adversarial self-review and independent closing review found no unresolved blockers.

Execution validation used Linux/GNU tools. macOS/BSD portability was reviewed but not executed; the temporary Bash/symlink fixture is skipped on native Windows.
