### PR TITLE
fix(examples): drain Azure example diagnostics before exiting

### DIFF
--- a/examples/azure/assistants.ts
+++ b/examples/azure/assistants.ts
@@ -62,5 +62,5 @@ async function main() {
 
 main().catch((err) => {
   console.error(err);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/examples/azure/chat.ts
+++ b/examples/azure/chat.ts
@@ -49,5 +49,5 @@ async function main() {
 
 main().catch((err) => {
   console.error(err);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/examples/azure/responses.ts
+++ b/examples/azure/responses.ts
@@ -46,5 +46,5 @@ async function main() {
 
 main().catch((err) => {
   console.error(err);
-  process.exit(1);
+  process.exitCode = 1;
 });


### PR DESCRIPTION
## Summary

Replace `process.exit(1)` with `process.exitCode = 1` in `examples/azure/chat.ts`, `examples/azure/responses.ts`, and `examples/azure/assistants.ts`.

When an unhandled error is caught in `main().catch(...)`, calling `process.exit(1)` immediately can prematurely terminate the process before queued diagnostics on `process.stderr` / `process.stdout` have finished flushing. Setting `process.exitCode = 1` preserves the failure exit status while allowing Node.js to drain output streams naturally ([Node's process-exit guidance](https://nodejs.org/api/process.html#processexitcode)).

This aligns these Azure examples with the pattern established in other handwritten examples (such as #2629 and #2639).

## Verification

- Verified syntax and updated exit handling across all three Azure example entrypoints (`examples/azure/chat.ts`, `examples/azure/responses.ts`, `examples/azure/assistants.ts`).
- No public API signatures, SDK source code, generated files, or dependencies are modified.