### PR TITLE
fix(auth): account for token exchange elapsed time

### DIFF
--- a/src/auth/workload-identity-auth.ts
+++ b/src/auth/workload-identity-auth.ts
@@ -19,6 +19,22 @@ const TOKEN_EXCHANGE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:token-exchan
 // workload-identity path, so short-lived tokens keep a usable cache window.
 const MAX_REFRESH_BUFFER_FRACTION = 0.5;
 
+function calculateExpiresAt(expiresIn: unknown, exchangeStartedAt: number): number {
+  if (typeof expiresIn !== 'number' || !Number.isFinite(expiresIn) || expiresIn <= 0) {
+    throw new OpenAIError("Token exchange response has invalid 'expires_in' field");
+  }
+
+  const expiresAt = exchangeStartedAt + expiresIn * 1000;
+  if (!Number.isSafeInteger(expiresAt) || expiresAt <= exchangeStartedAt) {
+    throw new OpenAIError("Token exchange response has invalid 'expires_in' field");
+  }
+  if (Date.now() >= expiresAt) {
+    throw new OpenAIError('Workload identity token expired before its exchange completed.');
+  }
+
+  return expiresAt;
+}
+
 function calculateRefreshAt(
   expiresAt: number,
   now: number,
@@ -217,6 +233,8 @@ export class WorkloadIdentityAuth {
       body['client_id'] = this.config.clientId;
     }
 
+    // Response delivery consumes the exchanged token's lifetime; provider acquisition does not.
+    const exchangeStartedAt = Date.now();
     const response = await this.fetch(this.tokenExchangeUrl, {
       method: 'POST',
       headers: {
@@ -261,21 +279,13 @@ export class WorkloadIdentityAuth {
     }
 
     const expiresIn = (tokenResponse as Partial<TokenExchangeResponse>).expires_in ?? 3600;
-    if (typeof expiresIn !== 'number' || !Number.isFinite(expiresIn) || expiresIn <= 0) {
-      throw new OpenAIError("Token exchange response has invalid 'expires_in' field");
-    }
-
-    const now = Date.now();
-    const expiresAt = now + expiresIn * 1000;
-    if (!Number.isSafeInteger(expiresAt) || expiresAt <= now) {
-      throw new OpenAIError("Token exchange response has invalid 'expires_in' field");
-    }
+    const expiresAt = calculateExpiresAt(expiresIn, exchangeStartedAt);
 
     if (this.tokenGeneration === generation) {
       this.cachedToken = {
         token: accessToken,
         expiresAt,
-        refreshAt: calculateRefreshAt(expiresAt, now, this.config.refreshBufferSeconds),
+        refreshAt: calculateRefreshAt(expiresAt, exchangeStartedAt, this.config.refreshBufferSeconds),
       };
     }
 

--- a/src/auth/workload-identity-auth.ts
+++ b/src/auth/workload-identity-auth.ts
@@ -24,11 +24,13 @@ function calculateExpiresAt(expiresIn: unknown, exchangeStartedAt: number): numb
     throw new OpenAIError("Token exchange response has invalid 'expires_in' field");
   }
 
-  const expiresAt = exchangeStartedAt + expiresIn * 1000;
-  if (!Number.isSafeInteger(expiresAt) || expiresAt <= exchangeStartedAt) {
+  const now = Date.now();
+  const fullLifetimeDeadline = now + expiresIn * 1000;
+  if (!Number.isSafeInteger(fullLifetimeDeadline) || fullLifetimeDeadline <= now) {
     throw new OpenAIError("Token exchange response has invalid 'expires_in' field");
   }
-  if (Date.now() >= expiresAt) {
+  const expiresAt = fullLifetimeDeadline - (performance.now() - exchangeStartedAt);
+  if (expiresAt <= now) {
     throw new OpenAIError('Workload identity token expired before its exchange completed.');
   }
 
@@ -37,11 +39,14 @@ function calculateExpiresAt(expiresIn: unknown, exchangeStartedAt: number): numb
 
 function calculateRefreshAt(
   expiresAt: number,
-  now: number,
+  lifetimeSeconds: number,
   refreshBufferSeconds: number | undefined,
 ): number {
   const configuredBufferMs = (refreshBufferSeconds ?? 1200) * 1000;
-  const effectiveBufferMs = Math.min(configuredBufferMs, (expiresAt - now) * MAX_REFRESH_BUFFER_FRACTION);
+  const effectiveBufferMs = Math.min(
+    configuredBufferMs,
+    lifetimeSeconds * 1000 * MAX_REFRESH_BUFFER_FRACTION,
+  );
   return expiresAt - effectiveBufferMs;
 }
 
@@ -233,8 +238,8 @@ export class WorkloadIdentityAuth {
       body['client_id'] = this.config.clientId;
     }
 
-    // Response delivery consumes the exchanged token's lifetime; provider acquisition does not.
-    const exchangeStartedAt = Date.now();
+    // Exclude provider acquisition and measure delivery time independently of wall-clock changes.
+    const exchangeStartedAt = performance.now();
     const response = await this.fetch(this.tokenExchangeUrl, {
       method: 'POST',
       headers: {
@@ -285,7 +290,7 @@ export class WorkloadIdentityAuth {
       this.cachedToken = {
         token: accessToken,
         expiresAt,
-        refreshAt: calculateRefreshAt(expiresAt, exchangeStartedAt, this.config.refreshBufferSeconds),
+        refreshAt: calculateRefreshAt(expiresAt, expiresIn, this.config.refreshBufferSeconds),
       };
     }
 

--- a/tests/auth/workload-identity-auth.test.ts
+++ b/tests/auth/workload-identity-auth.test.ts
@@ -118,6 +118,7 @@ describe('WorkloadIdentityAuth', () => {
     });
     const initialTime = Date.now();
     const dateNow = vi.spyOn(Date, 'now').mockReturnValue(initialTime);
+    const performanceNow = vi.spyOn(performance, 'now').mockReturnValue(0);
     const auth = new WorkloadIdentityAuth(config, customFetch);
 
     try {
@@ -134,12 +135,14 @@ describe('WorkloadIdentityAuth', () => {
       await vi.waitFor(() => expect(customFetch).toHaveBeenCalledTimes(2));
     } finally {
       dateNow.mockRestore();
+      performanceNow.mockRestore();
     }
   });
 
   test('keeps the configured refresh buffer for normal-lifetime tokens', async () => {
     const initialTime = Date.now();
     const dateNow = vi.spyOn(Date, 'now').mockReturnValue(initialTime);
+    const performanceNow = vi.spyOn(performance, 'now').mockReturnValue(0);
     const backgroundExchange = pendingTokenExchange();
     const config: WorkloadIdentity = {
       identityProviderId: 'test-identity-provider-id',
@@ -172,6 +175,7 @@ describe('WorkloadIdentityAuth', () => {
       await expect(auth.getToken()).resolves.toBe('refreshed-token');
     } finally {
       dateNow.mockRestore();
+      performanceNow.mockRestore();
     }
   });
 

--- a/tests/auth/workload-identity-expiration.test.ts
+++ b/tests/auth/workload-identity-expiration.test.ts
@@ -45,6 +45,140 @@ describe('workload-identity access-token expiration', () => {
     vi.restoreAllMocks();
   });
 
+  function delayedTokenResponse(expiresIn: number, accessToken: string, elapsed: number): Response {
+    return new Response(
+      new ReadableStream(
+        {
+          pull(controller) {
+            currentTime += elapsed;
+            controller.enqueue(
+              new TextEncoder().encode(JSON.stringify({ access_token: accessToken, expires_in: expiresIn })),
+            );
+            controller.close();
+          },
+        },
+        { highWaterMark: 0 },
+      ),
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  test.each(['headers', 'body'])('subtracts time spent receiving token response %s', async (stage) => {
+    let exchangeCount = 0;
+    const authorizations: (string | null)[] = [];
+    const clientFetch = async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      if (url.toString().includes('/oauth/token')) {
+        exchangeCount += 1;
+        if (exchangeCount === 1) {
+          if (stage === 'body') {
+            return delayedTokenResponse(1, 'initial-token', 750);
+          }
+          currentTime += 750;
+        }
+        return tokenExchangeResponse(1, exchangeCount === 1 ? 'initial-token' : 'replacement-token');
+      }
+      authorizations.push(new Headers(init?.headers).get('Authorization'));
+      return Response.json({ data: [] });
+    };
+    const client = new OpenAI({ apiKey: null, workloadIdentity, fetch: clientFetch });
+
+    await Promise.all([client.models.list(), client.models.list()]);
+    currentTime = INITIAL_TIME + 999;
+    await client.models.list();
+    expect(exchangeCount).toBe(1);
+    currentTime += 1;
+    await client.models.list();
+
+    expect(exchangeCount).toBe(2);
+    expect(authorizations).toEqual([
+      'Bearer initial-token',
+      'Bearer initial-token',
+      'Bearer initial-token',
+      'Bearer replacement-token',
+    ]);
+  });
+
+  test.each([
+    ['headers', 1000],
+    ['headers', 1500],
+    ['body', 1000],
+    ['body', 1500],
+  ])('rejects a token after %s consume its lifetime (%i ms)', async (stage, elapsed) => {
+    let exchangeCount = 0;
+    const authorizations: (string | null)[] = [];
+    const clientFetch = async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      if (url.toString().includes('/oauth/token')) {
+        exchangeCount += 1;
+        if (exchangeCount === 1) {
+          if (stage === 'body') {
+            return delayedTokenResponse(1, 'expired-token', elapsed);
+          }
+          currentTime += elapsed;
+          return tokenExchangeResponse(1, 'expired-token');
+        }
+        return tokenExchangeResponse(3600, 'replacement-token');
+      }
+      authorizations.push(new Headers(init?.headers).get('Authorization'));
+      return Response.json({ data: [] });
+    };
+    const client = new OpenAI({ apiKey: null, workloadIdentity, fetch: clientFetch });
+
+    const results = await Promise.allSettled([client.models.list(), client.models.list()]);
+    for (const result of results) {
+      expect(result.status).toBe('rejected');
+      if (result.status === 'rejected') {
+        expect(result.reason).toBeInstanceOf(OpenAIError);
+        expect(result.reason.message).toContain('token expired before its exchange completed');
+      }
+    }
+    expect(exchangeCount).toBe(1);
+    expect(authorizations).toEqual([]);
+
+    await client.models.list();
+    await client.models.list();
+    expect(exchangeCount).toBe(2);
+    expect(authorizations).toEqual(['Bearer replacement-token', 'Bearer replacement-token']);
+  });
+
+  test('does not count subject-token acquisition against the exchanged token lifetime', async () => {
+    const getToken = vi.fn(async () => {
+      currentTime += 10_000;
+      return 'subject-token';
+    });
+    const customFetch = vi.fn(async () => tokenExchangeResponse(1, 'valid-token'));
+    const auth = new WorkloadIdentityAuth(
+      { ...workloadIdentity, provider: { tokenType: 'jwt', getToken } },
+      customFetch,
+    );
+
+    await expect(auth.getToken()).resolves.toBe('valid-token');
+    currentTime += 999;
+    await expect(auth.getToken()).resolves.toBe('valid-token');
+    expect(getToken).toHaveBeenCalledTimes(1);
+    currentTime += 1;
+    await expect(auth.getToken()).resolves.toBe('valid-token');
+    expect(getToken).toHaveBeenCalledTimes(2);
+    expect(customFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('keeps proactive refresh relative to the original lifetime after a delayed exchange', async () => {
+    const customFetch = vi
+      .fn()
+      .mockImplementationOnce(async () => delayedTokenResponse(60, 'cached-token', 10_000))
+      .mockImplementationOnce(async () => tokenExchangeResponse(60, 'replacement-token'));
+    const auth = new WorkloadIdentityAuth({ ...workloadIdentity, refreshBufferSeconds: 1200 }, customFetch);
+
+    await expect(auth.getToken()).resolves.toBe('cached-token');
+    currentTime = INITIAL_TIME + 29_999;
+    await expect(auth.getToken()).resolves.toBe('cached-token');
+    expect(customFetch).toHaveBeenCalledTimes(1);
+    currentTime += 1;
+    await expect(auth.getToken()).resolves.toBe('cached-token');
+    await delay(0);
+    await expect(auth.getToken()).resolves.toBe('replacement-token');
+    expect(customFetch).toHaveBeenCalledTimes(2);
+  });
+
   test.each([
     ['a nonnumeric string', 'invalid'],
     ['a numeric string', '3600'],

--- a/tests/auth/workload-identity-expiration.test.ts
+++ b/tests/auth/workload-identity-expiration.test.ts
@@ -35,22 +35,31 @@ function tokenExchangeResponse(expiresIn: unknown, accessToken: string): Respons
 
 describe('workload-identity access-token expiration', () => {
   let currentTime = INITIAL_TIME;
+  let monotonicTime = 10_000;
 
   beforeEach(() => {
     currentTime = INITIAL_TIME;
+    monotonicTime = 10_000;
     vi.spyOn(Date, 'now').mockImplementation(() => currentTime);
+    vi.spyOn(performance, 'now').mockImplementation(() => monotonicTime);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  function delayedTokenResponse(expiresIn: number, accessToken: string, elapsed: number): Response {
+  function delayedTokenResponse(
+    expiresIn: number,
+    accessToken: string,
+    elapsed: number,
+    clockAdjustment = 0,
+  ): Response {
     return new Response(
       new ReadableStream(
         {
           pull(controller) {
-            currentTime += elapsed;
+            currentTime += elapsed + clockAdjustment;
+            monotonicTime += elapsed;
             controller.enqueue(
               new TextEncoder().encode(JSON.stringify({ access_token: accessToken, expires_in: expiresIn })),
             );
@@ -63,7 +72,14 @@ describe('workload-identity access-token expiration', () => {
     );
   }
 
-  test.each(['headers', 'body'])('subtracts time spent receiving token response %s', async (stage) => {
+  test.each([
+    ['headers', 0],
+    ['body', 0],
+    ['headers', -60_000],
+    ['body', -60_000],
+    ['headers', 60_000],
+    ['body', 60_000],
+  ])('subtracts %s delivery time with a %i ms wall-clock adjustment', async (stage, clockAdjustment) => {
     let exchangeCount = 0;
     const authorizations: (string | null)[] = [];
     const clientFetch = async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
@@ -71,9 +87,10 @@ describe('workload-identity access-token expiration', () => {
         exchangeCount += 1;
         if (exchangeCount === 1) {
           if (stage === 'body') {
-            return delayedTokenResponse(1, 'initial-token', 750);
+            return delayedTokenResponse(1, 'initial-token', 750, clockAdjustment);
           }
-          currentTime += 750;
+          currentTime += 750 + clockAdjustment;
+          monotonicTime += 750;
         }
         return tokenExchangeResponse(1, exchangeCount === 1 ? 'initial-token' : 'replacement-token');
       }
@@ -83,7 +100,7 @@ describe('workload-identity access-token expiration', () => {
     const client = new OpenAI({ apiKey: null, workloadIdentity, fetch: clientFetch });
 
     await Promise.all([client.models.list(), client.models.list()]);
-    currentTime = INITIAL_TIME + 999;
+    currentTime += 249;
     await client.models.list();
     expect(exchangeCount).toBe(1);
     currentTime += 1;
@@ -99,50 +116,63 @@ describe('workload-identity access-token expiration', () => {
   });
 
   test.each([
-    ['headers', 1000],
-    ['headers', 1500],
-    ['body', 1000],
-    ['body', 1500],
-  ])('rejects a token after %s consume its lifetime (%i ms)', async (stage, elapsed) => {
-    let exchangeCount = 0;
-    const authorizations: (string | null)[] = [];
-    const clientFetch = async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
-      if (url.toString().includes('/oauth/token')) {
-        exchangeCount += 1;
-        if (exchangeCount === 1) {
-          if (stage === 'body') {
-            return delayedTokenResponse(1, 'expired-token', elapsed);
+    ['headers', 1000, 0],
+    ['headers', 1500, 0],
+    ['body', 1000, 0],
+    ['body', 1500, 0],
+    ['headers', 1000, -60_000],
+    ['headers', 1500, -60_000],
+    ['body', 1000, -60_000],
+    ['body', 1500, -60_000],
+    ['headers', 1000, 60_000],
+    ['headers', 1500, 60_000],
+    ['body', 1000, 60_000],
+    ['body', 1500, 60_000],
+  ])(
+    'rejects expired %s (%i ms elapsed, %i ms clock adjustment)',
+    async (stage, elapsed, clockAdjustment) => {
+      let exchangeCount = 0;
+      const authorizations: (string | null)[] = [];
+      const clientFetch = async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        if (url.toString().includes('/oauth/token')) {
+          exchangeCount += 1;
+          if (exchangeCount === 1) {
+            if (stage === 'body') {
+              return delayedTokenResponse(1, 'expired-token', elapsed, clockAdjustment);
+            }
+            currentTime += elapsed + clockAdjustment;
+            monotonicTime += elapsed;
+            return tokenExchangeResponse(1, 'expired-token');
           }
-          currentTime += elapsed;
-          return tokenExchangeResponse(1, 'expired-token');
+          return tokenExchangeResponse(3600, 'replacement-token');
         }
-        return tokenExchangeResponse(3600, 'replacement-token');
-      }
-      authorizations.push(new Headers(init?.headers).get('Authorization'));
-      return Response.json({ data: [] });
-    };
-    const client = new OpenAI({ apiKey: null, workloadIdentity, fetch: clientFetch });
+        authorizations.push(new Headers(init?.headers).get('Authorization'));
+        return Response.json({ data: [] });
+      };
+      const client = new OpenAI({ apiKey: null, workloadIdentity, fetch: clientFetch });
 
-    const results = await Promise.allSettled([client.models.list(), client.models.list()]);
-    for (const result of results) {
-      expect(result.status).toBe('rejected');
-      if (result.status === 'rejected') {
-        expect(result.reason).toBeInstanceOf(OpenAIError);
-        expect(result.reason.message).toContain('token expired before its exchange completed');
+      const results = await Promise.allSettled([client.models.list(), client.models.list()]);
+      for (const result of results) {
+        expect(result.status).toBe('rejected');
+        if (result.status === 'rejected') {
+          expect(result.reason).toBeInstanceOf(OpenAIError);
+          expect(result.reason.message).toContain('token expired before its exchange completed');
+        }
       }
-    }
-    expect(exchangeCount).toBe(1);
-    expect(authorizations).toEqual([]);
+      expect(exchangeCount).toBe(1);
+      expect(authorizations).toEqual([]);
 
-    await client.models.list();
-    await client.models.list();
-    expect(exchangeCount).toBe(2);
-    expect(authorizations).toEqual(['Bearer replacement-token', 'Bearer replacement-token']);
-  });
+      await client.models.list();
+      await client.models.list();
+      expect(exchangeCount).toBe(2);
+      expect(authorizations).toEqual(['Bearer replacement-token', 'Bearer replacement-token']);
+    },
+  );
 
   test('does not count subject-token acquisition against the exchanged token lifetime', async () => {
     const getToken = vi.fn(async () => {
       currentTime += 10_000;
+      monotonicTime += 10_000;
       return 'subject-token';
     });
     const customFetch = vi.fn(async () => tokenExchangeResponse(1, 'valid-token'));
@@ -158,6 +188,33 @@ describe('workload-identity access-token expiration', () => {
     currentTime += 1;
     await expect(auth.getToken()).resolves.toBe('valid-token');
     expect(getToken).toHaveBeenCalledTimes(2);
+    expect(customFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('preserves a representable fractional-millisecond remaining lifetime', async () => {
+    const customFetch = vi
+      .fn()
+      .mockImplementationOnce(async () => delayedTokenResponse(0.001, 'short-lived-token', 0.5, -0.5))
+      .mockImplementationOnce(async () => tokenExchangeResponse(3600, 'replacement-token'));
+    const auth = new WorkloadIdentityAuth(workloadIdentity, customFetch);
+
+    await expect(auth.getToken()).resolves.toBe('short-lived-token');
+    await expect(auth.getToken()).resolves.toBe('short-lived-token');
+    expect(customFetch).toHaveBeenCalledTimes(1);
+    currentTime += 1;
+    await expect(auth.getToken()).resolves.toBe('replacement-token');
+    expect(customFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('rejects remaining lifetime that rounds down to the completion time', async () => {
+    const customFetch = vi
+      .fn()
+      .mockImplementationOnce(async () => delayedTokenResponse(0.001, 'expired-token', 0.99999, -0.99999))
+      .mockImplementationOnce(async () => tokenExchangeResponse(3600, 'replacement-token'));
+    const auth = new WorkloadIdentityAuth(workloadIdentity, customFetch);
+
+    await expect(auth.getToken()).rejects.toThrow('token expired before its exchange completed');
+    await expect(auth.getToken()).resolves.toBe('replacement-token');
     expect(customFetch).toHaveBeenCalledTimes(2);
   });
 


### PR DESCRIPTION
## Summary

- Measure workload-identity OAuth exchange duration with a monotonic clock, after acquiring the subject token.
- Derive the cache deadline from the remaining lifetime at response completion, and reject expired tokens before caching or API dispatch.
- Keep proactive refresh tied to the original lifetime, preserving zero-buffer behavior and the one-hour fallback.

## Why

The cache previously calculated `expiresAt` after reading the complete token response. That restarted the full lifetime after response delivery: a valid one-second token whose response body took 1.5 seconds to arrive was returned to concurrent callers and cached despite already being expired. Shorter delays also postponed later refreshes.

[OAuth 2.0 §5.1](https://www.rfc-editor.org/rfc/rfc6749#section-5.1) defines `expires_in` relative to response generation. The fix measures elapsed exchange time with `performance.now()` and converts the remaining lifetime into a completion-relative wall-clock deadline. Subject-token acquisition is deliberately excluded.

The [review follow-up](https://github.com/openai/openai-node/commit/886cd6ea662cde2f28d93e8c5962b6712ba67221) addresses wall-clock adjustments during exchange without adding new cache fields or changing the cache's existing wall-clock policy. It also rejects positive remaining lifetimes that are too small to represent beyond the completion timestamp.

This is a cache/retry reliability fix, not a change to token parsing, authentication destinations, exported APIs, or concurrency infrastructure. The expiration checks are grouped in a small helper to keep `refreshToken` within the existing complexity limit.

## Regression coverage and validation

- Seven original regressions failed before the initial fix; nine additional clock-adjustment/precision regressions failed before the review follow-up.
- All 51 expiration tests pass, including delayed headers/body, forward/backward clock adjustments, exact expiration, shared rejection and recovery, fractional remaining lifetime, original refresh buffering, and provider-acquisition exclusion.
- All 836 auth and public workload-identity tests pass on Node 22.22.2 and 24.19.0.
- 210 independent checks pass through the actual final built CJS/ESM public clients on exact Node 22.0.0, 24.19.0, and 26.7.0, including background refresh preserving an older usable cache entry.
- Full TypeScript check, canonical `./scripts/build`, pinned Oxfmt 0.62.0, available cached Oxlint 1.76.0, declaration comparison, and `git diff --check` pass.
- Full unit suite after the follow-up: 7,490 passed; one pre-existing formatter-fixture failure in `tests/oxlint-config.test.ts`, reproduced identically in the clean `f83de8fe` base. Local dependency installation remains blocked by the configured registry's missing publication-time metadata for `qs@6.16.0`; the available cache has Vitest 4.1.10 and Oxlint 1.76.0 rather than the pinned versions. No registry, lockfile, policy, or dependency changes are included; pinned CI remains authoritative.

## Scope and review

Only the handwritten implementation and its existing expiration/auth test files change. The additional auth-test changes freeze and restore the monotonic clock in two existing exact-boundary tests. All three paths are absent from the current pinned generated snapshot `0669a894f02e0cd93cf431ebdbbab0529f81d8e8`; no overlapping open PR was found.

Repeated adversarial review covered security/privacy, missing/null/fractional lifetimes, zero refresh buffers, clock adjustments, background failures, callers joining a pending refresh, invalidation races, and supported runtime compatibility. No blocking findings remain in the final self-review; fresh CI and maintainer review apply to the new head.
