### PR TITLE
fix(docs): include image detail in the Vision example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ const response = await client.responses.create({
         { type: 'input_text', text: 'What is in this image?' },
         {
           type: 'input_image',
+          detail: 'auto',
           image_url:
             'https://api.nga.gov/iiif/a2e6da57-3cd1-4235-b20e-95dcaefed6c8/full/!800,800/0/default.jpg',
         },


### PR DESCRIPTION
## Summary

Add `detail: 'auto'` to the image item in the README Vision example. The public `ResponseInputImage` type requires this field, so the current example fails with TS2769 (`No overload matches this call`). Both the type documentation and checked-in schema identify `auto` as the default, preserving the example's intended behavior.

This changes **one line in the handwritten README**. No SDK source, generated schema, declarations, dependencies, or lockfiles change. README is absent from the pinned Castiron generated snapshot. Open PR #2595 touches only unrelated webhook examples; no open PR addresses this Vision issue.

## Validation and adversarial review

- Compiled the **exact README code fence**, unchanged, against public SDK imports using TypeScript 6.0.3 and repository strictness settings: TS2769 before; no diagnostics after. ESNext module mode accommodates the example's existing top-level `await`.
- Repeated the compiler check under Node 22.0.0, 24.19.0, and 26.7.0.
- Pinned Oxfmt 0.62.0 and `git diff --check` passed.
- The verification does not execute the example, use credentials, or make API calls. No full SDK test/build rerun is needed for this one-line documentation correction.
- Adversarial self-review and independent review checked the required field, default behavior, type compatibility, scope, and verification. No actionable issues remained; no new parsing or test infrastructure is added.