### PR TITLE
fix(docs): correct the chat streaming helper contract

### DIFF
--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -384,10 +384,10 @@ will trigger consumption of the stream until completion and then return the rele
 ### Streaming Responses
 
 ```ts
-openai.chat.completions.stream({ stream?: false, … }, options?): ChatCompletionStreamingRunner
+openai.chat.completions.stream({ stream?: true, … }, options?): ChatCompletionStream
 ```
 
-`openai.chat.completions.stream()` returns a `ChatCompletionStreamingRunner`, which emits events, has an async
+`openai.chat.completions.stream()` returns a `ChatCompletionStream`, which emits events, has an async
 iterator, and exposes helper methods to accumulate chunks into a convenient shape and make it easy to reason
 about the conversation.
 


### PR DESCRIPTION
## Summary

Correct three tokens in the handwritten Chat Streaming guide:

- The optional `stream` flag accepted by `chat.completions.stream()` is `true`, not `false`.
- The helper returns `ChatCompletionStream`, not `ChatCompletionStreamingRunner` (which is used for streaming tool runners).

The current documented `stream: false` call fails type checking with TS2322. The public helper always enables streaming. No SDK implementation, generated files, public declarations, dependencies, or lockfiles change. `docs/helpers.md` is absent from the pinned Castiron generated snapshot. I checked open PRs; #2591 edits an unrelated `afterCompletion` section of the same guide and does not address this issue.

## Validation

- Compiler reproduction through the public `OpenAI` export: `stream: false` is rejected; omitted `stream` and `stream: true` are accepted.
- Public `.stream()` smoke test with synthetic SSE: exact `ChatCompletionStream` prototype, not a `ChatCompletionStreamingRunner`, serialized `stream: true`, successful completion, no live API calls.
- `./scripts/test tests/lib/ChatCompletionStream.test.ts`: **40 passed** on Node 22.22.2 and **40 passed** on Node 24.19.0.
- Pinned Oxfmt 0.62.0 check and `git diff --check` passed.
- Local focused tests used available cached Vitest 4.1.10; the repository pins 4.1.11. A fresh frozen install remains blocked by missing publication-time metadata for `qs@6.16.0` in the configured registry; no installation safeguards or configuration were changed.

## Adversarial self-review

Reviewed public types, actual return identity, optional/explicit stream behavior, compatibility, and security implications. Independent review found no actionable issues. This is a documentation-only correction; compiler/runtime verification and the existing stream suite are proportionate, without adding a Markdown-parsing test harness for three tokens.