### PR TITLE
docs(helpers): remove undefined main call from parsing example

### DIFF
--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -147,8 +147,6 @@ if (toolCall?.type === 'function') {
   console.log(args);
   console.log(args.table_name);
 }
-
-main();
 ```
 
 ### Differences from `.create()`


### PR DESCRIPTION
## Summary

Remove the trailing `main();` call from the self-contained function-tool parsing example in `docs/helpers.md`.

The snippet already runs at the top level and does not define `main`. As written, copying it into a TypeScript module produces `TS2304: Cannot find name 'main'`. Transpile-only execution also throws `ReferenceError: main is not defined` after an otherwise successful API response. Removing the obsolete call preserves the existing request, parsing, output, and error propagation.

This changes only two lines in a handwritten guide (the call and its preceding blank line). No SDK code, generated files, dependencies, or other examples change.

## Verification

- Extracted the original and actual revised fenced examples and compiled them against the real public SDK declarations. The final example passes strict TypeScript 4.9.5 and 6.0.3; the original has the undefined-`main` diagnostic. The neighboring complete Zod example remains a clean control.
- Executed the original and actual final snippet using the real built SDK and a synthetic-authenticated loopback HTTP server on Node 22.0.0, 24.19.0, and 26.7.0: 18 executions covering a function call, an ordinary assistant message, and an HTTP 400, before and after.
- Successful responses now exit naturally with status 0 instead of 1, with identical stdout. HTTP 400 responses still exit with status 1 through the existing SDK error path. Each execution makes exactly one request with the existing strict query tool.
- Canonical `./scripts/format`, `./scripts/lint`, and `git diff --check` pass.
- Adversarial self-review and independent review confirm that no missing wrapper or second invocation is required.

Validation is scoped to the exact documentation artifact; this PR does not add a separate test framework or claim a full SDK test run. No live API calls or real credentials were used.
