### PR TITLE
fix(ci): propagate Node matrix check failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,9 @@ jobs:
 
       - name: Read policy matrix
         id: policy
-        run: echo "matrix=$(node --experimental-strip-types scripts/check-node-version-policy.ts --matrix)" >> "$GITHUB_OUTPUT"
+        run: |
+          matrix="$(node --experimental-strip-types scripts/check-node-version-policy.ts --matrix)"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   test:
     name: test (${{ matrix.node-version }})

--- a/tests/node-matrix-workflow.test.ts
+++ b/tests/node-matrix-workflow.test.ts
@@ -1,0 +1,104 @@
+import { spawnSync } from 'node:child_process';
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const root = process.cwd();
+const workflow = readFileSync(path.join(root, '.github/workflows/ci.yml'), 'utf-8').split('\r\n').join('\n');
+const policyStep = workflow.split('      - name: Read policy matrix\n')[1]?.split(/\n(?: {6}- | {2}\S)/u)[0];
+const run = policyStep?.split('        run: ')[1]?.trimEnd();
+
+if (!run) {
+  throw new Error('Missing Read policy matrix workflow step');
+}
+
+const script = run.startsWith('|\n')
+  ? run
+      .slice(2)
+      .split('\n')
+      .map((line) => line.slice(10))
+      .join('\n')
+  : run;
+const existingOutput = 'existing=preserved\n';
+
+// The workflow runs on Ubuntu; native Windows does not use this Bash step.
+const describeOnUnix = process.platform === 'win32' ? describe.skip : describe;
+describeOnUnix('Node.js policy matrix workflow', () => {
+  let fixture: string;
+  let outputFile: string;
+
+  beforeEach(() => {
+    fixture = mkdtempSync(path.join(tmpdir(), 'openai-node-policy-matrix-'));
+    for (const file of [
+      'scripts/check-node-version-policy.ts',
+      '.github/workflows/ci.yml',
+      '.github/CONTRIBUTING.md',
+      '.nvmrc',
+      'package.json',
+      'README.md',
+      'NODE_VERSION_POLICY.md',
+    ]) {
+      const target = path.join(fixture, file);
+      mkdirSync(path.dirname(target), { recursive: true });
+      copyFileSync(path.join(root, file), target);
+    }
+    outputFile = path.join(fixture, 'github output');
+    writeFileSync(outputFile, existingOutput);
+  });
+
+  afterEach(() => {
+    rmSync(fixture, { recursive: true, force: true });
+  });
+
+  function runStep() {
+    const result = spawnSync('bash', ['-e', '-c', script], {
+      cwd: fixture,
+      encoding: 'utf-8',
+      timeout: 10_000,
+      env: {
+        PATH: `${path.dirname(process.execPath)}${path.delimiter}${process.env['PATH'] ?? ''}`,
+        GITHUB_OUTPUT: outputFile,
+      },
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.stdout).toBe('');
+    return result;
+  }
+
+  test('appends the unchanged policy matrix on success', () => {
+    const checker = spawnSync(
+      process.execPath,
+      ['--experimental-strip-types', 'scripts/check-node-version-policy.ts', '--matrix'],
+      { cwd: fixture, encoding: 'utf-8', timeout: 10_000, env: {} },
+    );
+    expect(checker.error).toBeUndefined();
+    expect(checker.status).toBe(0);
+    expect(JSON.parse(checker.stdout).include.length).toBeGreaterThan(0);
+
+    expect(runStep().status).toBe(0);
+    expect(readFileSync(outputFile, 'utf-8')).toBe(`${existingOutput}matrix=${checker.stdout}\n`);
+  });
+
+  test('fails at the policy step without publishing a matrix when metadata drifts', () => {
+    const packagePath = path.join(fixture, 'package.json');
+    const metadata = JSON.parse(readFileSync(packagePath, 'utf-8'));
+    metadata.engines.node = '>=0.0.0';
+    writeFileSync(packagePath, JSON.stringify(metadata));
+
+    const result = runStep();
+    expect(result.stderr).toContain('package.json#engines.node must match the policy minimum');
+    expect(result.status).toBe(1);
+    expect(readFileSync(outputFile, 'utf-8')).toBe(existingOutput);
+  });
+
+  test('preserves a policy file read failure without publishing a matrix', () => {
+    rmSync(path.join(fixture, 'NODE_VERSION_POLICY.md'));
+
+    const result = runStep();
+    expect(result.stderr).toContain('ENOENT');
+    expect(result.stderr).toContain('NODE_VERSION_POLICY.md');
+    expect(result.status).toBe(1);
+    expect(readFileSync(outputFile, 'utf-8')).toBe(existingOutput);
+  });
+});


### PR DESCRIPTION
## Problem

The `Read policy matrix` step embeds the policy checker inside `echo`. If the checker fails, `echo` still returns zero and appends an empty `matrix=` output. The producer step is marked successful even though the downstream test job cannot parse its matrix.

## Change

Capture the matrix in a standalone assignment before appending it to `GITHUB_OUTPUT`. The existing [default Bash `-e` behavior](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsshell) then preserves the checker failure at the policy step, with its original diagnostic and without publishing a matrix. Successful output is unchanged.

This is a CI failure-reporting fix, not a new policy requirement or a security-bypass fix.

## Regression coverage

Three isolated process-level tests execute the actual workflow command with the real policy checker and copied repository inputs:

- Successful policy output is appended byte-for-byte, preserving an existing output and a path containing spaces.
- Drift between package metadata and the policy fails with the checker diagnostic and leaves the output unchanged.
- A missing policy document preserves the read failure without publishing a matrix.

Before the fix, both error cases returned zero; the success control passed. All three pass after the fix. The Bash fixture is skipped on native Windows because this workflow runs on Ubuntu.

## Validation

- Final local suite: 7,012 handwritten tests, 556 generated tests, and 12 snapshots passed.
- [Full CI on this commit passed](https://github.com/openai/openai-node/actions/runs/33590460969), including the same suites on Node 22/24/26, all 14 ecosystem fixtures, packed-package checks on Node 22/24, the exact Node 22.0 compatibility fixture, build, lint, and benchmarks.
- Root TypeScript checking, canonical lint, package build, and diff checks passed locally.
- Adversarial self-review and independent closing review found no unresolved blockers.

Only the handwritten CI workflow and one regression test change. SDK runtime code, generated files, dependencies, workflow permissions/triggers, and supported Node versions are unchanged.
