### PR TITLE
fix(bedrock): cancel requests awaiting AWS credentials

### DIFF
--- a/src/internal/bedrock.ts
+++ b/src/internal/bedrock.ts
@@ -290,7 +290,7 @@ export function assertValidBedrockBearerCredential(credential: string): void {
   }
 }
 
-interface BedrockBearerSignalFailure {
+interface BedrockAuthSignalFailure {
   error?: { value: unknown };
   removeListeners?: () => void;
 }
@@ -313,13 +313,13 @@ function removeBedrockAbortListener(signal: AbortSignal, listener: () => void): 
   }
 }
 
-function resolveAbortableBedrockBearerToken(
-  tokenProvider: ApiKeySetter,
+function resolveAbortableBedrockAuth<T>(
+  operation: () => Promise<T>,
   signals: readonly AbortSignal[],
-  failure: BedrockBearerSignalFailure,
-): Promise<string> {
+  failure: BedrockAuthSignalFailure,
+): Promise<T> {
   // oxlint-disable-next-line promise/avoid-new -- AbortSignal events require a Promise callback bridge.
-  return new Promise<string>((resolve, reject) => {
+  return new Promise<T>((resolve, reject) => {
     let settled = false;
     const listeners: { signal: AbortSignal; listener: () => void }[] = [];
 
@@ -333,13 +333,13 @@ function resolveAbortableBedrockBearerToken(
     };
     failure.removeListeners = removeListeners;
 
-    const settle = (result: { token: string } | { error: unknown }) => {
+    const settle = (result: { value: T } | { error: unknown }) => {
       if (settled) {
         return;
       }
       settled = true;
-      if ('token' in result) {
-        resolve(result.token);
+      if ('value' in result) {
+        resolve(result.value);
       } else {
         removeListeners();
         reject(result.error);
@@ -399,24 +399,73 @@ function resolveAbortableBedrockBearerToken(
       }
     }
 
-    let token: Promise<string>;
+    let pending: Promise<T>;
     try {
-      token = tokenProvider();
+      pending = operation();
     } catch (error) {
       settle({ error });
       return;
     }
 
-    const observeToken = async () => {
+    const observeResult = async () => {
       try {
-        settle({ token: await token });
+        settle({ value: await pending });
       } catch (error) {
         settle({ error });
       }
     };
     // Observe the result even if the provider synchronously triggered cancellation.
-    void observeToken();
+    void observeResult();
   });
+}
+
+/**
+ * Resolves Bedrock authentication work with caller cancellation, then applies
+ * its result synchronously after the final cancellation checks.
+ *
+ * @internal
+ */
+export async function prepareBedrockAuth<T>(
+  request: FinalizedRequestInit,
+  context: ProviderRequestContext,
+  operation: {
+    resolve: () => Promise<T>;
+    failureMessage: string;
+    apply: (value: T) => void;
+  },
+): Promise<void> {
+  const signals: AbortSignal[] = [];
+  for (const signal of [context.options.signal, request.signal]) {
+    if (signal != null && !signals.includes(signal)) {
+      signals.push(signal);
+    }
+  }
+  const signalFailure: BedrockAuthSignalFailure = {};
+  let value: T;
+  try {
+    try {
+      value =
+        signals.length > 0
+          ? await resolveAbortableBedrockAuth(operation.resolve, signals, signalFailure)
+          : await operation.resolve();
+    } catch (cause) {
+      if (signalFailure.error && Object.is(cause, signalFailure.error.value)) {
+        throw cause;
+      }
+      throw errorWithCause(operation.failureMessage, cause);
+    }
+    if (signalFailure.error) {
+      throw signalFailure.error.value;
+    }
+    for (const signal of signals) {
+      if (signal.aborted) {
+        throw createBedrockUserAbortError(signal);
+      }
+    }
+  } finally {
+    signalFailure.removeListeners?.();
+  }
+  operation.apply(value);
 }
 
 class BedrockBearerAuth implements BedrockRequestAuth {
@@ -430,52 +479,29 @@ class BedrockBearerAuth implements BedrockRequestAuth {
     const headers = new Headers(request.headers);
     assertProviderOwnsAuthorization(headers);
 
-    const signals: AbortSignal[] = [];
-    for (const signal of [context.options.signal, request.signal]) {
-      if (signal != null && !signals.includes(signal)) {
-        signals.push(signal);
-      }
-    }
-    const signalFailure: BedrockBearerSignalFailure = {};
-    let token: unknown;
-    try {
-      try {
-        token =
-          signals.length > 0
-            ? await resolveAbortableBedrockBearerToken(() => this.tokenProvider(), signals, signalFailure)
-            : await this.tokenProvider();
-      } catch (cause) {
-        if (signalFailure.error && Object.is(cause, signalFailure.error.value)) {
-          throw cause;
+    await prepareBedrockAuth(request, context, {
+      resolve: () => this.tokenProvider(),
+      failureMessage: 'Failed to resolve a bearer credential for Bedrock.',
+      apply: (token) => {
+        if (typeof token !== 'string' || !token.trim()) {
+          throw new Errors.OpenAIError(
+            'The Bedrock bearer credential provider must return a non-empty string.',
+          );
         }
-        throw errorWithCause('Failed to resolve a bearer credential for Bedrock.', cause);
-      }
-      if (signalFailure.error) {
-        throw signalFailure.error.value;
-      }
-      for (const signal of signals) {
-        if (signal.aborted) {
-          throw createBedrockUserAbortError(signal);
+        assertValidBedrockBearerCredential(token);
+        try {
+          headers.set('authorization', `Bearer ${token}`);
+        } catch (error) {
+          if (error instanceof TypeError) {
+            // oxlint-disable-next-line eslint/preserve-caught-error -- The original error contains the bearer credential.
+            throw new TypeError('Bedrock bearer credential contains an invalid HTTP header value.');
+          }
+          throw error;
         }
-      }
-    } finally {
-      signalFailure.removeListeners?.();
-    }
-    if (typeof token !== 'string' || !token.trim()) {
-      throw new Errors.OpenAIError('The Bedrock bearer credential provider must return a non-empty string.');
-    }
-    assertValidBedrockBearerCredential(token);
-    try {
-      headers.set('authorization', `Bearer ${token}`);
-    } catch (error) {
-      if (error instanceof TypeError) {
-        // oxlint-disable-next-line eslint/preserve-caught-error -- The original error contains the bearer credential.
-        throw new TypeError('Bedrock bearer credential contains an invalid HTTP header value.');
-      }
-      throw error;
-    }
-    request.redirect = 'manual';
-    request.headers = headers;
+        request.redirect = 'manual';
+        request.headers = headers;
+      },
+    });
   }
 }
 

--- a/src/providers/bedrock/aws.ts
+++ b/src/providers/bedrock/aws.ts
@@ -7,9 +7,9 @@ import type { BodyInit } from '../../internal/builtin-types';
 import {
   assertBedrockRequestOrigin,
   assertProviderOwnsAuthorization,
-  errorWithCause,
   normalizeOptionalString,
   parseBedrockEndpointHostname,
+  prepareBedrockAuth,
   resolveBedrockBearerAuth,
   resolveBedrockEndpoint,
 } from '../../internal/bedrock';
@@ -194,14 +194,14 @@ class BedrockSigV4Auth implements BedrockRequestAuth {
     }));
   }
 
-  async prepareRequest(request: FinalizedRequestInit, { url }: ProviderRequestContext): Promise<void> {
+  async prepareRequest(request: FinalizedRequestInit, context: ProviderRequestContext): Promise<void> {
     if (Object.prototype.toString.call((globalThis as any).process) !== '[object process]') {
       throw new Errors.OpenAIError(
         'Bedrock AWS credential authentication is only supported in Node.js and compatible server runtimes. Use bearer authentication in this runtime.',
       );
     }
 
-    const parsedURL = new URL(url);
+    const parsedURL = new URL(context.url);
     const canonicalEndpoint = parseBedrockEndpointHostname(parsedURL.hostname);
     if (canonicalEndpoint && canonicalEndpoint.endpoint !== this.options.endpoint) {
       throw new Errors.OpenAIError(
@@ -225,27 +225,26 @@ class BedrockSigV4Auth implements BedrockRequestAuth {
     const body = signableBody(request.body);
     const target = requestTarget(parsedURL);
 
-    let signed: { headers: Record<string, string> };
-    try {
-      signed = await this.signatureV4().sign({
-        protocol: parsedURL.protocol,
-        hostname: parsedURL.hostname,
-        ...(parsedURL.port ? { port: Number(parsedURL.port) } : {}),
-        method,
-        ...target,
-        headers: Object.fromEntries(headers.entries()),
-        ...(body === undefined ? {} : { body }),
-      });
-    } catch (cause) {
-      const message = this.options.usesDefaultChain
+    await prepareBedrockAuth(request, context, {
+      resolve: () =>
+        this.signatureV4().sign({
+          protocol: parsedURL.protocol,
+          hostname: parsedURL.hostname,
+          ...(parsedURL.port ? { port: Number(parsedURL.port) } : {}),
+          method,
+          ...target,
+          headers: Object.fromEntries(headers.entries()),
+          ...(body === undefined ? {} : { body }),
+        }),
+      failureMessage: this.options.usesDefaultChain
         ? 'Could not find credentials for Bedrock. Pass AWS credentials to `bedrock(...)` or configure the default AWS credential chain.'
-        : 'Failed to resolve AWS credentials for Bedrock. Verify your AWS profile, environment variables, or runtime identity configuration and try again.';
-      throw errorWithCause(message, cause);
-    }
-
-    request.method = method;
-    request.redirect = 'manual';
-    request.headers = new Headers(signed.headers);
+        : 'Failed to resolve AWS credentials for Bedrock. Verify your AWS profile, environment variables, or runtime identity configuration and try again.',
+      apply: (signed) => {
+        request.method = method;
+        request.redirect = 'manual';
+        request.headers = new Headers(signed.headers);
+      },
+    });
   }
 }
 

--- a/tests/lib/bedrock-provider-bearer-cancellation.test.ts
+++ b/tests/lib/bedrock-provider-bearer-cancellation.test.ts
@@ -28,12 +28,28 @@ class SignalReplacingOpenAI extends OpenAI {
 const dependencyFreeProvider: ProviderFactory = (endpoint, tokenProvider) =>
   bearerBedrock({ endpoint, region: 'us-east-1', tokenProvider });
 
+const sigV4Provider: ProviderFactory = (endpoint, tokenProvider) =>
+  awsBedrock({
+    endpoint,
+    region: 'us-east-1',
+    baseURL:
+      endpoint === 'mantle'
+        ? 'https://bedrock-mantle.us-east-1.api.aws/openai/v1'
+        : 'https://bedrock-runtime.us-east-1.amazonaws.com/openai/v1',
+    apiKey: null,
+    credentialProvider: async () => ({
+      accessKeyId: 'synthetic-access-key',
+      secretAccessKey: await tokenProvider(),
+    }),
+  });
+
 const providerFactories: [string, ProviderFactory][] = [
   ['dependency-free bearer', dependencyFreeProvider],
   [
     'AWS-entrypoint bearer',
     (endpoint, tokenProvider) => awsBedrock({ endpoint, region: 'us-east-1', tokenProvider }),
   ],
+  ['AWS SigV4', sigV4Provider],
 ];
 
 const providerCases: [string, Endpoint, ProviderFactory][] = providerFactories.flatMap(([name, create]) =>
@@ -117,7 +133,7 @@ function throwAfterRemovingOnce(signal: AbortSignal): void {
 
 afterEach(() => vi.restoreAllMocks());
 
-describe.each(providerCases)('%s %s bearer credentials', (_name, endpoint, create) => {
+describe.each(providerCases)('%s %s credentials', (_name, endpoint, create) => {
   test('cancels a documented public models request while its token provider remains pending', async () => {
     const controller = new AbortController();
     const reason = new Error('caller cancelled credential resolution');
@@ -191,6 +207,85 @@ describe.each(providerCases)('%s %s bearer credentials', (_name, endpoint, creat
     expect(tokenProvider).not.toHaveBeenCalled();
     expect(getEventListeners(original.signal, 'abort')).toEqual([]);
     expect(getEventListeners(finalized.signal, 'abort')).toEqual([]);
+  });
+});
+
+describe.each(['mantle', 'runtime'] as const)('Bedrock %s SigV4 credential lifecycle', (endpoint) => {
+  test.each(['resolve', 'reject'] as const)(
+    'keeps cancellation when late credentials %s and permits a fresh request',
+    async (settlement) => {
+      const controller = new AbortController();
+      const lateFailure = new Error('synthetic late credential refresh failure');
+      let finishLate!: () => void;
+      // oxlint-disable-next-line promise/avoid-new -- The deferred credential exercises settlement after cancellation.
+      const lateCredential = new Promise<string>((resolve, reject) => {
+        finishLate = () => {
+          if (settlement === 'resolve') {
+            resolve('synthetic-late-secret-key');
+          } else {
+            reject(lateFailure);
+          }
+        };
+      });
+      const tokenProvider = vi
+        .fn<TokenProvider>()
+        .mockReturnValueOnce(lateCredential)
+        .mockResolvedValue('synthetic-fresh-secret-key');
+      const { client, fetch } = createClient(tokenProvider, sigV4Provider, endpoint);
+      const pending = observe(client.models.list({ signal: controller.signal }));
+      const unhandled = vi.fn();
+      process.on('unhandledRejection', unhandled);
+
+      try {
+        await waitForProvider(tokenProvider);
+        controller.abort(new Error('caller cancelled pending AWS credentials'));
+        await expectImmediateCancellation(pending, controller.signal, fetch);
+        finishLate();
+        await nextTurn();
+
+        await expect(pending).resolves.toBeInstanceOf(APIUserAbortError);
+        expect(fetch).not.toHaveBeenCalled();
+        expect(unhandled).not.toHaveBeenCalled();
+        expect(getEventListeners(controller.signal, 'abort')).toEqual([]);
+
+        await expect(client.models.list()).resolves.toBeDefined();
+        expect(tokenProvider).toHaveBeenCalledTimes(2);
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(new Headers(fetch.mock.calls[0]?.[1]?.headers).get('authorization')).toContain(
+          'Credential=synthetic-access-key/',
+        );
+      } finally {
+        finishLate();
+        await pending;
+        process.removeListener('unhandledRejection', unhandled);
+      }
+    },
+  );
+
+  test('cancels credential refresh on a retry without sending a second request', async () => {
+    const controller = new AbortController();
+    const tokenProvider = vi
+      .fn<TokenProvider>()
+      .mockResolvedValueOnce('synthetic-first-secret-key')
+      .mockImplementationOnce(() => Promise.race([]));
+    const fetch = vi.fn<Fetch>(async () =>
+      Response.json(
+        { error: { message: 'retry once' } },
+        { status: 500, headers: { 'retry-after-ms': '1' } },
+      ),
+    );
+    const client = new OpenAI({
+      provider: sigV4Provider(endpoint, tokenProvider),
+      fetch,
+      maxRetries: 1,
+    });
+    const pending = observe(client.models.list({ signal: controller.signal }));
+
+    await vi.waitFor(() => expect(tokenProvider).toHaveBeenCalledTimes(2), { timeout: 1000, interval: 1 });
+    controller.abort(new Error('caller cancelled the refreshed AWS credentials'));
+
+    await expectImmediateCancellation(pending, controller.signal, fetch, 1);
+    expect(getEventListeners(controller.signal, 'abort')).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

Fix request cancellation while Bedrock AWS credential resolution or SigV4 signing is still pending. Previously, `client.models.list({ signal })` kept waiting after abort until the credential provider settled; a later provider rejection could replace the earlier cancellation with a credential error. This reproduces on both Mantle and Runtime.

Reuse the existing Bedrock bearer cancellation implementation as one shared authentication-operation helper:

- Observe both the caller signal and a finalized signal supplied by the protected request hook.
- Preserve the winning cancellation reason and existing credential-error wrapping.
- Apply bearer credentials or signed headers synchronously after the final cancellation checks.
- Continue observing late operation results without applying them or sending the cancelled request.

Cancellation settles the SDK request; it does **not** cancel arbitrary credential-provider or signing work. No new timeout, cache, listener framework, dependency, endpoint, or public credential-provider contract is introduced. Existing validation order, per-attempt credential refresh, successful signing, and optional AWS dependency isolation are preserved.

Only three wholly handwritten files change. All are absent from the verified Castiron generated snapshot `0669a894`; no generated or mixed files change. The root and both Bedrock provider CJS/ESM type declarations remain byte-identical.

## Validation

- **Before:** 18 new public SigV4 cancellation regressions failed; 71 existing controls passed.
- **After:** **796 related tests passed on Node 22.22.2 and 24.19.0**, covering cancellation, signing fixtures, retries, endpoint routing, credential privacy, query handling, legacy providers, and optional-dependency isolation.
- **132 independent built-public checks passed** across CJS/ESM on Node **22.0.0**, **24.19.0**, and **26.7.0**. The same built entrypoints reproduced 24 expected cancellation hangs before the fix.
- Checked pre-abort, original/replaced signals, late resolve/reject, unchanged cancelled-request headers, no late fetch/unhandled rejection, concurrent isolation, recovery, and retry credential refresh.
- Whole-project TypeScript, canonical `./scripts/build`, pinned Oxfmt 0.62.0, cached Oxlint 1.76.0, and `git diff --check` passed.
- Full handwritten suite: **7,486 passed, 1 failed**. The sole failure is the existing `tests/oxlint-config.test.ts:464` formatter fixture, reproduced identically on a clean `41f85bde` baseline. Available cached Vitest is 4.1.10 rather than pinned 4.1.11, and Oxlint is 1.76.0 rather than pinned 1.79.0. Fresh frozen installation remains blocked by missing `qs@6.16.0` publication-time metadata in the configured registry; no dependency safeguards, configuration, or lockfiles were changed.

## Adversarial self-review

Reviewed signal-error provenance versus provider-originated abort errors, first-cause priority, listener cleanup, late settlement, synchronous header application, request isolation, validation precedence, credential privacy, and CJS/ESM/minimum-runtime compatibility. Two independent final reviews found no actionable issues. The implementation reuses the existing tested owner and stays limited to this cancellation boundary.