### PR TITLE
docs: correct Bun ecosystem test instructions

### DIFF
--- a/ecosystem-tests/bun/README.md
+++ b/ecosystem-tests/bun/README.md
@@ -1,13 +1,18 @@
 # openai-bun-test
 
-To install dependencies:
+After [setting up the repository](../../.github/CONTRIBUTING.md#setting-up-the-environment) and installing Bun,
+run this fixture from the repository root:
 
-```bash
-bun install
+```sh
+pnpm tsn ecosystem-tests/cli.ts bun
 ```
 
-To run:
+The runner builds and installs the local SDK, type-checks the fixture, and runs loopback tests without
+live API credentials.
 
-```bash
-bun run index.ts
+Live tests can incur API charges and upload synthetic files that the suite does not delete.
+Set `OPENAI_API_KEY` in your environment and add `--live` to run them:
+
+```sh
+pnpm tsn ecosystem-tests/cli.ts bun --live
 ```


### PR DESCRIPTION
## Summary

Replace the Bun fixture README's `bun run index.ts` instructions: that file does not exist in the fixture. The README now links repository setup and uses the existing ecosystem runner from the repository root:

```sh
pnpm tsn ecosystem-tests/cli.ts bun
```

Explain that the default run builds and installs the local SDK, type-checks the fixture, and runs loopback tests. Document the separate `--live` option and required environment variable, including a warning that live tests can incur API charges and leave synthetic uploads behind.

## Verification

**CI update at `e13837e`:** all 38 repository checks are terminal (22 successful, 16 skipped), with no failures. [Both ecosystem runs](https://github.com/openai/openai-node/actions/runs/33941995858) pass all 14 projects; actual Bun 1.3.14 installs the local SDK, runs typechecking, and passes all 10 loopback tests. [Full CI](https://github.com/openai/openai-node/actions/runs/33941982936) passes 7,596 handwritten and 556 generated tests on each Node 22/24/26 run, plus packed-package and exact Node 22.0.0 consumer checks. [External OkTest](https://github.com/openai/ok-test/actions/runs/33941996777) passes all 237 tests across 42 suites and completes its report job. Code and security reviews completed without findings.

- Confirmed the old entrypoint is absent and the setup link and heading anchor resolve.
- Cross-checked the commands, working directory, local-package setup, default test selection, and live credential gating against the existing runner, package script, tests, and CI configuration.
- Ran the typechecked CLI help path without credentials; no live API calls were made. Bun is not installed locally, so no actual Bun test run is claimed for this documentation change.
- The full README is byte-identical to pinned Oxfmt 0.62.0 output, and `git diff --check` passes.
- Repeated adversarial review after adding the live-test side-effect warning.

Only this handwritten README changes. It is absent from the verified pure-generated snapshot. No runtime, test fixture, package metadata, dependency, or lockfile changes.
