### PR TITLE
fix(build): fail on reported transpile errors

### DIFF
--- a/scripts/_vendor/tsc-multi/src/worker/worker.ts
+++ b/scripts/_vendor/tsc-multi/src/worker/worker.ts
@@ -50,8 +50,7 @@ export class Worker {
 
   public run(): number {
     if (this.data.transpileOnly) {
-      this.transpile();
-      return 0;
+      return this.transpile();
     }
 
     const builder = this.createBuilder();
@@ -375,13 +374,17 @@ export class Worker {
     );
   }
 
-  private transpile() {
+  private transpile(): number {
+    let exitCode = 0;
     for (const project of this.data.projects) {
-      this.transpileProject(project);
+      if (this.transpileProject(project) !== 0) {
+        exitCode = 1;
+      }
     }
+    return exitCode;
   }
 
-  private transpileProject(projectPath: string) {
+  private transpileProject(projectPath: string): number {
     const tsConfigPath = this.system.fileExists(projectPath)
       ? projectPath
       : nodePath.join(projectPath, 'tsconfig.json');
@@ -394,7 +397,7 @@ export class Worker {
 
     const config = this.ts.getParsedCommandLineOfConfigFile(tsConfigPath, options, parseConfigFileHost);
     if (!config) {
-      return;
+      return 1;
     }
 
     let resolvedShareHelpers: string | undefined;
@@ -420,6 +423,7 @@ export class Worker {
       ],
     };
 
+    let exitCode = 0;
     for (const inputPath of config.fileNames) {
       // - Ignore if file does not exist
       // - or if file is a declaration file, which will generate an empty file and
@@ -439,6 +443,9 @@ export class Worker {
 
       for (const diag of output.diagnostics ?? []) {
         this.reporter.reportDiagnostic(diag);
+        if (diag.category === this.ts.DiagnosticCategory.Error) {
+          exitCode = 1;
+        }
       }
 
       this.system.writeFile(outputPath, output.outputText);
@@ -453,5 +460,6 @@ export class Worker {
       assert.ok(out, 'outDir must be set when specifying shareHelpers');
       this.writeHelpers(helpersNeeded, this.system.writeFile, out, config.options);
     }
+    return exitCode;
   }
 }

--- a/tests/tsc-multi-transpile-status.test.ts
+++ b/tests/tsc-multi-transpile-status.test.ts
@@ -1,0 +1,138 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const repoRoot = process.cwd();
+const cli = path.join(repoRoot, 'scripts/_vendor/tsc-multi/src/cli.ts');
+const register = createRequire(path.join(repoRoot, 'package.json')).resolve(
+  'ts-node/register/transpile-only',
+);
+
+function expectOutput(output: string, content: string) {
+  expect(readFileSync(output, 'utf-8')).toContain(content);
+  expect(JSON.parse(readFileSync(`${output}.map`, 'utf-8'))).toHaveProperty('version', 3);
+}
+
+describe('tsc-multi transpile-only status', () => {
+  let fixture: string;
+
+  beforeEach(() => {
+    fixture = mkdtempSync(path.join(tmpdir(), 'openai-tsc-transpile-status-'));
+  });
+
+  afterEach(() => {
+    rmSync(fixture, { recursive: true, force: true });
+  });
+
+  function createProject(name: string, source: string, withConfig = true) {
+    const project = path.join(fixture, name);
+    mkdirSync(path.join(project, 'src'), { recursive: true });
+    writeFileSync(path.join(project, 'src/index.ts'), source);
+    if (withConfig) {
+      writeFileSync(
+        path.join(project, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            target: 'es2020',
+            module: 'commonjs',
+            rootDir: 'src',
+            outDir: 'dist',
+            sourceMap: true,
+            types: [],
+            skipLibCheck: true,
+          },
+          include: ['src/**/*.ts'],
+        }),
+      );
+    }
+    return path.join(project, 'dist/index.js');
+  }
+
+  function runCLI(projects: string[]) {
+    writeFileSync(
+      path.join(fixture, 'tsc-multi.json'),
+      JSON.stringify({ projects, targets: [{ transpileOnly: true }] }),
+    );
+    const result = spawnSync(process.execPath, ['--require', register, cli, '--maxWorkers', '1'], {
+      cwd: fixture,
+      encoding: 'utf-8',
+      timeout: 15_000,
+      env: {
+        ...process.env,
+        TS_NODE_SKIP_PROJECT: 'true',
+        TS_NODE_COMPILER_OPTIONS: JSON.stringify({
+          esModuleInterop: true,
+          module: 'commonjs',
+          moduleResolution: 'bundler',
+          target: 'es2020',
+        }),
+      },
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    return result;
+  }
+
+  test.each([
+    {
+      name: 'a syntax error',
+      source: 'export const value = ;',
+      output: 'exports.value = ;',
+      status: 1,
+      diagnostic: 'TS1109',
+    },
+    {
+      name: 'valid source',
+      source: 'export const value: number = 1;',
+      output: 'exports.value = 1;',
+      status: 0,
+      diagnostic: undefined,
+    },
+    {
+      name: 'a semantic-only type error',
+      source: "export const value: number = 'not-a-number';",
+      output: "exports.value = 'not-a-number';",
+      status: 0,
+      diagnostic: undefined,
+    },
+  ])('returns $status for $name without changing emitted files', ({ source, output, status, diagnostic }) => {
+    const emitted = createProject('project', source);
+
+    const result = runCLI(['project']);
+
+    expectOutput(emitted, output);
+    if (diagnostic) {
+      expect(result.stderr).toContain(diagnostic);
+    } else {
+      expect(result.stderr).not.toMatch(/TS\d+:/u);
+    }
+    const syntax = spawnSync(process.execPath, ['--check', emitted], { encoding: 'utf-8', timeout: 5000 });
+    expect(syntax.error).toBeUndefined();
+    expect(syntax.status).toBe(status);
+    expect(result.status).toBe(status);
+  });
+
+  test('preserves failure status while still emitting a later valid project', () => {
+    const first = createProject('first', 'export const value = ;');
+    const later = createProject('later', 'export const value = 42;');
+
+    const result = runCLI(['first', 'later']);
+
+    expectOutput(first, 'exports.value = ;');
+    expectOutput(later, 'exports.value = 42;');
+    expect(result.stderr).toContain('TS1109');
+    expect(result.status).toBe(1);
+  });
+
+  test('fails when a selected project reports an unreadable tsconfig', () => {
+    const output = createProject('missing-config', 'export const value = 1;', false);
+
+    const result = runCLI(['missing-config']);
+
+    expect(result.stderr).toContain('TS5083');
+    expect(existsSync(output)).toBe(false);
+    expect(result.status).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

The vendored compiler worker always returns success in `transpileOnly` mode, even after TypeScript reports an error. A syntax-error fixture prints TS1109 and emits JavaScript that `node --check` rejects, but the real compiler CLI exits zero. An unreadable project tsconfig likewise reports TS5083 and exits successfully without emitting output.

This lets callers treat a failed transpilation as a successful build. Transpile-only mode should still skip semantic type checking; it should not discard errors already reported by the compiler.

## Change

Return the existing transpilation result through the worker and CLI. Error-category diagnostics and reported unreadable-config failures produce a nonzero status. Aggregate that status across every project so a later successful project cannot erase an earlier failure, while continuing to process and emit all projects.

Diagnostic reporting, JavaScript/source-map/helper emission, semantic-type-error skipping, and the normal non-transpile build path remain unchanged. The implementation uses local return values and accumulators; it adds no parser, reporter abstraction, retained state, or new type checking.

Only the handwritten worker and a new cohesive regression file change. Both paths are absent from the verified pure-generated snapshot `d223f5ab382c6a7d64f3863e75865624cbefad21`; SDK maintainers own the vendored build tool. Dependencies, configuration, generated helpers, provenance, license, and published SDK APIs are untouched. No open PR covers this issue.

## Verification

- The exact final five-case regression on unchanged main `aa08b4498b1923f9fa8c11d0055e83411d9457f3` has three expected false-success failures and two passing controls. The failures cover syntax errors, mixed failed/successful projects, and an unreadable tsconfig.
- All five real-CLI cases pass after the change on Node 22.22.3, 24.19.0, and 26.7.0. Valid code and semantic-only type mismatches still succeed; syntax errors preserve their emitted files and diagnostics but fail the build. Node's own syntax check independently confirms the invalid emitted JavaScript.
- The new regressions plus existing worker-exit and worker-limit tests pass all 17 cases on Node 24.19.0.
- All 7,678 handwritten tests pass across 200 files on Node 24.19.0 through the canonical test script with two workers.
- Full repository lint and TypeScript checks, targeted vendored-worker type/format checks, the canonical build, and the final diff check pass with the pinned tools.
- Every file in the normal SDK `dist` output is byte-for-byte identical to the verified build of unchanged main, including CommonJS/ESM output and source maps.

## Adversarial review

Reviewed Error-category filtering, every-file/every-project processing, failure retention, unreadable-config handling, exception behavior, and unchanged diagnostics/emission/semantic skipping. Independent review found no remaining required changes. A test-only helper placement adjustment was rerun against both main and the fix without weakening assertions.

All regression projects and compiler inputs are synthetic, with bounded subprocesses and owned temporary-directory cleanup. No live API calls are made.
