### PR TITLE
fix(ci): serialize release-please branch updates

### DIFF
--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -47,6 +47,10 @@ jobs:
         github.repository == 'openai/openai-node'
       }}
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-please-${{ github.ref }}
+      queue: max
+      cancel-in-progress: false
     environment: release
     permissions: {}
     steps:

--- a/tests/release-concurrency-workflow.test.ts
+++ b/tests/release-concurrency-workflow.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const workflow = readFileSync(path.join(process.cwd(), '.github/workflows/create-releases.yml'), 'utf-8');
+
+describe('release-please scheduling', () => {
+  test('queues main release updates without cancelling an active update', () => {
+    const releaseJob = workflow.split('\n  release:\n')[1]?.split('\n  publication-check:\n')[0] ?? '';
+
+    expect(releaseJob).toContain("github.event_name == 'push'");
+    expect(releaseJob).toContain("github.ref == 'refs/heads/main'");
+    expect(releaseJob).toContain(
+      [
+        '    concurrency:',
+        `      group: release-please-\${{ github.ref }}`,
+        '      queue: max',
+        '      cancel-in-progress: false',
+      ].join('\n'),
+    );
+  });
+
+  test('keeps PR validation and npm publication scheduling independent', () => {
+    const workflowSettings = workflow.split('\njobs:\n')[0] ?? '';
+    const validationJob =
+      workflow.split('\n  validate-release-version:\n')[1]?.split('\n  release:\n')[0] ?? '';
+    const publishJob = workflow.split('\n  publish:\n')[1] ?? '';
+
+    expect(workflowSettings).not.toMatch(/^concurrency:/mu);
+    expect(validationJob).toContain("github.event_name == 'pull_request'");
+    expect(validationJob).not.toMatch(/^ {4}concurrency:/mu);
+    expect(publishJob).toContain(`group: publish-npm-\${{ needs.publication-check.outputs.release_sha }}`);
+    expect(publishJob).not.toContain('group: release-please-');
+  });
+});


### PR DESCRIPTION
## Summary

Serialize only the `release` job that updates the shared release-please branch. Nearby main pushes currently run this job concurrently.

The observed failure is on actual main automation: [run 33946334884](https://github.com/openai/openai-node/actions/runs/33946334884) failed updating the release branch to `168584ab68eeed5d7710f3fe4652d3745e175430`, while [an overlapping run](https://github.com/openai/openai-node/actions/runs/33946334127) successfully applied that exact commit 89 milliseconds earlier. A successful sibling subsequently updated the existing release PR with the same intended contents; no recovery or publication action is needed for the historical failure.

Add a stable, per-ref concurrency group to `jobs.release`, with `cancel-in-progress: false` and `queue: max`. This prevents these jobs from writing the release branch concurrently without cancelling an active update. Unlike the default single pending slot, `queue: max` retains up to 100 pending jobs. See [GitHub's concurrency rules](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency).

PR version validation, downstream release CI/build checks, and the existing per-release-SHA npm publication lock remain independent. Token creation stays inside the scheduled release job. No triggers, permissions, action pins, release content, or publication safeguards change.

## Verification

**CI update at `71f3c0c`:** all 38 repository checks are terminal (22 successful, 16 skipped), with no failures. [Full CI](https://github.com/openai/openai-node/actions/runs/33946893551) passes 7,635 unit tests and 556 generated tests on each Node 22/24/26 run, including the new concurrency regressions. Packed-package checks, the exact Node 22.0.0 consumer, pinned formatting/linting, and both 14-project ecosystem runs pass. [External OkTest](https://github.com/openai/ok-test/actions/runs/33946903576) passes all 237 tests across 42 suites and completes all three jobs against the exact base/head merge.

The [normal Create releases PR run](https://github.com/openai/openai-node/actions/runs/33946902724) accepts this exact changed workflow and skips all seven jobs as intended, without executing release steps. An automated unsupported-key finding is [answered with GitHub's May 7, 2026 announcement, immutable job-level schema, and native-run evidence](https://github.com/openai/openai-node/pull/2631#discussion_r3939577634); it does not require removing the supported `queue` key. Both automated reviews completed, and a maintainer approved this exact head.

- The new regression fails on unchanged main because the release job has no concurrency policy; it passes with this change.
- Canonical `./scripts/test tests/release-concurrency-workflow.test.ts tests/release-publish-workflow.test.ts tests/node-matrix-workflow.test.ts`: all 9 tests pass on Node 24.19.0. Local execution used the existing Vitest 4.1.10 installation; repository CI pins 4.1.11.
- Mutation checks fail as expected for a single pending slot, active-job cancellation, a per-run group, and workflow-wide locking. The exact final workflow was restored and the passing suite repeated afterward.
- Parsing the complete workflow as YAML and removing only `jobs.release.concurrency` produces the same object as main: all other workflow configuration is unchanged.
- TypeScript 6.0.3 no-emit checking, pinned Oxfmt 0.62.0 on both files, pinned Oxlint 1.79.0 on the test, and `git diff --check` pass.
- Repeated adversarial review covered cancellation, queue scope, token lifetime, dependency cycles, PR validation, publication isolation, and the final regression tests. No further changes were required.

These are configuration/artifact checks, not a simulation or manual rerun of GitHub's scheduler. No releases, live API calls, or workflow reruns were initiated for verification.

## Scope and limits

The production change is four YAML lines, plus one small regression file. Both files are wholly handwritten and absent from the verified pure-generated snapshot. No SDK code, dependencies, lockfiles, generation metadata, or custom-code policy changes.

This lock covers this job's future runs, not other branch writers or already-running workflows using the old definition. GitHub's queue is bounded at 100 pending jobs and does not guarantee push-SHA order. The existing `target-branch: main` behavior is unchanged.

Existing PR #2589 covers publication CI-gate tests and documentation, not release-please serialization; this change uses a separate test file and does not overlap its files.
