### PR TITLE
fix(test): run Bun validation with --from-npm

### DIFF
--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -477,12 +477,11 @@ const projectRunners = {
   bun: async () => {
     if (state.fromNpm) {
       await run('bun', ['install', '-D', state.fromNpm]);
-      return;
+    } else {
+      const packFile = getPackFile();
+      await fs.copyFile(packFile, `./${TAR_NAME}`);
+      await run('bun', ['install', '-D', `./${TAR_NAME}`]);
     }
-
-    const packFile = getPackFile();
-    await fs.copyFile(packFile, `./${TAR_NAME}`);
-    await run('bun', ['install', '-D', `./${TAR_NAME}`]);
 
     await run('npm', ['run', 'tsc']);
 

--- a/tests/ecosystem-cli.test.ts
+++ b/tests/ecosystem-cli.test.ts
@@ -243,6 +243,93 @@ describe('ecosystem test CLI', () => {
   });
 
   test.each([
+    ['selected package', true, false, ''],
+    ['live selected package', true, true, ''],
+    ['install failure', true, false, 'install'],
+    ['typecheck failure', true, false, 'typecheck'],
+    ['test failure', true, false, 'test'],
+    ['local tarball', false, false, ''],
+    ['live local tarball', false, true, ''],
+    ['local tarball test failure', false, false, 'test'],
+  ] as const)('runs Bun validation for %s', (_name, fromNpm, live, failure) => {
+    const fixture = mkdtempSync(path.join(tmpdir(), 'openai-bun-cli-'));
+    const bin = path.join(fixture, 'bin');
+    const project = path.join(fixture, 'ecosystem-tests', 'bun');
+    const selectedPackage = path.join(fixture, 'selected package = fixture');
+    const observations = path.join(fixture, 'commands.jsonl');
+    const recordCommand = [
+      "const fs = require('node:fs');",
+      'const args = process.argv.slice(2);',
+      "const phase = tool === 'npm' ? 'typecheck' : args[0] === 'install' ? 'install' : 'test';",
+      'const observation = { tool, args, apiKeyPresent: Boolean(process.env.OPENAI_API_KEY) };',
+      "fs.appendFileSync(process.env.ECOSYSTEM_COMMAND_OBSERVATIONS, JSON.stringify(observation) + '\\n');",
+      'process.exit(phase === process.env.ECOSYSTEM_COMMAND_FAILURE ? 47 : 0);',
+    ].join('\n');
+
+    try {
+      mkdirSync(bin);
+      mkdirSync(project, { recursive: true });
+      mkdirSync(path.join(fixture, '.pack'));
+      writeFileSync(path.join(fixture, 'package.json'), '{}\n');
+      writeFileSync(path.join(fixture, '.pack', 'openai.tgz'), 'synthetic command-dispatch fixture');
+      // Record command dispatch and exit statuses; no real Bun or package installation is needed.
+      for (const tool of ['bun', 'npm']) {
+        const script = path.join(bin, process.platform === 'win32' ? `${tool}.cjs` : tool);
+        writeFileSync(script, `#!/usr/bin/env node\nconst tool = '${tool}';\n${recordCommand}`, {
+          mode: 0o755,
+        });
+        if (process.platform === 'win32') {
+          writeFileSync(path.join(bin, `${tool}.cmd`), `@"${process.execPath}" "${script}" %*\r\n`);
+        }
+      }
+
+      const result = runCli(
+        [
+          'bun',
+          ...(fromNpm ? [`--from-npm=${selectedPackage}`] : []),
+          '--skipPack',
+          '--noCleanup',
+          '--retry=0',
+          ...(live ? ['--live'] : []),
+        ],
+        fixture,
+        {
+          PATH: `${bin}${path.delimiter}${path.dirname(process.execPath)}`,
+          OPENAI_API_KEY: 'synthetic-bun-cli-key',
+          ECOSYSTEM_COMMAND_OBSERVATIONS: observations,
+          ECOSYSTEM_COMMAND_FAILURE: failure,
+        },
+      );
+
+      expect(result.error, result.stdout + result.stderr).toBeUndefined();
+      expect(result.status, result.stdout + result.stderr).toBe(failure ? 1 : 0);
+      const expected = [
+        {
+          tool: 'bun',
+          args: ['install', '-D', fromNpm ? selectedPackage : './openai.tgz'],
+          apiKeyPresent: false,
+        },
+        { tool: 'npm', args: ['run', 'tsc'], apiKeyPresent: false },
+        {
+          tool: 'bun',
+          args: live ? ['test'] : ['test', 'workload-identity-access-token.test.ts'],
+          apiKeyPresent: live,
+        },
+      ];
+      const failedPhase = ['install', 'typecheck', 'test'].indexOf(failure);
+      expect(
+        readFileSync(observations, 'utf-8')
+          .trim()
+          .split('\n')
+          .map((line) => JSON.parse(line)),
+      ).toEqual(expected.slice(0, failedPhase === -1 ? expected.length : failedPhase + 1));
+      expect(result.stdout + result.stderr).not.toContain('synthetic-bun-cli-key');
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
     {
       projectName: 'node-ts-cjs',
       option: '--live',


### PR DESCRIPTION
## Summary

Run Bun's existing validation steps after installing a package selected with `--from-npm`.

The Bun runner previously returned immediately after the selected-package installation. It never reached `npm run tsc` or `bun test`, so the CLI reported success even when either validation command would fail. The local-tarball path already ran those checks.

Make the two installation paths an `if`/`else`, then reuse the unchanged validation tail. Selected-package arguments, local tarball copying, filtered non-live tests, full live tests, credential handling, retries, and failure reporting retain their existing behavior.

The production change removes one net line. Only the handwritten ecosystem CLI and its existing test file change; SDK runtime code and dependencies are untouched.

## Regression

Add eight table-driven cases to the existing CLI suite. Each executes the actual CLI in an isolated temporary project with synthetic Bun/npm executables that record arguments and return controlled exit codes. The cases cover selected packages, live/non-live execution, installation/typecheck/test failures, and local-tarball controls.

Before the fix, the new cases produced the intended **4 failures and 4 passes**: selected packages skipped both checks, and selected-package validation failures incorrectly exited 0. After the fix, all **31 CLI tests pass** on Node 24.19.0; the eight new cases also pass on Node 22.22.3 and 26.7.0.

These are command-dispatch and failure-propagation tests, not a claim that a real Bun installation, Bun test suite, or live API request was executed. The Windows command wrappers were reviewed but not executed on Windows locally.

## Verification

- Canonical `./scripts/test tests/ecosystem-cli.test.ts`: 31/31 pass on tooling Node 24.19.0.
- An independent actual-CLI fixture reproduces the baseline false greens, then passes all 11 final cases, including exact selected arguments containing spaces and `=`, selected mode without any `.pack` directory, byte-preserved local tarballs, every failure stage, unchanged default zero retries, case-insensitive credential stripping, live-only credential forwarding, and keyless-live rejection before launching a child.
- Full-project TypeScript 6.0.3 check and an explicitly typechecked CLI `--help` execution pass.
- Both changed files pass pinned Oxfmt 0.62.0, pinned Oxlint 1.79.0, and whitespace checks. The CLI's formatting was checked through stdin against its full source because ecosystem fixtures are excluded from the default formatter scan.
- The full canonical handwritten suite reports **7,603 passed and 1 failed**. The sole failure is the existing formatter fixture at `tests/oxlint-config.test.ts:464`, independently reproduced on clean current `main` with the same shared cached tool installation. Local Vitest is 4.1.10 instead of pinned 4.1.11. No dependency metadata, configuration, or safeguards were changed to bypass this limitation.

Clean CI subsequently passed **all 7,604 unit tests** on Node 22.23.2, 24.20.0, and 26.8.1 with pinned Vitest 4.1.11, including all 31 CLI tests and the formatter fixture above. Each runtime also passed 556 generated tests (2 skipped). Packed-package checks and the exact Node 22.0.0 floor passed. Both ecosystem jobs additionally executed real Bun 1.3.14's default local-tarball installation, typecheck, and filtered loopback suite (10 passed); the selected-package dispatch remains covered by the eight explicit CLI fixtures. The external [OkTest run](https://github.com/openai/ok-test/actions/runs/33940475142) passed all 237 tests across 42 suites against the verified merge of this exact head and base.

## Adversarial review

Independent reviews checked that only installation selection changed and that both validation calls and their credential options remain unchanged. Final checks cover error short-circuiting, exact argument forwarding, live/non-live selection, default retries, local-tarball behavior, and fixture isolation. The actual CLI was exercised again after the implementation and tests were finalized. No remaining findings were identified within this two-file change.
