### PR TITLE
docs: correct error handling diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,10 +389,10 @@ const job = await client.fineTuning.jobs
   .create({ model: 'gpt-4o', training_file: 'file-abc123' })
   .catch(async (err) => {
     if (err instanceof OpenAI.APIError) {
-      console.log(err.request_id);
+      console.log(err.requestID);
       console.log(err.status); // 400
-      console.log(err.name); // BadRequestError
-      console.log(err.headers); // {server: 'nginx', ...}
+      console.log(err instanceof OpenAI.BadRequestError); // true for an HTTP 400 response
+      console.log(err.headers); // response Headers
     } else {
       throw err;
     }
@@ -407,6 +407,7 @@ Error codes are as follows:
 | 401         | `AuthenticationError`      |
 | 403         | `PermissionDeniedError`    |
 | 404         | `NotFoundError`            |
+| 409         | `ConflictError`            |
 | 422         | `UnprocessableEntityError` |
 | 429         | `RateLimitError`           |
 | >=500       | `InternalServerError`      |

--- a/tests/lib/core-error.test.ts
+++ b/tests/lib/core-error.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { runInNewContext } from 'node:vm';
 import { vi } from 'vitest';
 
@@ -169,6 +170,53 @@ describe('APIError', () => {
     [undefined, undefined, undefined, '(no status code or body)'],
   ] as const)('formats errors without assuming a string response body', (status, body, message, expected) => {
     expect(new APIError(status, body, message, headers).message).toBe(expected);
+  });
+});
+
+describe('README error handling', () => {
+  const section = readFileSync('README.md', 'utf-8')
+    .split('## Handling errors')[1]
+    ?.split(/\r?\n## /u)[0];
+  const example = section?.match(/```ts\r?\n(?<source>[\s\S]*?)\r?\n```/u)?.groups?.['source'];
+  if (!example) {
+    throw new Error('Expected the README error-handling example');
+  }
+
+  test.each([400, 409])('reports request IDs and narrows HTTP %i errors', async (status) => {
+    const response = Response.json(
+      { error: { message: 'Synthetic request failure', type: 'invalid_request_error' } },
+      { status, headers: { 'x-request-id': 'req_readme_example' } },
+    );
+    const fetch = vi.fn(async () => response);
+    const client = new OpenAI({ apiKey: 'synthetic-test-key', fetch, maxRetries: 0 });
+    const log = vi.fn();
+
+    await runInNewContext(`(async () => {\n${example}\n})()`, { OpenAI, client, console: { log } });
+
+    expect(log).toHaveBeenCalledTimes(4);
+    expect(log.mock.calls.slice(0, 3)).toEqual([['req_readme_example'], [status], [status === 400]]);
+    expect(log.mock.calls[3]?.[0]).toBe(response.headers);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('rethrows unexpected errors without logging them', async () => {
+    const failure = new Error('Synthetic non-API failure');
+    const fetch = vi.fn(async () => {
+      throw new Error('The rejected example operation must not reach fetch');
+    });
+    const client = new OpenAI({ apiKey: 'synthetic-test-key', fetch, maxRetries: 0 });
+    const create = vi.spyOn(client.fineTuning.jobs, 'create').mockRejectedValueOnce(failure);
+    const log = vi.fn();
+
+    try {
+      await expect(
+        runInNewContext(`(async () => {\n${example}\n})()`, { OpenAI, client, console: { log } }),
+      ).rejects.toBe(failure);
+      expect(log).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalled();
+    } finally {
+      create.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Correct the README's existing error-handling example to match the public SDK:

- Use `err.requestID`, not the nonexistent `err.request_id`.
- Demonstrate `err instanceof OpenAI.BadRequestError` instead of claiming the inherited `err.name` is `BadRequestError`.
- Describe `err.headers` as response `Headers` and include the existing HTTP 409 `ConflictError` in the status table, consistent with `docs/configuration.md`.

This is a documentation/test correction, not a runtime change. Error names, classes, metadata, response `_request_id`, and `withResponse().request_id` are unchanged.

## Verification

- Executed the exact original README snippet against the built public SDK: it logged `undefined` for the request ID and `Error` for the name despite its comment.
- Added three artifact regressions in the existing core-error suite. They execute the actual README code block through the real public client with synthetic fetch responses. HTTP 400/409 verify the request ID, status, typed error check, original response-header identity, and single request. An asynchronous non-API rejection verifies rethrow identity and no logging or fetch.
- Both HTTP regressions fail against the original README and pass afterward; the non-API control remains passing. All 33 core-error tests pass on Node 22.22.3, 24.19.0, and 26.7.0.
- Independent execution of the actual final snippet passes 12 public-artifact checks across CJS/ESM and exact Node 22.0.0/24.19.0, including HTTP 400/409 and unexpected-rejection cases.
- Type-checked the exact README snippet against published CJS and ESM declarations with TypeScript 4.9.5 and 6.0.3, with strict checking and `skipLibCheck: false`. All four original compiler/module combinations produce TS2551 for `request_id`; all four corrected combinations have zero diagnostics, without suppressions.
- Repository-wide TypeScript 6 checks, pinned Oxfmt 0.62.0 and Oxlint 1.79.0 checks, and `git diff --check` pass.
- Full local handwritten suite: 7,625 pass, with the same pre-existing formatter-fixture failure at `tests/oxlint-config.test.ts:464` independently reproduced on clean main `fcd12bb2`. Local unit tests use cached Vitest 4.1.10 instead of the repository's pinned 4.1.11; the changed files pass the actual pinned formatter/linter checks.

## Scope and adversarial review

Only the handwritten README error section and its existing core-error test file change. The test extracts one bounded documentation section; it does not add a Markdown parser, dependency, API wrapper, or runtime behavior. All verification uses synthetic values and no live API calls.

Reviewed actual property and class contracts, typed error checks independent of minified constructor names, 400/409 positive and negative cases, non-API rejection identity, local console interception, spy restoration, and the distinction between error request IDs and response metadata. The open retry/authentication PR's README changes do not touch this error-handling section.

## Exact-head CI results

[Pinned CI](https://github.com/openai/openai-node/actions/runs/33945084140) passed on head `bc5a12015e4d1167797c92f81f4c6d1d2fe2bc49`: Node 22/24/26 each passed all 7,626 unit tests, including all 33 core-error tests, plus 556 generated tests. The local formatter-fixture failure does not reproduce with pinned dependencies. Build, lint, packed CJS/ESM/browser/source-map checks, the exact Node 22.0.0 consumer, both 14-project ecosystem jobs, and code/security checks passed. All 38 repository check entries are terminal: 22 successful and 16 intentionally skipped, with none failed or pending.

[External OkTest](https://github.com/openai/ok-test/actions/runs/33945093816) passed all 237 tests across 42 suites, with all three workflow jobs successful. Its tested SDK merge `d82d5d1a09f26ddd1343325a386dfd085f93013f` has exact parents `fcd12bb29cbc53cfcecbbc7bff2416c1d00bd9ea` and the PR head above. The exact head also has a human approving review.
