### PR TITLE
fix(ecosystem): restore explicit web type-test module markers

### DIFF
--- a/ecosystem-tests/node-ts-cjs-web/types-test.ts
+++ b/ecosystem-tests/node-ts-cjs-web/types-test.ts
@@ -4,3 +4,6 @@ async function typeTests(client: OpenAI) {
   const response = await client.chat.completions.create({ model: 'gpt-4o', messages: [] }).asResponse();
   const url: string = response.url;
 }
+
+// oxlint-disable-next-line unicorn/require-module-specifiers, typescript/no-useless-empty-export -- preserve the intentional module marker in this type-only fixture
+export {};

--- a/ecosystem-tests/node-ts-esm-web/types-test.ts
+++ b/ecosystem-tests/node-ts-esm-web/types-test.ts
@@ -4,3 +4,6 @@ async function typeTests(client: OpenAI) {
   const response = await client.chat.completions.create({ model: 'gpt-4o', messages: [] }).asResponse();
   const url: string = response.url;
 }
+
+// oxlint-disable-next-line unicorn/require-module-specifiers, typescript/no-useless-empty-export -- preserve the intentional module marker in this type-only fixture
+export {};


### PR DESCRIPTION
Restore the explicit `export {};` module markers in the CommonJS and ESM web type-test fixtures, removed in #2542. Earlier lint migrations (#2170 and #2272) deliberately preserved these markers. Keep that intent with exceptions for `unicorn/require-module-specifiers` and `typescript/no-useless-empty-export` scoped to the two export lines.

Validated with frozen pnpm installation, `pnpm lint`, `pnpm build`, and direct CJS/ESM fixture typechecks and emitted-module checks against the built SDK using TypeScript 4.9.5 and 6.0.3. The direct checks explicitly include these root-level files, which the normal ecosystem tsconfig include patterns omit.
