### PR TITLE
fix(examples): drain manual conversation error output

### DIFF
--- a/examples/responses/manual-conversation-state.ts
+++ b/examples/responses/manual-conversation-state.ts
@@ -40,5 +40,5 @@ async function main() {
 
 main().catch((error) => {
   console.error(error);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/tests/lib/nonstreaming-example-exit-status.test.ts
+++ b/tests/lib/nonstreaming-example-exit-status.test.ts
@@ -217,3 +217,44 @@ describe.each(examples)('$file exit status', ({ file, kind, model }) => {
     }
   });
 });
+
+test('manual conversation example drains large error diagnostics before exiting', async () => {
+  const message = `Synthetic rejection start:${'x'.repeat(1024 * 1024)}:synthetic rejection end`;
+  const requests: { method: string | undefined; url: string | undefined }[] = [];
+  const server = createServer((request, response) => {
+    requests.push({ method: request.method, url: request.url });
+    request.resume();
+    request.on('end', () => {
+      response.writeHead(400, { 'content-type': 'application/json', connection: 'close' });
+      response.end(JSON.stringify({ error: { message, type: 'invalid_request_error' } }));
+    });
+  });
+
+  try {
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Expected a loopback HTTP address');
+    }
+    const result = await runExample(
+      'responses/manual-conversation-state.ts',
+      `http://127.0.0.1:${address.port}/v1`,
+      false,
+    );
+
+    expect(result).toMatchObject({ code: 1, signal: null, stdout: '' });
+    expect(requests).toEqual([{ method: 'POST', url: '/v1/responses' }]);
+    expect(result.stderr).toContain('BadRequestError: 400 Synthetic rejection start:');
+    // Compare without dumping the synthetic megabyte into a failed assertion.
+    expect(result.stderr.includes(message)).toBe(true);
+    expect(result.stderr).not.toContain(credential);
+  } finally {
+    if (server.listening) {
+      const closed = once(server, 'close');
+      server.close();
+      server.closeAllConnections();
+      await closed;
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Let the manual-conversation-state example drain its diagnostic output before exiting after a failure. The catch handler currently logs the error and immediately calls `process.exit(1)`, which can discard queued pipe writes. Replace that call with `process.exitCode = 1`; the example still reports failure, while Node can finish its pending output naturally ([Node's process-exit guidance](https://nodejs.org/api/process.html#processexitcode)).

The actual example, run against an owned loopback server with a synthetic 1 MiB API error and ordinary native pipes, emitted only 8,192 stderr bytes on exact Node 22.0.0 and 65,536 bytes on Node 24.19.0. Both outputs lost the end of the error. With the one-line change, both preserve the complete message and exit with status 1 after exactly one request.

## Verification

- Added one regression to the existing executable-example suite. It launches the real example, supplies a synthetic loopback HTTP 400, checks the complete error message and nonzero exit status, and verifies request count and credential omission. It fails before the change and passes afterward, without sleeps or mocked output streams.
- All 11 tests in that example suite pass on Node 22.22.3, Node 24.19.0, and Node 26.7.0.
- Independent baseline/control checks on exact Node 22.0.0 and Node 24.19.0 cover complete large-error output, ordinary two-turn success, and second-request failure. They preserve ordered conversation-history replay and clean up every child/server/socket. The graceful-exit control finished within 308 ms.
- The actual patched example preserves the complete large error on exact Node 22.0.0, Node 24.19.0, and Node 26.7.0, still exiting 1 with one request.
- Independent final-source subprocess checks also preserve two-turn success and second-request failure on exact Node 22.0.0/24.19.0, with correct ordered replay and no leaked child/server/socket.
- Repository-wide TypeScript 6 checking, actual pinned Oxfmt 0.62.0 and Oxlint 1.79.0 checks, and `git diff --check` pass. The formatter checks the example through stdin, and lint includes it with `--no-ignore`.
- Full local handwritten suite: 7,623 pass and one pre-existing formatter-fixture failure at `tests/oxlint-config.test.ts:464`. That same failure was independently reproduced on clean main `fcd12bb2`; the local cache has Vitest 4.1.10 instead of the pinned 4.1.11. The changed files pass pinned formatting/lint checks.

## Scope and review

Only the handwritten example's failure exit and its regression test change: one example line plus 41 test lines. SDK runtime code, request behavior, conversation replay, logging content, dependencies, generated files, and custom-code policy are unchanged. No live API calls or credentials were used.

Adversarial review covers preserved failure/success status, output completeness, pending handles and cleanup, public example execution, synthetic data isolation, and compatibility. No flushing framework, artificial delay, output limit, or additional logging is introduced.

An independent lifecycle probe also passes on exact Node 22.0.0 and Node 24.19.0 with a 60-second HTTP keep-alive and stderr paused for one second: the complete diagnostic drains, exit status remains 1, and the child exits in about 1.02 seconds without waiting on the idle connection. The pause belongs only to that adversarial test, not to the implementation or committed regression.

## Exact-head CI results

[Pinned CI](https://github.com/openai/openai-node/actions/runs/33944801239) passed on head `60859093710d8f332d49ddb36af8eb5c40d3569a`: Node 22/24/26 each passed 7,624 unit tests (including all 11 example tests and the named drain regression), 556 generated tests, and 12 snapshots. The local formatter-fixture failure does not reproduce with the pinned dependencies. Build, lint, packed-package checks, the exact Node 22.0.0 consumer, both 14-project ecosystem jobs, and code/security checks passed. All 38 repository check entries are terminal: 22 successful and 16 intentionally skipped, with none failed or pending.

[External OkTest](https://github.com/openai/ok-test/actions/runs/33944807645) passed all 237 tests across 42 suites, with all three workflow jobs successful. Its tested SDK merge `7ac868b6ee52ab67c49a5de43b5b3b8db834903a` has exact parents `fcd12bb29cbc53cfcecbbc7bff2416c1d00bd9ea` and the PR head above. The exact head also has a human approving review.
