### PR TITLE
fix(build): preserve CommonJS source-map positions

### DIFF
--- a/ecosystem-tests/node-js/test.js
+++ b/ecosystem-tests/node-js/test.js
@@ -1,4 +1,7 @@
 const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const { SourceMap } = require('node:module');
+const path = require('node:path');
 const OpenAI = require('openai');
 
 const requests = [];
@@ -67,6 +70,27 @@ void (async () => {
       assert.equal(url.pathname, '/v1/models/synthetic-model');
       assert.equal(url.searchParams.get('caller'), 'present');
       assert.equal(url.searchParams.get('from_subclass'), 'true');
+    }
+
+    const indexPath = require.resolve('openai');
+    const packageDir = path.dirname(indexPath);
+    const generatedLines = readFileSync(indexPath, 'utf-8').split('\n');
+    const payload = JSON.parse(readFileSync(`${indexPath}.map`, 'utf-8'));
+    const sourceMap = new SourceMap(payload);
+    assert.equal(payload.sources.length, 1);
+    assert.equal(path.basename(payload.sources[0]), 'index.ts');
+    const sourcePath = path.resolve(packageDir, payload.sourceRoot ?? '', payload.sources[0]);
+    const sourceLines = readFileSync(sourcePath, 'utf-8').split('\n');
+    for (const symbol of ['toFile', 'APIPromise', 'AzureOpenAI', 'BedrockOpenAI']) {
+      const generatedLine = generatedLines.findIndex((line) =>
+        line.includes(`Object.defineProperty(exports, "${symbol}"`),
+      );
+      assert.notEqual(generatedLine, -1, `Missing CommonJS getter for ${symbol}`);
+      const column = generatedLines[generatedLine].indexOf('return ');
+      assert.notEqual(column, -1);
+      const mapping = sourceMap.findEntry(generatedLine, column);
+      assert.equal(mapping.originalSource, payload.sources[0]);
+      assert.match(sourceLines[mapping.originalLine] ?? '', new RegExp(`\\b${symbol}\\b`, 'u'));
     }
 
     console.log('CommonJS constructor compatibility checks passed.');

--- a/scripts/utils/fix-index-exports.cjs
+++ b/scripts/utils/fix-index-exports.cjs
@@ -6,12 +6,10 @@ const indexJs = process.env['DIST_PATH']
   : path.resolve(__dirname, '..', '..', 'dist', 'index.js');
 
 const before = fs.readFileSync(indexJs, 'utf-8');
+// Keep the wrapper on the unmapped header line to preserve source-map positions.
 const after = before.replace(
   /^(\s*Object\.defineProperty\s*\(exports,\s*["']__esModule["'].+)$/m,
-  `exports = module.exports = function (...args) {
-    return Reflect.construct(exports.default, args, new.target || exports.default)
-  }
-  $1`.replaceAll(/^ {2}/gm, ''),
+  `exports = module.exports = function (...args) { return Reflect.construct(exports.default, args, new.target || exports.default); }; $1`,
 );
 // Retain the callable CommonJS export while sharing the SDK class's inheritance.
 fs.writeFileSync(


### PR DESCRIPTION
## Summary

Preserve source-map positions when adding the callable CommonJS compatibility wrapper.

The packaging helper inserts three lines before TypeScript's `__esModule` marker but leaves `index.js.map` unchanged. In the installed package, the `toFile` getter consequently maps to the `APIPromise` source line, and other exports point to similarly shifted locations.

Emit the same wrapper on the existing, unmapped compiler-header line instead. Explicit semicolons separate the wrapper and marker without inserting new lines. Every mapped generated line and column keeps its original position; no source-map parsing or rewriting is needed.

Only the handwritten packaging helper and existing plain-Node ecosystem test change. Constructor forwarding, `new.target`, default/named exports, instance/static prototype links, output-path selection, and ESM output remain unchanged.

## Regression

Extend the existing packed-package Node fixture by 24 lines. It resolves the installed public entrypoint and source map, reads the published TypeScript source, and checks four early/late export locations using Node's native `SourceMap` API. There are no hard-coded source line numbers or custom mapping parsers.

All existing construction-with/without-`new`, subclass, static inheritance, `withOptions()`, and synthetic SDK-request assertions remain intact.

The new test fails against a freshly built, packed, and installed baseline on Node 22.0.0, 24.19.0, and 26.7.0. It passes on all three runtimes after the fix.

## Verification

- Fresh canonical `./scripts/build` runs pass before and after, including CJS/ESM and Bedrock import smoke checks.
- Comparing all 2,953 build outputs shows that only `index.js` changes. All 1,302 source maps, declarations, ESM files, package metadata, and published sources remain byte-identical.
- All 32 generated lines with mappings remain byte-identical at their original positions. The modified compiler-header line has no mappings.
- The unchanged packed-package suite passes on Node 22.22.3 and 24.19.0: CJS, ESM, ES2020 browser bundling, TypeScript 4.9.5/6.0.3, and published-source checks.
- A fresh packed consumer passes the regression, constructor/subclass checks, CJS/ESM exports, and browser conditions on exact Node 22.0.0. Exact-floor X.509 checks also pass with Undici 7.29.0, including direct and HTTP/HTTPS CONNECT transport construction with synthetic certificates and no network requests.
- Normal full-project `tsc --noEmit`, pinned Oxfmt 0.62.0 and Oxlint 1.79.0 on both changed files, JavaScript syntax, and whitespace checks pass.

Locally, the canonical ecosystem CLI was blocked before running by pnpm's dependency-metadata guard: the shared cached installation does not match the current override metadata. No metadata, configuration, or dependency safeguards were changed. Local validation instead used the canonical build script, fresh local tarball installation, and the exact ecosystem test bytes.

Clean CI subsequently passed with the pinned dependencies, including the canonical ecosystem CLI and all four new native source-map assertions on Node 24.20.0. Node 22.23.2, 24.20.0, and 26.8.1 each passed 7,596 unit tests and 556 generated tests (2 skipped); packed-package checks and the exact Node 22.0.0 floor also passed. The external [OkTest run](https://github.com/openai/ok-test/actions/runs/33939255097) passed all 237 tests against the verified merge of this exact head and base.

## Adversarial review

Independent reviews checked strict-mode preservation, statement separation, constructor/prototype behavior, every mapped generated line, the unchanged map bytes, and default/relative/absolute output paths, including spaces, quotes, and Unicode. Final checks were repeated against the actual helper and installed artifact. No remaining findings were identified within this two-file change.
