### PR TITLE
test(ci): cover release gate and document CI policy

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -282,6 +282,41 @@ format-on-save and lint-autofix editor settings.
 Changes made to this repository via the automated release PR pipeline publish to npm automatically. Publishing
 requires GitHub Actions OIDC trusted publishing; local token-based publishing is not supported.
 
+### CI coverage and release policy
+
+The table describes workflow execution and npm publication dependencies for changes targeting `main`
+in `openai/openai-node`.
+Required merge checks are configured in repository rules. The `test matrix` check requires the Node.js
+tests, benchmarks, and credential-free ecosystem job to succeed.
+
+| Checks                                                              | PR             | Merge queue   | Push to `main`    | Release PR     | npm publication                             |
+| ------------------------------------------------------------------- | -------------- | ------------- | ----------------- | -------------- | ------------------------------------------- |
+| CI lint, build, Node.js tests, packed-package tests, benchmarks     | Runs¹          | Runs          | Runs              | Runs¹          | CI gate                                     |
+| Credential-free ecosystem startup/import and compatibility checks   | Runs           | Runs          | Runs              | Runs           | CI gate                                     |
+| Live examples and live ecosystem tests                              | Skipped        | Skipped       | Runs²             | Skipped        | CI gate²                                    |
+| CodeQL merge protection, breaking-change detection, Castiron checks | Runs           | Runs          | Not triggered     | Runs           | Merge protection; no separate release gate  |
+| Standalone Node.js support policy workflow                          | Not triggered  | Not triggered | Runs              | Not triggered  | No separate gate; assertions also run in CI |
+| Release PR title/version validation                                 | Not applicable | Not triggered | Not applicable    | Runs           | Checked before release creation             |
+| Release state, native-browser compatibility, release-package build  | Not applicable | Not triggered | Release workflow³ | Not applicable | Required                                    |
+
+¹ Same-repository PRs run these checks through branch pushes; duplicate PR-event jobs may be skipped.
+Fork PRs and `ready_for_review` events run them directly. Release PRs receive the same CI coverage.
+² Live checks require credentials and skip main pushes triggered by `dependabot[bot]`.
+³ Release state is checked on main pushes; browser compatibility and package build run when publication is due.
+
+The **CI gate** in [`create-releases.yml`](workflows/create-releases.yml) requires a successful
+[`ci.yml`](workflows/ci.yml) push run on `main` for the immutable release SHA, including live checks when
+they run. Missing CI, a mismatched SHA, failure, cancellation, or timeout prevents publication; a green
+run for another commit cannot satisfy the gate. The gate checks the overall workflow conclusion, so it
+does not independently reject skipped jobs. Experimental Node.js results remain advisory as defined by
+[the Node.js support policy](../NODE_VERSION_POLICY.md).
+
+When adding or changing checks, especially main-only checks, explicitly choose whether they block
+publication or are advisory. Update this table and the focused workflow regressions in
+[`tests/release-publish-workflow.test.ts`](../tests/release-publish-workflow.test.ts) to preserve the
+release SHA, failure handling, and publication dependencies. Keep merge-only workflows distinct from
+the publication gate.
+
 ### Override an automated release version
 
 Do not edit an automated release PR title to change its version. The title must match the version generated in

--- a/tests/release-publish-workflow.test.ts
+++ b/tests/release-publish-workflow.test.ts
@@ -68,7 +68,6 @@ describe('release commit CI gate', () => {
         path.join(fixture, 'gh'),
         `
 const { appendFileSync } = require('node:fs');
-const { execFileSync } = require('node:child_process');
 const args = process.argv.slice(2);
 const data = JSON.parse(process.env.GATE_FIXTURE);
 appendFileSync(process.env.GATE_INVOCATIONS, JSON.stringify(args) + '\\n');
@@ -86,7 +85,14 @@ if (args[0] === 'api') {
   } else {
     throw new Error('Unexpected API request: ' + JSON.stringify(args));
   }
-  process.stdout.write(execFileSync('jq', ['-r', query], { input: JSON.stringify(response), encoding: 'utf8' }));
+  if (query === '.workflow_runs | map(select(.head_branch == "main")) | first | .id // empty') {
+    const selected = response.workflow_runs.find(run => run.head_branch === 'main');
+    if (selected) process.stdout.write(String(selected.id) + '\\n');
+  } else if (query === '.head_sha') {
+    process.stdout.write(String(response.head_sha) + '\\n');
+  } else {
+    throw new Error('Unexpected jq query: ' + query);
+  }
 } else if (args[0] === 'run' && args[1] === 'watch') {
   process.exit(args.includes('--exit-status') ? data.watchExit : 0);
 } else {
@@ -94,6 +100,8 @@ if (args[0] === 'api') {
 }
 `,
       );
+      // The release-gate fixture must not depend on an undeclared host jq binary.
+      writeExecutable(path.join(fixture, 'jq'), 'process.exit(91);');
       // Keep the missing-run polling path deterministic and fast.
       writeExecutable(path.join(fixture, 'sleep'), 'process.exit(0);');
 

--- a/tests/release-publish-workflow.test.ts
+++ b/tests/release-publish-workflow.test.ts
@@ -12,11 +12,14 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 const root = process.cwd();
-const workflow = readFileSync(path.join(root, '.github/workflows/create-releases.yml'), 'utf-8');
+const workflow = readFileSync(path.join(root, '.github/workflows/create-releases.yml'), 'utf-8')
+  .split('\r\n')
+  .join('\n');
 const publishJob = workflow.split('\n  publish:\n')[1] ?? '';
+const releaseCIJob = workflow.split('\n  release-ci:\n')[1]?.split(/\n {2}[\w-]+:\n/u)[0] ?? '';
 
-function workflowRunStep(name: string): string {
-  const [, step] = publishJob.split(`      - name: ${name}\n`);
+function workflowRunStep(name: string, job = publishJob): string {
+  const [, step] = job.split(`      - name: ${name}\n`);
   const script = step?.split('        run: |\n')[1]?.split('\n      - ')[0];
 
   if (!script) {
@@ -32,6 +35,121 @@ function workflowRunStep(name: string): string {
 function writeExecutable(filename: string, source: string) {
   writeFileSync(filename, `#!/usr/bin/env node\n${source}\n`, { mode: 0o755 });
 }
+
+describe('release commit CI gate', () => {
+  test('requires successful release CI before publication', () => {
+    const publicationCondition = "    if: needs.publication-check.outputs.should_publish == 'true'\n";
+    expect(publishJob).toContain(publicationCondition);
+    expect(publishJob).toContain('\n      - release-ci\n');
+    expect(releaseCIJob).toContain(publicationCondition);
+    expect(releaseCIJob).toContain('\n    needs: publication-check\n');
+    // oxlint-disable-next-line no-template-curly-in-string -- This is a literal GitHub Actions expression.
+    expect(releaseCIJob).toContain('RELEASE_SHA: ${{ needs.publication-check.outputs.release_sha }}');
+    expect(releaseCIJob).toContain('      actions: read\n      checks: read');
+    expect(releaseCIJob).not.toContain('continue-on-error:');
+  });
+
+  test.each([
+    { name: 'successful CI', exitCode: 0, watchExit: 0 },
+    { name: 'failed CI', exitCode: 1, watchExit: 1 },
+    { name: 'cancelled CI', exitCode: 1, watchExit: 1 },
+    { name: 'missing CI', exitCode: 1, missing: true, error: 'No CI push workflow found' },
+    { name: 'mismatched commit', exitCode: 1, mismatch: true, error: 'targets' },
+    { name: 'API failure', exitCode: 73, apiFailure: true },
+  ])('handles $name for the immutable release commit', (scenario) => {
+    const fixture = mkdtempSync(path.join(tmpdir(), 'openai-node-release-ci-'));
+    const releaseSHA = 'a'.repeat(40);
+    const repository = 'openai/test-sdk';
+    const invocations = path.join(fixture, 'gh.jsonl');
+    const selectedRun = { id: 42, event: 'push', head_sha: releaseSHA, head_branch: 'main' };
+
+    try {
+      writeExecutable(
+        path.join(fixture, 'gh'),
+        `
+const { appendFileSync } = require('node:fs');
+const { execFileSync } = require('node:child_process');
+const args = process.argv.slice(2);
+const data = JSON.parse(process.env.GATE_FIXTURE);
+appendFileSync(process.env.GATE_INVOCATIONS, JSON.stringify(args) + '\\n');
+if (args[0] === 'api') {
+  if (data.apiFailure) process.exit(73);
+  const query = args[args.indexOf('--jq') + 1];
+  let response;
+  if (args.includes('repos/' + process.env.GITHUB_REPOSITORY + '/actions/workflows/ci.yml/runs')) {
+    const filters = Object.fromEntries(args.flatMap((arg, index) => arg === '-f' ? [args[index + 1].split('=')] : []));
+    response = { workflow_runs: data.runs.filter(run =>
+      (!filters.event || run.event === filters.event) && (!filters.head_sha || run.head_sha === filters.head_sha)
+    ) };
+  } else if (args.includes('repos/' + process.env.GITHUB_REPOSITORY + '/actions/runs/42')) {
+    response = { head_sha: data.runSHA };
+  } else {
+    throw new Error('Unexpected API request: ' + JSON.stringify(args));
+  }
+  process.stdout.write(execFileSync('jq', ['-r', query], { input: JSON.stringify(response), encoding: 'utf8' }));
+} else if (args[0] === 'run' && args[1] === 'watch') {
+  process.exit(args.includes('--exit-status') ? data.watchExit : 0);
+} else {
+  throw new Error('Unexpected gh invocation: ' + JSON.stringify(args));
+}
+`,
+      );
+      // Keep the missing-run polling path deterministic and fast.
+      writeExecutable(path.join(fixture, 'sleep'), 'process.exit(0);');
+
+      const result = spawnSync(
+        'bash',
+        [
+          '-e',
+          '-o',
+          'pipefail',
+          '-c',
+          workflowRunStep('Wait for CI on the immutable release commit', releaseCIJob),
+        ],
+        {
+          cwd: fixture,
+          encoding: 'utf-8',
+          timeout: 15_000,
+          env: {
+            PATH: `${fixture}${path.delimiter}${path.dirname(process.execPath)}${path.delimiter}${process.env['PATH']}`,
+            GITHUB_REPOSITORY: repository,
+            RELEASE_SHA: releaseSHA,
+            GH_TOKEN: 'synthetic-github-token',
+            GATE_INVOCATIONS: invocations,
+            GATE_FIXTURE: JSON.stringify({
+              ...scenario,
+              runSHA: scenario.mismatch ? 'b'.repeat(40) : releaseSHA,
+              runs: [
+                { ...selectedRun, id: 11, head_sha: 'b'.repeat(40) },
+                { ...selectedRun, id: 12, event: 'pull_request' },
+                { ...selectedRun, id: 13, head_branch: 'feature' },
+                ...(scenario.missing ? [] : [selectedRun]),
+              ],
+            }),
+          },
+        },
+      );
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(scenario.exitCode);
+      if (scenario.error) {
+        expect(result.stdout).toContain(scenario.error);
+      }
+
+      const calls: string[][] = readFileSync(invocations, 'utf-8')
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line));
+      const watchCalls = calls.filter((args) => args[0] === 'run');
+      expect(watchCalls).toEqual(
+        scenario.watchExit === undefined
+          ? []
+          : [['run', 'watch', '42', '--repo', repository, '--exit-status']],
+      );
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('trusted npm release publication', () => {
   test('preserves immutable publisher, artifact, OIDC, and npm provenance boundaries', () => {


### PR DESCRIPTION
The release-SHA CI gate added in #2543 has no focused regression coverage, and maintainers lack a single table showing which checks run before merge and block npm publication.

Document the PR, merge-queue, main, release-PR, and publication coverage, including skipped live checks and advisory checks. Extend the existing release workflow tests to execute the actual gate Bash against synthetic GitHub responses, covering successful, failed, cancelled, missing, mismatched-SHA, and API-error results. The tests also protect the publication dependency and ensure selection excludes other commits, events, and branches.

Validation on Node 24:

- `./scripts/test tests/release-publish-workflow.test.ts` — 11 passed.
- `./scripts/test tests/ecosystem-cli.test.ts tests/node-matrix-workflow.test.ts` — 26 passed.
- `./scripts/lint` and `node node_modules/typescript/bin/tsc --noEmit` — passed.
- Mutation checks failed as expected when removing the publication dependency, release-SHA filter, or `--exit-status`; the workflow was restored afterward.

A fresh frozen installation was blocked by missing publication-time metadata for `qs@6.16.0` in the configured registry. Checks used an existing installation with matching test/lint tooling and relevant type dependency graphs. No dependency policy or lockfile changes were made, and no live examples or publication were executed.

Closes #2509.

