### PR TITLE
fix(examples): reject incomplete image streams

### DIFF
--- a/examples/images/image-stream.ts
+++ b/examples/images/image-stream.ts
@@ -16,6 +16,7 @@ const main = async () => {
     partial_images: 3,
   });
 
+  let receivedFinalImage = false;
   for await (const event of stream) {
     let filename: string;
     let imageBuffer: Buffer;
@@ -39,6 +40,7 @@ const main = async () => {
         filename = 'final_image.png';
         imageBuffer = Buffer.from(event.b64_json, 'base64');
         fs.writeFileSync(filename, imageBuffer);
+        receivedFinalImage = true;
         console.log(`    Saved to: ${path.resolve(filename)}`);
         break;
       }
@@ -46,6 +48,10 @@ const main = async () => {
         console.log(`❓ Unknown event: ${event}`);
       }
     }
+  }
+
+  if (!receivedFinalImage) {
+    throw new Error('Image stream ended without a final image.');
   }
 };
 

--- a/tests/lib/image-streaming-example.test.ts
+++ b/tests/lib/image-streaming-example.test.ts
@@ -57,10 +57,21 @@ async function runExample(directory: string, baseURL: string) {
 }
 
 describe('image-streaming executable example', () => {
-  test.each(['HTTP rejection', 'SSE error', 'output write failure', 'success'] as const)(
-    'reports the process result for %s',
+  test.each([
+    'HTTP rejection',
+    'SSE error',
+    'output write failure',
+    'success',
+    'empty EOF',
+    'partial-only EOF',
+    'completed without partial',
+  ] as const)(
+    'reports the executable process result, output image files, and diagnostics for %s',
     async (scenario) => {
       const directory = await mkdtemp(path.join(tmpdir(), 'openai-image-stream-example-'));
+      const incomplete = scenario === 'empty EOF' || scenario === 'partial-only EOF';
+      const hasPartial =
+        scenario !== 'HTTP rejection' && scenario !== 'empty EOF' && scenario !== 'completed without partial';
       const requests: {
         method: string | undefined;
         url: string | undefined;
@@ -80,13 +91,19 @@ describe('image-streaming executable example', () => {
         }
 
         response.writeHead(200, { 'content-type': 'text/event-stream', connection: 'close' });
-        response.write(
-          `data: ${JSON.stringify({
-            type: 'image_generation.partial_image',
-            partial_image_index: 0,
-            b64_json: partialImage.toString('base64'),
-          })}\n\n`,
-        );
+        if (hasPartial) {
+          response.write(
+            `data: ${JSON.stringify({
+              type: 'image_generation.partial_image',
+              partial_image_index: 0,
+              b64_json: partialImage.toString('base64'),
+            })}\n\n`,
+          );
+        }
+        if (incomplete) {
+          response.end();
+          return;
+        }
         response.end(
           scenario === 'SSE error'
             ? `event: error\ndata: ${JSON.stringify({ error: failure })}\n\n`
@@ -117,16 +134,26 @@ describe('image-streaming executable example', () => {
             authorization: 'Bearer synthetic-image-example-key',
           },
         ]);
-        if (scenario === 'HTTP rejection') {
+        if (scenario === 'HTTP rejection' || scenario === 'empty EOF') {
           expect(await readdir(directory)).toEqual([]);
-        } else {
+        } else if (hasPartial) {
           expect(await readFile(path.join(directory, 'partial_1.png'))).toEqual(partialImage);
+        } else {
+          expect(await readdir(directory)).toEqual(['final_image.png']);
         }
-        if (scenario === 'success') {
+        if (scenario === 'success' || scenario === 'completed without partial') {
           expect(await readFile(path.join(directory, 'final_image.png'))).toEqual(finalImage);
           expect(result.stdout).toContain('Saved to:');
           expect(result.stderr).toBe('');
           expect(result.code).toBe(0);
+        } else if (incomplete) {
+          expect(result.code).toBe(1);
+          expect(result.stderr).toContain('Error generating image:');
+          expect(result.stderr).toContain('Image stream ended without a final image.');
+          expect(await readdir(directory)).toEqual(hasPartial ? ['partial_1.png'] : []);
+          expect(result.stdout + result.stderr).not.toContain(partialImage.toString('base64'));
+          expect(result.stdout + result.stderr).not.toContain(finalImage.toString('base64'));
+          expect(result.stdout + result.stderr).not.toContain('synthetic-image-example-key');
         } else {
           expect(result.stderr).toContain('Error generating image:');
           expect(result.stderr).toContain(


### PR DESCRIPTION
## Summary

Make the image-streaming example reject clean EOF when it has not received and saved a final image. An empty stream or a stream containing only partial images currently exits with code 0 despite producing no final image.

Add one local completion flag, set only after the `image_generation.completed` event's file write succeeds, and check it after iteration. Incomplete streams now use the existing catch handler and exit with code 1, with the fixed diagnostic `Image stream ended without a final image.` Partial files remain available.

Completion does not depend on receiving all three requested partial images: the API contract allows the final image to arrive earlier. SDK EOF semantics, request parameters, image formats, filenames, and existing HTTP/SSE/filesystem errors are unchanged. Only the handwritten example and its existing test file change; no generated code or dependencies are modified.

## Verification

- Added empty-EOF and partial-only-EOF regressions plus a completed-without-partials success control to the existing real-HTTP/subprocess suite. Before the fix, the two new failure cases failed and all five controls passed.
- All seven scenarios passed on exact Node 22.0.0, 24.19.0, and 26.7.0: 21 real-process checks using the actual TypeScript example and public SDK. Existing HTTP errors, SSE errors, write failures, partial/final file bytes, and successful completion remain covered.
- Independent public-example checks also confirmed that receiving all three partial images without a final event still fails, while completion with zero or one partial succeeds.
- New failure cases verify a nonzero exit, no final-image file, retained partial output, and diagnostics without encoded image data or credentials. All network traffic and image fixtures were synthetic and local; no live image generation occurred.
- Normal full-project TypeScript checking, pinned Oxfmt 0.62.0 and Oxlint 1.79.0, and whitespace checks pass. Local Vitest is 4.1.10; CI will exercise the pinned 4.1.11 environment.

## Adversarial review

Three independent reviews checked completion ordering, early final events, existing error preservation, output-file behavior, privacy, runtime compatibility, and subprocess/server cleanup. The flag is set only after a successful final write and adds no parser, count requirement, size limit, cancellation policy, or shared state. Final review found no blocking issues.