### PR TITLE
fix(build): narrow Git-install staging detection

### DIFF
--- a/scripts/utils/check-is-in-git-install.sh
+++ b/scripts/utils/check-is-in-git-install.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-# Check if you happen to call prepare for a repository that's already in node_modules.
-[ "$(basename "$(dirname "$PWD")")" = 'node_modules' ] ||
-# The name of the containing directory that 'npm` uses, which looks like
-# $HOME/.npm/_cacache/git-cloneXXXXXX
-[ "$(basename "$(dirname "$PWD")")" = 'tmp' ] ||
-# The name of the containing directory that some package managers use, e.g. .tmp/XXXXX
-[ "$(basename "$(dirname "$PWD")")" = '.tmp' ]
+# Keep installed packages and the staging names used by npm, pnpm, and Yarn Classic.
+# A tmp or .tmp parent alone does not identify a disposable Git-install checkout.
+parent="${PWD%/*}"
+case "${parent##*/}/${PWD##*/}" in
+  node_modules/* | tmp/git-clone* | tmp/_tmp_* | .tmp/*.prepare)
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac

--- a/tests/git-install-scripts.test.ts
+++ b/tests/git-install-scripts.test.ts
@@ -1,0 +1,127 @@
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const {
+  scripts: { prepare },
+} = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf-8'));
+const describeBash = process.platform === 'win32' ? describe.skip : describe;
+const checkoutFiles = {
+  '.git/HEAD': 'ref: refs/heads/local-work\n',
+  'tests/local.test.ts': 'export const localTest = true;\n',
+  'local-notes.txt': 'untracked developer notes\n',
+  'src/index.ts': 'export const source = true;\n',
+};
+const builtPackage = JSON.stringify({ name: 'git-install-fixture', version: '1.0.0', main: 'index.js' });
+const builtModule = "module.exports = require('fixture-dependency');\n";
+const dependency = "module.exports = 'compiled fixture\\n';\n";
+
+describeBash('Git install prepare scripts', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'openai git-install-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function runPrepare(layout: string): string {
+    const cwd = path.join(root, layout);
+    const files = {
+      ...checkoutFiles,
+      'package.json': JSON.stringify({ name: 'git-install-fixture', scripts: { prepare } }),
+      'dist/package.json': builtPackage,
+      'dist/index.js': builtModule,
+      'node_modules/fixture-dependency/index.js': dependency,
+    };
+    for (const [filename, contents] of Object.entries(files)) {
+      const target = path.join(cwd, filename);
+      mkdirSync(path.dirname(target), { recursive: true });
+      writeFileSync(target, contents);
+    }
+    mkdirSync(path.join(cwd, 'scripts/utils'), { recursive: true });
+    for (const script of ['check-is-in-git-install.sh', 'git-swap.sh']) {
+      const target = path.join(cwd, 'scripts/utils', script);
+      copyFileSync(path.join(repoRoot, 'scripts/utils', script), target);
+      chmodSync(target, 0o755);
+    }
+    // Only the successful build is stubbed; preparation uses the real lifecycle
+    // command, detector, and artifact promotion script from this checkout.
+    writeFileSync(
+      path.join(cwd, 'scripts/build'),
+      '#!/usr/bin/env bash\nset -eu\ntest -f dist/package.json\nprintf "built\\n" >> "$BUILD_LOG"\n',
+      { mode: 0o755 },
+    );
+    const result = spawnSync('bash', ['-c', prepare], {
+      cwd,
+      env: { PATH: process.env['PATH'], BUILD_LOG: path.join(root, 'build.log') },
+      encoding: 'utf-8',
+      timeout: 10_000,
+    });
+    expect(result.error).toBeUndefined();
+    expect({
+      status: result.status,
+      output: result.status === 0 ? '' : result.stdout + result.stderr,
+    }).toEqual({ status: 0, output: '' });
+    expect(readFileSync(path.join(cwd, 'node_modules/fixture-dependency/index.js'), 'utf-8')).toBe(
+      dependency,
+    );
+    return cwd;
+  }
+
+  test.each([
+    'work/openai',
+    'tmp/openai',
+    '.tmp/openai',
+    'tmp/git-clone-parent/project',
+    '.tmp/project.prepare\n',
+    'tmp\n/git-cloneABC123',
+  ])('retains an ordinary checkout at %j', (layout) => {
+    const cwd = runPrepare(layout);
+    for (const [filename, contents] of Object.entries(checkoutFiles)) {
+      expect(readFileSync(path.join(cwd, filename), 'utf-8')).toBe(contents);
+    }
+    expect(JSON.parse(readFileSync(path.join(cwd, 'package.json'), 'utf-8')).scripts.prepare).toBe(prepare);
+    expect(readFileSync(path.join(cwd, 'dist/package.json'), 'utf-8')).toBe(builtPackage);
+    expect(readFileSync(path.join(cwd, 'dist/index.js'), 'utf-8')).toBe(builtModule);
+    expect(existsSync(path.join(cwd, 'index.js'))).toBe(false);
+    expect(existsSync(path.join(root, 'build.log'))).toBe(false);
+  });
+
+  test.each([
+    'tmp/git-cloneABC123',
+    'tmp/_tmp_123_abcd',
+    '.tmp/repository.commit.prepare',
+    'node_modules/openai',
+  ])('promotes the built package in Git dependency staging at %s', (layout) => {
+    const cwd = runPrepare(layout);
+    expect(readFileSync(path.join(root, 'build.log'), 'utf-8')).toBe('built\n');
+    expect(readFileSync(path.join(cwd, 'package.json'), 'utf-8')).toBe(builtPackage);
+    expect(readFileSync(path.join(cwd, 'index.js'), 'utf-8')).toBe(builtModule);
+    for (const filename of [...Object.keys(checkoutFiles), 'dist', 'scripts']) {
+      expect(existsSync(path.join(cwd, filename))).toBe(false);
+    }
+    const loaded = spawnSync(process.execPath, ['-e', 'process.stdout.write(require(process.cwd()))'], {
+      cwd,
+      encoding: 'utf-8',
+      timeout: 10_000,
+    });
+    expect(loaded.error).toBeUndefined();
+    expect(loaded.status).toBe(0);
+    expect(loaded.stderr).toBe('');
+    expect(loaded.stdout).toBe('compiled fixture\n');
+  });
+});


### PR DESCRIPTION
## Summary

Narrow the Git-install detector so an ordinary checkout is not classified as package-manager staging merely because its parent is named `tmp` or `.tmp`.

The detector gates the existing prepare command's build-and-swap workflow. A false positive replaces the checkout with the built package, deleting Git metadata, tests, and untracked notes. This was reproduced with ordinary offline installs in disposable `tmp/openai-node` and `.tmp/openai-node` checkouts.

Match the immediate parent and basename against the existing installed-package layout and observed staging names:

- `node_modules/*` — existing behavior, unchanged.
- `tmp/git-clone*` — npm Git staging.
- `tmp/_tmp_*` — pnpm Git staging.
- `.tmp/*.prepare` — Yarn Classic Git preparation.

Use native Bash parameter expansion to preserve literal path components. Command substitution around `basename` strips trailing newlines and can accidentally turn a nonmatching directory name into a matching one.

Only the handwritten detector and a regression test change. The prepare command, build script, swap implementation, dependencies, SDK source, and generation metadata remain unchanged.

## Verification

- The initial lifecycle regression run failed for the two ordinary temporary checkouts and passed all six controls. Ten final tests pass on exact Node 22.0.0, 24.19.0, and 26.7.0, including ancestor-name and literal-newline controls.
- Tests execute the repository's actual prepare command with byte-copied detector and swap scripts in disposable fixtures. Only successful compilation is stubbed. They check checkout-file preservation, skipped builds, expected staging promotion, retained dependencies, and loading the resulting fixture package.
- Genuine dependency-free local-Git installs pass with npm 10.5.1, pnpm 11.5.1, and Yarn Classic 1.22.22 using the final detector bytes and fixture-local caches/stores. Ordinary installs retain Git metadata, tests, and notes; Git-dependency installs run the original swap and produce loadable flattened artifacts. Compilation is stubbed in these fixtures as well; these are lifecycle checks, not a claim that the complete SDK was installed from Git.
- An independent Bash 3.2.57 matrix passes 40 isolated directory-name cases, including spaces, misleading ancestors, trailing newlines, and native cwd normalization.
- Normal full-project `tsc --noEmit`, pinned Oxfmt 0.62.0 and Oxlint 1.79.0 for the TypeScript test, `bash -n`, and whitespace checks pass. Local Vitest is 4.1.10; CI will run the pinned 4.1.11 environment.

## Adversarial review and scope

Independent review found the newline-normalization issue in the first implementation. The detector was tightened to use literal Bash expansion, two regression cases were added, and the real package-manager and isolated-name checks were repeated against the final bytes. Final reviews found no remaining issues within this scope.

Detection remains a layout heuristic, not proof that a directory is disposable: a manually created directory using one of the staging-like names can still match. This PR does not redefine the existing `node_modules` case or introduce a general package-manager detection framework. Compatibility was exercised for the versions above; older or custom staging conventions are not claimed as verified.
