### PR TITLE
fix(examples): reject unsuccessful background responses

### DIFF
--- a/examples/responses/stream_background.ts
+++ b/examples/responses/stream_background.ts
@@ -20,6 +20,9 @@ async function main() {
     }
 
     console.log('event', event);
+    if (event.type === 'response.failed' || event.type === 'response.incomplete') {
+      throw new Error(`Response ended with ${event.type}.`);
+    }
     if (event.type === 'response.completed') {
       completed = true;
     }
@@ -46,6 +49,9 @@ async function main() {
   }
 
   const result = await runner2.finalResponse();
+  if (result.status !== 'completed') {
+    throw new Error(`Response ended with status ${result.status}.`);
+  }
   console.log(result);
 }
 

--- a/tests/lib/background-streaming-example.test.ts
+++ b/tests/lib/background-streaming-example.test.ts
@@ -6,7 +6,10 @@ import path from 'node:path';
 import type { Response, ResponseStreamEvent } from 'openai/resources/responses/responses';
 import { expect, test } from 'vitest';
 
-function responseEvents(chunks: readonly string[]): ResponseStreamEvent[] {
+type TerminalStatus = 'completed' | 'failed' | 'incomplete';
+const privateErrorDetail = 'Synthetic private response error detail';
+
+function responseEvents(chunks: readonly string[], status: TerminalStatus): ResponseStreamEvent[] {
   const response: Response = {
     id: 'resp_background_example',
     object: 'response',
@@ -56,18 +59,20 @@ function responseEvents(chunks: readonly string[]): ResponseStreamEvent[] {
   }
   const text = chunks.join('');
   events.push({
-    type: 'response.completed',
+    type: `response.${status}`,
     sequence_number: events.length,
     response: {
       ...response,
-      status: 'completed',
+      status,
+      error: status === 'failed' ? { code: 'server_error', message: privateErrorDetail } : null,
+      incomplete_details: status === 'incomplete' ? { reason: 'max_output_tokens' } : null,
       output_text: text,
       output: [
         {
           id: 'msg_example',
           type: 'message',
           role: 'assistant',
-          status: 'completed',
+          status: status === 'completed' ? 'completed' : 'incomplete',
           content: [{ type: 'output_text', annotations: [], text }],
         },
       ],
@@ -78,33 +83,37 @@ function responseEvents(chunks: readonly string[]): ResponseStreamEvent[] {
 
 const scenarios = [
   {
-    name: 'completion before the cutoff',
+    name: 'before the cutoff',
     chunks: ['Synthetic completion.'],
     resumed: false,
     partial: false,
   },
   {
-    name: 'completion at the cutoff',
+    name: 'at the cutoff',
     chunks: ['Synthetic ', 'response ', 'completed ', 'exactly ', 'at ', 'the ', 'cutoff.'],
     resumed: false,
     partial: false,
   },
   {
-    name: 'explicit interruption',
+    name: 'after explicit interruption',
     chunks: ['Synthetic ', 'background ', 'response ', 'resumed ', 'after ', 'the ', 'demo ', 'break.'],
     resumed: true,
     partial: false,
   },
   {
-    name: 'clean EOF before completion',
+    name: 'after clean EOF',
     chunks: ['Synthetic completion.'],
     resumed: true,
     partial: true,
   },
 ] as const;
 
-test.each(scenarios)('background example: $name', async ({ chunks, resumed, partial }) => {
-  const events = responseEvents(chunks);
+const cases = scenarios.flatMap((scenario) =>
+  (['completed', 'failed', 'incomplete'] as const).map((status) => ({ ...scenario, status })),
+);
+
+test.each(cases)('background example: $status $name', async ({ chunks, resumed, partial, status }) => {
+  const events = responseEvents(chunks, status);
   const body = `${events.map((event) => `data: ${JSON.stringify(event)}`).join('\n\n')}\n\ndata: [DONE]\n\n`;
   const partialBody = `${events
     .slice(0, -1)
@@ -168,9 +177,16 @@ test.each(scenarios)('background example: $name', async ({ chunks, resumed, part
   try {
     const [exitCode, signal] = await once(child, 'close');
     expect(signal).toBeNull();
-    expect(stderr).toBe('');
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain(chunks.join(''));
+    expect(exitCode).toBe(status === 'completed' ? 0 : 1);
+    if (status === 'completed') {
+      expect(stderr).toBe('');
+      expect(stdout).toContain(chunks.join(''));
+    } else {
+      expect(stderr).toContain(
+        resumed ? `Response ended with status ${status}.` : `Response ended with response.${status}.`,
+      );
+      expect(stderr).not.toContain(privateErrorDetail);
+    }
     expect(stdout.includes('Interrupted. Continuing...')).toBe(resumed);
     expect(stdout).not.toContain('synthetic-example-key');
     expect(requests).toHaveLength(resumed ? 2 : 1);


### PR DESCRIPTION
## Summary

The background streaming example treats an initial `response.failed` or `response.incomplete` event as an interruption, unnecessarily retrieves the response again, and can finish with exit code 0. An unsuccessful resumed response is also printed as a successful result.

Add six lines to the example:

- Reject failed/incomplete events in the initial stream before the demonstration's sequence-10 cutoff can trigger a resume.
- Require the resumed `finalResponse()` status to be `completed` before printing its result.

The final-status check is necessary because `starting_after: 10` can filter an early terminal event from iteration while the accumulated response still records its failed/incomplete status. No cursor, replay, SDK, parsing, retry, or timeout behavior changes.

Only the handwritten example and its existing test harness change; both are absent from the pinned Castiron generated snapshot. Open PRs were checked and none covers this issue.

## Regression coverage and validation

- Reused the existing real-CLI/public-SDK subprocess and loopback-HTTP harness. Its four original completion/resumption scenarios now also cover failed and incomplete responses: before and at the initial cutoff, after explicit resumption, and after early EOF with a filtered terminal event.
- **8 new regressions failed before the fix; all 4 original success controls passed.**
- **49 focused tests passed on Node 22.22.2 and Node 24.19.0** via `./scripts/test tests/lib/background-streaming-example.test.ts tests/lib/ResponseStream.test.ts`.
- **36 independent actual CLI cases passed**—12 each on Node 22.0.0, 24.19.0, and 26.7.0. Verified exit codes, one POST versus POST+GET, resumption behavior, and successful output. No live API calls or real credentials were used.
- `tsc --noEmit`, pinned Oxfmt 0.62.0, available Oxlint 1.76.0, and `git diff --check` passed.

Local focused tests used cached Vitest 4.1.10/Oxlint 1.76.0 rather than the repository's 4.1.11/1.79.0 pins. Fresh frozen installation remains blocked by missing publication-time metadata for `qs@6.16.0` in the configured registry; no safeguards, dependencies, lockfiles, or configuration were changed. CI will verify the pinned toolchain.

## Adversarial self-review

Reviewed cutoff ordering, filtered replay events, terminal status, existing iterator abort/cleanup, API/transport error precedence, minimum-runtime compatibility, and missing regressions. Independent review of the actual diff found no actionable issue. New thrown errors contain only event type/status, and tests exclude synthetic private server details from stderr; the example's existing explicit event logging is unchanged.