### PR TITLE
fix(test): preserve unrelated processes on mock startup failure

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -138,7 +138,12 @@ if ! is_overriding_api_base_url && ! steady_is_running ; then
   trap 'kill_server_on_port 4010' EXIT
 
   # Start the dev server
-  ./scripts/mock --daemon
+  ./scripts/mock --daemon || {
+    mock_status=$?
+    # The launcher already cleans up its own process when startup fails.
+    trap - EXIT
+    exit "$mock_status"
+  }
 fi
 
 if is_overriding_api_base_url ; then

--- a/scripts/test
+++ b/scripts/test
@@ -140,8 +140,10 @@ if ! is_overriding_api_base_url && ! steady_is_running ; then
   # Start the dev server
   ./scripts/mock --daemon || {
     mock_status=$?
-    # The launcher already cleans up its own process when startup fails.
-    trap - EXIT
+    # The launcher cleans up ordinary startup failures. Signals may skip its trap.
+    if [ "$mock_status" -le 128 ]; then
+      trap - EXIT
+    fi
     exit "$mock_status"
   }
 fi

--- a/tests/test-script-cleanup.test.ts
+++ b/tests/test-script-cleanup.test.ts
@@ -1,0 +1,197 @@
+import type { ChildProcess } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
+import { once } from 'node:events';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { vi } from 'vitest';
+
+const repoRoot = process.cwd();
+const describeBash = process.platform === 'win32' ? describe.skip : describe;
+
+function isRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ESRCH') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+describeBash('scripts/test mock-server cleanup', () => {
+  let fixture: string;
+  let env: NodeJS.ProcessEnv;
+  let existingProcess: ChildProcess | undefined;
+
+  function writeExecutable(filename: string, interpreter: string, body: string): void {
+    writeFileSync(path.join(fixture, filename), `#!/usr/bin/env ${interpreter}\n${body}\n`, { mode: 0o755 });
+  }
+
+  function fixturePid(filename = 'server.pid'): number {
+    const pid = Number(readFileSync(path.join(fixture, filename), 'utf-8'));
+    expect(Number.isSafeInteger(pid) && pid > 0).toBe(true);
+    return pid;
+  }
+
+  beforeEach(() => {
+    fixture = mkdtempSync(path.join(tmpdir(), 'openai-test-cleanup-'));
+    env = {
+      ...process.env,
+      PATH: [path.join(fixture, 'bin'), path.dirname(process.execPath), process.env['PATH']].join(
+        path.delimiter,
+      ),
+      FIXTURE_ROOT: fixture,
+      OPENAI_TEST_SUITE: 'generated',
+      TEST_API_BASE_URL: '',
+      STARTUP_EXIT: '0',
+      PAUSE_STARTUP: 'false',
+      REUSE_HEALTHY: 'false',
+      JEST_EXIT: '0',
+    };
+    for (const directory of ['scripts', 'bin', 'node_modules/.bin']) {
+      mkdirSync(path.join(fixture, directory), { recursive: true });
+    }
+    for (const file of ['scripts/test', 'scripts/generated-test-patterns.json']) {
+      copyFileSync(path.join(repoRoot, file), path.join(fixture, file));
+    }
+    writeExecutable('bin/curl', 'bash', '[ "$REUSE_HEALTHY" = true ] || [ -f "$FIXTURE_ROOT/mock.ready" ]');
+    writeExecutable('bin/lsof', 'bash', 'touch "$FIXTURE_ROOT/lsof.called"\ncat "$FIXTURE_ROOT/server.pid"');
+    writeExecutable('node_modules/.bin/jest', 'bash', 'touch "$FIXTURE_ROOT/jest.called"\nexit "$JEST_EXIT"');
+    writeExecutable(
+      'server.cjs',
+      'node',
+      `const fs = require('node:fs');
+const root = process.env.FIXTURE_ROOT;
+process.on('SIGTERM', () => { fs.writeFileSync(root + '/server.stopped', 'SIGTERM'); process.exit(0); });
+fs.writeFileSync(root + '/server.pid', String(process.pid));
+setInterval(() => {}, 1000);
+process.send('ready');`,
+    );
+    writeExecutable(
+      'scripts/mock',
+      'node',
+      `const fs = require('node:fs');
+const { spawn } = require('node:child_process');
+const root = process.env.FIXTURE_ROOT;
+fs.writeFileSync(root + '/mock.called', String(process.pid));
+if (process.env.STARTUP_EXIT !== '0') process.exit(Number(process.env.STARTUP_EXIT));
+const child = spawn(process.execPath, [root + '/server.cjs'], { stdio: ['ignore', 'ignore', 'ignore', 'ipc'] });
+child.once('error', () => process.exit(1));
+child.once('message', () => {
+  if (process.env.PAUSE_STARTUP === 'true') { fs.writeFileSync(root + '/startup.paused', ''); return; }
+  fs.writeFileSync(root + '/mock.ready', '');
+  child.disconnect();
+  child.unref();
+});`,
+    );
+  });
+
+  afterEach(async () => {
+    try {
+      const pids = ['server.pid', 'mock.called']
+        .filter((filename) => existsSync(path.join(fixture, filename)))
+        .map((filename) => fixturePid(filename));
+      for (const pid of pids) {
+        if (isRunning(pid)) {
+          process.kill(pid, 'SIGTERM');
+        }
+      }
+      await vi.waitFor(() => expect(pids.some(isRunning)).toBe(false));
+    } finally {
+      existingProcess?.kill('SIGTERM');
+      existingProcess = undefined;
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  async function startExistingProcess(): Promise<void> {
+    existingProcess = spawn(process.execPath, [path.join(fixture, 'server.cjs')], {
+      env,
+      stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+    });
+    await once(existingProcess, 'message');
+  }
+
+  function runTests(expectedExit: number): void {
+    const result = spawnSync('bash', [path.join(fixture, 'scripts/test'), '--showConfig'], {
+      cwd: fixture,
+      env,
+      encoding: 'utf-8',
+      timeout: 10_000,
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect({ status: result.status, stderr: result.stderr }).toEqual({ status: expectedExit, stderr: '' });
+  }
+
+  test('does not kill an unrelated process when mock startup fails', async () => {
+    await startExistingProcess();
+    env['STARTUP_EXIT'] = '23';
+
+    runTests(23);
+
+    expect(existsSync(path.join(fixture, 'mock.called'))).toBe(true);
+    expect(existsSync(path.join(fixture, 'jest.called'))).toBe(false);
+    expect(existsSync(path.join(fixture, 'lsof.called'))).toBe(false);
+    expect(isRunning(fixturePid())).toBe(true);
+  });
+
+  test.each([0, 17])('cleans up its started mock and preserves Jest exit %i', async (exitCode) => {
+    env['JEST_EXIT'] = String(exitCode);
+
+    runTests(exitCode);
+
+    expect(existsSync(path.join(fixture, 'mock.called'))).toBe(true);
+    expect(existsSync(path.join(fixture, 'jest.called'))).toBe(true);
+    expect(existsSync(path.join(fixture, 'lsof.called'))).toBe(true);
+    await vi.waitFor(() => expect(isRunning(fixturePid())).toBe(false));
+    expect(readFileSync(path.join(fixture, 'server.stopped'), 'utf-8')).toBe('SIGTERM');
+  });
+
+  test.each([0, 17])('reuses a healthy mock after Jest exit %i', async (exitCode) => {
+    await startExistingProcess();
+    env['REUSE_HEALTHY'] = 'true';
+    env['JEST_EXIT'] = String(exitCode);
+
+    runTests(exitCode);
+
+    expect(existsSync(path.join(fixture, 'mock.called'))).toBe(false);
+    expect(existsSync(path.join(fixture, 'jest.called'))).toBe(true);
+    expect(existsSync(path.join(fixture, 'lsof.called'))).toBe(false);
+    expect(isRunning(fixturePid())).toBe(true);
+  });
+
+  test('cleans up its mock when the wrapper is terminated during startup', async () => {
+    env['PAUSE_STARTUP'] = 'true';
+    const wrapper = spawn('bash', [path.join(fixture, 'scripts/test')], {
+      cwd: fixture,
+      env,
+      stdio: 'ignore',
+    });
+    const closed = once(wrapper, 'close');
+    try {
+      await vi.waitFor(() => expect(existsSync(path.join(fixture, 'startup.paused'))).toBe(true), {
+        timeout: 5000,
+      });
+      expect(isRunning(fixturePid())).toBe(true);
+      wrapper.kill('SIGTERM');
+      expect(await closed).toEqual([null, 'SIGTERM']);
+      await vi.waitFor(() => expect(isRunning(fixturePid())).toBe(false));
+      expect(existsSync(path.join(fixture, 'lsof.called'))).toBe(true);
+      expect(existsSync(path.join(fixture, 'jest.called'))).toBe(false);
+    } finally {
+      wrapper.kill('SIGTERM');
+    }
+  });
+});

--- a/tests/test-script-cleanup.test.ts
+++ b/tests/test-script-cleanup.test.ts
@@ -172,7 +172,10 @@ child.once('message', () => {
     expect(isRunning(fixturePid())).toBe(true);
   });
 
-  test('cleans up its mock when the wrapper is terminated during startup', async () => {
+  test.each([
+    { target: 'wrapper', status: null },
+    { target: 'launcher', status: 137 },
+  ])('cleans up its mock when the $target is terminated during startup', async ({ target, status }) => {
     env['PAUSE_STARTUP'] = 'true';
     const wrapper = spawn('bash', [path.join(fixture, 'scripts/test')], {
       cwd: fixture,
@@ -185,8 +188,12 @@ child.once('message', () => {
         timeout: 5000,
       });
       expect(isRunning(fixturePid())).toBe(true);
-      wrapper.kill('SIGTERM');
-      expect(await closed).toEqual([null, 'SIGTERM']);
+      if (target === 'wrapper') {
+        wrapper.kill('SIGTERM');
+      } else {
+        process.kill(fixturePid('mock.called'), 'SIGKILL');
+      }
+      expect(await closed).toEqual([status, target === 'wrapper' ? 'SIGTERM' : null]);
       await vi.waitFor(() => expect(isRunning(fixturePid())).toBe(false));
       expect(existsSync(path.join(fixture, 'lsof.called'))).toBe(true);
       expect(existsSync(path.join(fixture, 'jest.called'))).toBe(false);


### PR DESCRIPTION
## Summary

Do not run the test wrapper's port-wide cleanup when the mock launcher returns an ordinary startup failure.

`scripts/test` installs an EXIT trap that finds processes on port 4010 and terminates them. If an unrelated local service owns that port but fails the health probe, the attempted mock startup fails with `EADDRINUSE`. The launcher correctly cleans up its own child, but the wrapper then terminates the unrelated service.

Keep the existing EXIT trap armed during startup and successful test execution. On a returned launcher failure, capture its exit status and disarm the wrapper's trap only for ordinary statuses up to 128, then exit with the same status. The launcher retains responsibility for its ordinary failure cleanup. For signal-style statuses above 128, retain the wrapper's fallback because a killed launcher may not have run its own EXIT trap.

The production change is limited to the handwritten test wrapper. The mock launcher, health checks, successful-run cleanup, suite routing, SDK source, dependencies, and generation metadata remain unchanged.

## Regression coverage

Seven POSIX subprocess cases execute a byte-copied `scripts/test` with real fixture-owned processes and isolated health/port-lookup commands:

- Failed startup preserves the unrelated process and exact exit status 23, without running Jest or port cleanup.
- Successful startup terminates its mock after both successful and failing Jest runs, preserving exit statuses 0 and 17.
- A pre-existing healthy mock is reused and preserved after either Jest result.
- SIGTERM sent only to the wrapper during startup still terminates its owned mock.
- SIGKILL sent only to the launcher still lets the wrapper terminate the server and preserve exit status 137.

Fixtures record and clean up both server and launcher PIDs; these unit tests do not bind the shared mock port or act on real user processes.

## Verification

- The original code fails the unrelated-process regression. A first trap-move implementation failed the new startup-interruption regression; the final failure-only disarm passes both.
- All seven final cases pass on exact Node 22.0.0, 24.19.0, and 26.7.0.
- The new suite and neighboring test-wrapper, mock-launcher, and mock-fetch suites pass 46/46 on Node 24.19.0.
- The full canonical generated suite passes on Node 24.19.0 with the installed, verified Steady 0.22.2 / Deno 2.7.11 toolchain: 82 suites and 556 tests pass, with one suite and two tests skipped; all 12 snapshots pass. The wrapper exits 0, its owned server PID exits, and port 4010 is released afterward.
- Independent native Bash/curl/lsof fixtures use the actual test and mock scripts with synthetic loopback services. On all three runtimes, failed startup now leaves the unrelated listener alive and healthy-server reuse remains unchanged. A fresh before/after wrapper-only SIGTERM comparison confirms startup cleanup is preserved.
- An additional native baseline/reviewed/final comparison reproduces the launcher-only SIGKILL leak, verifies its correction, and checks ordinary statuses 23 and 128, exact exit 137, wrapper SIGTERM, successful/failing Jest runs, and healthy reuse. These fixtures use owned ephemeral ports and clean up their exact PIDs.
- Normal full-project `tsc --noEmit`, pinned Oxfmt 0.62.0 and Oxlint 1.79.0, Bash 3 syntax, and whitespace checks pass.

Local handwritten tests use Vitest 4.1.10; repository CI runs the pinned 4.1.11 environment. The new process-signal regressions are POSIX-only; existing cross-platform coverage is unchanged.

## Adversarial review and scope

Adversarial review caught that simply moving the EXIT trap after startup regressed interruption cleanup. The implementation was tightened to disarm cleanup only on a returned startup failure, a dedicated regression was added, and independent reviews and native-process checks were repeated against the final bytes.

PR review then identified that a launcher killed with SIGKILL cannot perform its own cleanup. A seventh regression failed on that revision. The follow-up retains the wrapper's fallback for signal-style statuses and repeats the lifecycle, native-process, full generated-suite, type, and lint checks.

This is a finite ordinary-startup-failure correction, not a general process-ownership redesign. A status above 128 is treated conservatively, not as proof of a signal; an explicit high exit code also retains the legacy fallback. Existing port-based cleanup after successful startup and existing signal behavior remain in place. The PR does not claim to solve every possible later port-reuse race.
