### PR TITLE
fix(runners): reuse caller abort listeners across tool turns

### DIFF
--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -1452,6 +1452,9 @@ export class EventStream<EventTypes extends BaseEvents> {
       this.controller.abort();
       return;
     }
+    if (this.#abortListeners.some((registration) => registration.signal === signal)) {
+      return;
+    }
 
     const listener = () => this.controller.abort();
     signal.addEventListener('abort', listener, { once: true });

--- a/tests/lib/runner-abort-listeners.test.ts
+++ b/tests/lib/runner-abort-listeners.test.ts
@@ -1,0 +1,143 @@
+import { getEventListeners } from 'node:events';
+import { vi } from 'vitest';
+import OpenAI from 'openai';
+import { APIConnectionError, APIUserAbortError } from 'openai/error';
+import { EventStream } from 'openai/lib/EventStream';
+import type { BaseEvents } from 'openai/lib/EventStream';
+
+describe.each([false, true])('runTools abort subscriptions (stream=%s)', (streaming) => {
+  test.each(['success', 'error', 'abort'] as const)(
+    'reuses the caller subscription across turns and cleans up after %s',
+    async (outcome) => {
+      const caller = new AbortController();
+      const unrelated = vi.fn();
+      caller.signal.addEventListener('abort', unrelated);
+      const add = vi.spyOn(caller.signal, 'addEventListener');
+      const remove = vi.spyOn(caller.signal, 'removeEventListener');
+      const listenerCounts: number[] = [];
+      let requests = 0;
+      const client = new OpenAI({
+        apiKey: 'synthetic-api-key',
+        baseURL: 'https://example.invalid/v1',
+        maxRetries: 0,
+        fetch: async () => {
+          requests += 1;
+          listenerCounts.push(getEventListeners(caller.signal, 'abort').length);
+          if (outcome === 'error' && requests === 12) {
+            throw new Error('synthetic fetch failure');
+          }
+          const call = {
+            id: `call_${requests}`,
+            type: 'function',
+            function: { name: 'readValue', arguments: '{}' },
+          };
+          const completion = {
+            id: `completion_${requests}`,
+            object: streaming ? 'chat.completion.chunk' : 'chat.completion',
+            created: 1,
+            model: 'gpt-4o-mini',
+            choices: [
+              {
+                index: 0,
+                finish_reason: 'tool_calls',
+                logprobs: null,
+                [streaming ? 'delta' : 'message']: {
+                  role: 'assistant',
+                  content: null,
+                  refusal: null,
+                  tool_calls: [streaming ? { ...call, index: 0 } : call],
+                },
+              },
+            ],
+          };
+          return streaming
+            ? new Response(`data: ${JSON.stringify(completion)}\n\ndata: [DONE]\n\n`, {
+                headers: { 'Content-Type': 'text/event-stream' },
+              })
+            : Response.json(completion);
+        },
+      });
+      const tool = vi.fn(() => {
+        if (outcome === 'abort' && requests === 12) {
+          caller.abort();
+        }
+        return 'synthetic tool result';
+      });
+      const params = {
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user' as const, content: 'Read a value' }],
+        tools: [
+          {
+            type: 'function' as const,
+            function: {
+              name: 'readValue',
+              description: 'Returns a synthetic value',
+              parameters: { type: 'object' },
+              function: tool,
+            },
+          },
+        ],
+      };
+      const options = { signal: caller.signal, maxChatCompletions: 12 };
+      const runner = streaming
+        ? client.chat.completions.runTools({ ...params, stream: true }, options)
+        : client.chat.completions.runTools({ ...params, stream: false }, options);
+      const abort = vi.spyOn(runner.controller, 'abort');
+
+      await (outcome === 'success'
+        ? expect(runner.done()).resolves.toBeUndefined()
+        : expect(runner.done()).rejects.toBeInstanceOf(
+            outcome === 'error' ? APIConnectionError : APIUserAbortError,
+          ));
+
+      expect(requests).toBe(12);
+      expect(tool).toHaveBeenCalledTimes(outcome === 'error' ? 11 : 12);
+      expect(listenerCounts).toEqual(Array.from({ length: 12 }, () => 2));
+      expect(add).toHaveBeenCalledTimes(1);
+      const listener = add.mock.calls[0]?.[1];
+      expect(add).toHaveBeenCalledWith('abort', listener, { once: true });
+      expect(remove).toHaveBeenCalledTimes(1);
+      expect(remove).toHaveBeenCalledWith('abort', listener);
+      expect(getEventListeners(caller.signal, 'abort')).toEqual([unrelated]);
+      expect(abort).toHaveBeenCalledTimes(outcome === 'abort' ? 1 : 0);
+      expect(runner.aborted).toBe(outcome === 'abort');
+
+      abort.mockClear();
+      caller.abort();
+      expect(abort).not.toHaveBeenCalled();
+      expect(unrelated).toHaveBeenCalledTimes(1);
+      caller.signal.removeEventListener('abort', unrelated);
+    },
+  );
+});
+
+class TestStream extends EventStream<BaseEvents> {
+  observe(signal: AbortSignal) {
+    this._listenForAbort(signal);
+  }
+
+  end() {
+    this._emit('end');
+  }
+}
+
+test('keeps distinct abort sources and immediately observes an already-aborted source', () => {
+  const stream = new TestStream();
+  const first = new AbortController();
+  const second = new AbortController();
+  for (const signal of [first.signal, second.signal, first.signal, second.signal]) {
+    stream.observe(signal);
+  }
+  expect(getEventListeners(first.signal, 'abort')).toHaveLength(1);
+  expect(getEventListeners(second.signal, 'abort')).toHaveLength(1);
+
+  second.abort();
+  expect(stream.controller.signal.aborted).toBe(true);
+  stream.controller = new AbortController();
+  stream.observe(second.signal);
+  expect(stream.controller.signal.aborted).toBe(true);
+
+  stream.end();
+  expect(getEventListeners(first.signal, 'abort')).toHaveLength(0);
+  expect(getEventListeners(second.signal, 'abort')).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary

Reuse the existing caller-abort subscription across `runTools` completion turns. Each turn currently installs another listener on the same signal and retains it until the runner ends. A 12-turn public JSON or SSE run accumulates 12 listeners; one caller abort invokes the runner controller 12 times. The exact supported Node 22.0.0 minimum also emits `MaxListenersExceededWarning`.

The production change is a three-line identity check in `EventStream._listenForAbort`. It comes after the existing already-aborted check and leaves the listener registry, distinct-signal support, and terminal cleanup unchanged. There is no new cache or change to event buffering, parsing, warning thresholds, request options, or public declarations.

## Regression coverage

Seven focused regressions fail before the change and pass afterward:

- Public JSON and SSE tool runners, each spanning 12 requests, ending in success, fetch failure, or caller cancellation.
- Exactly one SDK subscription/removal, one forwarded abort, and no forwarding after the runner ends.
- Unrelated caller listeners remain installed.
- Distinct sources and already-aborted sources still cancel correctly, including after replacing the public runner controller.

The tests use synthetic responses and tool output with an in-memory fetch transport; no live API is required.

## Verification and review

- 411 related runner/stream tests pass on Node 24.19.0 and 22.22.2.
- 36 built CJS/ESM lifecycle checks pass across exact Node 22.0.0, Node 24.19.0, and Node 26.7.0 (432 synthetic requests). Every run keeps one caller subscription per turn, cleans up to zero, and preserves terminal error types, events, and tool history; no listener warnings remain.
- Canonical `./scripts/build`, TypeScript `--noEmit`, changed-file lint, pinned Oxfmt 0.62.0, and `git diff --check` pass. Emitted `EventStream.d.ts` and `.d.mts` are unchanged.
- Full handwritten unit suite: 7,421 pass / 1 fails. The sole failure is the pre-existing `tests/oxlint-config.test.ts` package-command check: cached dependencies cause `ERR_PNPM_VERIFY_DEPS_BEFORE_RUN`. The same failure is reproduced on the clean baseline.
- Repeated adversarial security, compatibility, lifecycle, and regression-test review found no remaining blockers. Existing public runner factories capture one caller signal, so the existing-array lookup stays bounded on the affected loop.
- Both changed files are wholly handwritten and absent from the pinned Castiron snapshot `efa35b8b45ad152d9b5f9c327c48e35bca65c7ce`. No open PR addresses this registration issue.

Local validation uses cached Vitest 4.1.10, TypeScript 6.0.3, and Oxlint 1.76.0. A fresh pinned install remains blocked by the configured registry's missing publication-time metadata for `qs@6.16.0`; no dependency, lockfile, registry, or install-policy changes are included. CI will run the pinned repository toolchain.