### PR TITLE
fix: preserve chat runner abort reasons

### DIFF
--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -443,15 +443,7 @@ export class AbstractChatCompletionRunner<
     };
 
     let allowBufferedToolCall = false;
-    const userAbortError = () => {
-      const error = new APIUserAbortError();
-      Object.defineProperty(error, 'cause', {
-        value: this.controller.signal.reason,
-        writable: true,
-        configurable: true,
-      });
-      return error;
-    };
+    const userAbortError = () => this._userAbortError();
 
     const runToolCall = async (toolCall: ChatCompletionMessageToolCall): Promise<ToolCallResult> => {
       const bufferedToolCall = allowBufferedToolCall;
@@ -500,7 +492,7 @@ export class AbstractChatCompletionRunner<
         try {
           rawContent = await fn.function(parsed, runner, toolContext);
         } catch (error) {
-          if (this.controller.signal.aborted && error === this.controller.signal.reason) {
+          if (this.controller.signal.aborted && Object.is(error, this.controller.signal.reason)) {
             throw userAbortError();
           }
           throw error;
@@ -512,7 +504,7 @@ export class AbstractChatCompletionRunner<
         try {
           rawContent = await fn.function(args, runner, toolContext);
         } catch (error) {
-          if (this.controller.signal.aborted && error === this.controller.signal.reason) {
+          if (this.controller.signal.aborted && Object.is(error, this.controller.signal.reason)) {
             throw userAbortError();
           }
           throw error;

--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -443,6 +443,15 @@ export class AbstractChatCompletionRunner<
     };
 
     let allowBufferedToolCall = false;
+    const userAbortError = () => {
+      const error = new APIUserAbortError();
+      Object.defineProperty(error, 'cause', {
+        value: this.controller.signal.reason,
+        writable: true,
+        configurable: true,
+      });
+      return error;
+    };
 
     const runToolCall = async (toolCall: ChatCompletionMessageToolCall): Promise<ToolCallResult> => {
       const bufferedToolCall = allowBufferedToolCall;
@@ -480,18 +489,18 @@ export class AbstractChatCompletionRunner<
           parsed = await fn.parse(args);
         } catch (error) {
           if (this.controller.signal.aborted) {
-            throw new APIUserAbortError();
+            throw userAbortError();
           }
           const content = error instanceof Error ? error.message : String(error);
           return { message: { role, tool_call_id, content }, functionCalled: false };
         }
         if (this.controller.signal.aborted) {
-          throw new APIUserAbortError();
+          throw userAbortError();
         }
         rawContent = await fn.function(parsed, runner, toolContext);
       } else {
         if (this.controller.signal.aborted && !bufferedToolCall) {
-          throw new APIUserAbortError();
+          throw userAbortError();
         }
         rawContent = await fn.function(args, runner, toolContext);
       }
@@ -531,7 +540,7 @@ export class AbstractChatCompletionRunner<
             this._addMessage(result.message);
           }
           if (this.controller.signal.aborted) {
-            throw new APIUserAbortError();
+            throw userAbortError();
           }
 
           if (singleFunctionToCall && result.functionCalled) {
@@ -560,7 +569,7 @@ export class AbstractChatCompletionRunner<
           }
         }
         if (this.controller.signal.aborted) {
-          throw new APIUserAbortError();
+          throw userAbortError();
         }
       }
 

--- a/src/lib/AbstractChatCompletionRunner.ts
+++ b/src/lib/AbstractChatCompletionRunner.ts
@@ -497,12 +497,26 @@ export class AbstractChatCompletionRunner<
         if (this.controller.signal.aborted) {
           throw userAbortError();
         }
-        rawContent = await fn.function(parsed, runner, toolContext);
+        try {
+          rawContent = await fn.function(parsed, runner, toolContext);
+        } catch (error) {
+          if (this.controller.signal.aborted && error === this.controller.signal.reason) {
+            throw userAbortError();
+          }
+          throw error;
+        }
       } else {
         if (this.controller.signal.aborted && !bufferedToolCall) {
           throw userAbortError();
         }
-        rawContent = await fn.function(args, runner, toolContext);
+        try {
+          rawContent = await fn.function(args, runner, toolContext);
+        } catch (error) {
+          if (this.controller.signal.aborted && error === this.controller.signal.reason) {
+            throw userAbortError();
+          }
+          throw error;
+        }
       }
 
       const content = AbstractChatCompletionRunner.#stringifyFunctionCallResult(rawContent);

--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -20,7 +20,7 @@ import type {
 } from '../resources/beta/threads/runs/runs';
 import type { ReadableStream } from '../internal/shim-types';
 import { Stream } from '../streaming';
-import { APIError, APIUserAbortError, OpenAIError } from '../error';
+import { APIError, OpenAIError } from '../error';
 import type {
   AssistantStreamEvent,
   MessageStreamEvent,
@@ -204,7 +204,7 @@ export class AssistantStream
       this.#addEvent(event);
     }
     if (stream.controller.signal?.aborted) {
-      throw new APIUserAbortError();
+      throw this._userAbortError();
     }
     return this._addRun(this.#endRequest());
   }
@@ -252,7 +252,7 @@ export class AssistantStream
       this.#addEvent(event);
     }
     if (stream.controller.signal?.aborted) {
-      throw new APIUserAbortError();
+      throw this._userAbortError();
     }
 
     return this._addRun(this.#endRequest());
@@ -355,7 +355,7 @@ export class AssistantStream
       this.#addEvent(event);
     }
     if (stream.controller.signal?.aborted) {
-      throw new APIUserAbortError();
+      throw this._userAbortError();
     }
 
     return this._addRun(this.#endRequest());
@@ -378,7 +378,7 @@ export class AssistantStream
       this.#addEvent(event);
     }
     if (stream.controller.signal?.aborted) {
-      throw new APIUserAbortError();
+      throw this._userAbortError();
     }
 
     return this._addRun(this.#endRequest());

--- a/src/lib/ChatCompletionStream.ts
+++ b/src/lib/ChatCompletionStream.ts
@@ -1,7 +1,6 @@
 import { MalformedJSON, partialParse } from '../_vendor/partial-json-parser/parser';
 import {
   APIError,
-  APIUserAbortError,
   ContentFilterFinishReasonError,
   LengthFinishReasonError,
   OpenAIError,
@@ -1754,7 +1753,7 @@ export class ChatCompletionStream<ParsedT = null>
       this.#addChunk(chunk);
     }
     if (stream.controller.signal?.aborted) {
-      throw new APIUserAbortError();
+      throw this._userAbortError();
     }
     return this._addChatCompletion(this.#endRequest());
   }
@@ -1807,7 +1806,7 @@ export class ChatCompletionStream<ParsedT = null>
       }
     }
     if (stream.controller.signal?.aborted) {
-      throw new APIUserAbortError();
+      throw this._userAbortError();
     }
     if (this.#currentChatCompletionSnapshot) {
       return this._addChatCompletion(this.#endRequest());

--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -1444,19 +1444,37 @@ export class EventStream<EventTypes extends BaseEvents> {
     this.controller.abort();
   }
 
+  protected _userAbortError(): APIUserAbortError {
+    const error = new APIUserAbortError();
+    Object.defineProperty(error, 'cause', {
+      value: this.controller.signal.reason,
+      writable: true,
+      configurable: true,
+    });
+    return error;
+  }
+
+  #abortFromSignal(signal: AbortSignal) {
+    try {
+      this.controller.abort(signal.reason);
+    } catch {
+      this.controller.abort();
+    }
+  }
+
   protected _listenForAbort(signal: AbortSignal | null | undefined) {
     if (!signal || this.ended) {
       return;
     }
     if (signal.aborted) {
-      this.controller.abort(signal.reason);
+      this.#abortFromSignal(signal);
       return;
     }
     if (this.#abortListeners.some((registration) => registration.signal === signal)) {
       return;
     }
 
-    const listener = () => this.controller.abort(signal.reason);
+    const listener = () => this.#abortFromSignal(signal);
     signal.addEventListener('abort', listener, { once: true });
     this.#abortListeners.push({ signal, listener });
   }
@@ -1897,7 +1915,7 @@ export class EventStream<EventTypes extends BaseEvents> {
   #handleError(this: EventStream<EventTypes>, error: unknown) {
     this.#errored = true;
     if (error instanceof Error && error.name === 'AbortError') {
-      error = new APIUserAbortError();
+      error = this._userAbortError();
     }
     if (error instanceof APIUserAbortError) {
       this.#aborted = true;

--- a/src/lib/EventStream.ts
+++ b/src/lib/EventStream.ts
@@ -1449,14 +1449,14 @@ export class EventStream<EventTypes extends BaseEvents> {
       return;
     }
     if (signal.aborted) {
-      this.controller.abort();
+      this.controller.abort(signal.reason);
       return;
     }
     if (this.#abortListeners.some((registration) => registration.signal === signal)) {
       return;
     }
 
-    const listener = () => this.controller.abort();
+    const listener = () => this.controller.abort(signal.reason);
     signal.addEventListener('abort', listener, { once: true });
     this.#abortListeners.push({ signal, listener });
   }

--- a/src/lib/responses/ResponseStream.ts
+++ b/src/lib/responses/ResponseStream.ts
@@ -8,7 +8,7 @@ import type {
 } from '../../resources/responses/responses';
 import type { RequestOptions } from '../../internal/request-options';
 import type { ReadableStream } from '../../internal/shim-types';
-import { APIError, APIUserAbortError, OpenAIError } from '../../error';
+import { APIError, OpenAIError } from '../../error';
 import type OpenAI from '../../index';
 import { EventStream } from '../EventStream';
 import type { BaseEvents } from '../EventStream';
@@ -263,7 +263,7 @@ export class ResponseStream<ParsedT = null>
       this.#addEvent(event, starting_after);
     }
     if (stream.controller.signal?.aborted) {
-      throw new APIUserAbortError();
+      throw this._userAbortError();
     }
     return this.#endRequest();
   }
@@ -280,7 +280,7 @@ export class ResponseStream<ParsedT = null>
       this.#addEvent(event, null);
     }
     if (stream.controller.signal?.aborted) {
-      throw new APIUserAbortError();
+      throw this._userAbortError();
     }
     return this.#endRequest();
   }

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -1404,6 +1404,48 @@ describe('resource completions', () => {
       expect(listener.gotAbort).toBe(true);
     });
 
+    test('uses SameValue semantics for NaN abort reasons from sequential tool callbacks', async () => {
+      const { fetch, handleRequest } = mockChatCompletionFetch();
+      const openai = new OpenAI({ apiKey: 'something1234', baseURL: 'http://127.0.0.1:4010', fetch });
+      const controller = new AbortController();
+      const abortReason = Number.NaN;
+      const runner = openai.chat.completions.runTools(
+        {
+          messages: [{ role: 'user', content: 'run the tool' }],
+          model: 'gpt-3.5-turbo',
+          parallel_tool_calls: false,
+          tools: [{
+            type: 'function',
+            function: {
+              function: (_args: string, activeRunner: ChatCompletionRunner<any>) => {
+                controller.abort(abortReason);
+                activeRunner.controller.signal.throwIfAborted();
+                return 'unreachable';
+              },
+              parameters: {},
+              description: 'aborts while running',
+            },
+          }],
+        },
+        { signal: controller.signal, maxChatCompletions: 1 },
+      );
+      await handleRequest(async () => ({
+        id: '1',
+        choices: [{
+          index: 0, finish_reason: 'tool_calls', logprobs: null,
+          message: {
+            role: 'assistant', content: null, refusal: null, parsed: null,
+            tool_calls: [{ type: 'function', id: 'abort-call', function: { arguments: '', name: 'function' } }],
+          },
+        }],
+        created: Math.floor(Date.now() / 1000), model: 'gpt-3.5-turbo', object: 'chat.completion',
+      }));
+      const error = await runner.done().catch((caught) => caught);
+      expect(error).toBeInstanceOf(APIUserAbortError);
+      expect(error.cause).toBe(abortReason);
+      expect(runner.aborted).toBe(true);
+    });
+
     test('successful flow with parse', async () => {
       const { fetch, handleRequest } = mockChatCompletionFetch();
 

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -1,7 +1,7 @@
 import OpenAI from 'openai';
 import { Stream } from 'openai/core/streaming';
 import type { OpenAIError } from 'openai/error';
-import { APIConnectionError } from 'openai/error';
+import { APIConnectionError, APIUserAbortError } from 'openai/error';
 import { PassThrough } from 'node:stream';
 import {
   ParsingToolFunction,
@@ -1340,6 +1340,70 @@ describe('resource completions', () => {
       await listener.sanityCheck({ error: 'Request was aborted.' });
       expect(runner.aborted).toBe(true);
     });
+    test('classifies a sequential tool callback throwing the caller abort reason as a user abort', async () => {
+      const { fetch, handleRequest } = mockChatCompletionFetch();
+      const openai = new OpenAI({ apiKey: 'something1234', baseURL: 'http://127.0.0.1:4010', fetch });
+      const controller = new AbortController();
+      const abortReason = new Error('stop during tool callback');
+
+      const runner = openai.chat.completions.runTools(
+        {
+          messages: [{ role: 'user', content: 'run the tool' }],
+          model: 'gpt-3.5-turbo',
+          parallel_tool_calls: false,
+          tools: [
+            {
+              type: 'function',
+              function: {
+                function: (_args: string, activeRunner: ChatCompletionRunner<any>) => {
+                  controller.abort(abortReason);
+                  activeRunner.controller.signal.throwIfAborted();
+                  return 'unreachable';
+                },
+                parameters: {},
+                description: 'aborts while running',
+              },
+            },
+          ],
+        },
+        { signal: controller.signal, maxChatCompletions: 1 },
+      );
+      const listener = new RunnerListener(runner);
+
+      await handleRequest(async () => ({
+        id: '1',
+        choices: [
+          {
+            index: 0,
+            finish_reason: 'tool_calls',
+            logprobs: null,
+            message: {
+              role: 'assistant',
+              content: null,
+              refusal: null,
+              parsed: null,
+              tool_calls: [
+                {
+                  type: 'function',
+                  id: 'abort-call',
+                  function: { arguments: '', name: 'function' },
+                },
+              ],
+            },
+          },
+        ],
+        created: Math.floor(Date.now() / 1000),
+        model: 'gpt-3.5-turbo',
+        object: 'chat.completion',
+      }));
+
+      const error = await runner.done().catch((caught) => caught);
+      expect(error).toBeInstanceOf(APIUserAbortError);
+      expect(error).toMatchObject({ cause: abortReason });
+      expect(runner.aborted).toBe(true);
+      expect(listener.gotAbort).toBe(true);
+    });
+
     test('successful flow with parse', async () => {
       const { fetch, handleRequest } = mockChatCompletionFetch();
 

--- a/tests/lib/ChatCompletionRunFunctions.test.ts
+++ b/tests/lib/ChatCompletionRunFunctions.test.ts
@@ -1253,6 +1253,7 @@ describe('resource completions', () => {
       const openai = new OpenAI({ apiKey: 'something1234', baseURL: 'http://127.0.0.1:4010', fetch });
 
       const controller = new AbortController();
+      const abortReason = new Error('stop after assistant message');
       const runner = openai.chat.completions.runTools(
         {
           messages: [{ role: 'user', content: 'tell me what the weather is like' }],
@@ -1276,7 +1277,7 @@ describe('resource completions', () => {
 
       runner.on('message', (message) => {
         if (message.role === 'assistant') {
-          controller.abort();
+          controller.abort(abortReason);
         }
       });
       await handleRequest(async (request) => {
@@ -1312,7 +1313,8 @@ describe('resource completions', () => {
         };
       });
 
-      await runner.done().catch(() => {});
+      const abortError = await runner.done().catch((error) => error);
+      expect(abortError).toMatchObject({ cause: abortReason });
 
       expect(listener.messages).toEqual([
         {

--- a/tests/lib/runner-abort-listeners.test.ts
+++ b/tests/lib/runner-abort-listeners.test.ts
@@ -144,3 +144,24 @@ test('keeps distinct abort sources and immediately observes an already-aborted s
   expect(getEventListeners(first.signal, 'abort')).toHaveLength(0);
   expect(getEventListeners(second.signal, 'abort')).toHaveLength(0);
 });
+
+
+test('still aborts when a structural signal reason getter throws', () => {
+  const stream = new TestStream();
+  const target = new EventTarget();
+  let aborted = false;
+  Object.defineProperties(target, {
+    aborted: { get: () => aborted },
+    reason: {
+      get: () => {
+        throw new Error('reason getter failed');
+      },
+    },
+  });
+  const signal = target as AbortSignal;
+
+  stream.observe(signal);
+  aborted = true;
+  expect(() => target.dispatchEvent(new Event('abort'))).not.toThrow();
+  expect(stream.controller.signal.aborted).toBe(true);
+});

--- a/tests/lib/runner-abort-listeners.test.ts
+++ b/tests/lib/runner-abort-listeners.test.ts
@@ -131,11 +131,14 @@ test('keeps distinct abort sources and immediately observes an already-aborted s
   expect(getEventListeners(first.signal, 'abort')).toHaveLength(1);
   expect(getEventListeners(second.signal, 'abort')).toHaveLength(1);
 
-  second.abort();
+  const reason = new Error('second source aborted');
+  second.abort(reason);
   expect(stream.controller.signal.aborted).toBe(true);
+  expect(stream.controller.signal.reason).toBe(reason);
   stream.controller = new AbortController();
   stream.observe(second.signal);
   expect(stream.controller.signal.aborted).toBe(true);
+  expect(stream.controller.signal.reason).toBe(reason);
 
   stream.end();
   expect(getEventListeners(first.signal, 'abort')).toHaveLength(0);

--- a/tests/lib/streaming-core.test.ts
+++ b/tests/lib/streaming-core.test.ts
@@ -104,16 +104,20 @@ describe('Stream.fromSSEResponse', () => {
             .create({ ...params, stream: true }, { signal: caller.signal })
             .then((stream) => stream[Symbol.asyncIterator]().next())
         : client.responses.stream(params, { signal: caller.signal }).finalResponse();
-    const assertion =
+    const rawAssertion =
       kind === 'raw'
         ? expect(settlesSoon(completion)).resolves.toEqual({ value: undefined, done: true })
-        : expect(settlesSoon(completion)).rejects.toBeInstanceOf(APIUserAbortError);
+        : undefined;
     const reason = new Error('private caller abort reason');
 
     await vi.waitFor(() => expect(body.locked).toBe(true));
     caller.abort(reason);
 
-    await assertion;
+    if (kind === 'raw') {
+      await rawAssertion;
+    } else {
+      await expect(settlesSoon(completion)).rejects.toMatchObject({ cause: reason });
+    }
     expect(caller.signal.reason).toBe(reason);
     expect(caller.signal.onabort).toBe(onabort);
     expect(cancel).toHaveBeenCalledWith(undefined);


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Preserve caller-provided abort reasons across chat completion convenience runners.

The direct request layer already attaches `signal.reason` to `APIUserAbortError.cause`, but chat completion runners could lose or misclassify that reason at internal cancellation boundaries. This change:

- forwards `signal.reason` when `EventStream` bridges an external signal into its runner-owned controller;
- attaches the runner controller's reason to abort errors raised at tool-callback cancellation checkpoints;
- normalizes a sequential tool callback that throws the aborted runner signal's exact reason into `APIUserAbortError`, preserving that reason as `cause`;
- covers both later aborts and already-aborted source signals;
- verifies parity with the existing streaming runner behavior.

Fixes #2606.

## Review follow-up

The current head addresses the sequential-callback classification issue raised in review. Both parsed and unparsed tool callback paths now catch a rejection equal to `runner.controller.signal.reason` after cancellation and translate it through the same `userAbortError()` helper. The regression exercises `parallel_tool_calls: false`, cancels with a custom `Error`, has the active callback call `throwIfAborted()`, and verifies `runner.done()` rejects with `APIUserAbortError`, preserves the custom cause, emits the abort path, and leaves `runner.aborted === true`.

Fresh code/security review is running on commit `69e2710cce37947e2f51476d8b57ab3f05c836fb`.

## Validation

Previous-head validation:

- `pnpm test tests/lib/ChatCompletionRunFunctions.test.ts tests/lib/runner-abort-listeners.test.ts` — 48 passed
- `pnpm exec tsc --noEmit` — passed
- repository-wide Ultracite formatting/lint check — passed, 0 warnings/errors
- `pnpm build` — passed
- `git diff --check` — passed

Pushed-head CI/review is required for the new regression.

## Additional context & links

The change does not alter cancellation timing or add a new API; it preserves and consistently classifies the same abort-cause information already exposed by direct requests.