### PR TITLE
fix(embeddings): preserve numeric responses after request hooks

### DIFF
--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -34,7 +34,6 @@ export function createEmbedding(
     ...options,
     __security: { bearerAuth: true },
   };
-  const hasBodyOverride = requestOptions.body !== optimizedBody;
   const response: APIPromise<CreateEmbeddingResponse> = client.post('/embeddings', requestOptions);
 
   // Explicit encodings return the original response promise unchanged.
@@ -55,8 +54,8 @@ export function createEmbedding(
         if (index in embeddings) {
           const embeddingBase64Obj = embeddings[index] as Embedding;
           const { embedding } = embeddingBase64Obj;
-          // A body override can request float embeddings or omit the format.
-          if (hasBodyOverride && Array.isArray(embedding)) {
+          // Request hooks and serialization can also select float embeddings.
+          if (Array.isArray(embedding)) {
             continue;
           }
           embeddingBase64Obj.embedding = toFloat32Array(embedding as unknown as string);

--- a/tests/lib/embeddings-request.test.ts
+++ b/tests/lib/embeddings-request.test.ts
@@ -2,7 +2,7 @@ import { vi } from 'vitest';
 import OpenAI, { BadRequestError } from 'openai';
 import { APIPromise } from 'openai/api-promise';
 import type { Fetch } from 'openai/internal/builtin-types';
-import type { RequestOptions } from 'openai/internal/request-options';
+import type { FinalRequestOptions, RequestOptions } from 'openai/internal/request-options';
 import type { PromiseOrValue } from 'openai/internal/types';
 import { compareType } from '../utils/typing';
 
@@ -11,11 +11,17 @@ const encodedVector = Buffer.from(new Float32Array(vector).buffer).toString('bas
 const request = { input: 'hello', model: 'text-embedding-3-small' };
 
 class RecordingClient extends OpenAI {
+  prepareRequestOptions?: (options: FinalRequestOptions) => void;
   readonly requests: {
     path: string;
     options: PromiseOrValue<RequestOptions> | undefined;
     response: APIPromise<unknown>;
   }[] = [];
+
+  protected override async prepareOptions(options: FinalRequestOptions): Promise<void> {
+    await super.prepareOptions(options);
+    this.prepareRequestOptions?.(options);
+  }
 
   override post<Rsp>(path: string, options?: PromiseOrValue<RequestOptions>): APIPromise<Rsp> {
     const response = super.post<Rsp>(path, options);
@@ -197,6 +203,46 @@ describe('embedding request compatibility', () => {
     },
   );
 
+  test.each(['mutation', 'replacement', 'serialization'] as const)(
+    'preserves numeric output after request-body %s',
+    async (customization) => {
+      const floatVector = [1.25, -2.5, 3.75, 4.5];
+      const floatBody = { ...request, encoding_format: 'float' };
+      const body = Object.freeze({
+        ...request,
+        ...(customization === 'serialization' ? { toJSON: () => floatBody } : {}),
+      });
+      const originalBody = { ...body };
+      const fetch = vi.fn<Fetch>(async (_url, init) => {
+        expect(JSON.parse(String(init?.body))).toEqual(floatBody);
+        return embeddingResponse(floatVector);
+      });
+      const client = new RecordingClient({ apiKey: 'test-key', fetch });
+      client.prepareRequestOptions = (options) => {
+        if (customization === 'replacement') {
+          options.body = floatBody;
+        } else if (customization === 'mutation') {
+          if (typeof options.body !== 'object' || options.body === null) {
+            throw new Error('Expected an object request body');
+          }
+          Object.assign(options.body, { encoding_format: 'float' });
+        }
+      };
+      const promise = client.embeddings.create(body);
+      const rawResponse = await promise.asResponse();
+      expect(await rawResponse.clone().json()).toMatchObject({ data: [{ embedding: floatVector }] });
+
+      const response = await promise;
+      expect(response.data[0]?.embedding).toEqual(floatVector);
+      const dataAndResponse = await promise.withResponse();
+      expect(dataAndResponse.data).toBe(response);
+      expect(dataAndResponse.response).toBe(rawResponse);
+      expect(dataAndResponse.request_id).toBe('req_embeddings');
+      expect(body).toEqual(originalBody);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    },
+  );
+
   test('preserves response identity and sparse entries from custom parsers', async () => {
     const client = new OpenAI({ apiKey: 'test-key' });
     const entries: OpenAI.Embedding[] = [];
@@ -207,6 +253,12 @@ describe('embedding request compatibility', () => {
       embedding: encodedVector as unknown as number[],
     };
     entries[1] = entry;
+    const numericEntry = Object.freeze({
+      object: 'embedding' as const,
+      index: 2,
+      embedding: vector,
+    });
+    entries[2] = numericEntry;
     const data: OpenAI.CreateEmbeddingResponse = {
       object: 'list',
       data: entries,
@@ -221,6 +273,8 @@ describe('embedding request compatibility', () => {
     expect(result.data[1]).toBe(entry);
     expect(0 in result.data).toBe(false);
     expect(entry.embedding).toEqual(vector);
+    expect(result.data[2]).toBe(numericEntry);
+    expect(numericEntry.embedding).toBe(vector);
   });
 
   test('keeps the original iteration length when a custom parser mutates the array', async () => {


### PR DESCRIPTION
## Summary

Default-format `embeddings.create()` requests can receive valid float embeddings after a protected `prepareOptions` hook or a request's `toJSON()` changes the wire encoding. The helper only preserved numeric arrays when it detected a direct `RequestOptions.body` override before dispatch, so later customization incorrectly sent those arrays through the base64 decoder.

Reproduced through the public client with synthetic fetch: the serialized request asks for `float`, the raw response contains `[1.25, -2.5, 3.75, 4.5]`, but the SDK returned `[1.551560886955465e-36]`.

- Preserve already-numeric arrays at the decoding boundary; remove the stale body-identity flag.
- Cover in-place hook mutation, hook body replacement, and JSON serialization, including raw/parsed response accessors and unchanged caller input.
- Extend the existing sparse-parser test with a frozen numeric entry beside a base64 entry, protecting identity and mixed decoding.

This is a small follow-up to merged #2549. Explicit float/base64 requests, base64 decoding, request precedence, public types, and promise behavior remain unchanged.

## Ownership and scope

Only the handwritten `src/lib/embeddings.ts` and its existing handwritten test change. Neither file belongs to the pinned Castiron generated snapshot. No generated files, dependencies, exports, or parsing infrastructure change.

## Verification

- The three new wire-customization regressions fail on unchanged main and pass after the fix.
- Both embeddings suites: **23 passed** on Node 24.19.0 and 22.22.2.
- Built CommonJS/ESM entrypoints: **36 cases passed** across Node **22.0.0**, 24.19.0, and 26.7.0, including default/explicit-format controls and all three customization paths.
- `tsc --noEmit`, canonical `./scripts/build`, changed-file lint/format checks, and `git diff --check` pass.
- Full handwritten suite with the host's unrelated `AWS_BEDROCK_BASE_URL` unset: **7,409 passed, 1 failed**. The remaining `oxlint-config` package-command test fails with `ERR_PNPM_VERIFY_DEPS_BEFORE_RUN`; the same failure reproduces in an unchanged-main worktree.
- Two independent adversarial reviews covered security, compatibility, malformed/out-of-contract inputs, sparse/frozen/custom-parser values, response identity, and regression gaps. The suggested frozen-entry coverage was added and the final review was clean.

### Local tooling limitation

A fresh `pnpm install --frozen-lockfile` was blocked because the configured registry lacks publication-time metadata for `qs@6.16.0`. Verification used already-available local dependencies (Vitest 4.1.10, oxlint 1.75.0, oxfmt 0.60.0; TypeScript 6.0.3). Full repository formatting also reports two unchanged files with that older formatter, reproduced on main. CI remains the authoritative check with the repository's pinned toolchain. No registry, lockfile, or supply-chain safeguards were changed.
