### PR TITLE
test: make release publisher fixture portable without jq

### DIFF
--- a/tests/release-publish-workflow.test.ts
+++ b/tests/release-publish-workflow.test.ts
@@ -114,6 +114,27 @@ describe('trusted npm release publication', () => {
             'process.exit(91);',
           ].join('\n'),
         );
+        if (spawnSync('jq', ['--version']).status !== 0) {
+          writeExecutable(
+            path.join(executableDirectory, 'jq'),
+            [
+              "const fs = require('node:fs');",
+              'const args = process.argv.slice(2);',
+              "const expression = args.find((arg) => !arg.startsWith('-'));",
+              'const filename = expression && args[args.indexOf(expression) + 1];',
+              "const input = fs.readFileSync(filename || 0, 'utf-8');",
+              'const value = JSON.parse(input);',
+              'let output;',
+              "if (expression === '.') output = value;",
+              "else if (expression === '.name') output = value.name;",
+              "else if (expression === '.version') output = value.version;",
+              "else if (expression === '.error.code == \"E404\"') output = value?.error?.code === 'E404';",
+              "else throw new Error('Unsupported jq expression: ' + expression);",
+              "if (args.includes('-e') && (output === false || output == null)) process.exit(1);",
+              "process.stdout.write(typeof output === 'string' && args.includes('-r') ? output : JSON.stringify(output));",
+            ].join('\n'),
+          );
+        }
 
         const env = {
           ...process.env,


### PR DESCRIPTION
## Problem

On a supported Windows contributor checkout without a host `jq` binary, the existing historical release-publisher cases in `tests/release-publish-workflow.test.ts` fail before they exercise the captured publisher:

```text
./bin/check-npm-version: line 7: jq: command not found
Test Files  1 failed (1)
Tests  3 failed | 1 passed (4)
```

`jq` is not a documented repository setup prerequisite. The test already supplies controlled `npm` and `pnpm` executables, but still depends on the host for JSON evaluation.

## Root cause

The fixture executes the real `bin/publish-npm` and `bin/check-npm-version` scripts. Those scripts invoke four small `jq` expressions, while the fixture does not provide `jq` when it is absent from the contributor environment.

## Fix

Provide a fixture-local Node executable when `jq --version` is unavailable. It implements only the exact controlled expressions used by the captured publisher and fails on any unexpected expression. Environments with a real `jq` continue using it.

## Tests

Windows 11, Node 24.19.0, pnpm 11.5.1:

- Baseline `./scripts/test tests/release-publish-workflow.test.ts`: 3 failed / 1 passed (`jq: command not found`).
- Fixed `./scripts/test tests/release-publish-workflow.test.ts`: 4 passed.
- `pnpm install --frozen-lockfile`: passed, including supply-chain policy verification.
- `pnpm lint`: passed.
- `pnpm exec tsc --noEmit`: passed.
- `pnpm build`: passed, including CJS/ESM and Bedrock import checks.
- `git diff --check`: passed.

A broader pre-fix `pnpm test:unit` run completed with 7,490 passed and 80 failed. Three failures were the cases fixed here; the remaining failures are in unrelated Windows-sensitive Cloudflare credential, child-process, X.509 timing, and mock-cleanup suites. This PR does not weaken or skip those tests, and does not claim the full Windows unit suite passes.

## Compatibility / Risk

Test-only change; no SDK runtime, declarations, generated code, workflow, dependency, lockfile, or release behavior changes. The fallback is used only when host `jq` is unavailable, accepts synthetic fixture data only, and rejects unsupported expressions.

Duplicate search found no equivalent open PR. #2589 also edits this test file for separate release-CI gate coverage, but does not make the existing historical publisher fixture independent of a host `jq` installation.