### PR TITLE
fix(examples): reject early Realtime socket closure

### DIFF
--- a/examples/azure/realtime/websocket.ts
+++ b/examples/azure/realtime/websocket.ts
@@ -14,6 +14,7 @@ async function main() {
     deployment: deploymentName,
   });
   const rt = await OpenAIRealtimeWebSocket.azure(client);
+  let responseDone = false;
 
   // access the underlying `ws.WebSocket` instance
   rt.socket.addEventListener('open', () => {
@@ -54,6 +55,7 @@ async function main() {
 
   // response.done also covers failed, cancelled, and incomplete responses.
   rt.on('response.done', (event) => {
+    responseDone = true;
     if (event.response.status !== 'completed') {
       console.error('Response did not complete successfully.');
       process.exitCode = 1;
@@ -61,7 +63,13 @@ async function main() {
     rt.close();
   });
 
-  rt.socket.addEventListener('close', () => console.log('\nConnection closed!'));
+  rt.socket.addEventListener('close', () => {
+    if (!responseDone) {
+      console.error('WebSocket closed before the response completed.');
+      process.exitCode = 1;
+    }
+    console.log('\nConnection closed!');
+  });
 }
 
 main();

--- a/examples/azure/realtime/ws.ts
+++ b/examples/azure/realtime/ws.ts
@@ -14,6 +14,7 @@ async function main() {
     deployment: deploymentName,
   });
   const rt = await OpenAIRealtimeWS.azure(client);
+  let responseDone = false;
 
   // access the underlying `ws.WebSocket` instance
   rt.socket.on('open', () => {
@@ -54,6 +55,7 @@ async function main() {
 
   // response.done also covers failed, cancelled, and incomplete responses.
   rt.on('response.done', (event) => {
+    responseDone = true;
     if (event.response.status !== 'completed') {
       console.error('Response did not complete successfully.');
       process.exitCode = 1;
@@ -61,7 +63,13 @@ async function main() {
     rt.close();
   });
 
-  rt.socket.on('close', () => console.log('\nConnection closed!'));
+  rt.socket.on('close', () => {
+    if (!responseDone) {
+      console.error('WebSocket closed before the response completed.');
+      process.exitCode = 1;
+    }
+    console.log('\nConnection closed!');
+  });
 }
 
 main();

--- a/examples/realtime/websocket.ts
+++ b/examples/realtime/websocket.ts
@@ -2,6 +2,7 @@ import { OpenAIRealtimeWebSocket } from 'openai/realtime/websocket';
 
 async function main() {
   const rt = new OpenAIRealtimeWebSocket({ model: 'gpt-realtime' });
+  let responseDone = false;
 
   // access the underlying `ws.WebSocket` instance
   rt.socket.addEventListener('open', () => {
@@ -42,6 +43,7 @@ async function main() {
 
   // response.done also covers failed, cancelled, and incomplete responses.
   rt.on('response.done', (event) => {
+    responseDone = true;
     if (event.response.status !== 'completed') {
       console.error('Response did not complete successfully.');
       process.exitCode = 1;
@@ -49,7 +51,13 @@ async function main() {
     rt.close();
   });
 
-  rt.socket.addEventListener('close', () => console.log('\nConnection closed!'));
+  rt.socket.addEventListener('close', () => {
+    if (!responseDone) {
+      console.error('WebSocket closed before the response completed.');
+      process.exitCode = 1;
+    }
+    console.log('\nConnection closed!');
+  });
 }
 
 main();

--- a/examples/realtime/ws.ts
+++ b/examples/realtime/ws.ts
@@ -2,6 +2,7 @@ import { OpenAIRealtimeWS } from 'openai/realtime/ws';
 
 async function main() {
   const rt = new OpenAIRealtimeWS({ model: 'gpt-realtime' });
+  let responseDone = false;
 
   // access the underlying `ws.WebSocket` instance
   rt.socket.on('open', () => {
@@ -42,6 +43,7 @@ async function main() {
 
   // response.done also covers failed, cancelled, and incomplete responses.
   rt.on('response.done', (event) => {
+    responseDone = true;
     if (event.response.status !== 'completed') {
       console.error('Response did not complete successfully.');
       process.exitCode = 1;
@@ -49,7 +51,13 @@ async function main() {
     rt.close();
   });
 
-  rt.socket.on('close', () => console.log('\nConnection closed!'));
+  rt.socket.on('close', () => {
+    if (!responseDone) {
+      console.error('WebSocket closed before the response completed.');
+      process.exitCode = 1;
+    }
+    console.log('\nConnection closed!');
+  });
 }
 
 main();

--- a/tests/lib/realtime-example-status.test.ts
+++ b/tests/lib/realtime-example-status.test.ts
@@ -13,15 +13,17 @@ import { createX509TestLab } from '../utils/x509-test-lab';
 
 const cases = (['openai', 'azure'] as const).flatMap((provider) =>
   (['ws', 'websocket'] as const).flatMap((example) =>
-    (['completed', 'failed', 'cancelled', 'incomplete'] as const).map((status) => ({
-      provider,
-      example,
-      status,
-    })),
+    (['completed', 'failed', 'cancelled', 'incomplete', 'clean close', 'abrupt close'] as const).map(
+      (scenario) => ({
+        provider,
+        example,
+        scenario,
+      }),
+    ),
   ),
 );
 
-test.each(cases)('$provider Realtime $example handles $status', async ({ provider, example, status }) => {
+test.each(cases)('$provider Realtime $example handles $scenario', async ({ provider, example, scenario }) => {
   const lab = createX509TestLab();
   const directory = await mkdtemp(path.join(tmpdir(), 'openai-realtime-example-'));
   const certificatePath = path.join(directory, 'ca.pem');
@@ -52,26 +54,28 @@ test.each(cases)('$provider Realtime $example handles $status', async ({ provide
       event_id: 'event_text_done',
       text,
     },
-    {
+  ];
+  if (scenario !== 'clean close' && scenario !== 'abrupt close') {
+    events.push({
       type: 'response.done',
       event_id: 'event_response_done',
       response: {
         id: 'resp_example',
         object: 'realtime.response',
-        status,
+        status: scenario,
         output: [
           {
             id: 'msg_example',
             type: 'message',
             role: 'assistant',
-            status: status === 'completed' ? 'completed' : 'incomplete',
+            status: scenario === 'completed' ? 'completed' : 'incomplete',
             content: [{ type: 'output_text', text }],
           },
         ],
         metadata: { note: 'SYNTHETIC_PRIVATE_RESPONSE_METADATA' },
       },
-    },
-  ];
+    });
+  }
   sockets.on('connection', (socket, request) => {
     urls.push(request.url);
     authorization.push(request.headers.authorization);
@@ -84,8 +88,15 @@ test.each(cases)('$provider Realtime $example handles $status', async ({ provide
         'type' in event &&
         event.type === 'response.create'
       ) {
-        for (const responseEvent of events) {
-          socket.send(JSON.stringify(responseEvent));
+        if (scenario === 'abrupt close') {
+          socket.terminate();
+        } else {
+          for (const responseEvent of events) {
+            socket.send(JSON.stringify(responseEvent));
+          }
+          if (scenario === 'clean close') {
+            socket.close(1000, 'SYNTHETIC_PRIVATE_CLOSE_REASON');
+          }
         }
       }
     });
@@ -181,13 +192,20 @@ Module._load = function(request, ...args) {
         },
         { type: 'response.create' },
       ]);
-      expect(stdout).toContain(text);
+      if (scenario !== 'abrupt close') {
+        expect(stdout).toContain(text);
+      }
       expect(stdout).toContain('Connection closed!');
       expect(stdout + stderr).not.toContain('synthetic-example-key');
       expect(stdout + stderr).not.toContain(azureToken);
       expect(stdout + stderr).not.toContain('SYNTHETIC_PRIVATE_RESPONSE_METADATA');
-      expect(exitCode).toBe(status === 'completed' ? 0 : 1);
-      expect(stderr.includes('Response did not complete successfully.')).toBe(status !== 'completed');
+      expect(stdout + stderr).not.toContain('SYNTHETIC_PRIVATE_CLOSE_REASON');
+      expect(exitCode).toBe(scenario === 'completed' ? 0 : 1);
+      const closedEarly = scenario === 'clean close' || scenario === 'abrupt close';
+      expect(stderr.includes('Response did not complete successfully.')).toBe(
+        scenario !== 'completed' && !closedEarly,
+      );
+      expect(stderr.includes('WebSocket closed before the response completed.')).toBe(closedEarly);
     } finally {
       child.kill();
     }


### PR DESCRIPTION
## Summary

Make the four handwritten Realtime examples report failure when their WebSocket closes before a terminal `response.done` event.

On current main, a server can send text (including `response.output_text.done`) and close the connection normally before `response.done`; both OpenAI and Azure examples then print `Connection closed!` and exit successfully. The two `ws` examples also exit successfully on an abrupt disconnect. This makes an unfinished request look successful to anyone running or adapting the examples.

Each example now records receipt of `response.done` and checks that flag in its existing socket-close handler. An early close prints a fixed diagnostic and sets `process.exitCode = 1`, allowing buffered output to drain. Successful responses still exit 0. Failed, cancelled, and incomplete terminal responses retain their existing diagnostic and exit status without an additional early-close warning. Existing transport-error handling is unchanged.

The implementation is eight net new lines per standalone example. There are no SDK implementation, generated-file, public API, dependency, authentication, or endpoint changes, and no reconnection or timeout framework.

## Regression coverage

Extend the existing real-entrypoint loopback TLS/WebSocket suite from 16 to 24 cases, covering OpenAI and Azure with both `ws` and the native WebSocket transport:

- A clean close after text completion but before `response.done`.
- An abrupt disconnect before response output.
- Existing completed, failed, cancelled, and incomplete terminal-response controls.

The tests run the actual examples and SDK transports, verify their three outgoing client events and provider URLs, retain the Azure bearer-header assertion, and ensure synthetic credentials, response metadata, and close reasons are not printed. Only Azure credential acquisition is replaced with a synthetic token; the connection and socket events are real.

Before the fix, the four clean-close cases and two `ws` abrupt-close cases returned exit code 0. Native abrupt-close cases already returned 1 but lacked the close diagnostic. All 16 terminal-response controls passed. With the fix, all 24 cases pass.

## Validation

- All 24 Realtime example cases pass on Node 22.22.3, 24.19.0, and 26.7.0.
- The complete canonical handwritten unit suite passes on Node 24.19.0: 7,681 tests across 199 files.
- Canonical `./scripts/lint`, repository TypeScript checks, and `git diff --check` pass.
- Canonical `./scripts/build` passes; the complete default SDK output is byte-identical to the clean main baseline.

## Adversarial review

Self-review and an independent adversarial review checked terminal-event versus socket-close ordering, preservation of failed terminal results, native and `ws` error behavior, output draining, synthetic credential isolation, and absence of close-reason or response-metadata logging. No required changes remained. The guard belongs only to these single-response examples; SDK transport behavior is unchanged.
