### PR TITLE
fix: identify modern Edge browser runtime headers

### DIFF
--- a/src/internal/detect-platform.ts
+++ b/src/internal/detect-platform.ts
@@ -128,7 +128,7 @@ function getBrowserInfo(): BrowserInfo | null {
 
   // NOTE: The order matters here!
   const browserPatterns = [
-    { key: 'edge' as const, pattern: /Edge(?:\W+(\d+)\.(\d+)(?:\.(\d+))?)?/ },
+    { key: 'edge' as const, pattern: /\bEdg(?:e|A|iOS)?\b(?:\W+(\d+)\.(\d+)(?:\.(\d+))?)?/ },
     { key: 'ie' as const, pattern: /MSIE(?:\W+(\d+)\.(\d+)(?:\.(\d+))?)?/ },
     { key: 'ie' as const, pattern: /Trident(?:.*rv\:(\d+)\.(\d+)(?:\.(\d+))?)?/ },
     { key: 'chrome' as const, pattern: /Chrome(?:\W+(\d+)\.(\d+)(?:\.(\d+))?)?/ },

--- a/tests/internal/detect-platform.test.ts
+++ b/tests/internal/detect-platform.test.ts
@@ -27,7 +27,7 @@ async function withGlobals<T>(overrides: PlatformGlobals, run: (detection: Platf
       }
     }
 
-    return run(detection);
+    return await run(detection);
   } finally {
     for (const [name, descriptor] of descriptors) {
       if (descriptor) {
@@ -166,6 +166,7 @@ describe('platform detection', () => {
 
   test.each([
     ['Edge/105.3.1', 'edge', '105.3.1'],
+    ['Edge', 'edge', '0.0.0'],
     ['MSIE 11.0', 'ie', '11.0.0'],
     ['Trident/7.0; rv:11.2', 'ie', '11.2.0'],
     ['Chrome/126.5.2', 'chrome', '126.5.2'],
@@ -186,21 +187,69 @@ describe('platform detection', () => {
     });
   });
 
-  test.each([{ userAgent: 'unrecognized browser' }, null, undefined])(
-    'returns unknown runtime information when no platform is recognizable',
-    async (navigator) => {
-      const headers = await withGlobals({ process: undefined, navigator }, ({ getPlatformHeaders }) =>
-        getPlatformHeaders(),
-      );
-
-      expect(headers).toMatchObject({
-        'X-Stainless-OS': 'Unknown',
-        'X-Stainless-Arch': 'unknown',
-        'X-Stainless-Runtime': 'unknown',
-        'X-Stainless-Runtime-Version': 'unknown',
-      });
+  test.each([
+    {
+      name: 'desktop',
+      userAgent:
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.1.2.3',
+      version: '120.1.2',
     },
-  );
+    {
+      name: 'Android',
+      userAgent:
+        'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36 EdgA/121.2.3.4',
+      version: '121.2.3',
+    },
+    {
+      name: 'iOS',
+      userAgent:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1 EdgiOS/122.3.4.5',
+      version: '122.3.4',
+    },
+  ])('sends Edge $name browser metadata on public SDK requests', async ({ userAgent, version }) => {
+    vi.resetModules();
+    const { default: OpenAI } = await import('openai');
+    const response = Response.json({ object: 'list', data: [] });
+    const requests: Headers[] = [];
+    const client = new OpenAI({
+      apiKey: 'test-key',
+      dangerouslyAllowBrowser: true,
+      organization: null,
+      project: null,
+      maxRetries: 0,
+      fetch: async (_url, init) => {
+        requests.push(new Headers(init?.headers));
+        return response;
+      },
+    });
+
+    await withGlobals({ process: undefined, navigator: { userAgent }, window: { document: {} } }, () =>
+      client.models.list(),
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.get('X-Stainless-Runtime')).toBe('browser:edge');
+    expect(requests[0]?.get('X-Stainless-Runtime-Version')).toBe(version);
+  });
+
+  test.each([
+    { userAgent: 'unrecognized browser' },
+    { userAgent: 'EdgarBot/1.2.3' },
+    { userAgent: 'EdgX/1.2.3' },
+    null,
+    undefined,
+  ])('returns unknown runtime information when no platform is recognizable', async (navigator) => {
+    const headers = await withGlobals({ process: undefined, navigator }, ({ getPlatformHeaders }) =>
+      getPlatformHeaders(),
+    );
+
+    expect(headers).toMatchObject({
+      'X-Stainless-OS': 'Unknown',
+      'X-Stainless-Arch': 'unknown',
+      'X-Stainless-Runtime': 'unknown',
+      'X-Stainless-Runtime-Version': 'unknown',
+    });
+  });
 
   test.each([
     [{ document: {} }, { userAgent: 'browser' }, true],


### PR DESCRIPTION
## Summary

Correct the existing browser runtime headers for Microsoft Edge. The detector recognizes the legacy `Edge` token, but modern Edge uses `Edg` on desktop, `EdgA` on Android, and `EdgiOS` on iOS ([Microsoft's documented identifiers](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-guidance#identifiers-for-microsoft-edge-on-various-platforms)). As a result, desktop/Android requests currently report `browser:chrome`, and iOS requests report `browser:safari`, including the wrong browser version.

This changes one existing detection pattern to recognize those tokens before the Chrome/Safari patterns. It retains the legacy Edge token, the existing three-component version format and missing-version fallback, and rejects lookalike names such as `EdgarBot` and `EdgX`.

No new telemetry fields, Client Hints collection, dependencies, browser credential permissions, runtime support promises, or generated files are introduced. Only the handwritten detector and its existing test file change.

## Verification

- Reproduced the incorrect outgoing headers through the built public `OpenAI` client in both CJS and ESM on exact Node 22.0.0 and Node 24.19.0. All requests used synthetic browser globals, a synthetic credential, and a local custom fetch; no live API calls were made.
- Added three public-request regressions for full desktop/Android/iOS user-agent strings. All three fail before the change and pass afterward. The test-global helper now awaits asynchronous callbacks before restoring global descriptors.
- All 35 platform tests pass on Node 22.22.3, 24.19.0, and 26.7.0. Existing Node, Deno, edge-runtime, IE, Chrome, Firefox, Safari, browser-guard, and memoization controls remain in place.
- The built CJS and ESM clients report the expected Edge runtime and version on exact Node 22.0.0, Node 24.19.0, and Node 26.7.0.
- Canonical build, TypeScript 6 typecheck, pinned Oxfmt 0.62.0 and Oxlint 1.79.0 checks, and `git diff --check` pass. All 651 published declaration files are byte-identical to the base build.
- Packed-package checks pass on Node 22.22.3 and 24.19.0, including CJS/ESM, ES2020 browser bundling, TypeScript 4.9/6 consumers, and 1,302 source maps.
- Full local handwritten suite: 7,628 pass, with one existing formatter-fixture failure at `tests/oxlint-config.test.ts:464`. The same failure was independently reproduced on clean main `fcd12bb2`; the local dependency cache has Vitest 4.1.10 rather than the repository-pinned 4.1.11. The changed files pass the actual pinned formatter/linter.

## Adversarial review

Reviewed exact-token boundaries, Edge-before-Chrome/Safari precedence, legacy/missing-version compatibility, unchanged version captures and memoization, public request headers, asynchronous test cleanup, supported runtime/type floors, and privacy/browser-credential scope. The production change remains a single bounded pattern; no broader user-agent parser or behavior-based browser branching is added.

Independent review also passed 52 built public-client probes: 13 user agents across CJS/ESM and exact Node 22.0.0/24.19.0, including other browsers and lookalike controls. These tests simulate browser globals under Node; they do not claim real Edge-browser execution.

## Exact-head CI results

[Pinned CI](https://github.com/openai/openai-node/actions/runs/33943243184) passed on head `1fdcd471ccf260d07fd11a0b8ae6a256ae05319a`: Node 22/24/26 each passed all 7,629 unit tests (including all 35 platform tests), 556 generated tests, and 12 snapshots. The local formatter-fixture failure does not reproduce with pinned CI dependencies. Packed-package checks on Node 22/24, the exact Node 22.0.0 consumer check, both 14-project ecosystem jobs, build, lint, and code/security checks passed. All 38 repository check entries are terminal: 22 successful and 16 intentionally skipped, with no failures or pending entries.

[External OkTest](https://github.com/openai/ok-test/actions/runs/33943252760) passed all 237 tests across 42 suites, with all three workflow jobs successful. Its tested SDK merge `7aa08221a8a3b71009df77faea5d82798b78e9b8` has the exact base `fcd12bb29cbc53cfcecbbc7bff2416c1d00bd9ea` and PR head above as parents. The exact head also has a human approving review.
