### PR TITLE
fix(examples): report unsuccessful fine-tuning jobs

### DIFF
--- a/examples/fine-tuning/fine-tuning.ts
+++ b/examples/fine-tuning/fine-tuning.ts
@@ -76,6 +76,10 @@ async function main() {
 
     await new Promise((resolve) => setTimeout(resolve, 5000));
   }
+
+  if (fineTune.status !== 'succeeded') {
+    throw new Error('Fine-tuning job did not complete successfully.');
+  }
 }
 
 main().catch((err) => {

--- a/tests/lib/fine-tuning-example.test.ts
+++ b/tests/lib/fine-tuning-example.test.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { inspect } from 'node:util';
 import { runInNewContext } from 'node:vm';
 import ts from 'typescript';
 import { vi } from 'vitest';
@@ -8,6 +9,7 @@ import type { FileObject } from 'openai/resources/files';
 import type { FineTuningJob } from 'openai/resources/fine-tuning';
 
 type Status = FineTuningJob['status'];
+const privateErrorDetail = 'Synthetic private fine-tuning error detail';
 const filename = 'examples/fine-tuning/fine-tuning.ts';
 const source = ts.transpileModule(fs.readFileSync(filename, 'utf-8'), {
   compilerOptions: {
@@ -43,7 +45,8 @@ async function executeExample(
     id: 'ftjob_test',
     object: 'fine_tuning.job',
     created_at: 0,
-    error: null,
+    error:
+      status === 'failed' ? { code: 'synthetic_failure', message: privateErrorDetail, param: null } : null,
     fine_tuned_model: null,
     finished_at: null,
     hyperparameters: { n_epochs: 'auto' },
@@ -126,8 +129,20 @@ async function executeExample(
 
 async function runExample(initialStatus: Status, followingStatuses: Status[]) {
   const { requests, waits, log, error, exit } = await executeExample(initialStatus, followingStatuses);
-  expect(error).not.toHaveBeenCalled();
-  expect(exit).not.toHaveBeenCalled();
+  // oxlint-disable-next-line unicorn/prefer-at -- Keep indexed access compatible with the repository's ES2020 type library.
+  const finalStatus = followingStatuses[followingStatuses.length - 1] ?? initialStatus;
+  if (finalStatus === 'succeeded') {
+    expect(error).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  } else {
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Fine-tuning job did not complete successfully.' }),
+    );
+    expect(exit).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(1);
+  }
+  expect(inspect([log.mock.calls, error.mock.calls], { depth: null })).not.toContain(privateErrorDetail);
   expect(requests.filter((request) => request === 'POST /fine_tuning/jobs')).toHaveLength(1);
   expect(requests.filter((request) => request === 'GET /fine_tuning/jobs/ftjob_test')).toHaveLength(
     followingStatuses.length,
@@ -186,6 +201,10 @@ test.each<Status>(['succeeded', 'failed', 'cancelled'])(
   },
 );
 
-test.each<Status>(['failed', 'cancelled'])('stops when validation ends with %s', async (status) => {
-  await runExample('validating_files', [status]);
+test.each(
+  (['validating_files', 'queued', 'running'] as const).flatMap((initialStatus) =>
+    (['failed', 'cancelled'] as const).map((status) => ({ initialStatus, status })),
+  ),
+)('stops when $initialStatus ends with $status', async ({ initialStatus, status }) => {
+  await runExample(initialStatus, [status]);
 });


### PR DESCRIPTION
## Summary

Make the fine-tuning example exit unsuccessfully when a job finishes as `failed` or `cancelled`. Its polling loop already stops for both states, but the script then returns normally and reports exit code 0.

Add a four-line check after the existing loop: only `succeeded` is successful. Other terminal outcomes raise a fixed diagnostic through the existing `main().catch(...)` handler and exit with code 1. The message does not include `fineTune.error` or training data.

Polling states, intervals, event reporting, file handling, model parameters, and successful behavior are unchanged. Only the handwritten example and its existing regression suite change; there are no SDK, generated-code, dependency, or public API changes.

## Verification

- Updated the existing actual-example/public-SDK harness rather than introducing a replacement polling loop. Eight failure cases failed before the fix, while seven successful/file-processing controls passed; all 15 scenarios now pass on Node 22.22.2 and 24.19.0.
- Cover initially failed/cancelled jobs and transitions from each active state (`validating_files`, `queued`, `running`), retaining exact request, event, and timer assertions.
- Independent real-subprocess checks passed all 18 scenarios on exact Node 22.0.0, 24.19.0, and 26.7.0. Initial and queued terminal states preserve their three/five requests and the real five-second polling wait. Before the fix, all 12 failed/cancelled cases incorrectly exited 0; succeeded controls remain unchanged.
- All uploads and job requests were synthetic and loopback-only. Both output channels were checked for private error details; no live fine-tuning job was created.
- Normal full-project `tsc --noEmit`, pinned Oxfmt 0.62.0 and Oxlint 1.79.0, and whitespace checks pass. The focused suite uses cached Vitest 4.1.10; CI will run the pinned 4.1.11 environment.

## Adversarial review

Three independent reviews checked the complete status contract, initial and polled terminal outcomes, existing file failures, request counts, timing, privacy, and compatibility. Review tightened the privacy assertion to cover stdout and stderr and kept indexed test access compatible with the repository's ES2020 type library. The final diff has no blocking findings and introduces no new polling state or helper infrastructure.