### PR TITLE
fix(docs): omit absent Bedrock provider session tokens

### DIFF
--- a/docs/bedrock.md
+++ b/docs/bedrock.md
@@ -230,11 +230,14 @@ For credentials that can change, pass a provider. It is called before every requ
 const client = new OpenAI({
   provider: bedrock({
     region: 'us-west-2',
-    credentialProvider: async () => ({
-      accessKeyId: process.env['AWS_ACCESS_KEY_ID']!,
-      secretAccessKey: process.env['AWS_SECRET_ACCESS_KEY']!,
-      sessionToken: process.env['AWS_SESSION_TOKEN'],
-    }),
+    credentialProvider: async () => {
+      const sessionToken = process.env['AWS_SESSION_TOKEN'];
+      return {
+        accessKeyId: process.env['AWS_ACCESS_KEY_ID']!,
+        secretAccessKey: process.env['AWS_SECRET_ACCESS_KEY']!,
+        ...(sessionToken === undefined ? {} : { sessionToken }),
+      };
+    },
   }),
 });
 ```


### PR DESCRIPTION
## Summary

Fix the handwritten Bedrock `credentialProvider` example so it compiles with `exactOptionalPropertyTypes` (enabled by this repository).

`AwsCredentialIdentity.sessionToken` is optional but, when present, must be a string. The existing example always returns `sessionToken: process.env['AWS_SESSION_TOKEN']`, whose type is `string | undefined`, and fails with TS2322.

Read the token inside the callback and conditionally include the property only when it is not `undefined`. This preserves per-call credential refresh, includes a supplied token unchanged, and preserves explicit empty strings for the SDK's existing validation to reject. The separate static-credentials example already permits undefined and is unchanged.

Only `docs/bedrock.md` changes. It is absent from the pinned Castiron generated snapshot. No SDK implementation, public types, dependencies, generated files, or lockfiles change; no open PR covers this example.

## Validation

- Compiled the exact documentation fence against public `OpenAI` and `openai/providers/bedrock/aws` imports with TypeScript 6.0.3 and strict optional-property checking: TS2322 before, no diagnostics after.
- Evaluated the exact snippet with isolated synthetic environment values and mocked constructor/provider: **3/3** missing/empty/nonempty token cases and **6/6** same-callback credential refresh/deletion transitions passed. No credentials were logged and no network calls were made. Repeated on Node **22.0.0**, **24.19.0**, and **26.7.0**.
- `./scripts/test tests/lib/bedrock-provider.test.ts tests/lib/bedrock-provider-dependencies.test.ts`: **164 passed** on Node 22.22.2 and **164 passed** on Node 24.19.0, including existing invalid/empty provider-identity rejection before fetch.
- Pinned Oxfmt 0.62.0 and `git diff --check` passed.
- Focused tests used available cached Vitest 4.1.10 rather than pinned 4.1.11. Fresh frozen installation remains blocked by missing publication-time metadata for `qs@6.16.0` in the configured registry; no safeguards or configuration were changed.

## Adversarial self-review

Reviewed missing versus empty tokens, nonempty-token preservation, environment rotation/deletion, credential secrecy, public type compatibility, and the distinction between static options and provider-returned identities. Independent review found no actionable issues. Existing provider tests plus exact-snippet validation cover this docs-only correction without adding authentication or Markdown-parsing infrastructure.