### PR TITLE
fix(streaming): abort before early-exit cleanup

### DIFF
--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -115,8 +115,17 @@ export class Stream<Item> implements AsyncIterable<Item> {
       consumed = true;
       let done = false;
       let receivedCompletionSentinel = false;
+      const messages = _iterSSEMessages(response, controller);
+      const closeMessages = messages.return.bind(messages);
+      messages.return = (value) => {
+        // Abort before nested iterator cleanup can wait on the response body's cancellation.
+        if (!receivedCompletionSentinel) {
+          controller.abort();
+        }
+        return closeMessages(value);
+      };
       try {
-        for await (const sse of _iterSSEMessages(response, controller)) {
+        for await (const sse of messages) {
           if (sse.data === '[DONE]') {
             receivedCompletionSentinel = true;
             break;

--- a/tests/lib/streaming-core.test.ts
+++ b/tests/lib/streaming-core.test.ts
@@ -1,3 +1,4 @@
+import { setImmediate as nextTurn } from 'node:timers/promises';
 import { vi } from 'vitest';
 import OpenAI from 'openai';
 import { APIError, APIUserAbortError, OpenAIError } from 'openai/core/error';
@@ -7,9 +8,27 @@ import { ReadableStreamFrom } from 'openai/internal/shims';
 import type { ResponseTextDeltaEvent } from 'openai/resources/responses/responses';
 
 const encoder = new TextEncoder();
+const responseEvent: ResponseTextDeltaEvent = {
+  type: 'response.output_text.delta',
+  sequence_number: 0,
+  item_id: 'msg_test',
+  output_index: 0,
+  content_index: 0,
+  delta: 'hello',
+  logprobs: [],
+};
 
 function responseForSSE(value: string): Response {
   return new Response(ReadableStreamFrom([encoder.encode(value)]));
+}
+
+async function publicSSEStream(body: ReadableStream<Uint8Array>) {
+  const client = new OpenAI({
+    apiKey: 'test-key',
+    maxRetries: 0,
+    fetch: async () => new Response(body, { headers: { 'content-type': 'text/event-stream' } }),
+  });
+  return await client.responses.create({ model: 'gpt-4o', input: 'hello', stream: true });
 }
 
 async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
@@ -237,6 +256,148 @@ describe('Stream.fromSSEResponse', () => {
   });
 });
 
+describe('public Responses SSE iterator early exit', () => {
+  const event = responseEvent;
+  const wire = `data: ${JSON.stringify(event)}\n\n`;
+
+  test.each([
+    ['break', 'resolve'],
+    ['break', 'reject'],
+    ['return', 'resolve'],
+    ['return', 'reject'],
+  ] as const)('settles %s before deferred body cancellation can %s', async (method, settlement) => {
+    let finishCleanup!: () => void;
+    // oxlint-disable-next-line promise/avoid-new -- The native cancellation fixture must remain pending during early exit.
+    const cleanup = new Promise<void>((resolve, reject) => {
+      finishCleanup = () =>
+        settlement === 'resolve' ? resolve() : reject(new Error('synthetic cleanup failure'));
+    });
+    const cancel = vi.fn(() => cleanup);
+    const body = new ReadableStream<Uint8Array>({
+      start(source) {
+        source.enqueue(encoder.encode(wire));
+      },
+      cancel,
+    });
+    const stream = await publicSSEStream(body);
+    const unhandled = vi.fn();
+    let pending: Promise<unknown>;
+    if (method === 'break') {
+      pending = (async () => {
+        for await (const item of stream) {
+          expect(item).toEqual(event);
+          break;
+        }
+      })();
+    } else {
+      const iterator = stream[Symbol.asyncIterator]();
+      await expect(iterator.next()).resolves.toEqual({ done: false, value: event });
+      pending = Promise.resolve(iterator.return?.());
+    }
+    let settled = false;
+    const observed = (async () => {
+      try {
+        return await pending;
+      } catch (error) {
+        return error;
+      } finally {
+        settled = true;
+      }
+    })();
+    process.on('unhandledRejection', unhandled);
+
+    try {
+      await nextTurn();
+      expect(settled).toBe(true);
+      expect(stream.controller.signal.aborted).toBe(true);
+      expect(body.locked).toBe(false);
+      expect(cancel).toHaveBeenCalledTimes(1);
+      await expect(observed).resolves.toEqual(
+        method === 'break' ? undefined : { done: true, value: undefined },
+      );
+    } finally {
+      finishCleanup();
+      stream.controller.abort();
+      try {
+        await settlesSoon(observed);
+        await nextTurn();
+      } finally {
+        process.removeListener('unhandledRejection', unhandled);
+      }
+    }
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(unhandled).not.toHaveBeenCalled();
+  });
+
+  test.each([false, true])(
+    'returning an unused iterator preserves the owner (started: %s)',
+    async (started) => {
+      const cancel = vi.fn();
+      const body = new ReadableStream<Uint8Array>({
+        start(source) {
+          source.enqueue(encoder.encode(`${wire}data: [DONE]\n\n`));
+        },
+        cancel,
+      });
+      const stream = await publicSSEStream(body);
+      const owner = stream[Symbol.asyncIterator]();
+      const unused = stream[Symbol.asyncIterator]();
+      if (started) {
+        await expect(owner.next()).resolves.toEqual({ done: false, value: event });
+      }
+      await expect(unused.return?.()).resolves.toEqual({ done: true, value: undefined });
+      expect(stream.controller.signal.aborted).toBe(false);
+      expect(cancel).not.toHaveBeenCalled();
+      expect(body.locked).toBe(started);
+      if (!started) {
+        await expect(owner.next()).resolves.toEqual({ done: false, value: event });
+      }
+      await expect(owner.next()).resolves.toEqual({ done: true, value: undefined });
+      expect(stream.controller.signal.aborted).toBe(false);
+      expect(body.locked).toBe(false);
+    },
+  );
+
+  test.each(['EOF', '[DONE]'])('return after %s does not abort a completed stream', async (ending) => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({
+      start(source) {
+        source.enqueue(encoder.encode(`${wire}${ending === '[DONE]' ? 'data: [DONE]\n\n' : ''}`));
+        if (ending === 'EOF') {
+          source.close();
+        }
+      },
+      cancel,
+    });
+    const stream = await publicSSEStream(body);
+    const iterator = stream[Symbol.asyncIterator]();
+    await expect(iterator.next()).resolves.toEqual({ done: false, value: event });
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+    await expect(iterator.return?.()).resolves.toEqual({ done: true, value: undefined });
+    expect(stream.controller.signal.aborted).toBe(false);
+    expect(body.locked).toBe(false);
+    expect(cancel).toHaveBeenCalledTimes(ending === 'EOF' ? 0 : 1);
+  });
+
+  test('preserves iterator throw identity with immediate body cleanup', async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({
+      start(source) {
+        source.enqueue(encoder.encode(wire));
+      },
+      cancel,
+    });
+    const stream = await publicSSEStream(body);
+    const iterator = stream[Symbol.asyncIterator]();
+    await expect(iterator.next()).resolves.toEqual({ done: false, value: event });
+    const failure = new Error('synthetic consumer failure');
+    await expect(iterator.throw?.(failure)).rejects.toBe(failure);
+    expect(stream.controller.signal.aborted).toBe(true);
+    expect(body.locked).toBe(false);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('Stream.fromReadableStream', () => {
   test('parses newline-separated JSON while ignoring blank lines and flushing the final line', async () => {
     const readable = ReadableStreamFrom([encoder.encode('{"id":1}\n\n'), encoder.encode('{"id":2}')]);
@@ -345,16 +506,7 @@ describe('Stream.tee', () => {
 });
 
 describe('Stream.toReadableStream', () => {
-  const event: ResponseTextDeltaEvent = {
-    type: 'response.output_text.delta',
-    sequence_number: 0,
-    item_id: 'msg_test',
-    output_index: 0,
-    content_index: 0,
-    delta: 'hello',
-    logprobs: [],
-  };
-
+  const event = responseEvent;
   test('round-trips structured values as newline-delimited JSON', async () => {
     const original = new Stream(
       () =>

--- a/tests/lib/streaming-core.test.ts
+++ b/tests/lib/streaming-core.test.ts
@@ -1,4 +1,3 @@
-import { setImmediate as nextTurn } from 'node:timers/promises';
 import { vi } from 'vitest';
 import OpenAI from 'openai';
 import { APIError, APIUserAbortError, OpenAIError } from 'openai/core/error';
@@ -8,27 +7,9 @@ import { ReadableStreamFrom } from 'openai/internal/shims';
 import type { ResponseTextDeltaEvent } from 'openai/resources/responses/responses';
 
 const encoder = new TextEncoder();
-const responseEvent: ResponseTextDeltaEvent = {
-  type: 'response.output_text.delta',
-  sequence_number: 0,
-  item_id: 'msg_test',
-  output_index: 0,
-  content_index: 0,
-  delta: 'hello',
-  logprobs: [],
-};
 
 function responseForSSE(value: string): Response {
   return new Response(ReadableStreamFrom([encoder.encode(value)]));
-}
-
-async function publicSSEStream(body: ReadableStream<Uint8Array>) {
-  const client = new OpenAI({
-    apiKey: 'test-key',
-    maxRetries: 0,
-    fetch: async () => new Response(body, { headers: { 'content-type': 'text/event-stream' } }),
-  });
-  return await client.responses.create({ model: 'gpt-4o', input: 'hello', stream: true });
 }
 
 async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
@@ -256,148 +237,6 @@ describe('Stream.fromSSEResponse', () => {
   });
 });
 
-describe('public Responses SSE iterator early exit', () => {
-  const event = responseEvent;
-  const wire = `data: ${JSON.stringify(event)}\n\n`;
-
-  test.each([
-    ['break', 'resolve'],
-    ['break', 'reject'],
-    ['return', 'resolve'],
-    ['return', 'reject'],
-  ] as const)('settles %s before deferred body cancellation can %s', async (method, settlement) => {
-    let finishCleanup!: () => void;
-    // oxlint-disable-next-line promise/avoid-new -- The native cancellation fixture must remain pending during early exit.
-    const cleanup = new Promise<void>((resolve, reject) => {
-      finishCleanup = () =>
-        settlement === 'resolve' ? resolve() : reject(new Error('synthetic cleanup failure'));
-    });
-    const cancel = vi.fn(() => cleanup);
-    const body = new ReadableStream<Uint8Array>({
-      start(source) {
-        source.enqueue(encoder.encode(wire));
-      },
-      cancel,
-    });
-    const stream = await publicSSEStream(body);
-    const unhandled = vi.fn();
-    let pending: Promise<unknown>;
-    if (method === 'break') {
-      pending = (async () => {
-        for await (const item of stream) {
-          expect(item).toEqual(event);
-          break;
-        }
-      })();
-    } else {
-      const iterator = stream[Symbol.asyncIterator]();
-      await expect(iterator.next()).resolves.toEqual({ done: false, value: event });
-      pending = Promise.resolve(iterator.return?.());
-    }
-    let settled = false;
-    const observed = (async () => {
-      try {
-        return await pending;
-      } catch (error) {
-        return error;
-      } finally {
-        settled = true;
-      }
-    })();
-    process.on('unhandledRejection', unhandled);
-
-    try {
-      await nextTurn();
-      expect(settled).toBe(true);
-      expect(stream.controller.signal.aborted).toBe(true);
-      expect(body.locked).toBe(false);
-      expect(cancel).toHaveBeenCalledTimes(1);
-      await expect(observed).resolves.toEqual(
-        method === 'break' ? undefined : { done: true, value: undefined },
-      );
-    } finally {
-      finishCleanup();
-      stream.controller.abort();
-      try {
-        await settlesSoon(observed);
-        await nextTurn();
-      } finally {
-        process.removeListener('unhandledRejection', unhandled);
-      }
-    }
-    expect(cancel).toHaveBeenCalledTimes(1);
-    expect(unhandled).not.toHaveBeenCalled();
-  });
-
-  test.each([false, true])(
-    'returning an unused iterator preserves the owner (started: %s)',
-    async (started) => {
-      const cancel = vi.fn();
-      const body = new ReadableStream<Uint8Array>({
-        start(source) {
-          source.enqueue(encoder.encode(`${wire}data: [DONE]\n\n`));
-        },
-        cancel,
-      });
-      const stream = await publicSSEStream(body);
-      const owner = stream[Symbol.asyncIterator]();
-      const unused = stream[Symbol.asyncIterator]();
-      if (started) {
-        await expect(owner.next()).resolves.toEqual({ done: false, value: event });
-      }
-      await expect(unused.return?.()).resolves.toEqual({ done: true, value: undefined });
-      expect(stream.controller.signal.aborted).toBe(false);
-      expect(cancel).not.toHaveBeenCalled();
-      expect(body.locked).toBe(started);
-      if (!started) {
-        await expect(owner.next()).resolves.toEqual({ done: false, value: event });
-      }
-      await expect(owner.next()).resolves.toEqual({ done: true, value: undefined });
-      expect(stream.controller.signal.aborted).toBe(false);
-      expect(body.locked).toBe(false);
-    },
-  );
-
-  test.each(['EOF', '[DONE]'])('return after %s does not abort a completed stream', async (ending) => {
-    const cancel = vi.fn();
-    const body = new ReadableStream<Uint8Array>({
-      start(source) {
-        source.enqueue(encoder.encode(`${wire}${ending === '[DONE]' ? 'data: [DONE]\n\n' : ''}`));
-        if (ending === 'EOF') {
-          source.close();
-        }
-      },
-      cancel,
-    });
-    const stream = await publicSSEStream(body);
-    const iterator = stream[Symbol.asyncIterator]();
-    await expect(iterator.next()).resolves.toEqual({ done: false, value: event });
-    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
-    await expect(iterator.return?.()).resolves.toEqual({ done: true, value: undefined });
-    expect(stream.controller.signal.aborted).toBe(false);
-    expect(body.locked).toBe(false);
-    expect(cancel).toHaveBeenCalledTimes(ending === 'EOF' ? 0 : 1);
-  });
-
-  test('preserves iterator throw identity with immediate body cleanup', async () => {
-    const cancel = vi.fn();
-    const body = new ReadableStream<Uint8Array>({
-      start(source) {
-        source.enqueue(encoder.encode(wire));
-      },
-      cancel,
-    });
-    const stream = await publicSSEStream(body);
-    const iterator = stream[Symbol.asyncIterator]();
-    await expect(iterator.next()).resolves.toEqual({ done: false, value: event });
-    const failure = new Error('synthetic consumer failure');
-    await expect(iterator.throw?.(failure)).rejects.toBe(failure);
-    expect(stream.controller.signal.aborted).toBe(true);
-    expect(body.locked).toBe(false);
-    expect(cancel).toHaveBeenCalledTimes(1);
-  });
-});
-
 describe('Stream.fromReadableStream', () => {
   test('parses newline-separated JSON while ignoring blank lines and flushing the final line', async () => {
     const readable = ReadableStreamFrom([encoder.encode('{"id":1}\n\n'), encoder.encode('{"id":2}')]);
@@ -506,7 +345,16 @@ describe('Stream.tee', () => {
 });
 
 describe('Stream.toReadableStream', () => {
-  const event = responseEvent;
+  const event: ResponseTextDeltaEvent = {
+    type: 'response.output_text.delta',
+    sequence_number: 0,
+    item_id: 'msg_test',
+    output_index: 0,
+    content_index: 0,
+    delta: 'hello',
+    logprobs: [],
+  };
+
   test('round-trips structured values as newline-delimited JSON', async () => {
     const original = new Stream(
       () =>

--- a/tests/lib/streaming-early-exit.test.ts
+++ b/tests/lib/streaming-early-exit.test.ts
@@ -1,0 +1,175 @@
+import { setImmediate as nextTurn } from 'node:timers/promises';
+import { vi } from 'vitest';
+import OpenAI from 'openai';
+import type { ResponseTextDeltaEvent } from 'openai/resources/responses/responses';
+
+const encoder = new TextEncoder();
+const responseEvent: ResponseTextDeltaEvent = {
+  type: 'response.output_text.delta',
+  sequence_number: 0,
+  item_id: 'msg_test',
+  output_index: 0,
+  content_index: 0,
+  delta: 'hello',
+  logprobs: [],
+};
+
+async function publicSSEStream(body: ReadableStream<Uint8Array>) {
+  const client = new OpenAI({
+    apiKey: 'test-key',
+    maxRetries: 0,
+    fetch: async () => new Response(body, { headers: { 'content-type': 'text/event-stream' } }),
+  });
+  return await client.responses.create({ model: 'gpt-4o', input: 'hello', stream: true });
+}
+
+function settlesSoon<T>(promise: Promise<T>): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  // oxlint-disable-next-line promise/avoid-new -- Bound regression fixtures that intentionally never settle.
+  const expired = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => reject(new Error('Aborted SSE stream did not settle')), 1500);
+  });
+  return Promise.race([promise, expired]).finally(() => clearTimeout(timeout));
+}
+
+describe('public Responses SSE iterator early exit', () => {
+  const event = responseEvent;
+  const wire = `data: ${JSON.stringify(event)}\n\n`;
+
+  test.each([
+    ['break', 'resolve'],
+    ['break', 'reject'],
+    ['return', 'resolve'],
+    ['return', 'reject'],
+  ] as const)('settles %s before deferred body cancellation can %s', async (method, settlement) => {
+    let finishCleanup!: () => void;
+    // oxlint-disable-next-line promise/avoid-new -- The native cancellation fixture must remain pending during early exit.
+    const cleanup = new Promise<void>((resolve, reject) => {
+      finishCleanup = () =>
+        settlement === 'resolve' ? resolve() : reject(new Error('synthetic cleanup failure'));
+    });
+    const cancel = vi.fn(() => cleanup);
+    const body = new ReadableStream<Uint8Array>({
+      start(source) {
+        source.enqueue(encoder.encode(wire));
+      },
+      cancel,
+    });
+    const stream = await publicSSEStream(body);
+    const unhandled = vi.fn();
+    let pending: Promise<unknown>;
+    if (method === 'break') {
+      pending = (async () => {
+        for await (const item of stream) {
+          expect(item).toEqual(event);
+          break;
+        }
+      })();
+    } else {
+      const iterator = stream[Symbol.asyncIterator]();
+      await expect(iterator.next()).resolves.toEqual({ done: false, value: event });
+      pending = Promise.resolve(iterator.return?.());
+    }
+    let settled = false;
+    const observed = (async () => {
+      try {
+        return await pending;
+      } catch (error) {
+        return error;
+      } finally {
+        settled = true;
+      }
+    })();
+    process.on('unhandledRejection', unhandled);
+
+    try {
+      await nextTurn();
+      expect(settled).toBe(true);
+      expect(stream.controller.signal.aborted).toBe(true);
+      expect(body.locked).toBe(false);
+      expect(cancel).toHaveBeenCalledTimes(1);
+      await expect(observed).resolves.toEqual(
+        method === 'break' ? undefined : { done: true, value: undefined },
+      );
+    } finally {
+      finishCleanup();
+      stream.controller.abort();
+      try {
+        await settlesSoon(observed);
+        await nextTurn();
+      } finally {
+        process.removeListener('unhandledRejection', unhandled);
+      }
+    }
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(unhandled).not.toHaveBeenCalled();
+  });
+
+  test.each([false, true])(
+    'returning an unused iterator preserves the owner (started: %s)',
+    async (started) => {
+      const cancel = vi.fn();
+      const body = new ReadableStream<Uint8Array>({
+        start(source) {
+          source.enqueue(encoder.encode(`${wire}data: [DONE]\n\n`));
+        },
+        cancel,
+      });
+      const stream = await publicSSEStream(body);
+      const owner = stream[Symbol.asyncIterator]();
+      const unused = stream[Symbol.asyncIterator]();
+      if (started) {
+        await expect(owner.next()).resolves.toEqual({ done: false, value: event });
+      }
+      await expect(unused.return?.()).resolves.toEqual({ done: true, value: undefined });
+      expect(stream.controller.signal.aborted).toBe(false);
+      expect(cancel).not.toHaveBeenCalled();
+      expect(body.locked).toBe(started);
+      if (!started) {
+        await expect(owner.next()).resolves.toEqual({ done: false, value: event });
+      }
+      await expect(owner.next()).resolves.toEqual({ done: true, value: undefined });
+      expect(stream.controller.signal.aborted).toBe(false);
+      expect(body.locked).toBe(false);
+    },
+  );
+
+  test.each(['EOF', '[DONE]'])('return after %s does not abort a completed stream', async (ending) => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({
+      start(source) {
+        source.enqueue(encoder.encode(`${wire}${ending === '[DONE]' ? 'data: [DONE]\n\n' : ''}`));
+        if (ending === 'EOF') {
+          source.close();
+        }
+      },
+      cancel,
+    });
+    const stream = await publicSSEStream(body);
+    const iterator = stream[Symbol.asyncIterator]();
+    await expect(iterator.next()).resolves.toEqual({ done: false, value: event });
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+    await expect(iterator.return?.()).resolves.toEqual({ done: true, value: undefined });
+    expect(stream.controller.signal.aborted).toBe(false);
+    expect(body.locked).toBe(false);
+    expect(cancel).toHaveBeenCalledTimes(ending === 'EOF' ? 0 : 1);
+  });
+
+  test('preserves iterator throw identity with immediate body cleanup', async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({
+      start(source) {
+        source.enqueue(encoder.encode(wire));
+      },
+      cancel,
+    });
+    const stream = await publicSSEStream(body);
+    const iterator = stream[Symbol.asyncIterator]();
+    await expect(iterator.next()).resolves.toEqual({ done: false, value: event });
+    const failure = new Error('synthetic consumer failure');
+    await expect(iterator.throw?.(failure)).rejects.toBe(failure);
+    expect(stream.controller.signal.aborted).toBe(true);
+    expect(body.locked).toBe(false);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/lib/streaming-early-exit.test.ts
+++ b/tests/lib/streaming-early-exit.test.ts
@@ -60,6 +60,7 @@ describe('public Responses SSE iterator early exit', () => {
     let pending: Promise<unknown>;
     if (method === 'break') {
       pending = (async () => {
+        // oxlint-disable-next-line no-unreachable-loop -- Exercise for-await cleanup after one event.
         for await (const item of stream) {
           expect(item).toEqual(event);
           break;


### PR DESCRIPTION
## Summary

Fix a response-backed SSE iterator lifecycle hang: after receiving an event, breaking from `for await` or returning the iterator could wait indefinitely for asynchronous body cancellation before the request controller was aborted.

Abort before the locally owned SSE-message iterator begins nested cleanup. This reuses the existing abort-aware cleanup and completion-sentinel state; normal EOF and `[DONE]`, unused/completed iterators, original errors, and tee sibling ownership are preserved.

This is a nine-line production change plus focused public-API regressions. No parser, buffering, timeout, generated code, public declaration, dependency, or retry changes. Native async-generator return queued behind an unresolved next remains outside this fix.

## Review follow-up (`626aa57b`)

Moved the nine public Responses early-exit lifecycle cases and their setup into `tests/lib/streaming-early-exit.test.ts`, addressing the maintainability review. All executable test code and helper declarations are unchanged. `tests/lib/streaming-core.test.ts` is byte-identical to the PR base (961 lines), so it is no longer part of the overall PR diff. Production code is unchanged from the initial implementation.

CI identified that the deliberate one-event `for await` loop had moved outside an existing filename-scoped lint exception. A single documented next-line `no-unreachable-loop` exception preserves that regression without changing the loop or broadening lint policy. The initial local check used the pinned linter binary with an older shared Ultracite preset; final validation below uses a clean, frozen installation of the complete pinned toolchain.

- The relocated suite retained its original before-fix detection on base `31bf7e79`: four expected deferred-cancellation failures and five passing controls.
- Final full canonical handwritten unit run: **7,540/7,540 tests passed across 191 files**, using Node 24.19.0 and pinned Vitest 4.1.11. The earlier cached-formatter failure is absent with the complete pinned installation.
- The combined core and early-exit suites passed all **75 tests** (66 core + 9 early-exit) on Node 22.22.3, 24.19.0, and 26.7.0 with Vitest 4.1.11.
- Full canonical `./scripts/lint`, TypeScript 6.0.3 checking, and whitespace checks passed with Ultracite 7.10.5, Oxfmt 0.62.0, and Oxlint 1.79.0. Normal `pnpm 11.5.1 install --frozen-lockfile` retained all dependency and supply-chain policies; no dependency or configuration files changed.
- Repeated adversarial self-review and independent equivalence reviews confirmed unchanged assertions, error identity, cancellation ordering, listener cleanup, imports, and test discovery. Both test paths are wholly handwritten.

The updated head is also subject to the repository's full CI. The implementation-level results below were collected before this test-only extraction.

## Initial implementation verification (`194a49a6`)

- Four new public `responses.create({ stream: true })` regressions failed on clean main before the fix; all nine new lifecycle cases now pass.
- 177 focused streaming tests pass on Node 22.22.2 and 24.19.0, including tee, SSE sentinel/error/privacy, and Bedrock Runtime coverage. The original combined streaming-core suite passed 75/75.
- 150 independent built-package checks pass across CJS/ESM and exact Node 22.0.0, 24.19.0, and 26.7.0. They cover public Responses/chat, ordinary/thread/synthesized SSE, pending/rejecting/throwing cleanup, error identity, locks/listeners, ordinary/nested tees, and real native-fetch loopback disconnects. All 30 baseline hang cases were reproduced before rebuilding.
- Canonical build, full TypeScript check, pinned Oxfmt 0.62.0, cached Oxlint 1.76.0, and whitespace checks pass. Root and core-streaming CJS/ESM declarations are byte-identical to main. All 24 streaming benchmarks completed successfully; no performance comparison is claimed.
- Final complete handwritten unit run: **7,539 passed / 7,540 total**. The sole failure also reproduces on untouched main: the cached formatter fixture leaves an assignment unformatted. Local dependencies contain Vitest 4.1.10 rather than pinned 4.1.11, and Oxlint 1.76.0 rather than pinned 1.79.0; pinned CI remains authoritative.

## Adversarial review

Independent reviews checked security, compatibility, cancellation/error ordering, `[DONE]`, unstarted/unused/completed iterators, cleanup rejection observation, and tee ownership. Test cleanup was tightened to guarantee listener removal on failures and assert exactly-once cancellation after delayed cleanup settles. No blocking findings remain.