### PR TITLE
test: stabilize Node CI subprocess fixtures

### DIFF
--- a/tests/ecosystem-cli.test.ts
+++ b/tests/ecosystem-cli.test.ts
@@ -201,10 +201,11 @@ describe('ecosystem test CLI', () => {
       for (const name of projects) {
         const project = path.join(fixture, 'ecosystem-tests', name);
         mkdirSync(project, { recursive: true });
-        // pnpm does not forward npm_config_* variables to its worker scripts.
+        // pnpm workers strip npm_config_* from the environment. Keep local installs offline
+        // even with npm versions that audit linked packages.
         writeFileSync(
           path.join(project, '.npmrc'),
-          'audit=false\nfund=false\noffline=true\npackage-lock=false\n',
+          'audit=false\nfund=false\noffline=true\npackage-lock=false\nupdate-notifier=false\n',
         );
         writeFileSync(
           path.join(project, 'package.json'),

--- a/tests/lib/audio-example-exit-status.test.ts
+++ b/tests/lib/audio-example-exit-status.test.ts
@@ -37,6 +37,7 @@ async function runExample(directory: string, example: string, baseURL: string, t
     process.execPath,
     [
       path.join(root, 'node_modules/ts-node/dist/bin.js'),
+      '--swc',
       '-r',
       path.join(root, 'node_modules/tsconfig-paths/register.js'),
       path.join(root, 'examples/audio', `${example}.ts`),

--- a/tests/lib/background-streaming-example.test.ts
+++ b/tests/lib/background-streaming-example.test.ts
@@ -138,7 +138,7 @@ test.each(scenarios)('background example: $name', async ({ chunks, resumed, part
     process.execPath,
     [
       path.join(root, 'node_modules/ts-node/dist/bin.js'),
-      '-T',
+      '--swc',
       '-r',
       path.join(root, 'node_modules/tsconfig-paths/register.js'),
       path.join(root, 'examples/responses/stream_background.ts'),

--- a/tests/lib/book-lookup-examples.test.ts
+++ b/tests/lib/book-lookup-examples.test.ts
@@ -31,7 +31,7 @@ async function runExample(file: string, baseURL: string) {
       moveCursor: (...args) => readline.moveCursor(process.stdout, ...args),
       clearScreenDown: (...args) => readline.clearScreenDown(process.stdout, ...args),
     });
-    require(${JSON.stringify(path.join(root, 'node_modules/ts-node/register/transpile-only'))});
+    require(${JSON.stringify(path.join(root, 'node_modules/ts-node'))}).register({ swc: true });
     require(${JSON.stringify(path.join(root, 'node_modules/tsconfig-paths/register.js'))});
     require(${JSON.stringify(path.join(root, 'examples/chat-completions', file))});
   `;

--- a/tests/lib/image-streaming-example.test.ts
+++ b/tests/lib/image-streaming-example.test.ts
@@ -15,6 +15,7 @@ async function runExample(directory: string, baseURL: string) {
     process.execPath,
     [
       path.join(root, 'node_modules/ts-node/dist/bin.js'),
+      '--swc',
       '-r',
       path.join(root, 'node_modules/tsconfig-paths/register.js'),
       path.join(root, 'examples/images/image-stream.ts'),

--- a/tests/lib/realtime-example-status.test.ts
+++ b/tests/lib/realtime-example-status.test.ts
@@ -96,7 +96,7 @@ test.each(cases)('Realtime $example example handles a $status response', async (
       process.execPath,
       [
         path.join(root, 'node_modules/ts-node/dist/bin.js'),
-        '-T',
+        '--swc',
         '-r',
         path.join(root, 'node_modules/tsconfig-paths/register.js'),
         path.join(root, 'examples/realtime', `${example}.ts`),

--- a/tests/lib/streaming-example-nontty.test.ts
+++ b/tests/lib/streaming-example-nontty.test.ts
@@ -72,7 +72,7 @@ test.each(examples)('%s completes a tool round trip with redirected stdout', asy
     process.execPath,
     [
       path.join(root, 'node_modules/ts-node/dist/bin.js'),
-      '-T',
+      '--swc',
       '-r',
       path.join(root, 'node_modules/tsconfig-paths/register.js'),
       path.join(root, 'examples/chat-completions', filename),

--- a/tests/lib/structured-output-tool-example.test.ts
+++ b/tests/lib/structured-output-tool-example.test.ts
@@ -33,6 +33,7 @@ async function runExample(baseURL: string) {
     process.execPath,
     [
       path.join(root, 'node_modules/ts-node/dist/bin.js'),
+      '--swc',
       '-r',
       path.join(root, 'node_modules/tsconfig-paths/register.js'),
       path.join(root, 'examples/responses/structured-outputs-tools.ts'),

--- a/tests/lib/websocket-example-close.test.ts
+++ b/tests/lib/websocket-example-close.test.ts
@@ -80,7 +80,7 @@ async function runExample(reply: (request: ResponsesClientEvent, index: number) 
     process.execPath,
     [
       path.join(root, 'node_modules/ts-node/dist/bin.js'),
-      '-T',
+      '--swc',
       '-r',
       path.join(root, 'node_modules/tsconfig-paths/register.js'),
       path.join(root, 'examples/responses/websocket.ts'),

--- a/tests/oxlint-config.test.ts
+++ b/tests/oxlint-config.test.ts
@@ -1,5 +1,13 @@
 import { spawnSync } from 'node:child_process';
-import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -7,11 +15,11 @@ const repoRoot = process.cwd();
 const oxlint = path.join(repoRoot, 'node_modules/oxlint/bin/oxlint');
 const oxfmt = path.join(repoRoot, 'node_modules/oxfmt/bin/oxfmt');
 
-function spawnPnpmScript(script: 'format' | 'lint') {
+function spawnPnpm(args: string[], cwd: string) {
   const command = process.platform === 'win32' ? (process.env['ComSpec'] ?? 'cmd.exe') : 'pnpm';
-  const args = process.platform === 'win32' ? ['/d', '/s', '/c', `pnpm ${script}`] : [script];
+  const commandArgs = process.platform === 'win32' ? ['/d', '/s', '/c', `pnpm ${args.join(' ')}`] : args;
 
-  return spawnSync(command, args, { cwd: repoRoot, encoding: 'utf-8' });
+  return spawnSync(command, commandArgs, { cwd, encoding: 'utf-8' });
 }
 
 test('keeps formatter inputs on LF across Git checkout configurations', () => {
@@ -384,10 +392,54 @@ test('rejects SDK package imports in generated source but allows them in generat
 });
 
 test('checks and fixes generated imports through the public package commands', () => {
-  const fixtureRoot = mkdtempSync(path.join(repoRoot, '.oxlint-public-entrypoints-'));
+  const fixtureRoot = mkdtempSync(path.join(tmpdir(), 'openai-node-oxlint-public-entrypoints-'));
 
   try {
+    // Exercise the real entrypoints without scanning or formatting other tests' fixtures.
+    mkdirSync(path.join(fixtureRoot, 'scripts'));
+    for (const file of [
+      'scripts/lint',
+      'scripts/format',
+      'scripts/lint-generated.cjs',
+      'scripts/generated-files.cjs',
+      'oxlint.config.ts',
+      'oxlint.generated.config.json',
+      'oxfmt.config.ts',
+    ]) {
+      copyFileSync(path.join(repoRoot, file), path.join(fixtureRoot, file));
+    }
+    const { packageManager, scripts } = JSON.parse(
+      readFileSync(path.join(repoRoot, 'package.json'), 'utf-8'),
+    );
+    writeFileSync(
+      path.join(fixtureRoot, 'package.json'),
+      JSON.stringify({
+        private: true,
+        packageManager,
+        scripts: { lint: scripts.lint, format: scripts.format },
+      }),
+    );
+    writeFileSync(
+      path.join(fixtureRoot, 'pnpm-workspace.yaml'),
+      'scriptShell: bash\nverifyDepsBeforeRun: error\n',
+    );
+    // Give the dependency-free fixture its own pnpm state before linking the installed tools.
+    const installed = spawnPnpm(['install', '--offline', '--ignore-scripts'], fixtureRoot);
+    expect({
+      status: installed.status,
+      output: installed.status === 0 ? '' : installed.stdout + installed.stderr,
+    }).toEqual({ status: 0, output: '' });
+    for (const dependency of ['.bin', 'oxlint', 'oxfmt', 'ultracite']) {
+      symlinkSync(
+        path.join(repoRoot, 'node_modules', dependency),
+        path.join(fixtureRoot, 'node_modules', dependency),
+        'junction',
+      );
+    }
+
     const generatedPath = path.join(fixtureRoot, 'generated.ts');
+    const handwrittenPath = path.join(fixtureRoot, 'handwritten.ts');
+    writeFileSync(handwrittenPath, 'export const formatted="value";\n');
     writeFileSync(
       generatedPath,
       [
@@ -398,19 +450,20 @@ test('checks and fixes generated imports through the public package commands', (
       ].join('\n'),
     );
 
-    const rejected = spawnPnpmScript('lint');
+    const rejected = spawnPnpm(['lint'], fixtureRoot);
 
     expect(rejected.status).toBe(1);
     expect(`${rejected.stdout}${rejected.stderr}`).toContain(
       "Identifier 'Unused' is imported but never used.",
     );
 
-    const fixed = spawnPnpmScript('format');
+    const fixed = spawnPnpm(['format'], fixtureRoot);
 
     expect(fixed.status).toBe(0);
     expect(readFileSync(generatedPath, 'utf-8')).not.toContain('Unused');
+    expect(readFileSync(handwrittenPath, 'utf-8')).toBe("export const formatted = 'value';\n");
 
-    const accepted = spawnPnpmScript('lint');
+    const accepted = spawnPnpm(['lint'], fixtureRoot);
 
     expect(accepted.status).toBe(0);
   } finally {


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Reduce repeated setup work in handwritten tests that intermittently exceed the Node 22 CI deadlines:

- Run the real `pnpm lint` → `pnpm format` → `pnpm lint` integration in a small temporary project containing the repository's actual aliases, scripts, and configs. Give the fixture its own offline pnpm state and link the installed tools. This avoids whole-repository scans and writes into other tests' temporary fixtures while preserving generated-import assertions and checking handwritten formatting.
- Select ts-node's existing SWC backend in the eight executable-example subprocess suites. Each child still runs the actual example against SDK source and synthetic local services, but avoids repeatedly compiling the SDK import graph with TypeScript. SWC is already a repository dependency.
- Disable npm's update notifier in the existing offline ecosystem fixtures. Main already contains their project-local offline configuration; preserve that configuration and its current smoke and credential coverage.

The existing 15-second child deadlines, 30-second test deadline, assertions, and worker modes remain. No production code, dependencies, lockfile, workflow policy, or generated files change. Main's newer LF and audio-input regression tests are preserved.

## Validation

- The equivalent test changes passed the full Node 22/24/26 suites: 7,329 handwritten tests and 556 generated tests per runtime, retaining the existing two generated skips; all 14 ecosystem projects and packaging/runtime-floor checks passed. Previously timing-out Node 22 WebSocket/audio cases completed in approximately two seconds under the same 15-second deadline.
- Independent review verified the public port preserves newer main-branch coverage and carries the same fixture and subprocess behavior. `git diff --check` passes.
- A fresh local frozen installation on the latest public base is blocked because the configured registry omits publication metadata for `qs@6.16.0`, also reported in [PR 2589](https://github.com/openai/openai-node/pull/2589). A fresh metadata cache gives the same missing-version result. The lockfile and dependency policies remain unchanged; this PR's CI will validate the current base.
