### PR TITLE
test: quote Cloudflare lifecycle preload paths

### DIFF
--- a/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
+++ b/tests/ecosystem-cloudflare-credential-lifecycle-security.test.ts
@@ -67,7 +67,8 @@ const credentialStates: CredentialState[] = [
 ];
 
 function withFixture(run: (fixture: Fixture) => void) {
-  const directory = mkdtempSync(path.join(tmpdir(), 'openai-node-cloudflare-lifecycle-'));
+  // Exercise preload paths containing spaces regardless of the system temporary directory.
+  const directory = mkdtempSync(path.join(tmpdir(), 'openai-node-cloudflare lifecycle-'));
   const worker = path.join(directory, 'ecosystem-tests', 'cloudflare-worker');
   const bin = path.join(directory, 'bin');
   const fixture: Fixture = {
@@ -207,6 +208,10 @@ function holdOriginalCredentialDescriptor(fixture: Fixture): string {
 
 function expectNoCloudflareCredentialArtifacts(fixture: Fixture) {
   expect(readdirSync(fixture.worker).filter((name) => name.startsWith('.dev.vars.openai-'))).toEqual([]);
+}
+
+function preloadNodeOptions(preload: string) {
+  return `--require "${preload.split('\\').join('\\\\').split('"').join('\\"')}"`;
 }
 
 function runCloudflare(
@@ -365,7 +370,7 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
       const result = runCloudflare(fixture, ['--live'], {
         CLOUDFLARE_FAILURE: 'capture-original',
         CLOUDFLARE_HELD_CAPTURE: capture,
-        NODE_OPTIONS: `--require ${preload}`,
+        NODE_OPTIONS: preloadNodeOptions(preload),
       });
 
       expect(result.error).toBeUndefined();
@@ -385,7 +390,7 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
 
       const result = runCloudflare(fixture, ['--live'], {
         CLOUDFLARE_FAILURE: 'edit-original',
-        NODE_OPTIONS: `--require ${preload}`,
+        NODE_OPTIONS: preloadNodeOptions(preload),
       });
 
       expect(result.error).toBeUndefined();
@@ -477,7 +482,7 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
         const result = runCloudflare(fixture, ['--live', '--retry=3', '--retryDelay=0'], {
           CLOUDFLARE_FAILURE: 'deny-path-validation',
           CLOUDFLARE_DENIAL_READY: marker,
-          NODE_OPTIONS: `--require ${preload}`,
+          NODE_OPTIONS: preloadNodeOptions(preload),
         });
 
         expect(result.error).toBeUndefined();
@@ -601,7 +606,7 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
           CLOUDFLARE_FAILURE: interruption.failure,
           CLOUDFLARE_INTERRUPT_COMMAND: interruption.command,
           CLOUDFLARE_INTERRUPT_SIGNAL: interruption.signal,
-          NODE_OPTIONS: `--require ${preload}`,
+          NODE_OPTIONS: preloadNodeOptions(preload),
         },
         false,
       );
@@ -677,7 +682,7 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
         const result = runCloudflare(fixture, ['--live', '--retry=3', '--retryDelay=0'], {
           CLOUDFLARE_FAILURE: 'replace-file',
           CLOUDFLARE_IDENTITY_FIELD: field,
-          NODE_OPTIONS: `--require ${preload}`,
+          NODE_OPTIONS: preloadNodeOptions(preload),
         });
 
         expect(result.error).toBeUndefined();
@@ -790,7 +795,7 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
         const result = runCloudflare(fixture, ['--live'], {
           CLOUDFLARE_FAILURE: 'replace-during-truncate',
           CLOUDFLARE_REPLACE_READY: marker,
-          NODE_OPTIONS: `--require ${preload}`,
+          NODE_OPTIONS: preloadNodeOptions(preload),
         });
 
         expect(result.error).toBeUndefined();
@@ -860,7 +865,7 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
           {
             CLOUDFLARE_ACQUISITION_PHASE: phase,
             CLOUDFLARE_ACQUISITION_SIGNAL: signal,
-            NODE_OPTIONS: `--require ${preload}`,
+            NODE_OPTIONS: preloadNodeOptions(preload),
           },
           noCleanup,
         );
@@ -919,7 +924,7 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
         const result = runCloudflare(
           fixture,
           flags,
-          { CLOUDFLARE_STAGING_SIGNAL: signal, NODE_OPTIONS: `--require ${preload}` },
+          { CLOUDFLARE_STAGING_SIGNAL: signal, NODE_OPTIONS: preloadNodeOptions(preload) },
           noCleanup,
         );
 
@@ -988,7 +993,7 @@ describe('Cloudflare ecosystem credential lifecycle', () => {
         ].join('\n'),
       );
 
-      const result = runCloudflare(fixture, ['--live'], { NODE_OPTIONS: `--require ${preload}` });
+      const result = runCloudflare(fixture, ['--live'], { NODE_OPTIONS: preloadNodeOptions(preload) });
 
       expect(result.error).toBeUndefined();
       expect(result.status).toBe(1);


### PR DESCRIPTION
## Summary

Fix the Cloudflare credential-lifecycle test fixture when its temporary directory contains spaces.

Nine fault-injection preloads were passed as `NODE_OPTIONS="--require <raw path>"`. Node split a spaced filename into separate arguments and exited before the fixture could exercise the credential lifecycle.

- Add a shared helper that quotes the preload filename and escapes backslashes and double quotes.
- Preserve literal control characters, the existing `NODE_OPTIONS` override behavior, and preload inheritance into child processes.
- Put a deliberate space in the fixture directory prefix so the existing real-process tests permanently cover this boundary.

## Reproduction and regression

On the unchanged test, changing only `TMPDIR` from an ordinary directory to a directory containing spaces makes “never exposes a staged key through a pre-opened readable original inode” fail: the child exits 1 instead of 0. A native Node control reports `Cannot find module` for the path segment before the first space.

Applying only the new spaced fixture prefix reproduces the same failure. With the helper applied, the test passes, and all 79 credential-lifecycle cases pass as part of the full suite.

## Validation

- `./scripts/format` and `./scripts/lint`: passed with the pinned tools.
- `tsc --noEmit`: passed.
- `CI=true OPENAI_TEST_SUITE=unit ./scripts/test` on Node 24.19.0: **7,745 tests / 203 files passed**.
- Independent native Node checks loaded the exact final helper's preload in both parent and inherited child processes: **66 checks passed** across Node 22.0.0, 24.19.0, and 26.2.0. The 11 real filename cases cover spaces, quotes, backslashes, combinations, tabs, newlines, carriage returns, a control character, and Unicode.
- Deliberately adversarial reviews checked argument encoding, compatibility, inheritance, cleanup, and unchanged security assertions. JSON encoding was rejected because [Node's option parser](https://github.com/nodejs/node/blob/v24.19.0/src/node_options.cc#L2055-L2091) does not decode JSON control escapes. The final helper also passes the project's ES2020 TypeScript library target without suppressions.

The initial full-suite invocation omitted pnpm from my restricted PATH and failed three unrelated tooling fixtures; restoring the normal pinned-tool PATH passed the complete suite without further source changes. Native execution was on macOS; this does not claim to reproduce or resolve the separate Windows failure report.

## Scope

One handwritten test file only. No production, generated, dependency, compiler-configuration, assertion, timeout, credential-policy, or notifier-reset changes. No open PR currently covers this preload-path issue.
