### PR TITLE
fix(docs): await headers in Next.js webhook examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ const client = new OpenAI({
 });
 
 export async function webhook(request: Request) {
-  const headersList = headers();
+  const headersList = await headers();
   const body = await request.text();
 
   try {
@@ -358,7 +358,7 @@ const client = new OpenAI({
 });
 
 export async function webhook(request: Request) {
-  const headersList = headers();
+  const headersList = await headers();
   const body = await request.text();
 
   try {

--- a/tests/lib/webhooks.test.ts
+++ b/tests/lib/webhooks.test.ts
@@ -1,6 +1,9 @@
 import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+import ts from 'typescript';
 import { vi } from 'vitest';
 import OpenAI, { InvalidWebhookSignatureError } from 'openai';
+import type { ClientOptions } from 'openai';
 
 const timestamp = 1_750_861_210;
 const webhookID = 'wh_685c059ae39c8190af8c71ed1022a24d';
@@ -133,9 +136,27 @@ describe('portable webhook verification', () => {
 });
 
 describe('webhook documentation', () => {
+  const readme = readFileSync('README.md', 'utf-8');
+  const examples = [...readme.matchAll(/```(?:ts|typescript)\r?\n(?<source>[\s\S]*?)\r?\n```/gu)].map(
+    (match) => match.groups?.['source'] ?? '',
+  );
+  const webhookExamples = examples
+    .filter((source) => source.includes("from 'next/headers'") && source.includes('client.webhooks.'))
+    .map((source) => ({
+      source,
+      method: source.includes('client.webhooks.unwrap') ? 'unwrap' : 'verifySignature',
+    }));
+
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(timestamp * 1000);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test('README awaits webhook verification before processing events', () => {
-    const readme = readFileSync('README.md', 'utf-8');
-    const examples = readme.match(/```(?:ts|typescript)\r?\n[\s\S]*?\r?\n```/gu) ?? [];
+    expect(webhookExamples).toHaveLength(2);
     const calls = examples.flatMap((example) => [
       ...example.matchAll(/(?:await\s+)?client\.webhooks\.(?<method>unwrap|verifySignature)\s*\(/gu),
     ]);
@@ -147,5 +168,77 @@ describe('webhook documentation', () => {
     for (const [call] of calls) {
       expect(call).toMatch(/^await\s+/u);
     }
+  });
+
+  describe.each(webhookExamples)('README $method example', ({ source, method }) => {
+    test.each([
+      { headersMode: 'async', valid: true },
+      { headersMode: 'async', valid: false },
+      { headersMode: 'sync', valid: true },
+      { headersMode: 'sync', valid: false },
+    ])('handles $headersMode headers with valid signature=$valid', async ({ headersMode, valid }) => {
+      const headerValues = makeHeaders(valid ? `v1,${signature}` : 'v1,not-valid-$$$');
+      const headers = vi.fn(() => (headersMode === 'async' ? Promise.resolve(headerValues) : headerValues));
+      const log = vi.fn();
+      const error = vi.fn();
+      const fetch = vi.fn(async () => {
+        throw new Error('Webhook verification must not make a network request');
+      });
+      class OfflineOpenAI extends OpenAI {
+        constructor(options: ClientOptions) {
+          super({ ...options, apiKey: 'synthetic-test-key', fetch });
+        }
+      }
+      const exported: { webhook?: (request: Request) => Promise<Response> } = {};
+      const compiled = ts.transpileModule(source, {
+        compilerOptions: {
+          module: ts.ModuleKind.CommonJS,
+          target: ts.ScriptTarget.ES2020,
+          esModuleInterop: true,
+        },
+      }).outputText;
+      runInNewContext(compiled, {
+        exports: exported,
+        require(specifier: string) {
+          if (specifier === 'openai') {
+            return { __esModule: true, default: OfflineOpenAI };
+          }
+          if (specifier === 'next/headers') {
+            return { headers };
+          }
+          throw new Error(`Unexpected README example import: ${specifier}`);
+        },
+        process: { env: { OPENAI_WEBHOOK_SECRET: secret } },
+        console: { log, error },
+        Response,
+      });
+      if (!exported.webhook) {
+        throw new Error('The README example did not export its webhook handler');
+      }
+
+      const response = await exported.webhook(
+        new Request('https://example.invalid/webhook', { method: 'POST', body: payload }),
+      );
+
+      expect(response.status).toBe(valid ? 200 : 400);
+      expect(headers).toHaveBeenCalledTimes(1);
+      expect(fetch).not.toHaveBeenCalled();
+      if (valid) {
+        expect(await response.json()).toEqual({ message: 'ok' });
+        expect(error).not.toHaveBeenCalled();
+        expect(log).toHaveBeenCalledTimes(1);
+        expect(log).toHaveBeenCalledWith(
+          method === 'unwrap' ? 'Response completed:' : 'Verified event:',
+          method === 'unwrap' ? { id: 'resp_123' } : JSON.parse(payload),
+        );
+      } else {
+        expect(await response.text()).toBe('Invalid signature');
+        expect(log).not.toHaveBeenCalled();
+        expect(error).toHaveBeenCalledWith(
+          'Invalid webhook signature:',
+          expect.any(InvalidWebhookSignatureError),
+        );
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary

Await `headers()` in both README Next.js webhook handlers before passing the returned headers to SDK verification.

[Next.js documents `headers()` as asynchronous](https://nextjs.org/docs/app/api-reference/functions/headers). The current snippets pass its Promise directly to `unwrap()` or `verifySignature()`, so even a correctly signed webhook returns HTTP 400 with `Missing required header: webhook-signature`.

The documentation fix adds two `await` keywords. It also works with older synchronous `headers()` implementations. Raw-body handling, signature verification, event processing, and invalid-signature responses are unchanged; no SDK implementation or generated files are modified.

## Regression coverage

Extend the existing webhook documentation test to execute both actual README snippets with the real public SDK and HMAC verification. Eight cases cover asynchronous/synchronous headers and valid/invalid signatures for both methods.

Valid requests must return 200 and process the expected event. Invalid requests must return 400 with the typed signature error and no event processing. Fixtures use synthetic credentials and a signed whitespace-preserving payload; network requests are forbidden.

Four asynchronous cases fail before the README correction and pass afterward. The existing assertion that webhook verification itself is awaited is retained.

## Verification

- 39 focused webhook tests pass on Node 24.19.0 and Node 22.22.2.
- 16 independent checks of the actual fixed README snippets pass on exact Node 22.0.0 and Node 26.7.0, without any in-memory source correction.
- TypeScript `--noEmit`, changed-file lint, pinned Oxfmt 0.62.0, and `git diff --check` pass.
- Adversarial review of security, compatibility, raw-body handling, and regression coverage found no remaining blockers.
- Both changed files are absent from the current pinned Castiron snapshot `efa35b8b45ad152d9b5f9c327c48e35bca65c7ce`.

Local checks used cached Vitest 4.1.10, TypeScript 6.0.3, and Oxlint 1.76.0. The configured registry's missing publication-time metadata for `qs@6.16.0` still prevents a fresh pinned install; no dependency, lockfile, registry, or install-policy changes are included. CI runs the pinned repository toolchain.