### PR TITLE
fix(build): fail when a compiler worker is signaled

### DIFF
--- a/scripts/_vendor/tsc-multi/src/build.ts
+++ b/scripts/_vendor/tsc-multi/src/build.ts
@@ -73,7 +73,7 @@ async function runWorker({
   try {
     return await new Promise<number>((resolve, reject) => {
       worker.on('error', reject);
-      worker.on('exit', resolve);
+      worker.on('exit', (code) => resolve(code ?? 1));
     });
   } finally {
     removeExitHandler();

--- a/tests/tsc-multi-worker-exit.test.ts
+++ b/tests/tsc-multi-worker-exit.test.ts
@@ -1,0 +1,74 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const cli = path.join(repoRoot, 'scripts/_vendor/tsc-multi/src/cli.ts');
+const register = createRequire(path.join(repoRoot, 'package.json')).resolve(
+  'ts-node/register/transpile-only',
+);
+const testSignals = process.platform === 'win32' ? test.skip : test;
+
+describe('tsc-multi compiler worker exits', () => {
+  let fixture: string;
+
+  beforeEach(() => {
+    fixture = mkdtempSync(path.join(tmpdir(), 'openai-tsc-worker-exit-'));
+  });
+
+  afterEach(() => {
+    rmSync(fixture, { recursive: true, force: true });
+  });
+
+  function runWorkers(outcomes: (number | NodeJS.Signals)[]): number | null {
+    const compiler = path.join(fixture, 'compiler.cjs');
+    const invocations = path.join(fixture, 'invocations');
+    writeFileSync(
+      path.join(fixture, 'tsc-multi.json'),
+      JSON.stringify({ targets: outcomes.map((_, index) => ({ extname: `.target${index}.js` })) }),
+    );
+    // The real worker loads this compiler; only that child process exits or receives the signal.
+    writeFileSync(
+      compiler,
+      `const { appendFileSync, existsSync, readFileSync } = require('node:fs');
+const invocations = ${JSON.stringify(invocations)};
+const index = existsSync(invocations) ? readFileSync(invocations, 'utf-8').length : 0;
+appendFileSync(invocations, 'x');
+const outcome = ${JSON.stringify(outcomes)}[index];
+if (typeof outcome === 'string') {
+  process.kill(process.pid, outcome);
+} else {
+  process.exit(outcome);
+}
+`,
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      ['-r', register, cli, '--cwd', fixture, '--compiler', compiler, '--maxWorkers', '1'],
+      { cwd: repoRoot, encoding: 'utf-8', timeout: 15_000 },
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(readFileSync(invocations, 'utf-8')).toBe('x'.repeat(outcomes.length));
+    return result.status;
+  }
+
+  test.each([0, 23])('preserves numeric worker exit code %i', (code) => {
+    expect(runWorkers([code])).toBe(code);
+  });
+
+  testSignals.each(['SIGTERM', 'SIGKILL'] as const)('fails when a compiler worker receives %s', (signal) => {
+    expect(runWorkers([signal])).toBe(1);
+  });
+
+  testSignals('does not hide a later failed target after a signaled worker', () => {
+    expect(runWorkers(['SIGTERM', 23])).toBe(1);
+  });
+
+  testSignals('preserves an earlier failed target when a later worker is signaled', () => {
+    expect(runWorkers([23, 'SIGTERM'])).toBe(23);
+  });
+});


### PR DESCRIPTION
## Problem

A compiler worker terminated by a signal reports a `null` exit code. The vendored build tool passed that value through as if it were numeric, then `codes.find(code => code !== 0) || 0` converted it to success. A signaled first target could also hide a later target's real compiler error.

This reproduces through the actual CLI, not a mocked child process. In an isolated copy of current main, the canonical `./scripts/build` also exited 0 despite a real TS2322 diagnostic when the first compiler worker received an injected SIGTERM after emitting its shared helpers. All later postprocessing and import smoke checks passed, so those checks did not recover the lost compiler failure.

## Change

Normalize a missing numeric exit code to `1` in the worker's exit callback. This is a one-line orchestration fix; successful `0`, ordinary numeric failures, first-failed-target ordering, spawn-error handling, and parent-exit cleanup remain unchanged.

Add a small real-CLI subprocess suite covering numeric 0/23, SIGTERM/SIGKILL, and both orders of mixed signaled/numeric failures. Each fixture compiler terminates only its own worker. Workers run sequentially and their invocation count is verified. Signal-specific cases are POSIX-only; numeric controls also run on Windows.

## Verification

- Before: the three signal-first regressions failed because the CLI returned 0; all three controls passed.
- After: all six regressions pass on Node 22.22.3, 24.19.0, and 26.7.0.
- The same isolated canonical-build failure now exits 1 at compilation, before postprocessing.
- Full handwritten suite: **7,660 tests passed across 197 files** on Node 24.19.0.
- Canonical `./scripts/lint`, TypeScript 6.0.3 `tsc --noEmit`, and normal `./scripts/build` pass with the repository-pinned tools.
- Normal build output is byte-for-byte identical to a clean build of main `03acf94b7d76551bf4d612fe7582ddb6975c8ea3`.

## Scope and review

Only the SDK-maintained vendored worker orchestration and a new handwritten test file change. Both files are absent from the verified pure-generated snapshot `d223f5ab382c6a7d64f3863e75865624cbefad21`; generated helpers, upstream provenance, license, dependencies, SDK source, and release policy are untouched. No existing open PR covers this failure.

Adversarial review checked signal ownership, numeric exit precedence, subprocess cleanup, platform differences, and regression false positives. The test was tightened to tolerate ambient Node warnings without changing the environment or weakening its exit-status assertions, then reviewed and verified again.