### PR TITLE
fix(examples): report unsuccessful Azure Realtime responses

### DIFF
--- a/examples/azure/realtime/websocket.ts
+++ b/examples/azure/realtime/websocket.ts
@@ -52,7 +52,14 @@ async function main() {
   rt.on('response.output_text.delta', (event) => process.stdout.write(event.delta));
   rt.on('response.output_text.done', () => console.log());
 
-  rt.on('response.done', () => rt.close());
+  // response.done also covers failed, cancelled, and incomplete responses.
+  rt.on('response.done', (event) => {
+    if (event.response.status !== 'completed') {
+      console.error('Response did not complete successfully.');
+      process.exitCode = 1;
+    }
+    rt.close();
+  });
 
   rt.socket.addEventListener('close', () => console.log('\nConnection closed!'));
 }

--- a/examples/azure/realtime/ws.ts
+++ b/examples/azure/realtime/ws.ts
@@ -52,7 +52,14 @@ async function main() {
   rt.on('response.output_text.delta', (event) => process.stdout.write(event.delta));
   rt.on('response.output_text.done', () => console.log());
 
-  rt.on('response.done', () => rt.close());
+  // response.done also covers failed, cancelled, and incomplete responses.
+  rt.on('response.done', (event) => {
+    if (event.response.status !== 'completed') {
+      console.error('Response did not complete successfully.');
+      process.exitCode = 1;
+    }
+    rt.close();
+  });
 
   rt.socket.on('close', () => console.log('\nConnection closed!'));
 }

--- a/tests/lib/realtime-example-status.test.ts
+++ b/tests/lib/realtime-example-status.test.ts
@@ -11,18 +11,27 @@ import { WebSocketServer } from 'ws';
 
 import { createX509TestLab } from '../utils/x509-test-lab';
 
-const cases = (['ws', 'websocket'] as const).flatMap((example) =>
-  (['completed', 'failed', 'cancelled', 'incomplete'] as const).map((status) => ({ example, status })),
+const cases = (['openai', 'azure'] as const).flatMap((provider) =>
+  (['ws', 'websocket'] as const).flatMap((example) =>
+    (['completed', 'failed', 'cancelled', 'incomplete'] as const).map((status) => ({
+      provider,
+      example,
+      status,
+    })),
+  ),
 );
 
-test.each(cases)('Realtime $example example handles a $status response', async ({ example, status }) => {
+test.each(cases)('$provider Realtime $example handles $status', async ({ provider, example, status }) => {
   const lab = createX509TestLab();
   const directory = await mkdtemp(path.join(tmpdir(), 'openai-realtime-example-'));
   const certificatePath = path.join(directory, 'ca.pem');
+  const identityPath = path.join(directory, 'azure-identity.cjs');
+  const azureToken = 'synthetic-azure-example-token';
   const server = createServer({ cert: lab.server.certificate, key: lab.server.privateKey });
   const sockets = new WebSocketServer({ server });
   const requests: unknown[] = [];
   const urls: (string | undefined)[] = [];
+  const authorization: (string | undefined)[] = [];
   const text = 'Synthetic Realtime answer.';
   const textFields = {
     content_index: 0,
@@ -65,6 +74,7 @@ test.each(cases)('Realtime $example example handles a $status response', async (
   ];
   sockets.on('connection', (socket, request) => {
     urls.push(request.url);
+    authorization.push(request.headers.authorization);
     socket.on('message', (data) => {
       const event: unknown = JSON.parse(data.toString());
       requests.push(event);
@@ -83,6 +93,21 @@ test.each(cases)('Realtime $example example handles a $status response', async (
 
   try {
     await writeFile(certificatePath, lab.certificateAuthority);
+    if (provider === 'azure') {
+      await writeFile(
+        identityPath,
+        `const Module = require('node:module');
+const load = Module._load;
+Module._load = function(request, ...args) {
+  if (request === '@azure/identity') return {
+    DefaultAzureCredential: class {},
+    getBearerTokenProvider: () => async () => ${JSON.stringify(azureToken)},
+  };
+  return Reflect.apply(load, this, [request, ...args]);
+};
+`,
+      );
+    }
     const listening = once(server, 'listening');
     server.listen(0, '127.0.0.1');
     await listening;
@@ -97,16 +122,22 @@ test.each(cases)('Realtime $example example handles a $status response', async (
       [
         path.join(root, 'node_modules/ts-node/dist/bin.js'),
         '--swc',
+        ...(provider === 'azure' ? ['-r', identityPath] : []),
         '-r',
         path.join(root, 'node_modules/tsconfig-paths/register.js'),
-        path.join(root, 'examples/realtime', `${example}.ts`),
+        path.join(root, 'examples', ...(provider === 'azure' ? ['azure'] : []), 'realtime', `${example}.ts`),
       ],
       {
         cwd: root,
         env: {
-          OPENAI_API_KEY: 'synthetic-example-key',
-          OPENAI_BASE_URL: `https://127.0.0.1:${address.port}/v1`,
+          ...(provider === 'azure'
+            ? { AZURE_OPENAI_ENDPOINT: `https://127.0.0.1:${address.port}` }
+            : {
+                OPENAI_API_KEY: 'synthetic-example-key',
+                OPENAI_BASE_URL: `https://127.0.0.1:${address.port}/v1`,
+              }),
           NODE_EXTRA_CA_CERTS: certificatePath,
+          DOTENV_CONFIG_PATH: path.join(directory, '.env'),
           TS_NODE_PROJECT: path.join(root, 'tsconfig.json'),
           DISABLE_V8_COMPILE_CACHE: '1',
           SystemRoot: process.env['SystemRoot'],
@@ -127,7 +158,14 @@ test.each(cases)('Realtime $example example handles a $status response', async (
     try {
       const [exitCode, signal] = await once(child, 'close');
       expect(signal).toBeNull();
-      expect(urls).toEqual(['/v1/realtime?model=gpt-realtime']);
+      expect(urls).toEqual([
+        provider === 'azure'
+          ? '/openai/v1/realtime?model=gpt-4o-realtime-preview-1001'
+          : '/v1/realtime?model=gpt-realtime',
+      ]);
+      if (provider === 'azure') {
+        expect(authorization).toEqual([`Bearer ${azureToken}`]);
+      }
       expect(requests).toEqual([
         {
           type: 'session.update',
@@ -146,6 +184,7 @@ test.each(cases)('Realtime $example example handles a $status response', async (
       expect(stdout).toContain(text);
       expect(stdout).toContain('Connection closed!');
       expect(stdout + stderr).not.toContain('synthetic-example-key');
+      expect(stdout + stderr).not.toContain(azureToken);
       expect(stdout + stderr).not.toContain('SYNTHETIC_PRIVATE_RESPONSE_METADATA');
       expect(exitCode).toBe(status === 'completed' ? 0 : 1);
       expect(stderr.includes('Response did not complete successfully.')).toBe(status !== 'completed');


### PR DESCRIPTION
## Summary

Make the Azure Realtime `ws` and native `websocket` examples report a nonzero exit status when `response.done` contains a failed, cancelled, or incomplete response. Previously both examples closed and exited 0 for these terminal failures.

Copy the existing canonical Realtime examples' terminal-status guard: emit a fixed diagnostic, set `process.exitCode = 1` for non-completed responses, and keep the existing orderly close for every terminal status. No SDK, authentication, URL, transport, dependency, or generated-code changes.

Extend the existing real TLS/WebSocket subprocess regression table to include both Azure examples. Only Azure credential acquisition is stubbed with a synthetic token; the actual examples, public SDK, and socket transports run. The child environment is isolated from developer `.env` files.

## Verification

- Before the fix, six new Azure failure cases failed and ten controls passed on exact Node 22.0.0 and Node 24.19.0.
- After the fix, all 16 real TLS/WebSocket cases passed independently on exact Node 22.0.0, 24.19.0, and 26.7.0 (48 checks), plus Node 22.22.2.
- An independent actual-example harness reproduced 18 incorrect successes across those three runtimes before the fix; all 24 success/failure cases passed afterward.
- Final example/Realtime privacy suites: 68/68 tests passed. Tests verify expected Azure route and bearer header, outbound messages, streamed text, socket closure, exit codes, and absence of synthetic credentials or private response metadata in output.
- Full TypeScript check, pinned Oxfmt 0.62.0, cached Oxlint 1.76.0, and whitespace checks pass. The local cache uses Vitest 4.1.10 and Oxlint 1.76.0 rather than pinned 4.1.11/1.79.0; pinned CI remains authoritative.

## Adversarial review

Independent reviews checked failure-status handling, successful exit compatibility, diagnostic privacy, credential/endpoint scope, subprocess isolation, and socket cleanup. Test isolation was tightened to prevent developer `.env` files from supplying credentials. The handlers match the canonical examples exactly; no blocking findings remain.