### PR TITLE
fix(examples): stop polling failed training files

### DIFF
--- a/examples/fine-tuning/fine-tuning.ts
+++ b/examples/fine-tuning/fine-tuning.ts
@@ -32,6 +32,8 @@ async function main() {
 
     if (file.status === 'processed') {
       break;
+    } else if (file.status === 'error') {
+      throw new Error(`File processing failed for ${file.id}`);
     } else {
       await new Promise((resolve) => setTimeout(resolve, 1000));
     }

--- a/tests/lib/fine-tuning-example.test.ts
+++ b/tests/lib/fine-tuning-example.test.ts
@@ -18,13 +18,18 @@ const source = ts.transpileModule(fs.readFileSync(filename, 'utf-8'), {
   fileName: filename,
 }).outputText;
 
-async function runExample(initialStatus: Status, followingStatuses: Status[]) {
+async function executeExample(
+  initialStatus: Status,
+  followingStatuses: Status[],
+  fileStatuses: readonly FileObject['status'][] = ['processed'],
+) {
   const requests: string[] = [];
   const waits: number[] = [];
   const log = vi.fn();
   const error = vi.fn();
   const exit = vi.fn();
   let statusIndex = 0;
+  let fileStatusIndex = 0;
   const file: FileObject = {
     id: 'file_test',
     object: 'file',
@@ -32,7 +37,7 @@ async function runExample(initialStatus: Status, followingStatuses: Status[]) {
     created_at: 0,
     filename: 'training.jsonl',
     purpose: 'fine-tune',
-    status: 'processed',
+    status: 'uploaded',
   };
   const job = (status: Status): FineTuningJob => ({
     id: 'ftjob_test',
@@ -61,7 +66,12 @@ async function runExample(initialStatus: Status, followingStatuses: Status[]) {
       return Response.json(file);
     }
     if (request === 'GET /files/file_test') {
-      return Response.json(file);
+      const status = fileStatuses[fileStatusIndex];
+      fileStatusIndex += 1;
+      if (status === undefined) {
+        throw new Error('The example polled past its terminal file status');
+      }
+      return Response.json({ ...file, status });
     }
     if (request === 'POST /fine_tuning/jobs') {
       return Response.json(job(initialStatus));
@@ -111,6 +121,11 @@ async function runExample(initialStatus: Status, followingStatuses: Status[]) {
     { filename },
   );
 
+  return { requests, waits, log, error, exit };
+}
+
+async function runExample(initialStatus: Status, followingStatuses: Status[]) {
+  const { requests, waits, log, error, exit } = await executeExample(initialStatus, followingStatuses);
   expect(error).not.toHaveBeenCalled();
   expect(exit).not.toHaveBeenCalled();
   expect(requests.filter((request) => request === 'POST /fine_tuning/jobs')).toHaveLength(1);
@@ -125,6 +140,36 @@ async function runExample(initialStatus: Status, followingStatuses: Status[]) {
     expect(log).toHaveBeenCalledWith(status);
   }
 }
+
+test.each([
+  { name: 'first processing check', statuses: ['error'] },
+  { name: 'previously uploaded file', statuses: ['uploaded', 'error'] },
+] as const)('stops after a file-processing error for the $name', async ({ statuses }) => {
+  const { requests, waits, error, exit } = await executeExample('succeeded', [], statuses);
+
+  expect(requests).toEqual(['POST /files', ...statuses.map(() => 'GET /files/file_test')]);
+  expect(waits).toEqual(statuses.slice(0, -1).map(() => 1000));
+  expect(error).toHaveBeenCalledTimes(1);
+  expect(error).toHaveBeenCalledWith(
+    expect.objectContaining({ message: 'File processing failed for file_test' }),
+  );
+  expect(exit).toHaveBeenCalledTimes(1);
+  expect(exit).toHaveBeenCalledWith(1);
+});
+
+test('starts fine-tuning after an uploaded file is processed', async () => {
+  const { requests, waits, error, exit } = await executeExample('succeeded', [], ['uploaded', 'processed']);
+
+  expect(requests).toEqual([
+    'POST /files',
+    'GET /files/file_test',
+    'GET /files/file_test',
+    'POST /fine_tuning/jobs',
+  ]);
+  expect(waits).toEqual([1000]);
+  expect(error).not.toHaveBeenCalled();
+  expect(exit).not.toHaveBeenCalled();
+});
 
 test('tracks a newly created job through file validation, queueing, and training', async () => {
   await runExample('validating_files', ['validating_files', 'queued', 'running', 'succeeded']);


### PR DESCRIPTION
## Summary

The fine-tuning example waits indefinitely when an uploaded file reaches the terminal `error` status: it sleeps for another second and retrieves the failed file again instead of stopping.

Stop that loop with a concise error and reuse the example's existing error-reporting/nonzero-exit path. The message includes only the already-logged file ID, not file contents or `status_details`. Successful processing is unchanged, and a failed file never reaches fine-tuning job creation.

The implementation is **two lines** in the handwritten example. Its existing offline regression harness now models file-status progression and checks:

- Failure on the first processing check.
- An uploaded file that subsequently fails.
- Exact retrieval and wait counts, error reporting, exit status 1, and no job creation after failure.
- An uploaded file that processes successfully and does start a job.

Only the example and its handwritten test change; no generated files, SDK behavior, dependencies, or polling framework changes.

## Verification

- The two new failure regressions fail on unchanged main because it polls again after the terminal error.
- **27 related tests pass** on Node 24.19.0 and 22.22.2, including all existing fine-tuning-job lifecycle tests.
- `tsc --noEmit`, changed-file formatting (Oxfmt 0.62.0), lint, and `git diff --check` pass.
- The tests execute the actual example with the real SDK and injected fetch; no API key, live request, or real timer delay is required.
- Adversarial review covered privacy, terminal-state handling, extra polling/job creation, and test fidelity. Tightened the upload fixture to start at `uploaded`, then repeated review with no remaining findings.

Local tests used cached Vitest 4.1.10 and Oxlint 1.76.0. Fresh frozen installation is still blocked by missing `qs@6.16.0` publication metadata in the configured registry; CI will verify the pinned toolchain. No registry or supply-chain settings were changed.
