### PR TITLE
docs(realtime): report unsuccessful responses in the guide

### DIFF
--- a/docs/realtime.md
+++ b/docs/realtime.md
@@ -13,6 +13,7 @@ Basic text based example with `ws`:
 import { OpenAIRealtimeWS } from 'openai/realtime/ws';
 
 const rt = new OpenAIRealtimeWS({ model: 'gpt-realtime' });
+let responseDone = false;
 
 // access the underlying `ws.WebSocket` instance
 rt.socket.on('open', () => {
@@ -49,10 +50,26 @@ rt.on('session.created', (event) => {
 rt.on('response.output_text.delta', (event) => process.stdout.write(event.delta));
 rt.on('response.output_text.done', () => console.log());
 
-rt.on('response.done', () => rt.close());
+// response.done also covers failed, cancelled, and incomplete responses.
+rt.on('response.done', (event) => {
+  responseDone = true;
+  if (event.response.status !== 'completed') {
+    console.error('Response did not complete successfully.');
+    process.exitCode = 1;
+  }
+  rt.close();
+});
 
-rt.socket.on('close', () => console.log('\nConnection closed!'));
+rt.socket.on('close', () => {
+  if (!responseDone) {
+    console.error('WebSocket closed before the response completed.');
+    process.exitCode = 1;
+  }
+  console.log('\nConnection closed!');
+});
 ```
+
+`response.done` indicates a terminal response, not necessarily a successful one. Check `event.response.status` for `completed`; a socket close before `response.done` also leaves the response unfinished.
 
 To use the web API `WebSocket` implementation, replace `OpenAIRealtimeWS` with `OpenAIRealtimeWebSocket` and adjust any `rt.socket` access:
 

--- a/tests/lib/realtime-example-status.test.ts
+++ b/tests/lib/realtime-example-status.test.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
+import { readFileSync } from 'node:fs';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { createServer } from 'node:https';
 import { tmpdir } from 'node:os';
@@ -11,15 +12,26 @@ import { WebSocketServer } from 'ws';
 
 import { createX509TestLab } from '../utils/x509-test-lab';
 
+const guideSnippet = readFileSync('docs/realtime.md', 'utf-8').match(/```ts\r?\n(?<source>[\s\S]*?)\r?\n```/u)
+  ?.groups?.['source'];
+if (!guideSnippet?.includes("import { OpenAIRealtimeWS } from 'openai/realtime/ws';")) {
+  throw new Error('Expected the basic ws example in the Realtime guide');
+}
+const inheritedCertificatePath = process.env['NODE_EXTRA_CA_CERTS'];
+const inheritedCertificateAuthority = inheritedCertificatePath
+  ? readFileSync(inheritedCertificatePath)
+  : Buffer.alloc(0);
+
 const cases = (['openai', 'azure'] as const).flatMap((provider) =>
-  (['ws', 'websocket'] as const).flatMap((example) =>
-    (['completed', 'failed', 'cancelled', 'incomplete', 'clean close', 'abrupt close'] as const).map(
-      (scenario) => ({
-        provider,
-        example,
-        scenario,
-      }),
-    ),
+  (provider === 'openai' ? (['ws', 'websocket', 'guide'] as const) : (['ws', 'websocket'] as const)).flatMap(
+    (example) =>
+      (['completed', 'failed', 'cancelled', 'incomplete', 'clean close', 'abrupt close'] as const).map(
+        (scenario) => ({
+          provider,
+          example,
+          scenario,
+        }),
+      ),
   ),
 );
 
@@ -103,7 +115,10 @@ test.each(cases)('$provider Realtime $example handles $scenario', async ({ provi
   });
 
   try {
-    await writeFile(certificatePath, lab.certificateAuthority);
+    await writeFile(
+      certificatePath,
+      Buffer.concat([inheritedCertificateAuthority, Buffer.from('\n'), lab.certificateAuthority]),
+    );
     if (provider === 'azure') {
       await writeFile(
         identityPath,
@@ -136,22 +151,34 @@ Module._load = function(request, ...args) {
         ...(provider === 'azure' ? ['-r', identityPath] : []),
         '-r',
         path.join(root, 'node_modules/tsconfig-paths/register.js'),
-        path.join(root, 'examples', ...(provider === 'azure' ? ['azure'] : []), 'realtime', `${example}.ts`),
+        ...(example === 'guide'
+          ? ['--eval', guideSnippet]
+          : [
+              path.join(
+                root,
+                'examples',
+                ...(provider === 'azure' ? ['azure'] : []),
+                'realtime',
+                `${example}.ts`,
+              ),
+            ]),
       ],
       {
         cwd: root,
         env: {
+          ...process.env,
+          OPENAI_API_KEY: 'synthetic-example-key',
+          OPENAI_ADMIN_KEY: undefined,
           ...(provider === 'azure'
-            ? { AZURE_OPENAI_ENDPOINT: `https://127.0.0.1:${address.port}` }
-            : {
-                OPENAI_API_KEY: 'synthetic-example-key',
-                OPENAI_BASE_URL: `https://127.0.0.1:${address.port}/v1`,
-              }),
+            ? { AZURE_OPENAI_ENDPOINT: `https://127.0.0.1:${address.port}`, OPENAI_BASE_URL: undefined }
+            : { OPENAI_BASE_URL: `https://127.0.0.1:${address.port}/v1`, AZURE_OPENAI_ENDPOINT: undefined }),
+          AZURE_OPENAI_API_KEY: undefined,
+          OPENAI_CUSTOM_HEADERS: undefined,
+          OPENAI_LOG: 'off',
           NODE_EXTRA_CA_CERTS: certificatePath,
           DOTENV_CONFIG_PATH: path.join(directory, '.env'),
           TS_NODE_PROJECT: path.join(root, 'tsconfig.json'),
           DISABLE_V8_COMPILE_CACHE: '1',
-          SystemRoot: process.env['SystemRoot'],
         },
         stdio: ['ignore', 'pipe', 'pipe'],
         timeout: 15_000,
@@ -176,6 +203,8 @@ Module._load = function(request, ...args) {
       ]);
       if (provider === 'azure') {
         expect(authorization).toEqual([`Bearer ${azureToken}`]);
+      } else if (example === 'guide') {
+        expect(authorization).toEqual(['Bearer synthetic-example-key']);
       }
       expect(requests).toEqual([
         {


### PR DESCRIPTION
## Summary

Make the basic `ws` example in `docs/realtime.md` distinguish a terminal Realtime response from a successful one.

Previously, the copied guide exited successfully after failed, cancelled, or incomplete responses, and after either a clean or abrupt socket close before `response.done`. All five failure cases reproduced against the unchanged guide and the real public SDK. A completed response remains the successful control.

The guide now uses the same small completion/status guards as the existing runnable Realtime examples: report an unsuccessful response or premature closure with a fixed diagnostic and a nonzero exit code, while preserving normal output and connection cleanup.

## Scope and regression coverage

- Change only the handwritten guide and its existing executable-example test file; no SDK implementation, public types, dependencies, or generated files change.
- Execute the guide's exact first TypeScript fence through the public `openai/realtime/ws` entrypoint against a synthetic TLS/WebSocket loopback server.
- Cover completed, failed, cancelled, incomplete, clean early-close, and abrupt early-close cases, including the exact requests, synthetic authentication, output, and private-data omission.
- Preserve inherited runtime/proxy configuration and CA trust while isolating SDK credentials and endpoints in the fixture. Keep all 24 existing OpenAI/Azure example cases.

## Validation

- Before the documentation fix: **5 new regressions failed, 1 success control passed**; 24 existing cases were skipped for that targeted run.
- After: **30/30 focused tests passed** on Node **22.22.3, 24.19.0, and 26.7.0**.
- All **6 guide cases passed on exact Node 22.0.0**.
- The exact guide fence passed strict public-declaration checks on **TypeScript 4.9.5 and 6.0.3** (using compatible installed Node type definitions for each compiler).
- Canonical `./scripts/format`, `./scripts/lint`, and the normal repository TypeScript check passed.
- Full canonical handwritten suite: **7,737 tests passed across 203 files**.
- Repeated adversarial review covered terminal status, premature closure, output draining, authentication transport differences, fixture cleanup, and supported-runtime compatibility.
