### PR TITLE
fix(examples): use the default audio recording input

### DIFF
--- a/examples/audio/speech-to-text.ts
+++ b/examples/audio/speech-to-text.ts
@@ -5,7 +5,7 @@ const openai = new OpenAI();
 
 async function main(): Promise<void> {
   console.log('Recording for 5 seconds...');
-  const response = await recordAudio({ timeout: 5000, device: 4 });
+  const response = await recordAudio({ timeout: 5000 });
 
   console.log('Transcribing...');
   const transcription = await openai.audio.transcriptions.create({

--- a/tests/lib/audio-example-exit-status.test.ts
+++ b/tests/lib/audio-example-exit-status.test.ts
@@ -16,8 +16,10 @@ const audioTool = [
   "const tool = require('node:path').basename(process.argv[1]);",
   "const failed = process.env.AUDIO_TOOL_FAILURE === 'true';",
   "if (tool === 'ffmpeg') {",
-  '  fs.writeFileSync(process.env.AUDIO_TRACE, JSON.stringify({ tool }));',
-  '  if (failed) process.exitCode = 47;',
+  "  const input = process.argv[process.argv.indexOf('-i') + 1];",
+  '  fs.writeFileSync(process.env.AUDIO_TRACE, JSON.stringify({ tool, input }));',
+  // Model a machine with only input zero available.
+  "  if (failed || ![':0', 'hw:0'].includes(input)) process.exitCode = 47;",
   "  else process.stdout.write(Buffer.from(process.env.AUDIO_BYTES, 'hex'));",
   '} else {',
   '  const chunks = [];',
@@ -160,9 +162,13 @@ describeOnUnix('audio executable examples', () => {
       if (!recording && scenario === 'HTTP rejection') {
         expect(existsSync(trace)).toBe(false);
       } else {
-        expect(JSON.parse(await readFile(trace, 'utf-8'))).toEqual(
-          recording ? { tool: 'ffmpeg' } : { tool: 'ffplay', audio: audio.toString('hex') },
-        );
+        const recorded = JSON.parse(await readFile(trace, 'utf-8'));
+        if (recording) {
+          expect(recorded.tool).toBe('ffmpeg');
+          expect([':0', 'hw:0']).toContain(recorded.input);
+        } else {
+          expect(recorded).toEqual({ tool: 'ffplay', audio: audio.toString('hex') });
+        }
       }
       if (scenario === 'success') {
         expect(result.stderr).toBe('');


### PR DESCRIPTION
## Summary

Use `recordAudio`'s documented default input (index 0) in the speech-to-text example instead of hardcoding input 4. The example currently fails before transcription on a machine with only input zero available.

This is a one-line executable-example change. The SDK helper, five-second timeout, transcription model, and error/exit behavior are unchanged.

## Regression coverage

Strengthen the existing audio subprocess harness so its synthetic `ffmpeg` accepts only input zero and records the selected input. The three speech-to-text cases now verify the selected input while preserving successful multipart upload, HTTP rejection, and recorder-failure/no-request behavior. The three playback controls are unchanged.

All three recording regressions fail on the original example: it selects `:4` and never reaches the expected transcription request. They pass after removing the override. Tests use synthetic audio/credentials and a loopback API, not microphone hardware or a live API.

## Verification

- 58 focused audio tests pass on Node 24.19.0 and 22.22.2.
- Independent executable-example smoke checks pass on exact Node 22.0.0 and Node 26.7.0, including the actual multipart request and one transcription call.
- TypeScript `--noEmit`, changed-file lint, pinned Oxfmt 0.62.0, and `git diff --check` pass.
- Adversarial security, compatibility, lifecycle, and regression-test review found no blockers.
- Both changed files are wholly handwritten and absent from the current pinned Castiron snapshot `efa35b8b45ad152d9b5f9c327c48e35bca65c7ce`.

Local checks used the available cached Vitest 4.1.10, TypeScript 6.0.3, and Oxlint 1.76.0. A fresh pinned install remains blocked by the configured registry's missing publication-time metadata for `qs@6.16.0`; no dependency, lockfile, registry, or install-policy changes are included. CI will run the pinned repository toolchain.