### PR TITLE
fix(helpers): reject unsupported oneOf in strict schemas

### DIFF
--- a/src/lib/transform.ts
+++ b/src/lib/transform.ts
@@ -70,6 +70,7 @@ const JSON_SCHEMA_UNSUPPORTED_SCHEMA_KEYWORDS = new Set([
   'minContains',
   'minProperties',
   'not',
+  'oneOf',
   'patternProperties',
   'prefixItems',
   'propertyNames',

--- a/tests/helpers/zod.test.ts
+++ b/tests/helpers/zod.test.ts
@@ -107,6 +107,39 @@ it('converts Zod v4 discriminated unions to anyOf for strict schemas', () => {
   expect(schema.properties.data.anyOf).toHaveLength(2);
 });
 
+describe.each([
+  { version: 'v4', schema: zv4.object({ value: zv4.xor([zv4.string(), zv4.number()]) }) },
+  {
+    version: 'v4 mini',
+    schema: zv4Mini.object({ value: zv4Mini.xor([zv4Mini.string(), zv4Mini.number()]) }),
+  },
+])('Zod $version XOR schemas', ({ schema }) => {
+  it.each([
+    { name: 'response format', create: () => zodResponseFormat(schema, 'xor') },
+    { name: 'text format', create: () => zodTextFormat(schema, 'xor') },
+    { name: 'chat function', create: () => zodFunction({ name: 'xor', parameters: schema }) },
+    { name: 'Responses function', create: () => zodResponsesFunction({ name: 'xor', parameters: schema }) },
+  ])('rejects oneOf in $name without changing the input schema', ({ create }) => {
+    const original = zv4.toJSONSchema(schema, { target: 'draft-7' });
+
+    expect(create).toThrow(
+      'Schema at `properties/value` uses unsupported keyword `oneOf` and cannot be represented in strict Structured Outputs.',
+    );
+    expect(zv4.toJSONSchema(schema, { target: 'draft-7' })).toEqual(original);
+  });
+
+  it('preserves oneOf in a non-strict Realtime function', () => {
+    const tool = zodRealtimeFunction({ name: 'xor', parameters: schema });
+
+    expect(tool.parameters).toMatchObject({
+      type: 'object',
+      properties: { value: { oneOf: [{ type: 'string' }, { type: 'number' }] } },
+      required: ['value'],
+    });
+    expect(tool).not.toHaveProperty('strict');
+  });
+});
+
 describe('Zod v4 mini', () => {
   const MiniSchema = zv4Mini.object({ hello: zv4Mini.literal('world') });
   const expectedSchema = {

--- a/tests/lib/transform.test.ts
+++ b/tests/lib/transform.test.ts
@@ -1300,6 +1300,7 @@ describe('toStrictJsonSchema', () => {
       'minContains',
       'minProperties',
       'not',
+      'oneOf',
       'patternProperties',
       'prefixItems',
       'propertyNames',


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Problem

`zodResponseFormat(z.object({ value: z.xor([z.string(), z.number()]) }), 'xor')` currently returns a strict schema containing `oneOf`. A reproduction through the public `chat.completions.parse()` entrypoint confirmed that the actual serialized request carries that unsupported keyword with `strict: true`.

[Structured Outputs supports `anyOf`, not arbitrary JSON Schema composition](https://developers.openai.com/api/docs/guides/structured-outputs#supported-schemas). The existing Standard Schema helper already treats `oneOf` as unsupported and converts it only when exclusivity is proven. The shared strict transformer was missing `oneOf` from its existing unsupported-keyword set.

## Changes

- Add **one entry** to the existing rejection set, so leftover `oneOf` fails with the existing schema-path diagnostic before a request is sent.
- Add a compact public-helper regression matrix for Zod v4 and v4-mini across response formats, text formats, Chat Completions tools, and Responses tools; preserve the original input schemas.
- Keep non-strict Realtime XOR output unchanged and add `oneOf` to the existing undefined/defined-placeholder tests.

Only three fully handwritten files change: **1 production line and 34 test lines**. No new parsing, traversal, normalization, reference handling, dependencies, generated files, or public declarations. Supported discriminated-union and Standard Schema conversions remain unchanged.

## Validation

- Before the change, all **8 public strict-helper regressions failed**; the two Realtime controls passed. All **12 focused cases** pass afterward.
- **1,129 related tests passed on Node 22.22.2 and 24.19.0**, including Zod v3/v4/v4-mini, Standard Schema, transformer, and parsing coverage.
- **228 independent built-package checks passed** across CJS/ESM on the exact minimum Node **22.0.0**, Node **24.19.0**, and forward-tested Node **26.7.0**. These cover rejection, unchanged input schemas, supported unions and parsed values, Standard Schema `oneOf` conversion, and non-strict Realtime.
- Public request-boundary repro on Node 22.0.0: XOR now rejects before the synthetic transport runs; a supported regular union still sends its expected `anyOf` schema. No live API calls or real credentials.
- `./scripts/build`, TypeScript 6.0.3 `--noEmit`, pinned Oxfmt 0.62.0, cached Oxlint 1.76.0, declaration comparison, and `git diff --check` pass.
- Full handwritten suite: **7,444 passed; 1 pre-existing local tooling failure** in `tests/oxlint-config.test.ts` (`ERR_PNPM_VERIFY_DEPS_BEFORE_RUN`). The exact failure was reproduced in a separate unmodified worktree at base `135ac7ef85ce`. Local tests use cached Vitest 4.1.10 rather than pinned 4.1.11, and cached Oxlint rather than pinned 1.79.0; fresh frozen installation remains blocked by the configured registry's missing publication metadata for `qs@6.16.0`. No dependency or policy changes are included; repository CI will validate the pinned toolchain.

## Adversarial review

Independent review found no actionable security, compatibility, edge-case, or regression gaps. Specifically checked undefined placeholders versus defined values, property/literal payload boundaries, all strict helper surfaces, Zod v3 isolation, existing supported union conversions, input preservation, and the non-strict Realtime boundary.