### PR TITLE
fix(build): postprocess the selected package manifest

### DIFF
--- a/scripts/utils/postprocess-files.cjs
+++ b/scripts/utils/postprocess-files.cjs
@@ -5,6 +5,7 @@ const path = require('node:path');
 const distDir = process.env['DIST_PATH']
   ? path.resolve(process.env['DIST_PATH'])
   : path.resolve(__dirname, '..', '..', 'dist');
+const packageJsonPath = path.join(distDir, 'package.json');
 
 async function* walk(dir) {
   for await (const d of await fs.promises.opendir(dir)) {
@@ -138,11 +139,11 @@ async function postprocess() {
     }
   }
   await fs.promises.writeFile(
-    'dist/package.json',
+    packageJsonPath,
     JSON.stringify(
       Object.assign(
         /** @type {Record<String, unknown>} */ (
-          JSON.parse(await fs.promises.readFile('dist/package.json', 'utf-8'))
+          JSON.parse(await fs.promises.readFile(packageJsonPath, 'utf-8'))
         ),
         {
           exports: newExports,

--- a/tests/postprocess-files.test.ts
+++ b/tests/postprocess-files.test.ts
@@ -1,0 +1,124 @@
+import { execFile } from 'node:child_process';
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+const execute = promisify(execFile);
+const sourceScript = path.resolve('scripts/utils/postprocess-files.cjs');
+
+test.each([
+  'absolute override',
+  'relative override',
+  'script-relative default',
+  'missing cwd dist',
+  'missing selected package',
+  'canonical default',
+] as const)('postprocesses only the selected output with %s', async (scenario) => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'openai-postprocess-'));
+  const project = path.join(directory, 'project space');
+  const canonical = scenario === 'canonical default';
+  const cwd = canonical ? project : path.join(directory, 'caller space');
+  const override = scenario !== 'script-relative default' && !canonical;
+  const dist = path.join(project, override ? 'alternate dist' : 'dist');
+  const script = path.join(project, 'scripts/utils/postprocess-files.cjs');
+  const unrelatedPackage = path.join(cwd, 'dist/package.json');
+  const unrelatedBytes = '{"name":"unrelated-package","exports":{"./untouched":"./untouched.js"}}\n';
+  const hasUnrelatedPackage = !canonical && scenario !== 'missing cwd dist';
+  const reference = '/// <reference lib="dom" />';
+  const declaration = 'export declare const value: string;\n';
+  const canonicalState =
+    '"use strict";\nexports.state = {};\n//# sourceMappingURL=x509-transport-state.cjs.map\n';
+  const sourceMap = '{"version":3,"sources":["src/index.ts"],"names":[],"mappings":""}\n';
+  const source = 'export const value = "synthetic source";\n';
+
+  try {
+    await mkdir(path.dirname(script), { recursive: true });
+    await mkdir(cwd, { recursive: true });
+    await copyFile(sourceScript, script);
+    const files = {
+      'package.json': JSON.stringify({
+        name: 'synthetic-target',
+        version: '0.0.0',
+        custom: { preserved: true },
+        exports: { './stale': './stale.js' },
+      }),
+      'index.js': "const state = require('#x509-transport-state');\n//# sourceMappingURL=index.js.map\n",
+      'index.mjs': "import state from '#x509-transport-state';\n//# sourceMappingURL=index.mjs.map\n",
+      'index.d.ts': `${reference}\n${declaration}`,
+      'index.js.map': sourceMap,
+      'src/index.ts': source,
+      'internal/auth/x509-transport-state.cjs': canonicalState,
+    };
+    await Promise.all(
+      Object.entries(files).map(async ([file, contents]) => {
+        if (file === 'package.json' && scenario === 'missing selected package') {
+          return;
+        }
+        const target = path.join(dist, file);
+        await mkdir(path.dirname(target), { recursive: true });
+        await writeFile(target, contents);
+      }),
+    );
+    if (hasUnrelatedPackage) {
+      await mkdir(path.dirname(unrelatedPackage), { recursive: true });
+      await writeFile(unrelatedPackage, unrelatedBytes);
+    }
+
+    const distPath = scenario === 'relative override' ? path.relative(cwd, dist) : dist;
+    const postprocess = execute(process.execPath, [script], {
+      cwd,
+      env: {
+        CI: 'true',
+        SystemRoot: process.env['SystemRoot'],
+        ...(override ? { DIST_PATH: distPath } : {}),
+      },
+      timeout: 15_000,
+    });
+    if (scenario === 'missing selected package') {
+      await expect(postprocess).rejects.toMatchObject({
+        code: 1,
+        stderr: expect.stringContaining('ENOENT'),
+      });
+      expect(await readFile(unrelatedPackage, 'utf-8')).toBe(unrelatedBytes);
+      return;
+    }
+    await postprocess;
+
+    const manifest = JSON.parse(await readFile(path.join(dist, 'package.json'), 'utf-8'));
+    expect(manifest).toMatchObject({
+      name: 'synthetic-target',
+      version: '0.0.0',
+      custom: { preserved: true },
+    });
+    expect(manifest.exports['.']).toEqual({
+      require: { types: './index.d.ts', default: './index.js' },
+      types: './index.d.mts',
+      default: './index.mjs',
+    });
+    expect(manifest.exports['./index']).toEqual({ import: './index.mjs', require: './index.js' });
+    expect(manifest.exports['./stale']).toBeUndefined();
+    expect(manifest.exports['./internal/*']).toBeUndefined();
+    expect(manifest.exports['./src/*']).toBeUndefined();
+    if (hasUnrelatedPackage) {
+      expect(await readFile(unrelatedPackage, 'utf-8')).toBe(unrelatedBytes);
+    }
+    expect(await readFile(path.join(dist, 'index.js'), 'utf-8')).toBe(
+      "const state = require('./internal/auth/x509-transport-state.js');\n//# sourceMappingURL=index.js.map\n",
+    );
+    expect(await readFile(path.join(dist, 'index.mjs'), 'utf-8')).toBe(
+      "import state from './internal/auth/x509-transport-state.mjs';\n//# sourceMappingURL=index.mjs.map\n",
+    );
+    expect(await readFile(path.join(dist, 'index.d.ts'), 'utf-8')).toBe(
+      `${' '.repeat(reference.length)}\n${declaration}`,
+    );
+    expect(await readFile(path.join(dist, 'index.js.map'), 'utf-8')).toBe(sourceMap);
+    expect(await readFile(path.join(dist, 'src/index.ts'), 'utf-8')).toBe(source);
+    expect(await readFile(path.join(dist, 'internal/auth/x509-transport-state.cjs'), 'utf-8')).toBe(
+      canonicalState,
+    );
+    expect(await readFile(script)).toEqual(await readFile(sourceScript));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Make the package postprocessor read and write `package.json` inside its already-resolved output directory.

The script honors `DIST_PATH` (or its script-relative `dist` default) when rewriting files and discovering exports, but its final manifest operations use the literal, cwd-relative `dist/package.json`. An alternate output directory or invocation from another working directory therefore leaves the intended package's exports stale and can overwrite an unrelated package's exports. If the unrelated path does not exist, postprocessing fails even though the selected output is valid.

Resolve one manifest path from `distDir` and reuse it for both operations. This is a three-line production change; export-map construction, file rewriting, and the canonical build command are unchanged. No generated SDK files, public SDK APIs, dependencies, or generation metadata change.

## Regression coverage

The tests copy the actual script byte-for-byte into disposable project fixtures and execute it in a native Node subprocess. They cover:

- Absolute and relative `DIST_PATH` values, including spaces in paths.
- The script-relative default when invoked from another working directory.
- A valid selected output without any `cwd/dist/package.json`.
- A missing selected manifest: fail with `ENOENT` and leave an unrelated manifest untouched.
- The normal repository-root build as a compatibility control.

All five failure modes were reproduced before the fix; the canonical control already passed. The tests verify the selected manifest's metadata and exports, unrelated manifest bytes, existing CommonJS/ESM private-state rewrites, declaration padding, and unchanged source-map/source files. No repository output or shared dependencies are used as writable fixtures.

## Verification

- All six focused subprocess tests pass on exact Node 22.0.0, 24.19.0, and 26.7.0.
- Independent before/after artifact checks cover the same six scenarios across all three runtimes; an additional review covers symlinked output directories.
- Fresh canonical builds on Node 24.19.0 are byte-for-byte identical before and after the change: all 2,953 output files, including package metadata and declarations.
- The existing packed-package suite passes on Node 22.22.3 and 24.19.0, including CommonJS, ESM, ES2020 browser bundling, type/export checks, and 1,302 source maps.
- Packed CommonJS and ESM authentication checks pass on the exact Node 22.0.0 floor with the supported Undici 7 dependency line.
- Normal full-project `tsc --noEmit`, pinned Oxfmt 0.62.0 and Oxlint 1.79.0, JavaScript syntax checking, and whitespace checks pass.

Local focused tests use cached Vitest 4.1.10; repository CI will verify the pinned 4.1.11 environment.

## Adversarial review

Independent reviews checked default and overridden directory selection, relative paths, symlink behavior, metadata preservation, private export exclusions, error propagation, and temporary-fixture cleanup. A final review added the missing-selected-manifest failure control and rechecked it. Both manifest operations now share the same directory as the existing file transformations, without changing parsing or export-map logic.
