### PR TITLE
fix(examples): reject early multi-agent WebSocket closure

### DIFF
--- a/examples/responses/multi-agent-websocket.ts
+++ b/examples/responses/multi-agent-websocket.ts
@@ -28,6 +28,9 @@ async function main() {
       if (message.type === 'error') {
         throw message.error;
       }
+      if (message.type === 'close') {
+        throw new Error('WebSocket closed before the coordinator response completed.');
+      }
       if (message.type !== 'message') {
         continue;
       }

--- a/tests/lib/multi-agent-websocket-example.test.ts
+++ b/tests/lib/multi-agent-websocket-example.test.ts
@@ -52,7 +52,10 @@ const textEvent: BetaResponsesServerEvent = {
   sequence_number: 1,
 };
 
-async function runExample(events: BetaResponsesServerEvent[], writeFailure?: Error) {
+async function runExample(
+  events: BetaResponsesServerEvent[],
+  options: { writeFailure?: Error; close?: 'clean' | 'abrupt' } = {},
+) {
   const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
   await once(server, 'listening');
   const address = server.address();
@@ -82,7 +85,12 @@ async function runExample(events: BetaResponsesServerEvent[], writeFailure?: Err
       for (const event of events) {
         socket.send(JSON.stringify(event));
       }
-      // Keep the server open: the one-response example owns closing its connection.
+      if (options.close === 'clean') {
+        socket.close(1000, 'SYNTHETIC_PRIVATE_CLOSE_REASON');
+      } else if (options.close === 'abrupt') {
+        socket.terminate();
+      }
+      // Otherwise keep the server open: the example owns closing its connection.
     });
   });
 
@@ -104,8 +112,8 @@ async function runExample(events: BetaResponsesServerEvent[], writeFailure?: Err
         process: {
           stdout: {
             write(value: string) {
-              if (writeFailure) {
-                throw writeFailure;
+              if (options.writeFailure) {
+                throw options.writeFailure;
               }
               output.push(value);
               return true;
@@ -125,7 +133,9 @@ async function runExample(events: BetaResponsesServerEvent[], writeFailure?: Err
     })();
 
     await vi.waitFor(() => expect(requests).toHaveLength(1), { timeout: 2000 });
-    await vi.waitFor(() => expect(closeCodes).toEqual([1000]), { timeout: 2000 });
+    await vi.waitFor(() => expect(closeCodes).toEqual([options.close === 'abrupt' ? 1006 : 1000]), {
+      timeout: 2000,
+    });
     expect(requests[0]).toMatchObject({
       type: 'response.create',
       model: 'gpt-5.6-sol',
@@ -145,6 +155,41 @@ async function runExample(events: BetaResponsesServerEvent[], writeFailure?: Err
 
 test('closes the multi-agent WebSocket example after a completed response', async () => {
   const result = await runExample([textEvent, terminalEvent('completed')]);
+
+  expect(result.error).toBeUndefined();
+  expect(result.output).toBe('━━━ Coordinator: /root ━━━\n\nSynthetic answer\n');
+});
+
+test.each([
+  ['clean', false],
+  ['abrupt', false],
+  ['clean', true],
+] as const)(
+  'rejects %s closure before coordinator completion (partial output: %s)',
+  async (close, partialOutput) => {
+    const result = await runExample(partialOutput ? [textEvent] : [], { close });
+
+    expect(result.error).toMatchObject({
+      message: 'WebSocket closed before the coordinator response completed.',
+    });
+    expect(result.output).toBe(partialOutput ? '━━━ Coordinator: /root ━━━\n\nSynthetic answer' : '');
+    expect(result.output).not.toContain('SYNTHETIC_PRIVATE_CLOSE_REASON');
+  },
+);
+
+test('rejects a close after only a child agent has completed', async () => {
+  const result = await runExample([{ ...terminalEvent('completed'), agent: { agent_name: '/root/alpha' } }], {
+    close: 'clean',
+  });
+
+  expect(result.error).toMatchObject({
+    message: 'WebSocket closed before the coordinator response completed.',
+  });
+  expect(result.output).toBe('');
+});
+
+test('accepts coordinator completion before the server closes', async () => {
+  const result = await runExample([textEvent, terminalEvent('completed')], { close: 'clean' });
 
   expect(result.error).toBeUndefined();
   expect(result.output).toBe('━━━ Coordinator: /root ━━━\n\nSynthetic answer\n');
@@ -231,9 +276,27 @@ test.each([
   expect(result.output).toBe('');
 });
 
+test('preserves an API error received before the server closes', async () => {
+  const result = await runExample(
+    [
+      {
+        type: 'error',
+        code: 'invalid_request',
+        message: 'Synthetic API failure',
+        param: null,
+        sequence_number: 0,
+      },
+    ],
+    { close: 'clean' },
+  );
+
+  expect(result.error).toMatchObject({ message: 'Synthetic API failure' });
+  expect(result.output).toBe('');
+});
+
 test('closes the example and preserves a failure while writing output', async () => {
   const error = new Error('Synthetic output failure');
-  const result = await runExample([textEvent], error);
+  const result = await runExample([textEvent], { writeFailure: error });
 
   expect(result.error).toBe(error);
   expect(result.output).toBe('');


### PR DESCRIPTION
## Summary

The multi-agent WebSocket example ignores iterator `close` messages. A clean or abrupt server close before the coordinator finishes therefore resolves `main()` successfully, potentially leaving only an empty or partial answer.

Add a three-line guard that rejects permanent closure before coordinator completion. Preserve the existing error-first handling, successful-completion break, and `finally` cleanup. The error is deliberately generic and does not expose the server's close reason or unsent payloads. Reconnection uses different iterator events and is unaffected.

Only the handwritten example and its existing test harness change; both are absent from the pinned Castiron generated snapshot. No SDK/generated code, dependencies, parsing, retries, or timeouts change. Open PRs were checked and none addresses this example's early-close behavior.

## Regression coverage and validation

- Reproduced the original bug using the actual example, public beta `ResponsesWS`, and a synthetic loopback server: clean/abrupt early closure incorrectly resolved successfully.
- **Four new regressions failed before the guard**: clean close before output, abrupt close, clean close after partial output, and close after only a child agent completed.
- Added positive controls for coordinator completion before server close and preservation of an earlier API error. Existing failed/incomplete response, child-agent, API-error, output-error, and cleanup controls remain.
- **76 focused tests passed on both Node 22.22.2 and Node 24.19.0** via `./scripts/test tests/lib/multi-agent-websocket-example.test.ts tests/lib/websocket-example-close.test.ts tests/lib/responsesWebSocket.test.ts`.
- **12 independent actual-example/real-SDK checks passed** across Node 22.0.0, 24.19.0, and 26.7.0, including partial output, exact error text, close codes, successful completion, and close-reason privacy. No live API calls or real credentials were used.
- `tsc --noEmit`, pinned Oxfmt 0.62.0, available Oxlint 1.76.0, and `git diff --check` passed.

Local tests used cached Vitest 4.1.10 and Oxlint 1.76.0 instead of the repository's 4.1.11/1.79.0 pins. Fresh frozen installation remains blocked by missing publication-time metadata for `qs@6.16.0` in the configured registry; no safeguards or configuration were changed. Repository CI will verify the pinned toolchain.

## Adversarial self-review

Reviewed permanent-close versus reconnect semantics, completion/close ordering, API-error priority, child-agent completion, partial output, cleanup, privacy, and minimum-runtime compatibility. Tightened the regression coverage for API-error-before-close, then repeated review and verification. No actionable issues remain.