### PR TITLE
fix(lint): preserve leading-dash generated file paths

### DIFF
--- a/scripts/lint-generated.cjs
+++ b/scripts/lint-generated.cjs
@@ -54,7 +54,7 @@ function fixGeneratedFiles(files) {
     const before = fingerprint(files);
     const result = spawnSync(
       process.execPath,
-      [oxlint, '--config', generatedConfig, '--fix', '--quiet', ...files],
+      [oxlint, '--config', generatedConfig, '--fix', '--quiet', '--', ...files],
       { cwd: repositoryRoot, stdio: 'inherit' },
     );
 
@@ -77,7 +77,7 @@ function fixGeneratedFiles(files) {
 function checkGeneratedFiles(files) {
   const result = spawnSync(
     process.execPath,
-    [oxlint, '--config', generatedConfig, '--format', 'json', ...files],
+    [oxlint, '--config', generatedConfig, '--format', 'json', '--', ...files],
     { cwd: repositoryRoot, encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
   );
 

--- a/tests/lint-generated-literal-paths.test.ts
+++ b/tests/lint-generated-literal-paths.test.ts
@@ -1,0 +1,98 @@
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const repoRoot = process.cwd();
+const oxlintURL = pathToFileURL(realpathSync(path.join(repoRoot, 'node_modules/oxlint/bin/oxlint'))).href;
+const header = '// File generated from our OpenAPI spec by Castiron. See CONTRIBUTING.md for details.';
+const handwritten = "import { Unused } from './dependency';\nexport const value = 1;\n";
+const generated = `${header}\n${handwritten}`;
+const clean = `${header}\nexport const value = 1;\n`;
+
+function lintGenerated(root: string, mode: string, files: string[]) {
+  const result = spawnSync(
+    process.execPath,
+    [path.join(root, 'scripts/lint-generated.cjs'), mode, ...files],
+    {
+      cwd: root,
+      encoding: 'utf-8',
+      timeout: 15_000,
+    },
+  );
+
+  expect(result.error).toBeUndefined();
+  expect(result.signal).toBeNull();
+  return result;
+}
+
+describe('generated lint literal paths', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'openai-node-generated-lint-paths-'));
+    mkdirSync(path.join(root, 'scripts'));
+    for (const file of [
+      'scripts/lint-generated.cjs',
+      'scripts/generated-files.cjs',
+      'oxlint.generated.config.json',
+    ]) {
+      copyFileSync(path.join(repoRoot, file), path.join(root, file));
+    }
+
+    // Keep all fixture directories owned while running the unchanged, real lint CLI.
+    const oxlintDirectory = path.join(root, 'node_modules/oxlint');
+    mkdirSync(path.join(oxlintDirectory, 'bin'), { recursive: true });
+    writeFileSync(path.join(oxlintDirectory, 'package.json'), '{"type":"module"}\n');
+    writeFileSync(path.join(oxlintDirectory, 'bin/oxlint'), `import ${JSON.stringify(oxlintURL)};\n`);
+
+    writeFileSync(path.join(root, 'unrelated-generated.ts'), generated);
+    writeFileSync(path.join(root, 'unrelated-handwritten.ts'), handwritten);
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test.each([
+    { filename: '-clean.ts', fileList: false },
+    { filename: '-clean.ts', fileList: true },
+    { filename: 'normal.ts', fileList: false },
+  ])('checks and fixes only $filename (file list: $fileList)', ({ filename, fileList }) => {
+    const selected = path.join(root, filename);
+    writeFileSync(selected, clean);
+    writeFileSync(path.join(root, 'files.txt'), `${filename}\n`);
+    const files = fileList ? ['--file-list', 'files.txt'] : [filename];
+
+    const cleanResults = ['--check', '--fix'].map((mode) => lintGenerated(root, mode, files).status);
+    expect(cleanResults).toEqual([0, 0]);
+    expect(readFileSync(selected, 'utf-8')).toBe(clean);
+
+    writeFileSync(selected, generated);
+    const checked = lintGenerated(root, '--check', files);
+    expect(checked.status).toBe(1);
+    expect(checked.stderr).toContain(`${filename}:`);
+    expect(checked.stderr).toContain("Identifier 'Unused' is imported but never used.");
+    expect(readFileSync(selected, 'utf-8')).toBe(generated);
+
+    const fixed = lintGenerated(root, '--fix', files);
+    expect(fixed.status).toBe(0);
+    expect(readFileSync(selected, 'utf-8')).not.toContain('Unused');
+    expect(readFileSync(selected, 'utf-8')).toContain('export const value = 1;');
+
+    const rechecked = lintGenerated(root, '--check', files);
+    expect(rechecked.status).toBe(0);
+    expect(rechecked.stderr).not.toContain("Identifier 'Unused' is imported but never used.");
+    expect(readFileSync(path.join(root, 'unrelated-generated.ts'), 'utf-8')).toBe(generated);
+    expect(readFileSync(path.join(root, 'unrelated-handwritten.ts'), 'utf-8')).toBe(handwritten);
+  });
+});


### PR DESCRIPTION
## Summary

Keep selected generated-file paths from being interpreted as oxlint command-line options.

The handwritten generated-file lint wrapper passes selected relative filenames directly after its options. A generated file named `-clean.ts` is therefore interpreted as oxlint's `-c` option instead of a file, causing both `--check` and `--fix` to fail before checking or fixing the intended file. This affects both direct filename arguments and the wrapper's existing file-list input.

Add the standard `--` end-of-options separator before the selected files in the two existing subprocess calls. File discovery, file-list parsing, generated ownership, lint configuration, repeated-fix convergence, and exit-status handling remain unchanged. No generated SDK files, dependencies, exported APIs, or custom-code budget settings change.

## Regression coverage

Three compact cases run the actual generated-file wrapper, discovery helper, configuration, and pinned oxlint CLI:

- A leading-dash filename passed directly.
- The same filename selected through a file list.
- An ordinary filename as the compatibility control.

Each case checks a clean file in both modes, verifies an unused-import diagnostic without modifying the file, applies the real fix, and checks the fixed file again. Unrelated generated and handwritten files must remain byte-identical.

Fixtures contain only owned directories and files. A fixture-owned launcher imports the unchanged real oxlint entrypoint by absolute file URL; no shared dependency directory is symlinked into the mutable fixture. Ambient runtime controls are preserved, and the test checks the relevant lint diagnostic rather than requiring all runtime stderr to be empty.

On unchanged main, both leading-dash cases fail while the ordinary-name control passes. With the two separators, all three cases pass.

## Validation

- All three new cases pass on Node 22.22.3, 24.19.0, and 26.7.0 with ambient runtime controls intact.
- The complete canonical handwritten unit suite passes on Node 24.19.0: 7,681 tests across 201 files.
- Canonical `./scripts/lint`, full repository TypeScript checking, and `git diff --check` pass.
- Canonical `./scripts/build` passes; the entire default SDK output is byte-identical to the clean `833e3e8d` baseline.

## Adversarial review

Self-review and an independent adversarial review checked placement of the separator after all intended options, unchanged direct/file-list selection and convergence behavior, real CLI execution, fixture ownership, and preservation of unrelated files. No required changes remained. The fix establishes the positional-argument boundary without adding path parsing or a new abstraction.
