### PR TITLE
fix(build): preserve config-relative compiler project paths

### DIFF
--- a/scripts/_vendor/tsc-multi/src/config.ts
+++ b/scripts/_vendor/tsc-multi/src/config.ts
@@ -32,7 +32,7 @@ export type Config = InferConfig & {
 };
 
 export async function resolveProjectPath(cwd: string, projects: string[]): Promise<string[]> {
-  return glob(projects, { cwd, onlyFiles: false });
+  return glob(projects, { cwd, absolute: true, onlyFiles: false });
 }
 
 export interface LoadConfigOptions {

--- a/tests/tsc-multi-project-paths.test.ts
+++ b/tests/tsc-multi-project-paths.test.ts
@@ -1,0 +1,108 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const cli = path.join(repoRoot, 'scripts/_vendor/tsc-multi/src/cli.ts');
+const register = createRequire(path.join(repoRoot, 'package.json')).resolve(
+  'ts-node/register/transpile-only',
+);
+
+describe('tsc-multi project path resolution', () => {
+  let fixture: string;
+
+  beforeEach(() => {
+    fixture = mkdtempSync(path.join(tmpdir(), 'openai-tsc-project-paths-'));
+  });
+
+  afterEach(() => {
+    rmSync(fixture, { recursive: true, force: true });
+  });
+
+  function createProject(relative: string, marker: string) {
+    const project = path.join(fixture, relative);
+    mkdirSync(path.join(project, 'src'), { recursive: true });
+    writeFileSync(
+      path.join(project, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          target: 'es2020',
+          module: 'commonjs',
+          rootDir: 'src',
+          outDir: 'dist',
+          types: [],
+          skipLibCheck: true,
+        },
+        include: ['src/**/*.ts'],
+      }),
+    );
+    writeFileSync(path.join(project, 'src/index.ts'), `export const selected = ${JSON.stringify(marker)};`);
+    return path.join(project, 'dist/index.js');
+  }
+
+  function writeConfig(relative: string, projects: string[]) {
+    const config = path.join(fixture, relative);
+    mkdirSync(path.dirname(config), { recursive: true });
+    writeFileSync(config, JSON.stringify({ projects }));
+  }
+
+  function runCLI(args: string[] = []) {
+    const result = spawnSync(process.execPath, ['--require', register, cli, '--maxWorkers', '1', ...args], {
+      cwd: fixture,
+      encoding: 'utf-8',
+      timeout: 15_000,
+      env: {
+        ...process.env,
+        TS_NODE_SKIP_PROJECT: 'true',
+        TS_NODE_COMPILER_OPTIONS: JSON.stringify({
+          esModuleInterop: true,
+          module: 'commonjs',
+          moduleResolution: 'bundler',
+          target: 'es2020',
+        }),
+      },
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(0);
+  }
+
+  test.each(['selected', 'selected/tsconfig.json'])(
+    'resolves nested config project %s relative to the config, not a same-name caller project',
+    (project) => {
+      const intended = createProject('nested/selected', 'INTENDED_NESTED_PROJECT');
+      const decoy = createProject('selected', 'WRONG_CALLER_DIRECTORY_PROJECT');
+      writeConfig('nested/tsc-multi.json', [project]);
+
+      runCLI(['--config', 'nested/tsc-multi.json']);
+
+      expect({ intended: existsSync(intended), decoy: existsSync(decoy) }).toEqual({
+        intended: true,
+        decoy: false,
+      });
+      expect(readFileSync(intended, 'utf-8')).toContain('INTENDED_NESTED_PROJECT');
+    },
+  );
+
+  test('builds projects from the default config alongside the caller', () => {
+    const output = createProject('selected', 'DEFAULT_CONFIG_PROJECT');
+    writeConfig('tsc-multi.json', ['selected']);
+
+    runCLI();
+
+    expect(readFileSync(output, 'utf-8')).toContain('DEFAULT_CONFIG_PROJECT');
+  });
+
+  test('resolves positional projects from the caller and lets them override nested config projects', () => {
+    const configured = createProject('nested/configured', 'CONFIGURED_PROJECT');
+    const positional = createProject('override', 'POSITIONAL_PROJECT');
+    writeConfig('nested/tsc-multi.json', ['configured']);
+
+    runCLI(['--config', 'nested/tsc-multi.json', 'override']);
+
+    expect(readFileSync(positional, 'utf-8')).toContain('POSITIONAL_PROJECT');
+    expect(existsSync(configured)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

The compiler CLI resolves configured project globs from the selected `tsc-multi.json` directory, but passes the resulting relative paths to workers running in the caller's working directory. With a nested or separately located config, a build can fail to find its project or silently compile a same-named project from the wrong directory.

The regression reproduces the silent case through the real CLI and TypeScript compiler. A nested config selects its own project, while a different project with the same relative name exists beside the caller. On main, the build exits successfully but emits the caller-directory decoy instead of the configured project.

## Change

Request absolute output paths from the existing `fast-glob` call. Each match then retains the directory it was resolved against when it reaches the compiler worker.

Configured projects remain relative to the selected config file. Positional CLI projects remain relative to the caller and continue to override configured projects. Worker working directories, compiler resolution, glob patterns, scheduling, and configuration defaults are unchanged.

The production change is one line in the handwritten config loader, with a separate four-case real-CLI regression file. Both paths are absent from the verified pure-generated snapshot `d223f5ab382c6a7d64f3863e75865624cbefad21`; SDK maintainers own this vendored build tool. No dependency, generated helper, provenance, license, SDK source, or published SDK API changes are included. No open PR covers this issue.

## Verification

- The exact final four-case regression on unchanged main `124b6525497a93315f8563d8e4e3d552cbb0518f` has two expected wrong-project failures and two passing controls. Both nested directory and explicit tsconfig-file selections emit the decoy before the fix.
- All four cases pass after the fix on Node 22.22.3, 24.19.0, and 26.7.0. Controls verify default same-directory configuration and positional-project precedence.
- The new regression and existing compiler-worker exit tests pass all 10 cases on Node 24.19.0.
- All 7,671 handwritten tests pass across 199 files on Node 24.19.0 through the canonical test script with two workers.
- Canonical lint, full repository TypeScript checking, targeted checking and formatting of the vendored config loader, and the canonical build pass with the pinned tools.
- The complete default `dist` output is byte-for-byte identical to the verified build of unchanged main, including CommonJS/ESM output and source maps.

## Adversarial review

Reviewed config-directory versus caller-directory ownership, directory and file project patterns, positional precedence, worker consumers, fixture cleanup, and generated ownership. Independent review found no remaining required changes. A test-only typing adjustment was rechecked against both main and the fix without weakening its assertions.

The fix uses the existing glob library's output option and preserves process working directories. All compiler fixtures are synthetic; no live API calls or dependency installations are needed by the regressions.
