### PR TITLE
fix(responses): omit parsed values from replayed history

### DIFF
--- a/src/lib/responses/ResponseInputItems.ts
+++ b/src/lib/responses/ResponseInputItems.ts
@@ -15,7 +15,8 @@ type ResponseAdditionalToolsInputItem = Extract<ResponseInputItem, { type: 'addi
 /**
  * Normalizes a mixed array of stored response history items into clean
  * `ResponseInputItem`s that can be sent back to `responses.create()`. Known items
- * that cannot be replayed without changing their meaning are omitted.
+ * that cannot be replayed without changing their meaning are omitted. SDK-only
+ * parsed values are removed without changing the stored items.
  *
  * @throws {TypeError} If an item type is not supported by the installed SDK.
  */
@@ -33,12 +34,38 @@ export function toResponseInputItems(items: Iterable<ResponseInputItemLike>): Re
 /**
  * Normalizes a stored response history item into a clean `ResponseInputItem`, or
  * returns `null` when a known item cannot be replayed without changing its
- * meaning.
+ * meaning. SDK-only parsed values are removed without changing the stored item.
  *
  * @throws {TypeError} If the item type is not supported by the installed SDK.
  */
 export function toResponseInputItem(item: ResponseInputItemLike): ResponseInputItem | null {
   switch (item.type) {
+    case 'message': {
+      if (item.role !== 'assistant' || !('id' in item) || !Array.isArray(item.content)) {
+        return stripCreatedBy(item);
+      }
+      const content = item.content.map((part) => {
+        if ((part.type === 'output_text' || part.type === 'refusal') && 'parsed' in part) {
+          const { parsed: _parsed, ...inputPart } = part;
+          return inputPart;
+        }
+        return part;
+      });
+      if (content.every((part, index) => part === item.content[index])) {
+        return stripCreatedBy(item);
+      }
+      return { ...stripCreatedBy(item), content };
+    }
+
+    case 'function_call': {
+      const inputItem = stripCreatedBy(item);
+      if (!('parsed_arguments' in inputItem)) {
+        return inputItem;
+      }
+      const { parsed_arguments: _parsedArguments, ...withoutParsedArguments } = inputItem;
+      return withoutParsedArguments;
+    }
+
     case 'additional_tools': {
       if (item.role !== 'developer') {
         return null;
@@ -87,7 +114,6 @@ export function toResponseInputItem(item: ResponseInputItemLike): ResponseInputI
     case 'configuration_update':
     case 'custom_tool_call':
     case 'file_search_call':
-    case 'function_call':
     case 'function_call_output':
     case 'image_generation_call':
     case 'item_reference':
@@ -97,7 +123,6 @@ export function toResponseInputItem(item: ResponseInputItemLike): ResponseInputI
     case 'mcp_approval_response':
     case 'mcp_call':
     case 'mcp_list_tools':
-    case 'message':
     case 'program':
     case 'program_output':
     case 'reasoning':

--- a/tests/lib/response-input-parsed-history.test.ts
+++ b/tests/lib/response-input-parsed-history.test.ts
@@ -1,0 +1,196 @@
+import OpenAI from 'openai';
+import { standardResponsesFunction, standardTextFormat } from 'openai/helpers/standard-schema';
+import { toResponseInputItem, toResponseInputItems } from 'openai/lib/responses/ResponseInputItems';
+import type {
+  Response as APIResponse,
+  ResponseCreateParamsNonStreaming,
+  ResponseInputItem,
+} from 'openai/resources/responses/responses';
+
+const text = '{"count":"42"}';
+const schema = {
+  type: 'object',
+  properties: { count: { type: 'string' } },
+  required: ['count'],
+  additionalProperties: false,
+};
+const validator = {
+  '~standard': {
+    version: 1 as const,
+    vendor: 'synthetic',
+    validate: () => ({ value: 42n }),
+  },
+};
+
+function makeResponse(kind: 'message' | 'function_call' | 'refusal'): APIResponse {
+  return {
+    id: 'resp_synthetic',
+    object: 'response',
+    created_at: 0,
+    status: 'completed',
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    metadata: null,
+    model: 'gpt-test',
+    output_text: kind === 'message' ? text : '',
+    output:
+      kind === 'function_call'
+        ? [
+            {
+              type: 'function_call',
+              id: 'fc_synthetic',
+              call_id: 'call_synthetic',
+              name: 'counter',
+              arguments: text,
+              status: 'completed',
+            },
+          ]
+        : [
+            {
+              type: 'message',
+              id: 'msg_synthetic',
+              role: 'assistant',
+              status: 'completed',
+              phase: 'final_answer',
+              content:
+                kind === 'message'
+                  ? [{ type: 'output_text', text, annotations: [], logprobs: [] }]
+                  : [{ type: 'refusal', refusal: 'No.' }],
+            },
+          ],
+    parallel_tool_calls: true,
+    temperature: null,
+    top_p: null,
+    tool_choice: 'auto',
+    tools: [],
+  };
+}
+
+describe.each(['parse', 'stream'] as const)('replaying %s response history', (mode) => {
+  test.each(['message', 'function_call', 'refusal'] as const)(
+    'omits parsed %s values from the next public request without changing the parsed response',
+    async (kind) => {
+      const response = makeResponse(kind);
+      const requests: unknown[] = [];
+      const client = new OpenAI({
+        apiKey: 'synthetic-key',
+        maxRetries: 0,
+        fetch: async (_url, init) => {
+          if (typeof init?.body !== 'string') {
+            throw new TypeError('Expected a serialized response request');
+          }
+          requests.push(JSON.parse(init.body));
+          if (mode === 'stream' && requests.length === 1) {
+            const events = [
+              {
+                type: 'response.created',
+                sequence_number: 0,
+                response: { ...response, output: [], status: 'in_progress' },
+              },
+              { type: 'response.completed', sequence_number: 1, response },
+            ];
+            return new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(''), {
+              headers: { 'content-type': 'text/event-stream' },
+            });
+          }
+          return Response.json(response);
+        },
+      });
+      const params: Omit<ResponseCreateParamsNonStreaming, 'stream'> = {
+        model: 'gpt-test',
+        input: 'Count it.',
+      };
+      if (kind === 'message') {
+        params.text = { format: standardTextFormat(validator, 'counter', { schema }) };
+      } else if (kind === 'function_call') {
+        params.tools = [standardResponsesFunction({ name: 'counter', parameters: validator, schema })];
+      }
+      const parsed =
+        mode === 'parse'
+          ? await client.responses.parse(params)
+          : await client.responses.stream(params).finalResponse();
+      const original = structuredClone(parsed.output);
+      const input = toResponseInputItems(parsed.output);
+      if (kind === 'function_call') {
+        input.push({ type: 'function_call_output', call_id: 'call_synthetic', output: 'Done.' });
+      }
+      input.push({ role: 'user', content: 'Continue.' });
+
+      await client.responses.create({ model: 'gpt-test', input });
+
+      expect(requests).toHaveLength(2);
+      expect(requests[1]).toEqual({ model: 'gpt-test', input: [...response.output, ...input.slice(1)] });
+      expect(parsed.output).toEqual(original);
+      const [item] = parsed.output;
+      if (item?.type === 'message') {
+        if (kind === 'refusal' && mode === 'parse') {
+          expect(item.content[0]).not.toHaveProperty('parsed');
+        } else {
+          expect(item.content[0]).toHaveProperty('parsed', kind === 'refusal' ? null : 42n);
+        }
+      } else {
+        expect(item).toHaveProperty('parsed_arguments', 42n);
+      }
+    },
+  );
+});
+
+test('preserves unrelated fields and unchanged input identities while removing known output metadata', () => {
+  const inputText = { type: 'input_text' as const, text: 'Keep it.', parsed: 'application metadata' };
+  const inputImage = {
+    type: 'input_image' as const,
+    detail: 'auto' as const,
+    image_url: 'https://example.invalid/synthetic.png',
+    parsed: 'image metadata',
+  };
+  const outputText = { type: 'output_text' as const, text, annotations: [], parsed: null, future: false };
+  const refusal = { type: 'refusal' as const, refusal: 'No.', parsed: null, future: 0 };
+  const output = {
+    type: 'message' as const,
+    id: 'msg_synthetic',
+    role: 'assistant' as const,
+    status: 'completed' as const,
+    phase: 'commentary' as const,
+    content: [outputText, refusal],
+    future: '',
+  };
+  const user: ResponseInputItem = { type: 'message', role: 'user', content: [inputText, inputImage] };
+  const stringMessage = {
+    type: 'message' as const,
+    role: 'assistant' as const,
+    content: 'Keep it.',
+    id: 'input_synthetic',
+  };
+  const assistantInput = { ...user, role: 'assistant' as const, id: 'input_synthetic' };
+  const normalized = toResponseInputItem(output);
+  if (!normalized) {
+    throw new Error('Expected replayable message history');
+  }
+
+  expect(normalized).toEqual({
+    ...output,
+    content: [
+      { type: 'output_text', text, annotations: [], future: false },
+      { type: 'refusal', refusal: 'No.', future: 0 },
+    ],
+  });
+  expect(outputText).toHaveProperty('parsed', null);
+  expect(refusal).toHaveProperty('parsed', null);
+  expect(toResponseInputItem(user)).toBe(user);
+  expect(toResponseInputItem(stringMessage)).toBe(stringMessage);
+  expect(toResponseInputItem(assistantInput)).toBe(assistantInput);
+  expect(toResponseInputItem(normalized)).toBe(normalized);
+
+  const call = {
+    type: 'function_call' as const,
+    name: 'counter',
+    call_id: 'call_synthetic',
+    arguments: text,
+    namespace: 'workspace',
+    future: false,
+  };
+  expect(toResponseInputItem(call)).toBe(call);
+  const parsedCall = { ...call, parsed_arguments: null };
+  expect(toResponseInputItem(parsedCall)).toEqual(call);
+});


### PR DESCRIPTION
## Problem

`toResponseInputItems()` promises clean input items for replaying response history, but it currently retains the SDK's enumerable `parsed` and `parsed_arguments` values. The public `responses.parse()` and `responses.stream()` helpers add those values for the application; they are not part of the response-history wire format.

This breaks an ordinary public workflow: a supported Standard Schema validator can return a `BigInt`, parsing succeeds, but `responses.create({ input: toResponseInputItems(parsed.output), ... })` then throws during JSON serialization before making the follow-up request. Streamed refusal content also retains the helper-added `parsed: null` field.

## Change

At the existing history-normalization boundary:

- Omit `parsed` from output-text and refusal content.
- Omit `parsed_arguments` from function-call items.
- Preserve the original parsed response, raw text/arguments, order, phase, namespaces, unknown API fields, and meaningful falsy values.
- Keep unchanged item identity and preserve input strings/content arrays, including assistant inputs with an extra ID. Existing `created_by` normalization remains in place.

Only the handwritten normalizer and a new cohesive regression file change. There is no parser, resource-type, request-encoder, dependency, generated-file, or exported API change. Both changed paths are absent from the verified pure-generated snapshot `d223f5ab382c6a7d64f3863e75865624cbefad21`; no open PR covers this issue.

## Verification

- The exact final seven-case regression file on unchanged main `03acf94b7d76551bf4d612fe7582ddb6975c8ea3` produces **six expected failures and one passing control**: four parse/stream × message/function-call BigInt failures, streamed-refusal metadata, and metadata removal fail; ordinary nonstreaming refusal remains successful.
- All seven cases pass after the fix. The public regressions make the follow-up request through the real SDK with in-memory fetch, assert its complete serialized input, and verify the original parsed values remain available.
- **7,661 handwritten tests pass across 197 files** on Node 24.19.0; the focused parser/stream/normalizer suite passes all 66 tests.
- Final normalizer regressions and existing tests pass all 11 cases on Node 22.22.3 and 26.7.0.
- Canonical full lint, full TypeScript 6.0.3 checking, and the final canonical build pass with the pinned tools. A focused helper-dependency check also passes TypeScript 4.9.5 on both main and the fix.
- The actual built CJS/ESM package passes all eight parse/stream × message/function-call replay probes on the exact Node 22.0.0 floor. The same built-package probe fails with the original BigInt error on main.
- CJS and ESM declaration contracts are unchanged apart from the explanatory JSDoc.

## Adversarial review

Reviewed message discrimination, string and array inputs, mutation and identity, non-JSON parsed values, refusal handling, function-call namespaces, future fields, and compatibility. Tightened the message-shape guard and its identity controls, then repeated review and verification. No broad schema filtering, new parsing logic, or global serialization change is introduced. All fixtures are synthetic; no live API request was made.

BEGIN_COMMIT_OVERRIDE
fix(responses): omit parsed values from replayed history (#2634)
END_COMMIT_OVERRIDE