### PR TITLE
fix(test): cancel Steady commands waiting for cache locks

### DIFF
--- a/scripts/steady/cache.cjs
+++ b/scripts/steady/cache.cjs
@@ -10,10 +10,10 @@ const { once } = require('node:events');
 const MAX_IDLE_MS = 30 * 24 * 60 * 60 * 1000;
 
 // Serialize lease changes and pruning, never the commands using the cache.
-async function locked(cache, action) {
+async function locked(cache, action, signal) {
   const lock = path.join(cache, '.lifecycle-lock');
   const deadline = Date.now() + 10_000;
-  for await (const tick of interval(50)) {
+  for await (const tick of interval(50, undefined, { signal })) {
     void tick;
     try {
       fs.mkdirSync(lock);
@@ -30,6 +30,7 @@ async function locked(cache, action) {
     }
   }
   try {
+    signal?.throwIfAborted();
     return action();
   } finally {
     fs.rmdirSync(lock);
@@ -87,41 +88,66 @@ async function run(cache, selected, command, args) {
   fs.mkdirSync(leases, { recursive: true });
   const lease = path.join(leases, `${process.pid}-${randomUUID()}.json`);
   let child;
-  const forward = (signal) => child?.kill(signal);
+  let cancelledBeforeSpawn = false;
+  const pending = new AbortController();
+  const forward = (signal) => {
+    if (child) {
+      child.kill(signal);
+    } else {
+      pending.abort(signal);
+    }
+  };
   const onTerm = () => forward('SIGTERM');
   const onInt = () => forward('SIGINT');
   process.on('SIGTERM', onTerm);
   process.on('SIGINT', onInt);
   try {
-    const { exited } = await locked(cache, () => {
-      prune(cache, selected);
-      child = spawn(command, args, { stdio: 'inherit', env: { ...process.env, STEADY_CACHE_LEASE: '1' } });
-      fs.writeFileSync(
-        lease,
-        JSON.stringify({ pids: [process.pid, child.pid].filter(Boolean), entries: selected }),
-        { flag: 'wx' },
-      );
-      return { exited: once(child, 'exit') };
-    });
+    const { exited } = await locked(
+      cache,
+      () => {
+        prune(cache, selected);
+        child = spawn(command, args, { stdio: 'inherit', env: { ...process.env, STEADY_CACHE_LEASE: '1' } });
+        fs.writeFileSync(
+          lease,
+          JSON.stringify({ pids: [process.pid, child.pid].filter(Boolean), entries: selected }),
+          { flag: 'wx' },
+        );
+        return { exited: once(child, 'exit') };
+      },
+      pending.signal,
+    );
     const [code, signal] = await exited;
     return code ?? (signal === 'SIGINT' ? 130 : 143);
+  } catch (error) {
+    const { reason } = pending.signal;
+    if (
+      !child &&
+      pending.signal.aborted &&
+      (error === reason || (error?.name === 'AbortError' && error.cause === reason))
+    ) {
+      cancelledBeforeSpawn = true;
+      return reason === 'SIGINT' ? 130 : 143;
+    }
+    throw error;
   } finally {
     process.off('SIGTERM', onTerm);
     process.off('SIGINT', onInt);
-    await locked(cache, () => {
-      // Start the idle lifetime when the last command finishes using an entry.
-      const now = new Date();
-      for (const name of selected) {
-        const entry = path.join(cache, name);
-        if (fs.existsSync(entry)) {
-          fs.utimesSync(entry, now, now);
+    if (!cancelledBeforeSpawn) {
+      await locked(cache, () => {
+        // Start the idle lifetime when the last command finishes using an entry.
+        const now = new Date();
+        for (const name of selected) {
+          const entry = path.join(cache, name);
+          if (fs.existsSync(entry)) {
+            fs.utimesSync(entry, now, now);
+          }
         }
-      }
-      if (fs.existsSync(lease)) {
-        fs.unlinkSync(lease);
-      }
-      prune(cache, selected);
-    });
+        if (fs.existsSync(lease)) {
+          fs.unlinkSync(lease);
+        }
+        prune(cache, selected);
+      });
+    }
   }
 }
 

--- a/tests/steady-cache-cancellation.test.ts
+++ b/tests/steady-cache-cancellation.test.ts
@@ -1,0 +1,122 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { vi } from 'vitest';
+
+const wrapperPath = path.join(process.cwd(), 'scripts/steady/cache.cjs');
+const testSignals = process.platform === 'win32' ? test.skip : test;
+
+describe('Steady cache wrapper cancellation', () => {
+  let fixture: string;
+  let cache: string;
+  let running: ReturnType<typeof startWrapper> | undefined;
+
+  beforeEach(() => {
+    fixture = realpathSync(mkdtempSync(path.join(tmpdir(), 'steady-cache-cancel-')));
+    cache = path.join(fixture, 'cache');
+    mkdirSync(cache);
+    // Observe real listener registration without replacing the wrapper or its signal handlers.
+    writeFileSync(
+      path.join(fixture, 'ready.cjs'),
+      `process.on('newListener', (event) => {
+  if (event === 'SIGTERM') setImmediate(() => console.log('WRAPPER_READY'));
+});
+`,
+    );
+  });
+
+  afterEach(async () => {
+    if (running) {
+      if (running.child.exitCode === null && running.child.signalCode === null) {
+        running.child.kill('SIGKILL');
+      }
+      await running.closed;
+      running = undefined;
+    }
+    rmSync(fixture, { recursive: true, force: true });
+  });
+
+  function startWrapper(command: string) {
+    const child = spawn(
+      process.execPath,
+      [
+        '-r',
+        path.join(fixture, 'ready.cjs'),
+        wrapperPath,
+        cache,
+        path.join(cache, 'source-synthetic'),
+        path.join(cache, 'deno-synthetic'),
+        path.join(cache, 'deps-synthetic'),
+        process.execPath,
+        '-e',
+        command,
+      ],
+      { stdio: 'pipe' },
+    );
+    let output = '';
+    child.stdout.on('data', (chunk) => {
+      output += chunk;
+    });
+    child.stdin.end();
+    const closed = once(child, 'close');
+    const result = { child, closed, output: () => output };
+    running = result;
+    return result;
+  }
+
+  test.each([0, 23])('preserves ordinary command exit code %i and removes its lease', async (code) => {
+    const wrapper = startWrapper(`console.log('CHILD_EXECUTED'); process.exit(${code});`);
+
+    await expect(wrapper.closed).resolves.toEqual([code, null]);
+    expect(wrapper.output()).toContain('CHILD_EXECUTED');
+    expect(readdirSync(path.join(cache, '.leases'))).toEqual([]);
+    expect(existsSync(path.join(cache, '.lifecycle-lock'))).toBe(false);
+  });
+
+  testSignals.each([
+    { signal: 'SIGINT' as const, code: 130 },
+    { signal: 'SIGTERM' as const, code: 143 },
+  ])('cancels a pending command on $signal without taking another process lock', async ({ signal, code }) => {
+    const lock = path.join(cache, '.lifecycle-lock');
+    mkdirSync(lock);
+    writeFileSync(path.join(lock, 'owner'), 'another cache user');
+    const wrapper = startWrapper("console.log('CHILD_EXECUTED')");
+    await vi.waitFor(() => expect(wrapper.output()).toContain('WRAPPER_READY'), { timeout: 5000 });
+
+    wrapper.child.kill(signal);
+
+    // The other owner keeps its lock throughout cancellation; waiting for it is not cleanup.
+    await vi.waitFor(() => expect(wrapper.child.exitCode).toBe(code), { timeout: 5000 });
+    await expect(wrapper.closed).resolves.toEqual([code, null]);
+    expect(wrapper.output()).not.toContain('CHILD_EXECUTED');
+    expect(readFileSync(path.join(lock, 'owner'), 'utf-8')).toBe('another cache user');
+    expect(readdirSync(path.join(cache, '.leases'))).toEqual([]);
+  });
+
+  testSignals.each([
+    { signal: 'SIGINT' as const, code: 130 },
+    { signal: 'SIGTERM' as const, code: 143 },
+  ])('forwards $signal to a started command and removes its lease', async ({ signal, code }) => {
+    const wrapper = startWrapper("console.log('CHILD_READY'); setTimeout(() => process.exit(97), 10_000)");
+    await vi.waitFor(() => expect(wrapper.output()).toContain('CHILD_READY'), { timeout: 5000 });
+    expect(readdirSync(path.join(cache, '.leases'))).toHaveLength(1);
+
+    wrapper.child.kill(signal);
+
+    await vi.waitFor(() => expect(wrapper.child.exitCode).toBe(code), { timeout: 5000 });
+    await expect(wrapper.closed).resolves.toEqual([code, null]);
+    expect(readdirSync(path.join(cache, '.leases'))).toEqual([]);
+    expect(existsSync(path.join(cache, '.lifecycle-lock'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Steady's cache wrapper installs SIGINT and SIGTERM handlers before acquiring the cache lifecycle lock, but those handlers only forward signals to an already-created child. If an install or mock command is waiting for another cache user, cancellation is swallowed. Once the lock is released, the cancelled command can still start and exit successfully.

This is reproducible through the actual wrapper CLI on unchanged main. Holding the lock, interrupting the wrapper, and then releasing the lock still prints the command's execution marker and exits zero for either signal.

## Change

Make the existing lock wait cancellable with a standard AbortSignal before child startup. Recheck cancellation after acquiring the lock and before running the command. A pending SIGINT or SIGTERM returns the existing signal-equivalent status of 130 or 143 without starting the command or reacquiring another owner's lock for cleanup.

Preserve the first cancellation signal, distinguish the actual cancellation error from unrelated filesystem failures, and keep active-child signal forwarding, exit codes, lease cleanup, cache pruning, and lock timeout behavior unchanged.

Only the handwritten cache wrapper and a new cohesive CLI regression file change. Both paths are absent from the verified pure-generated snapshot `d223f5ab382c6a7d64f3863e75865624cbefad21`. There are no dependency, manifest, downloaded-source, SDK, lease-format, or generated-file changes, and no open PR covers this issue.

## Verification

- The exact final six-case regression file on unchanged main `124b6525497a93315f8563d8e4e3d552cbb0518f` has two expected pending-cancellation failures and four passing controls. All six pass after the fix on Node 22.22.3, 24.19.0, and 26.7.0.
- The regressions run the actual wrapper, hold another owner's lock throughout cancellation, and verify no command starts, the ownership sentinel survives, and no lease is created. Controls cover normal zero/nonzero exits and both signals after the command starts.
- Existing cache-lifecycle tests pass on all three Node lines. Cache and concurrent-publication controls also pass on the exact Node 22.0.0 floor.
- The complete Steady integration passes both before and after the fix, including the pinned installation, offline launch, source/runtime integrity checks, relative paths, server health, and signal-driven shutdown.
- Full TypeScript checking, canonical lint, and the final diff check pass.
- All 7,673 handwritten tests pass across 199 files on Node 24.19.0 through the canonical test script with two workers. An initial full-suite attempt was interrupted by host disk exhaustion; the unchanged rerun passed after disk space recovered.

## Adversarial review

Reviewed cancellation during lock acquisition, lock and lease ownership, error filtering, first-signal behavior, and active-child compatibility. Independent review caught a test-cleanup risk involving historical process IDs; the final fixture uses a bounded child lifetime and only signals the live owned wrapper handle. Repeated review found no remaining required changes.

Signal-dependent regressions are POSIX-only; ordinary exit controls remain portable. All fixture data is synthetic, and no live OpenAI API call is made.
