### PR TITLE
fix(test): reject unknown ecosystem project names

### DIFF
--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -539,7 +539,7 @@ const projectRunners = {
 };
 
 let projectNames = Object.keys(projectRunners) as (keyof typeof projectRunners)[];
-const projectNamesSet = new Set(projectNames);
+const projectNamesSet = new Set<string>(projectNames);
 
 async function startProxy() {
   const proxy = createServer((_req, res) => {
@@ -631,6 +631,14 @@ function parseArgs() {
         type: 'boolean',
         default: false,
       },
+    })
+    .check((args) => {
+      for (const project of args._) {
+        if (typeof project !== 'string' || !projectNamesSet.has(project)) {
+          throw new Error(`Unknown ecosystem project: ${JSON.stringify(project)}`);
+        }
+      }
+      return true;
     })
     .help().argv;
 }

--- a/tests/ecosystem-cli.test.ts
+++ b/tests/ecosystem-cli.test.ts
@@ -171,6 +171,36 @@ describe('ecosystem test CLI', () => {
   });
 
   test.each([
+    ['an unknown project', ['bun-typo'], true],
+    ['mixed known and unknown projects', ['node-js', 'bun-typo'], true],
+    ['an inherited property name', ['toString'], true],
+    ['a numeric zero', ['0'], true],
+    ['an empty project name', [''], true],
+    ['an unknown project after --', ['--', 'bun-typo'], true],
+    ['an unknown project with packing enabled', ['bun-typo'], false],
+  ] as const)('rejects %s before ecosystem setup', (_name, projects, skipPack) => {
+    const fixture = mkdtempSync(path.join(tmpdir(), 'openai-ecosystem-project-selection-'));
+
+    try {
+      writeFileSync(path.join(fixture, 'package.json'), '{}\n');
+
+      const result = runCli([...(skipPack ? ['--skipPack'] : []), '--noCleanup', ...projects], fixture, {
+        PATH: path.join(fixture, 'missing-bin'),
+      });
+
+      expect(result.error, result.stdout + result.stderr).toBeUndefined();
+      expect(result.status, result.stdout + result.stderr).toBe(1);
+      expect(result.stderr).toContain('Unknown ecosystem project:');
+      expect(result.stderr).not.toContain('running projects:');
+      expect(result.stdout).not.toContain('[run]:');
+      expect(existsSync(path.join(fixture, '.pack'))).toBe(false);
+      expect(existsSync(path.join(fixture, 'tmp'))).toBe(false);
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  test.each([
     { name: 'sequential', options: [], packageOption: '--fromNpm' },
     { name: 'explicit worker count', options: ['--jobs=2'], packageOption: '--fromNpm' },
     { name: 'parallel', options: ['--parallel'], packageOption: '--from-npm' },


### PR DESCRIPTION
## Summary

Reject unknown positional ecosystem-test project names through the existing yargs validation hook, before package discovery, builds, fixture changes, proxy startup, or worker dispatch.

Currently, `ecosystem-tests/cli.ts bun-typo --skipPack --noCleanup` exits successfully without running a project. Mixed valid/invalid selections silently drop the invalid names; numeric zero and empty positional names can instead fall back to the default project set. The CLI already advertises a fixed set of supported project names.

The check uses the existing project registry before `--skip` mutates it. Valid selections, default-all behavior, help, intentionally skipped valid projects, package-option aliases, and parallel workers retain their existing behavior. This does not change the argument grammar or the separate Bun `--from-npm` fix in #2625.

## Verification

**CI update at `73ece2a`:** all 38 repository checks are terminal (22 successful, 16 skipped), with no failures. [Pinned CI](https://github.com/openai/openai-node/actions/runs/33941769535) passes 7,603 unit tests and 556 generated tests on each of Node 22.23.2, 24.20.0, and 26.8.1, including all 30 CLI tests. Packed-package, exact Node 22.0.0 consumer, and both ecosystem runs pass. [External OkTest](https://github.com/openai/ok-test/actions/runs/33941791499) passes all 237 tests across 42 suites, and its report job completed; the tested SDK merge has the exact base/head parents. Code and security reviews completed without findings.

- All seven new actual-CLI regression cases failed against unchanged main and pass with this fix. They cover unknown/mixed selections, inherited property names, numeric zero, empty names, post-`--` arguments, and rejection before packing. Isolated fixtures also assert that no setup artifacts or commands were created.
- All 30 CLI tests pass on Node 24.19.0; the seven new cases also pass on Node 22.22.3 and 26.7.0.
- An independent 23-case before/after harness exercises the actual CLI with owned command stubs, including preserved valid/default/skip/help/parallel/alias behavior and rejection before build/pack dispatch. These are command-boundary checks, not real ecosystem installations or live API tests.
- This patch and #2625 compose cleanly, and all 38 combined CLI tests pass in an isolated checkout.
- Repository-wide TypeScript 6.0.3 checking and the explicit CLI `ts-node --typeCheck ... --help` check pass. Both changed files pass pinned Oxlint 1.79.0 and Oxfmt 0.62.0 checks.
- The canonical handwritten suite reports **7,602 passed / 1 failed** locally. The sole failure is the unchanged generated-import formatter fixture at `tests/oxlint-config.test.ts:464`, also reproduced on clean main. Local unit runs use cached Vitest 4.1.10 rather than the repository's 4.1.11 pin; CI will verify the pinned environment.

## Scope and review

Only the handwritten ecosystem CLI and its existing test file change: 39 additions and one deletion. Both paths are absent from the verified current pure-generated snapshot. No SDK runtime, exported API, dependency, lockfile, generation metadata, or custom-code budget changes.

Adversarial self-review and independent security/compatibility/edge-case review found no remaining actionable issues after the final formatting refinement. No custom parser or additional validation framework is introduced.
