### PR TITLE
test: avoid subprocess-heavy mock timeout fixture on Windows

### DIFF
--- a/tests/mock-launcher.test.ts
+++ b/tests/mock-launcher.test.ts
@@ -200,13 +200,12 @@ exit 23`,
   test('terminates the daemon if it times out before becoming healthy', () => {
     const fixture = mkdtempSync(path.join(tmpdir(), 'openai-node-mock-launcher-timeout-'));
     const checkout = path.join(fixture, 'checkout');
-    const executableDirectory = path.join(fixture, 'executables');
+    const bashEnvironment = path.join(fixture, 'bash-env');
     const steadyPidFile = path.join(fixture, 'steady.pid');
     let steadyPid: number | undefined;
 
     try {
       mkdirSync(path.join(checkout, 'scripts'), { recursive: true });
-      mkdirSync(executableDirectory);
       writeFileSync(path.join(checkout, 'scripts/mock'), readFileSync(path.join(root, 'scripts/mock')));
 
       writeExecutable(
@@ -219,19 +218,24 @@ exit 23`,
           'setInterval(() => {}, 1000);',
         ].join('\n'),
       );
-      writeShellExecutable(
-        path.join(executableDirectory, 'curl'),
-        `attempts=0
+      writeFileSync(
+        bashEnvironment,
+        `curl() {
+  attempts=0
 while [[ ! -s "$STEADY_PID_FILE" && "$attempts" -lt 1000 ]]; do
   attempts=$((attempts + 1))
   :
 done
-exit 1`,
+  return 1
+}
+sleep() {
+  :
+}
+`,
       );
-      writeShellExecutable(path.join(executableDirectory, 'sleep'), 'exit 0');
 
-      const curlWithoutPid = spawnSync('bash', [path.join(executableDirectory, 'curl')], {
-        env: { ...process.env, STEADY_PID_FILE: steadyPidFile },
+      const curlWithoutPid = spawnSync('bash', ['-c', 'curl'], {
+        env: { ...process.env, BASH_ENV: bashEnvironment, STEADY_PID_FILE: steadyPidFile },
         timeout: 1000,
       });
       expect(curlWithoutPid.error).toBeUndefined();
@@ -242,7 +246,7 @@ exit 1`,
         encoding: 'utf-8',
         env: {
           ...process.env,
-          PATH: `${executableDirectory}${path.delimiter}${path.dirname(process.execPath)}${path.delimiter}${process.env['PATH']}`,
+          BASH_ENV: bashEnvironment,
           STEADY_PID_FILE: steadyPidFile,
         },
         timeout: 15_000,

--- a/tests/mock-launcher.test.ts
+++ b/tests/mock-launcher.test.ts
@@ -221,11 +221,11 @@ exit 23`,
       writeFileSync(
         bashEnvironment,
         `curl() {
-  attempts=0
-while [[ ! -s "$STEADY_PID_FILE" && "$attempts" -lt 1000 ]]; do
-  attempts=$((attempts + 1))
-  :
-done
+  local spin_attempts=0
+  while [[ ! -s "$STEADY_PID_FILE" && "$spin_attempts" -lt 1000 ]]; do
+    spin_attempts=$((spin_attempts + 1))
+    :
+  done
   return 1
 }
 sleep() {
@@ -234,10 +234,14 @@ sleep() {
 `,
       );
 
-      const curlWithoutPid = spawnSync('bash', ['-c', 'curl'], {
-        env: { ...process.env, BASH_ENV: bashEnvironment, STEADY_PID_FILE: steadyPidFile },
-        timeout: 1000,
-      });
+      const curlWithoutPid = spawnSync(
+        'bash',
+        ['-c', 'attempts=17; curl; curl_status=$?; [[ "$attempts" == 17 ]] || exit 99; exit "$curl_status"'],
+        {
+          env: { ...process.env, BASH_ENV: bashEnvironment, STEADY_PID_FILE: steadyPidFile },
+          timeout: 1000,
+        },
+      );
       expect(curlWithoutPid.error).toBeUndefined();
       expect(curlWithoutPid.status).toBe(1);
 


### PR DESCRIPTION
## Problem  `tests/mock-launcher.test.ts` times out on Windows before its unhealthy-daemon cleanup assertions run.  Baseline on Node 24.19.0 / Git Bash:  ```text ./scripts/test tests/mock-launcher.test.ts 3 passed, 1 failed Error: spawnSync bash ETIMEDOUT ```  ## Root cause  The fixture put shell-script shims for both `curl` and `sleep` on `PATH`. The launcher intentionally performs up to 300 failed health probes, so the timeout path creates roughly 600 nested Bash processes. Their startup overhead exceeds the test's 15-second guard on Windows even though the simulated sleeps are no-ops.  ## Fix  Load fixture-local `curl` and `sleep` functions through `BASH_ENV` so all 300 production polling iterations stay in the launcher shell. The copied `scripts/mock`, polling limit, cleanup trap, PID checks, and timeout assertions remain unchanged. The preflight verifies that the synthetic health check fails without hanging and explicitly asserts that its helper leaves the launcher counter unchanged.  ## Tests  - `./scripts/test tests/mock-launcher.test.ts`: 4/4 pass - Adjacent launcher/wrapper/fetch suites: 39 pass, 7 skipped - `pnpm lint`: pass - `pnpm exec tsc --noEmit`: pass - `pnpm build`: pass
- [Fork CI on exact head `313c4b3e`](https://github.com/huanglianggit/openai-node/actions/runs/34080731069): all jobs pass, including lint, build, ecosystem tests, Node 22/24/26, and the final test matrix - `pnpm test:unit`: the changed suite passes; the full Windows run reaches 7,624 passing tests and exits nonzero because 76 failures remain in four unrelated Windows-sensitive suites (`ecosystem-cli`, Cloudflare credential lifecycle, background streaming, and X.509 timing)  ## Compatibility / Risk  Test-only change in handwritten coverage. It does not alter SDK runtime behavior, generated files, dependencies, or release configuration. `BASH_ENV` is used only for the two isolated non-interactive Bash fixture processes.