### PR TITLE
docs(tools): support TypeScript 4.9 in the function loop

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -38,7 +38,9 @@ let response = await client.responses.create({
 });
 
 while (true) {
-  const calls = response.output.filter((item) => item.type === 'function_call');
+  const calls = response.output.filter(
+    (item): item is OpenAI.Responses.ResponseFunctionToolCall => item.type === 'function_call',
+  );
 
   if (response.status !== 'completed') {
     const details = response.error ?? response.incomplete_details;


### PR DESCRIPTION
## Summary

Add an explicit `OpenAI.Responses.ResponseFunctionToolCall` type predicate to the function-call filter in the first complete example in `docs/tools.md`.

The repository supports TypeScript 4.9, but that compiler does not infer a type predicate from `item.type === 'function_call'`. Consequently the original `calls` variable remains `ResponseOutputItem[]` and the example fails with four `TS2339` diagnostics when reading `name`, `arguments`, and `call_id`. The current compiler infers the narrowing, which hid the compatibility problem.

The explicit public subtype fixes TypeScript 4.9 without adding an import, a cast, a new SDK type, or any runtime code. The existing discriminator check and function loop are unchanged.

## Verification

- Compiled the exact original and actual final fence against the real public SDK declarations with strict TypeScript 4.9.5 and 6.0.3. The original reproduces four errors on 4.9; the final fence has zero diagnostics on both.
- Confirmed that `calls` is `ResponseFunctionToolCall[]` on both compilers and that emitted JavaScript is byte-identical before and after.
- Executed the original and revised complete snippets through the real SDK with an in-memory synthetic transport. Mixed reasoning, message, and function-call output still produces exactly one correctly associated function result, followed by the expected final text; both requests assert the synthetic Authorization header.
- A complete explicit-schema example from `docs/structured-outputs.md` compiles unchanged on both compilers as a control.
- Canonical `./scripts/format`, `./scripts/lint`, and `git diff --check` pass.
- Adversarial self-review and independent review pass.

Only the handwritten guide changes (three added lines, one removed). Validation targets the documentation's compiler boundary; no SDK source, generated files, dependencies, runtime behavior, or test infrastructure changes. No live API calls or real credentials were used.
