### PR TITLE
fix(audio): wait for input cleanup before reporting success

### DIFF
--- a/src/helpers/audio.ts
+++ b/src/helpers/audio.ts
@@ -67,10 +67,18 @@ async function nodejsPlayAudio(stream: NodeJS.ReadableStream | Response | File):
       ffplay.stderr?.resume();
       ffplay.on('error', reject);
 
+      // The player can exit before the input stream finishes its cleanup.
+      let inputFinished = false;
+      let processClosed = false;
       pipeline(source, ffplay.stdin, (error) => {
         if (error) {
           ffplay.kill();
           reject(error);
+          return;
+        }
+        inputFinished = true;
+        if (processClosed) {
+          resolve();
         }
       });
 
@@ -79,7 +87,10 @@ async function nodejsPlayAudio(stream: NodeJS.ReadableStream | Response | File):
           reject(new Error(`ffplay process exited with code ${code}`));
           return;
         }
-        resolve();
+        processClosed = true;
+        if (inputFinished) {
+          resolve();
+        }
       });
     } catch (error) {
       reject(error);

--- a/tests/helpers/audio-playback-completion.test.ts
+++ b/tests/helpers/audio-playback-completion.test.ts
@@ -1,0 +1,151 @@
+import { vi } from 'vitest';
+import { spawn } from 'node:child_process';
+import type * as ChildProcessModule from 'node:child_process';
+import { once } from 'node:events';
+import { Readable } from 'node:stream';
+import { setImmediate as nextTurn } from 'node:timers/promises';
+import { playAudio } from 'openai/helpers/audio';
+
+// Keep native child-process pipes without invoking ffplay or accessing audio hardware.
+vi.mock('node:child_process', async (importOriginal) => {
+  const original = await importOriginal<typeof ChildProcessModule>();
+  return {
+    ...original,
+    spawn: vi.fn(() =>
+      original.spawn(
+        process.execPath,
+        [
+          '-e',
+          [
+            'const chunks = [];',
+            "process.stdin.on('data', (chunk) => chunks.push(chunk));",
+            "process.stdin.on('end', () => process.send(Buffer.concat(chunks).toString()));",
+            "process.on('message', (code) => process.exit(code));",
+          ].join('\n'),
+        ],
+        { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] },
+      ),
+    ),
+  };
+});
+
+const spawnMock = vi.mocked(spawn);
+const audio = 'synthetic audio';
+
+function playbackChild() {
+  const [result] = spawnMock.mock.results;
+  if (result?.type !== 'return') {
+    throw new Error('Playback did not start a child process');
+  }
+  return result.value;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    spawnMock.mock.results.map(async (result) => {
+      if (result.type !== 'return') {
+        return;
+      }
+      const child = result.value;
+      if (child.exitCode === null && child.signalCode === null) {
+        const closed = once(child, 'close');
+        child.kill();
+        await closed;
+      }
+    }),
+  );
+  spawnMock.mockClear();
+});
+
+describe('playAudio completion', () => {
+  test.each(['success', 'failure'] as const)('waits for input %s after ffplay exits', async (outcome) => {
+    let finishInput: ((error?: Error | null) => void) | undefined;
+    const source = new Readable({
+      read() {
+        this.push(audio);
+        this.push(null);
+      },
+      // oxlint-disable-next-line promise/prefer-await-to-callbacks -- Hold the native destruction callback to control pipeline completion.
+      destroy(_error, callback) {
+        finishInput = callback;
+      },
+    });
+    let settled = false;
+    const playback = playAudio(source);
+    void playback.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+    try {
+      const child = playbackChild();
+      const [received] = await once(child, 'message');
+      expect(received).toBe(audio);
+      const closed = once(child, 'close');
+      child.send(0);
+      expect(await closed).toEqual([0, null]);
+      await nextTurn();
+      const settledBeforeInput = settled;
+      const failure = outcome === 'failure' ? new Error('input close failed') : undefined;
+      expect(finishInput).toBeDefined();
+      finishInput?.(failure);
+      finishInput = undefined;
+
+      if (failure) {
+        await expect(playback).rejects.toBe(failure);
+      } else {
+        expect(settledBeforeInput).toBe(false);
+        await playback;
+      }
+    } finally {
+      finishInput?.();
+      source.destroy();
+    }
+  });
+
+  test('waits for ffplay to close after the input finishes', async () => {
+    const source = Readable.from([audio]);
+    const inputClosed = once(source, 'close');
+    let settled = false;
+    const playback = playAudio(source).then(() => {
+      settled = true;
+    });
+    void playback.catch(() => {});
+    const child = playbackChild();
+    const [received] = await once(child, 'message');
+    expect(received).toBe(audio);
+    await inputClosed;
+    await nextTurn();
+    expect(settled).toBe(false);
+    child.send(0);
+    await playback;
+  });
+
+  test('preserves input failures and terminates the child', async () => {
+    const failure = new Error('input read failed');
+    const source = new Readable({
+      read() {
+        this.destroy(failure);
+      },
+    });
+    const playback = playAudio(source);
+    const closed = once(playbackChild(), 'close');
+
+    await expect(playback).rejects.toBe(failure);
+    await closed;
+  });
+
+  test('preserves unsuccessful ffplay exits', async () => {
+    const playback = playAudio(Readable.from([audio]));
+    void playback.catch(() => {});
+    const child = playbackChild();
+    const [received] = await once(child, 'message');
+    expect(received).toBe(audio);
+    child.send(47);
+
+    await expect(playback).rejects.toThrow('ffplay process exited with code 47');
+  });
+});


### PR DESCRIPTION
## Summary

Wait for both successful input-pipeline completion and a successful `ffplay` exit before resolving `playAudio()`.

A finite Node readable can deliver its bytes and EOF, then report an error from its asynchronous destruction callback. The player can exit successfully before that callback finishes. Previously, `playAudio()` resolved immediately on the player exit, silently losing the later pipeline error even though the helper promises to reject input failures.

Two local completion flags join the existing success callbacks. Input errors, spawn errors, and unsuccessful player exits still reject immediately; input failures still terminate the player. Source conversion, output draining, spawn arguments, and all recording behavior are unchanged.

Only the handwritten audio helper and one focused regression file change. There are no new dependencies, exported API changes, or general lifecycle abstractions.

## Regression

Add five tests using the public helper and genuine Node child-process pipes. The test substitutes a synthetic Node child for the `ffplay` executable, so it never accesses audio hardware. IPC and the native readable destruction callback explicitly control the two completion orders; assertions do not depend on wall-clock thresholds.

The tests cover delayed input success, the original late input-error identity, waiting for the player after input completion, immediate input failure with child termination, and unsuccessful player exit.

Before the source fix, the canonical focused run produced the intended **2 failures and 6 passes**. After the fix, the new tests and all existing audio tests pass: **60/60** on Node 22.22.3, 24.19.0, and 26.7.0.

## Verification

- Canonical `./scripts/build` before and after under tooling Node 24.19.0: CJS/ESM compilation and package-import smoke checks pass.
- Separate baseline/final npm archives loaded through the public CJS and ESM package exports on exact Node 22.0.0, Node 24.19.0, and Node 26.7.0: the baseline reproduces both premature-success cases in all six combinations; the final package passes **96/96 native-subprocess cases**.
- The packed matrix includes ordinary Readable/Response/File inputs, `autoDestroy: false`, `emitClose: false`, both completion orders, exact error identity, immediate failures while the other operation remains pending, missing/nonzero/signaled players, and draining both output pipes. No unhandled rejections or fixture-owned child processes remain.
- The packed file list remains identical at 2,953 paths, and all 651 declaration files remain byte-identical. Only the seven expected audio source, runtime, and source-map artifacts differ; the recording implementation is byte-identical.
- Full-project TypeScript 6.0.3 check, pinned Oxfmt 0.62.0 and Oxlint 1.79.0 on both changed files, and whitespace checks pass.
- The canonical full handwritten suite reports **7,600 passed and 1 failed**. The sole failure is the pre-existing formatter fixture at `tests/oxlint-config.test.ts:464`; an independent run on clean current `main` reproduces the identical failure with the shared cached tool installation. Local Vitest is 4.1.10 rather than the pinned 4.1.11. No dependency metadata, configuration, or safeguards were changed to bypass these local limitations.

Clean CI subsequently passed **all 7,601 unit tests** on Node 22.23.2, 24.20.0, and 26.8.1 using pinned Vitest 4.1.11, including all 60 audio tests and the formatter fixture above. Each runtime also passed 556 generated tests (2 skipped). Packed-package checks, the exact Node 22.0.0 floor, and both ecosystem jobs passed. The external [OkTest run](https://github.com/openai/ok-test/actions/runs/33939846121) passed all 237 tests across 42 suites against the verified merge of this exact head and the updated main branch; the PR ecosystem job tested that same merge.

## Adversarial review

Independent reviews checked both success orderings, immediate rejection of input/process errors, error identity, child termination, unchanged conversions and output drainage, minimum-runtime behavior, and the native regression fixture's cleanup. The final implementation and packed public exports were checked again after the tests and formatting were finalized. No remaining findings were identified within this two-file change.
