### PR TITLE
test(bedrock): isolate fixtures from endpoint overrides

### DIFF
--- a/tests/lib/bedrock-provider-bearer-cancellation.test.ts
+++ b/tests/lib/bedrock-provider-bearer-cancellation.test.ts
@@ -131,7 +131,15 @@ function throwAfterRemovingOnce(signal: AbortSignal): void {
   });
 }
 
-afterEach(() => vi.restoreAllMocks());
+beforeEach(() => {
+  // oxlint-disable-next-line unicorn/no-useless-undefined -- Vitest requires its second argument when removing an environment variable.
+  vi.stubEnv('AWS_BEDROCK_BASE_URL', undefined);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
 
 describe.each(providerCases)('%s %s credentials', (_name, endpoint, create) => {
   test('cancels a documented public models request while its token provider remains pending', async () => {

--- a/tests/lib/bedrock-runtime-streaming.test.ts
+++ b/tests/lib/bedrock-runtime-streaming.test.ts
@@ -1,3 +1,4 @@
+import { vi } from 'vitest';
 import OpenAI from 'openai';
 import { bedrock as bearerBedrock } from 'openai/providers/bedrock';
 import { bedrock } from 'openai/providers/bedrock/aws';
@@ -23,6 +24,12 @@ const RUNTIME_PROVIDERS = [
     authorization: '/bedrock/aws4_request',
   },
 ] as const;
+
+beforeEach(() => {
+  // oxlint-disable-next-line unicorn/no-useless-undefined -- Vitest requires its second argument when removing an environment variable.
+  vi.stubEnv('AWS_BEDROCK_BASE_URL', undefined);
+});
+afterEach(() => vi.unstubAllEnvs());
 
 function sseResponse(events: readonly unknown[]): Response {
   const body = events


### PR DESCRIPTION
## Summary

Keep the two Bedrock cancellation/streaming test fixtures independent of a developer's `AWS_BEDROCK_BASE_URL` setting. Their clients intentionally exercise fixed synthetic endpoints, but the supported environment override could replace those endpoints before the assertions ran.

- Clear only that variable with file-local Vitest setup and restore its original value after each test.
- Preserve all existing assertions, synthetic bearer-token environment cases, and mock cleanup.
- Keep provider precedence, endpoint/region validation, SDK behavior, dependencies, and the global test harness unchanged.

Both changed files are wholly handwritten and absent from the verified pure-generated snapshot. The explicit `undefined` argument uses a narrow, documented lint exception because Vitest's typed API requires the second argument when removing a variable.

## Verification

Using the synthetic override `https://bedrock-runtime.us-west-2.amazonaws.com/openai/v1` with the actual public-client fixtures:

- Before: 75 of the existing 93 tests failed on the untouched base because the override conflicted with their fixed regions/endpoints.
- After: all 93 tests pass with the override on Node 22.22.3, 24.19.0, and 26.7.0.
- The same 93 tests also pass without the override.
- All 7,688 handwritten tests across 202 files pass with the synthetic override still present.
- Canonical formatting/lint, the full repository TypeScript check, and `git diff --check` pass.

The tests use their existing in-memory fetch fixtures; no live API requests, installations, or credential values are needed. Adversarial self-review and independent review confirmed the setup/teardown lifetime, environment restoration, unchanged authentication cases, and test-only scope.
