### PR TITLE
fix(runners): observe cancellation after completion callbacks

### DIFF
--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -757,6 +757,8 @@ main();
 The `afterCompletion` callback runs after a completion's tool calls have finished and is awaited before the
 next request starts. It can inspect the completion and append context to the runner's mutable `messages` array.
 The callback also runs for the final completion, when no further request will be made.
+Once the callback resolves, any pending cancellation is reported through the `abort` event and rejects
+`done()` and the `final*` helpers, including on the final completion.
 
 ```ts
 const runner = client.chat.completions.runTools(

--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -385,6 +385,15 @@ export class AbstractChatCompletionRunner<
     const singleFunctionToCall =
       typeof tool_choice !== 'string' && tool_choice.type === 'function' && tool_choice?.function?.name;
     const { maxChatCompletions = DEFAULT_MAX_CHAT_COMPLETIONS, afterCompletion } = options || {};
+    const runAfterCompletion = async (completion: ChatCompletion) => {
+      if (afterCompletion == null) {
+        return;
+      }
+      await afterCompletion(completion, runner);
+      if (this.controller.signal.aborted) {
+        throw new APIUserAbortError();
+      }
+    };
 
     // Normalize tool definitions before invoking callbacks.
     const inputTools = params.tools.map((tool): RunnableToolFunction<any> => {
@@ -520,7 +529,7 @@ export class AbstractChatCompletionRunner<
         throw new OpenAIError(`missing message in ChatCompletion response`);
       }
       if (!message.tool_calls?.length) {
-        await afterCompletion?.(chatCompletion, runner);
+        await runAfterCompletion(chatCompletion);
         return;
       }
 
@@ -535,7 +544,7 @@ export class AbstractChatCompletionRunner<
           }
 
           if (singleFunctionToCall && result.functionCalled) {
-            await afterCompletion?.(chatCompletion, runner);
+            await runAfterCompletion(chatCompletion);
             return;
           }
         }
@@ -564,7 +573,7 @@ export class AbstractChatCompletionRunner<
         }
       }
 
-      await afterCompletion?.(chatCompletion, runner);
+      await runAfterCompletion(chatCompletion);
     }
   }
 

--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -128,6 +128,7 @@ export class AbstractChatCompletionRunner<
 > extends EventStream<EventTypes> {
   protected _chatCompletions: ParsedChatCompletion<ParsedT>[] = [];
   #completionArrivedBeforeAbort = false;
+  #afterCompletionInvoked = false;
   /** Mutable conversation history, including initial input, assistant replies, and tool results. */
   messages: ChatCompletionMessageParam[] = [];
 
@@ -306,6 +307,9 @@ export class AbstractChatCompletionRunner<
   protected override _emitFinal(
     this: AbstractChatCompletionRunner<AbstractChatCompletionRunnerEvents, ParsedT>,
   ) {
+    if (this.#afterCompletionInvoked) {
+      this.#throwIfAborted();
+    }
     const completion = this._chatCompletions[this._chatCompletions.length - 1];
     if (completion) {
       this._emit('finalChatCompletion', completion);
@@ -331,6 +335,18 @@ export class AbstractChatCompletionRunner<
 
     if (this._chatCompletions.some((c) => c.usage)) {
       this._emit('totalUsage', this.#calculateTotalUsage());
+    }
+  }
+
+  #throwIfAborted() {
+    if (this.controller.signal.aborted) {
+      const error = new APIUserAbortError();
+      Object.defineProperty(error, 'cause', {
+        value: this.controller.signal.reason,
+        writable: true,
+        configurable: true,
+      });
+      throw error;
     }
   }
 
@@ -389,16 +405,9 @@ export class AbstractChatCompletionRunner<
       if (afterCompletion == null) {
         return;
       }
+      this.#afterCompletionInvoked = true;
       await afterCompletion(completion, runner);
-      if (this.controller.signal.aborted) {
-        const error = new APIUserAbortError();
-        Object.defineProperty(error, 'cause', {
-          value: this.controller.signal.reason,
-          writable: true,
-          configurable: true,
-        });
-        throw error;
-      }
+      this.#throwIfAborted();
     };
 
     // Normalize tool definitions before invoking callbacks.

--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -391,7 +391,13 @@ export class AbstractChatCompletionRunner<
       }
       await afterCompletion(completion, runner);
       if (this.controller.signal.aborted) {
-        throw new APIUserAbortError();
+        const error = new APIUserAbortError();
+        Object.defineProperty(error, 'cause', {
+          value: this.controller.signal.reason,
+          writable: true,
+          configurable: true,
+        });
+        throw error;
       }
     };
 

--- a/tests/lib/chat-tool-runner-abort-security.test.ts
+++ b/tests/lib/chat-tool-runner-abort-security.test.ts
@@ -844,7 +844,14 @@ describe.each([
   describe.each(['final response', 'forced tool', 'parallel limit', 'sequential limit'] as const)(
     'afterCompletion on %s',
     (exitRoute) => {
-      test.each(['context.abort', 'runner.controller.abort', 'external signal', 'not aborted'] as const)(
+      const callbackCancellationCases = [
+        'context.abort',
+        'runner.controller.abort',
+        'external signal',
+        'callback promise reaction',
+        'not aborted',
+      ] as const;
+      test.each(callbackCancellationCases)(
         'settles correctly when %s while awaiting the callback',
         async (abortMethod) => {
           const calls = exitRoute === 'final response' ? [] : [toolCall('readBalance')];
@@ -852,16 +859,21 @@ describe.each([
           const controller = new AbortController();
           const abortReason = new Error('synthetic completion callback cancellation');
           const callbackStarted = deferred<boolean>();
-          const callbackReady = deferred<boolean>();
+          const callbackReady: Deferred<void> = deferred();
           const readBalance = vi.fn(() => 'balance already read');
           const afterCompletion = vi.fn<NonNullable<RunnerOptions['afterCompletion']>>(
-            async (_completion, context) => {
-              callbackStarted.resolve(true);
-              if (abortMethod === 'context.abort') {
-                context.abort();
-              }
-              await callbackReady.promise;
-            },
+            abortMethod === 'callback promise reaction'
+              ? () => {
+                  callbackStarted.resolve(true);
+                  return callbackReady.promise;
+                }
+              : async (_completion, context) => {
+                  callbackStarted.resolve(true);
+                  if (abortMethod === 'context.abort') {
+                    context.abort();
+                  }
+                  await callbackReady.promise;
+                },
           );
           const params = {
             model: 'gpt-4o-mini',
@@ -896,8 +908,10 @@ describe.each([
             controller.abort();
           } else if (abortMethod === 'runner.controller.abort') {
             runner.controller.abort(abortReason);
+          } else if (abortMethod === 'callback promise reaction') {
+            void callbackReady.promise.then(() => runner.controller.abort(abortReason));
           }
-          callbackReady.resolve(true);
+          callbackReady.resolve();
 
           if (abortMethod === 'not aborted') {
             await expect(runner.done()).resolves.toBeUndefined();
@@ -907,7 +921,7 @@ describe.each([
             expect(Object.getOwnPropertyDescriptor(abortError, 'cause')?.value).toBe(
               runner.controller.signal.reason,
             );
-            if (abortMethod === 'runner.controller.abort') {
+            if (abortMethod === 'runner.controller.abort' || abortMethod === 'callback promise reaction') {
               expect(runner.controller.signal.reason).toBe(abortReason);
             }
           }
@@ -926,6 +940,27 @@ describe.each([
       );
     },
   );
+
+  test('preserves completed-response cancellation behavior when no callback was invoked', async () => {
+    const { client, respond } = clientWithToolCalls(streaming, []);
+    const params = {
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user' as const, content: 'hello' }],
+      tools: [],
+    };
+    const runner: AbstractChatCompletionRunner<AbstractChatCompletionRunnerEvents, null> = streaming
+      ? client.chat.completions.runTools({ ...params, stream: true })
+      : client.chat.completions.runTools({ ...params, stream: false });
+    const onFinal = vi.fn();
+    runner.on('finalChatCompletion', onFinal);
+    runner.on('chatCompletion', () => runner.abort());
+
+    await respond();
+    await expect(runner.done()).resolves.toBeUndefined();
+    expect(runner.controller.signal.aborted).toBe(true);
+    expect(runner.aborted).toBe(false);
+    expect(onFinal).toHaveBeenCalledTimes(1);
+  });
 
   test('preserves a rejected afterCompletion error even when the callback aborts', async () => {
     const { client, respond } = clientWithToolCalls(streaming, []);

--- a/tests/lib/chat-tool-runner-abort-security.test.ts
+++ b/tests/lib/chat-tool-runner-abort-security.test.ts
@@ -1,6 +1,11 @@
 import { vi } from 'vitest';
 import OpenAI from 'openai';
-import { APIUserAbortError } from 'openai/error';
+import { APIUserAbortError, OpenAIError } from 'openai/error';
+import type {
+  AbstractChatCompletionRunner,
+  AbstractChatCompletionRunnerEvents,
+  RunnerOptions,
+} from 'openai/lib/AbstractChatCompletionRunner';
 
 import { mockFetch } from '../utils/mock-fetch';
 
@@ -47,12 +52,12 @@ function clientWithToolCalls(streaming: boolean, calls: ReturnType<typeof toolCa
           choices: [
             {
               index: 0,
-              finish_reason: 'tool_calls',
+              finish_reason: calls.length ? 'tool_calls' : 'stop',
               logprobs: null,
               delta: {
                 role: 'assistant',
-                content: null,
-                tool_calls: calls.map((call, index) => ({ ...call, index })),
+                content: calls.length ? null : 'Final answer',
+                tool_calls: calls.length ? calls.map((call, index) => ({ ...call, index })) : undefined,
               },
             },
           ],
@@ -71,13 +76,13 @@ function clientWithToolCalls(streaming: boolean, calls: ReturnType<typeof toolCa
         choices: [
           {
             index: 0,
-            finish_reason: 'tool_calls',
+            finish_reason: calls.length ? 'tool_calls' : 'stop',
             logprobs: null,
             message: {
               role: 'assistant',
-              content: null,
+              content: calls.length ? null : 'Final answer',
               refusal: null,
-              tool_calls: calls,
+              tool_calls: calls.length ? calls : undefined,
             },
           },
         ],
@@ -834,6 +839,111 @@ describe.each([
       },
     ]);
     expect(runner.aborted).toBe(true);
+  });
+
+  describe.each(['final response', 'forced tool', 'parallel limit', 'sequential limit'] as const)(
+    'afterCompletion on %s',
+    (exitRoute) => {
+      test.each(['context.abort', 'external signal', 'not aborted'] as const)(
+        'settles correctly when %s while awaiting the callback',
+        async (abortMethod) => {
+          const calls = exitRoute === 'final response' ? [] : [toolCall('readBalance')];
+          const { client, respond } = clientWithToolCalls(streaming, calls);
+          const controller = new AbortController();
+          const callbackStarted = deferred<boolean>();
+          const callbackReady = deferred<boolean>();
+          const readBalance = vi.fn(() => 'balance already read');
+          const afterCompletion = vi.fn<NonNullable<RunnerOptions['afterCompletion']>>(
+            async (_completion, context) => {
+              callbackStarted.resolve(true);
+              if (abortMethod === 'context.abort') {
+                context.abort();
+              }
+              await callbackReady.promise;
+            },
+          );
+          const params = {
+            model: 'gpt-4o-mini',
+            parallel_tool_calls: exitRoute !== 'sequential limit',
+            ...(exitRoute === 'forced tool'
+              ? { tool_choice: { type: 'function' as const, function: { name: 'readBalance' } } }
+              : {}),
+            messages: [{ role: 'user' as const, content: 'read the current balance' }],
+            tools: [
+              {
+                type: 'function' as const,
+                function: {
+                  name: 'readBalance',
+                  description: 'Reads the current balance',
+                  parameters: { type: 'object' as const },
+                  function: readBalance,
+                },
+              },
+            ],
+          };
+          const options = { signal: controller.signal, maxChatCompletions: 1, afterCompletion };
+          const runner: AbstractChatCompletionRunner<AbstractChatCompletionRunnerEvents, null> = streaming
+            ? client.chat.completions.runTools({ ...params, stream: true }, options)
+            : client.chat.completions.runTools({ ...params, stream: false }, options);
+          const onFinal = vi.fn();
+          runner.on('finalChatCompletion', onFinal);
+
+          await respond();
+          await callbackStarted.promise;
+          expect(onFinal).not.toHaveBeenCalled();
+          if (abortMethod === 'external signal') {
+            controller.abort();
+          }
+          callbackReady.resolve(true);
+
+          await (abortMethod === 'not aborted'
+            ? expect(runner.done()).resolves.toBeUndefined()
+            : expect(runner.done()).rejects.toBeInstanceOf(APIUserAbortError));
+          expect(runner.aborted).toBe(abortMethod !== 'not aborted');
+          expect(onFinal).toHaveBeenCalledTimes(abortMethod === 'not aborted' ? 1 : 0);
+          expect(afterCompletion).toHaveBeenCalledTimes(1);
+          expect(readBalance).toHaveBeenCalledTimes(calls.length);
+          expect(runner.messages.filter((message) => message.role === 'tool')).toEqual(
+            calls.map((call) => ({
+              role: 'tool',
+              tool_call_id: call.id,
+              content: 'balance already read',
+            })),
+          );
+        },
+      );
+    },
+  );
+
+  test('preserves a rejected afterCompletion error even when the callback aborts', async () => {
+    const { client, respond } = clientWithToolCalls(streaming, []);
+    const error = new OpenAIError('synthetic lifecycle callback failure');
+    const params = {
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user' as const, content: 'hello' }],
+      tools: [],
+    };
+    const options: RunnerOptions = {
+      afterCompletion: async (_completion, context) => {
+        context.abort();
+        throw error;
+      },
+    };
+    const runner: AbstractChatCompletionRunner<AbstractChatCompletionRunnerEvents, null> = streaming
+      ? client.chat.completions.runTools({ ...params, stream: true }, options)
+      : client.chat.completions.runTools({ ...params, stream: false }, options);
+    const onError = vi.fn();
+    const onAbort = vi.fn();
+    runner.on('error', onError);
+    runner.on('abort', onAbort);
+
+    await respond();
+    await expect(runner.done()).rejects.toBe(error);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(error);
+    expect(onAbort).not.toHaveBeenCalled();
+    expect(runner.controller.signal.aborted).toBe(true);
+    expect(runner.aborted).toBe(false);
   });
 
   test('preserves successful tool context, result ordering, and afterCompletion', async () => {

--- a/tests/lib/chat-tool-runner-abort-security.test.ts
+++ b/tests/lib/chat-tool-runner-abort-security.test.ts
@@ -844,12 +844,13 @@ describe.each([
   describe.each(['final response', 'forced tool', 'parallel limit', 'sequential limit'] as const)(
     'afterCompletion on %s',
     (exitRoute) => {
-      test.each(['context.abort', 'external signal', 'not aborted'] as const)(
+      test.each(['context.abort', 'runner.controller.abort', 'external signal', 'not aborted'] as const)(
         'settles correctly when %s while awaiting the callback',
         async (abortMethod) => {
           const calls = exitRoute === 'final response' ? [] : [toolCall('readBalance')];
           const { client, respond } = clientWithToolCalls(streaming, calls);
           const controller = new AbortController();
+          const abortReason = new Error('synthetic completion callback cancellation');
           const callbackStarted = deferred<boolean>();
           const callbackReady = deferred<boolean>();
           const readBalance = vi.fn(() => 'balance already read');
@@ -893,12 +894,23 @@ describe.each([
           expect(onFinal).not.toHaveBeenCalled();
           if (abortMethod === 'external signal') {
             controller.abort();
+          } else if (abortMethod === 'runner.controller.abort') {
+            runner.controller.abort(abortReason);
           }
           callbackReady.resolve(true);
 
-          await (abortMethod === 'not aborted'
-            ? expect(runner.done()).resolves.toBeUndefined()
-            : expect(runner.done()).rejects.toBeInstanceOf(APIUserAbortError));
+          if (abortMethod === 'not aborted') {
+            await expect(runner.done()).resolves.toBeUndefined();
+          } else {
+            const abortError = await runner.done().catch((error: unknown) => error);
+            expect(abortError).toBeInstanceOf(APIUserAbortError);
+            expect(Object.getOwnPropertyDescriptor(abortError, 'cause')?.value).toBe(
+              runner.controller.signal.reason,
+            );
+            if (abortMethod === 'runner.controller.abort') {
+              expect(runner.controller.signal.reason).toBe(abortReason);
+            }
+          }
           expect(runner.aborted).toBe(abortMethod !== 'not aborted');
           expect(onFinal).toHaveBeenCalledTimes(abortMethod === 'not aborted' ? 1 : 0);
           expect(afterCompletion).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary

Cancelling a tool runner during its final `afterCompletion` callback could be reported as success: `done()` resolved and successful final events were emitted even though the runner controller was aborted.

This PR observes callback cancellation at the existing post-callback boundary and again at successful final settlement:

- Continue awaiting the configured callback at all three exit sites: a final response, a forced function call, and the completion limit.
- Retain the early cancellation check before another request, and use one final-settlement check to cover later fulfillment reactions on a callback's returned promise.
- Preserve the runner signal's reason by identity on `APIUserAbortError.cause`.
- Preserve completed tool results and the original error when the callback itself rejects.

The final-settlement check is gated by a private flag set only when `afterCompletion` is actually invoked. Omitted/null callbacks, configured-but-never-invoked callbacks, and unrelated `ChatCompletionStream` behavior remain unchanged.

## Scope

Only handwritten `src/lib/AbstractChatCompletionRunner.ts`, its existing cancellation test, and `docs/helpers.md` change. No generated files, dependencies, exported types, or general `EventStream` machinery change.

[#2607](https://github.com/openai/openai-node/pull/2607) owns the broader external-signal reason forwarding and five preexisting tool checkpoints. Those changes are not duplicated here. This PR preserves the reason already present on the runner's signal at the new callback boundaries and composes with that separate forwarding fix.

## Verification

- Fail-before regressions cover callback/external cancellation, cause identity, and the late-promise-reaction race across JSON/SSE and every exit route. The final settlement addition made eight previously failing late-reaction cases pass while preserving 34 controls.
- **118 related tests pass** on Node 22.22.2 and 24.19.0, including callback-error-precedence and no-callback controls.
- **474 final built CJS/ESM checks pass** across exact Node 22.0.0, 24.19.0, and 26.7.0: a 324-case runner matrix plus 150 independent compatibility checks. These verify cause identity/descriptors, arbitrary/falsy reasons, late reactions, one request, retained history, lifecycle counts, omitted/null callbacks, never-invoked callbacks, and bare streams.
- `tsc --noEmit`, canonical `./scripts/build`, pinned Oxfmt 0.62.0, available cached Oxlint 1.76.0, and `git diff --check` pass. Emitted CJS/ESM runner declarations remain byte-identical.
- Full handwritten unit suite on the final revision: **7,450 passed, 1 failed**. The sole `oxlint-config` package-command dependency-verification failure reproduces identically on the clean `dde19c5c` base.
- Repeated independent adversarial review covered security, compatibility, callback/error precedence, final-settlement ordering, and regression gaps. No blocking implementation findings remain within this callback scope.

## Review follow-ups

- [`718da1c6`](https://github.com/openai/openai-node/commit/718da1c604054d4a606d7f35580604b98407d37d) adds cause preservation at the new checkpoint.
- [`4ae4ac34`](https://github.com/openai/openai-node/commit/4ae4ac34612f2b0813d86de029726c0c86bcdff4) closes the late-promise-reaction gap with the callback-scoped settlement guard.

## Local tooling limitation

Fresh frozen installation remains blocked by missing publication-time metadata for `qs@6.16.0` in the configured registry. Local checks use available cached Vitest 4.1.10 and Oxlint 1.76.0 rather than pinned 4.1.11 and 1.79.0; TypeScript 6.0.3 and Oxfmt 0.62.0 match their pins. Fresh CI validates the new head with the pinned toolchain. No lockfile, registry configuration, or supply-chain safeguards were changed.
