### PR TITLE
fix(build): honor configured compiler worker limits

### DIFF
--- a/scripts/_vendor/tsc-multi/src/cli.ts
+++ b/scripts/_vendor/tsc-multi/src/cli.ts
@@ -82,7 +82,7 @@ yargs(process.argv.slice(2))
         force: args.force,
         watch: args.watch,
         clean: args.clean,
-        maxWorkers: args.maxWorkers,
+        maxWorkers: args.maxWorkers ?? config.maxWorkers,
       });
     },
   )

--- a/tests/tsc-multi-config.test.ts
+++ b/tests/tsc-multi-config.test.ts
@@ -1,0 +1,69 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const cli = path.join(repoRoot, 'scripts/_vendor/tsc-multi/src/cli.ts');
+const build = path.join(repoRoot, 'scripts/_vendor/tsc-multi/src/build.ts');
+const register = createRequire(path.join(repoRoot, 'package.json')).resolve(
+  'ts-node/register/transpile-only',
+);
+
+describe('tsc-multi worker-limit configuration', () => {
+  let fixture: string;
+
+  beforeEach(() => {
+    fixture = mkdtempSync(path.join(tmpdir(), 'openai-tsc-config-'));
+    // Capture the build boundary while exercising the real CLI, config loader, and argument parser.
+    // Worker timing is irrelevant to whether the selected configuration reaches the scheduler.
+    writeFileSync(
+      path.join(fixture, 'capture-build.cjs'),
+      `require(${JSON.stringify(build)}).build = async (options) => {
+  process.stdout.write(JSON.stringify({ maxWorkers: options.maxWorkers ?? null }));
+  return 0;
+};
+`,
+    );
+  });
+
+  afterEach(() => {
+    rmSync(fixture, { recursive: true, force: true });
+  });
+
+  test.each([
+    { scenario: 'uses the configured limit without a flag', configured: 1, flag: undefined, expected: 1 },
+    { scenario: 'allows a smaller explicit override', configured: 2, flag: 1, expected: 1 },
+    { scenario: 'allows a larger explicit override', configured: 1, flag: 2, expected: 2 },
+    {
+      scenario: 'preserves the default when neither is set',
+      configured: undefined,
+      flag: undefined,
+      expected: null,
+    },
+    { scenario: 'uses a flag without a configured limit', configured: undefined, flag: 3, expected: 3 },
+    { scenario: 'passes explicit zero through for build validation', configured: 1, flag: 0, expected: 0 },
+  ])('$scenario', ({ configured, flag, expected }) => {
+    writeFileSync(path.join(fixture, 'tsc-multi.json'), JSON.stringify({ maxWorkers: configured }));
+    const result = spawnSync(
+      process.execPath,
+      [
+        '-r',
+        register,
+        '-r',
+        path.join(fixture, 'capture-build.cjs'),
+        cli,
+        '--cwd',
+        fixture,
+        ...(flag === undefined ? [] : ['--maxWorkers', String(flag)]),
+      ],
+      { cwd: repoRoot, encoding: 'utf-8', timeout: 15_000 },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({ maxWorkers: expected });
+  });
+});


### PR DESCRIPTION
## Problem

The vendored compiler tool accepts and validates `maxWorkers` in `tsc-multi.json`, and its build scheduler already supports that limit. However, the CLI overwrites the configured value with `undefined` whenever `--maxWorkers` is omitted. A configuration that requests one worker therefore still runs multiple compilation targets concurrently.

This makes the configured concurrency ceiling ineffective for normal CLI builds. It is a configuration-precedence bug, not a change to the default worker count.

## Change

Use the configured worker limit when the CLI flag is absent. Explicit flags still take precedence, and leaving both unset preserves the existing default. Explicit zero remains intact for the scheduler's existing rejection rather than silently falling back to the configuration.

The production change is one line in the handwritten CLI. A separate six-case test exercises the actual CLI, argument parser, and configuration loader in isolated subprocesses, capturing only the options passed to the build boundary. It covers configured limits, smaller and larger explicit overrides, the unset default, flag-only configuration, and explicit zero.

Both changed paths are absent from the verified pure-generated snapshot `d223f5ab382c6a7d64f3863e75865624cbefad21`. The vendored README assigns this build tool to SDK maintainers. Generated helpers, provenance, license, SDK sources, dependencies, and configuration defaults are unchanged. No open PR covers this issue.

## Verification

- On unchanged main `124b6525497a93315f8563d8e4e3d552cbb0518f`, the exact regression has one expected failure and five passing controls. All six cases pass after the change.
- A separate real-worker CLI probe confirms the behavior without scheduler mocks. With a configured limit of one and no flag, main starts two workers concurrently; the fix runs them serially. Explicit limits of one and two behave identically before and after. Explicit zero is rejected before starting any compiler.
- The new regression and the existing compiler-worker exit suite pass all 12 cases on Node 22.22.3, 24.19.0, and 26.7.0.
- All 7,673 handwritten tests pass across 199 files on Node 24.19.0 through the canonical test script with two test workers. An initial full-suite run encountered local disk exhaustion; the unchanged rerun passed.
- Full TypeScript 6.0.3 checking, the canonical build, and canonical lint pass with the pinned repository tools.
- Every file in the default `dist` output is byte-for-byte identical to a build of the unchanged base revision.

## Adversarial review

Reviewed configuration validation, CLI precedence, meaningful zero, default behavior, child-process isolation and cleanup, generated ownership, and the test seam. An independent final review found no remaining required changes. The committed regressions use deterministic boundary assertions rather than timing assertions; the separate real-worker probe verifies the actual concurrency effect. No live API calls were made.
