### PR TITLE
fix(client): make retry backoff abortable via AbortSignal

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1681,7 +1681,7 @@ export class OpenAI {
       await x509Authentication.waitForRetry(timeoutMillis, x509Authentication.effectiveSignal());
     } else {
       const retrySignals =
-        requestSignal === options.signal ? [requestSignal] : [requestSignal, options.signal];
+        requestSignal === options.signal ? [requestSignal] : [options.signal, requestSignal];
       try {
         await sleep(timeoutMillis, ...retrySignals);
       } catch (error) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1090,6 +1090,8 @@ export class OpenAI {
           props.options,
           retriesRemaining,
           props.retryOfRequestLogID ?? props.requestLogID,
+          undefined,
+          props.requestSignal,
         );
         Object.assign(props, next);
       } finally {
@@ -1300,7 +1302,13 @@ export class OpenAI {
             message: x509Authentication ? 'X.509 workload identity API connection failed.' : response.message,
           }),
         );
-        return this.retryRequest(options, retriesRemaining, retryOfRequestLogID ?? requestLogID);
+        return this.retryRequest(
+          options,
+          retriesRemaining,
+          retryOfRequestLogID ?? requestLogID,
+          undefined,
+          req.signal,
+        );
       }
       const terminalMessage = hasStreamingBody
         ? 'error; streaming body cannot be retried'
@@ -1424,6 +1432,7 @@ export class OpenAI {
           retriesRemaining,
           retryOfRequestLogID ?? requestLogID,
           response.headers,
+          req.signal,
         );
       }
 
@@ -1479,7 +1488,15 @@ export class OpenAI {
       helperMethod: options.__metadata?.['helperMethod'],
       ...(continueRequest ? { continueRequest } : {}),
     });
-    return { response, options, controller, requestLogID, retryOfRequestLogID, startTime };
+    return {
+      response,
+      options,
+      controller,
+      requestSignal: req.signal,
+      requestLogID,
+      retryOfRequestLogID,
+      startTime,
+    };
   }
 
   getAPIList<Item, PageClass extends Pagination.AbstractPage<Item> = Pagination.AbstractPage<Item>>(
@@ -1615,6 +1632,7 @@ export class OpenAI {
     retriesRemaining: number,
     requestLogID: string,
     responseHeaders?: Headers | undefined,
+    requestSignal: AbortSignal | null | undefined = options.signal,
   ): Promise<APIResponseProps> {
     let timeoutMillis: number | undefined;
 
@@ -1662,7 +1680,17 @@ export class OpenAI {
     if (x509Authentication) {
       await x509Authentication.waitForRetry(timeoutMillis, x509Authentication.effectiveSignal());
     } else {
-      await sleep(timeoutMillis);
+      const retrySignals =
+        requestSignal === options.signal ? [requestSignal] : [requestSignal, options.signal];
+      try {
+        await sleep(timeoutMillis, ...retrySignals);
+      } catch (error) {
+        const abortedSignal = retrySignals.find((signal) => signal?.aborted);
+        if (abortedSignal) {
+          throw this._makeUserAbortError(abortedSignal);
+        }
+        throw error;
+      }
     }
 
     return this.makeRequest(options, retriesRemaining - 1, requestLogID);

--- a/src/internal/parse.ts
+++ b/src/internal/parse.ts
@@ -9,6 +9,7 @@ export type APIResponseProps = {
   response: Response;
   options: FinalRequestOptions;
   controller: AbortController;
+  requestSignal?: AbortSignal | null | undefined;
   requestLogID: string;
   retryOfRequestLogID: string | undefined;
   startTime: number;

--- a/src/internal/utils/sleep.ts
+++ b/src/internal/utils/sleep.ts
@@ -4,13 +4,16 @@ export const sleep = (ms: number, ...signals: (AbortSignal | null | undefined)[]
     const activeSignals = [...new Set(signals.filter((signal): signal is AbortSignal => signal != null))];
     let timeout: ReturnType<typeof setTimeout> | undefined;
     let settled = false;
+    const removeAbortListener = (signal: AbortSignal) => {
+      try {
+        signal.removeEventListener('abort', abort);
+      } catch {
+        // Structural signal cleanup must not prevent the promise from settling.
+      }
+    };
     const cleanup = () => {
       for (const signal of activeSignals) {
-        try {
-          signal.removeEventListener('abort', abort);
-        } catch {
-          // Structural signal cleanup must not prevent the promise from settling.
-        }
+        removeAbortListener(signal);
       }
     };
     const settle = (callback: () => void) => {
@@ -43,11 +46,23 @@ export const sleep = (ms: number, ...signals: (AbortSignal | null | undefined)[]
       }
       try {
         signal.addEventListener('abort', abort, { once: true });
+        if (settled) {
+          removeAbortListener(signal);
+          break;
+        }
       } catch (error) {
-        settle(() => reject(error));
+        if (settled) {
+          removeAbortListener(signal);
+        } else {
+          settle(() => reject(error));
+        }
       }
     }
-    if (activeSignals.some((signal) => signal.aborted)) {
-      abort();
+    try {
+      if (!settled && activeSignals.some((signal) => signal.aborted)) {
+        abort();
+      }
+    } catch (error) {
+      settle(() => reject(error));
     }
   });

--- a/src/internal/utils/sleep.ts
+++ b/src/internal/utils/sleep.ts
@@ -1,1 +1,53 @@
-export const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+/** Resolve after `ms`, or reject promptly if any provided AbortSignal aborts. */
+export const sleep = (ms: number, ...signals: (AbortSignal | null | undefined)[]): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const activeSignals = [...new Set(signals.filter((signal): signal is AbortSignal => signal != null))];
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let settled = false;
+    const cleanup = () => {
+      for (const signal of activeSignals) {
+        try {
+          signal.removeEventListener('abort', abort);
+        } catch {
+          // Structural signal cleanup must not prevent the promise from settling.
+        }
+      }
+    };
+    const settle = (callback: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+        timeout = undefined;
+      }
+      cleanup();
+      callback();
+    };
+    const abort = () => {
+      settle(() => reject());
+    };
+
+    if (activeSignals.some((signal) => signal.aborted)) {
+      abort();
+      return;
+    }
+
+    timeout = setTimeout(() => {
+      settle(resolve);
+    }, ms);
+    for (const signal of activeSignals) {
+      if (settled) {
+        break;
+      }
+      try {
+        signal.addEventListener('abort', abort, { once: true });
+      } catch (error) {
+        settle(() => reject(error));
+      }
+    }
+    if (activeSignals.some((signal) => signal.aborted)) {
+      abort();
+    }
+  });

--- a/tests/client-behavior.test.ts
+++ b/tests/client-behavior.test.ts
@@ -4,10 +4,12 @@ import OpenAI from 'openai';
 import {
   APIConnectionError,
   APIConnectionTimeoutError,
+  APIUserAbortError,
   OAuthError,
   SubjectTokenProviderError,
 } from 'openai/core/error';
 import { CursorPage } from 'openai/core/pagination';
+import { createProvider } from 'openai/internal/provider';
 
 class IdempotentOpenAI extends OpenAI {
   protected override idempotencyHeader = 'Idempotency-Key';
@@ -22,6 +24,14 @@ function jsonResponse(value: unknown = {}, init: ResponseInit = {}): Response {
     ...init,
     headers: { 'content-type': 'application/json', ...init.headers },
   });
+}
+
+async function observe(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    return await promise;
+  } catch (error) {
+    return error;
+  }
 }
 
 describe('OpenAI client request behavior', () => {
@@ -193,6 +203,92 @@ describe('OpenAI client request behavior', () => {
 
     await expect(client.get('/items', { signal: controller.signal })).rejects.toThrow('Request was aborted');
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test.each(['caller', 'prepared'] as const)(
+    'rejects promptly when the %s signal aborts during retry backoff',
+    async (abortedSignal) => {
+      vi.useFakeTimers();
+      const reason = new Error(`stop ${abortedSignal} request`);
+      const callerController = new AbortController();
+      const preparedController = new AbortController();
+      const fetch = vi.fn(async () =>
+        jsonResponse(
+          { error: { message: 'rate limited' } },
+          { status: 429, headers: { 'retry-after-ms': '60000' } },
+        ),
+      );
+      const client = new OpenAI({
+        provider: createProvider({
+          configure: () => ({
+            name: 'test-provider',
+            baseURL: 'https://api.openai.com/v1',
+            prepareRequest(request) {
+              request.signal = preparedController.signal;
+            },
+          }),
+        }),
+        maxRetries: 1,
+        fetch,
+      });
+      const request = client.get('/items', {
+        signal: callerController.signal,
+      });
+      const observed = observe(request);
+
+      try {
+        await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+        const controller = abortedSignal === 'caller' ? callerController : preparedController;
+        controller.abort(reason);
+        await vi.advanceTimersByTimeAsync(0);
+
+        const waiting = Symbol('request still waiting for retry delay');
+        const result = await Promise.race([observed, Promise.resolve(waiting)]);
+        expect(result).not.toBe(waiting);
+        expect(result).toBeInstanceOf(APIUserAbortError);
+        expect(result).toMatchObject({ cause: reason });
+        expect(fetch).toHaveBeenCalledTimes(1);
+      } finally {
+        await vi.runAllTimersAsync();
+        await observed;
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  test('retries a response body timeout without treating it as a user abort', async () => {
+    const random = vi.spyOn(Math, 'random').mockReturnValue(0);
+    const preparedController = new AbortController();
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(new ReadableStream(), {
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ recovered: true }));
+    const client = new OpenAI({
+      provider: createProvider({
+        configure: () => ({
+          name: 'test-provider',
+          baseURL: 'https://api.openai.com/v1',
+          prepareRequest(request) {
+            request.signal = preparedController.signal;
+          },
+        }),
+      }),
+      maxRetries: 1,
+      timeout: 10,
+      fetch,
+    });
+    const request = client.get('/items');
+
+    try {
+      await expect(request).resolves.toEqual({ recovered: true });
+      expect(fetch).toHaveBeenCalledTimes(2);
+    } finally {
+      random.mockRestore();
+    }
   });
 
   test('encodes URL-encoded request objects with the configured content type', async () => {

--- a/tests/client-behavior.test.ts
+++ b/tests/client-behavior.test.ts
@@ -256,6 +256,56 @@ describe('OpenAI client request behavior', () => {
     },
   );
 
+  test('prefers the caller abort reason when both signals abort during retry backoff', async () => {
+    vi.useFakeTimers();
+    const callerReason = new Error('stop caller request');
+    const preparedReason = new Error('stop prepared request');
+    const callerController = new AbortController();
+    const preparedController = new AbortController();
+    const fetch = vi.fn(async () =>
+      jsonResponse(
+        { error: { message: 'rate limited' } },
+        { status: 429, headers: { 'retry-after-ms': '60000' } },
+      ),
+    );
+    const client = new OpenAI({
+      provider: createProvider({
+        configure: () => ({
+          name: 'test-provider',
+          baseURL: 'https://api.openai.com/v1',
+          prepareRequest(request) {
+            request.signal = preparedController.signal;
+          },
+        }),
+      }),
+      maxRetries: 1,
+      fetch,
+    });
+    const request = client.get('/items', {
+      signal: callerController.signal,
+    });
+    const observed = observe(request);
+
+    try {
+      await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+      // Provider/replacement signal aborts first (e.g. linked to caller), then caller.
+      preparedController.abort(preparedReason);
+      callerController.abort(callerReason);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const waiting = Symbol('request still waiting for retry delay');
+      const result = await Promise.race([observed, Promise.resolve(waiting)]);
+      expect(result).not.toBe(waiting);
+      expect(result).toBeInstanceOf(APIUserAbortError);
+      expect(result).toMatchObject({ cause: callerReason });
+      expect(fetch).toHaveBeenCalledTimes(1);
+    } finally {
+      await vi.runAllTimersAsync();
+      await observed;
+      vi.useRealTimers();
+    }
+  });
+
   test('retries a response body timeout without treating it as a user abort', async () => {
     const random = vi.spyOn(Math, 'random').mockReturnValue(0);
     const preparedController = new AbortController();

--- a/tests/internal/utils.test.ts
+++ b/tests/internal/utils.test.ts
@@ -168,6 +168,76 @@ describe('environment and request utilities', () => {
       vi.useRealTimers();
     }
   });
+
+  test('cleans up when the post-registration abort probe throws', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const controller = new AbortController();
+      let abortedReads = 0;
+      const signal = new Proxy(controller.signal, {
+        get(target, property) {
+          if (property === 'aborted') {
+            abortedReads += 1;
+            if (abortedReads > 1) {
+              throw new Error('aborted probe failed');
+            }
+            return false;
+          }
+          if (property === 'addEventListener') {
+            return () => {};
+          }
+          if (property === 'removeEventListener') {
+            return () => {};
+          }
+          return Reflect.get(target, property, target);
+        },
+      });
+      let rejection: unknown;
+      void sleep(25, signal).catch((error) => {
+        rejection = error;
+      });
+      await Promise.resolve();
+
+      expect(rejection).toMatchObject({ message: 'aborted probe failed' });
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('removes listeners installed after synchronous cancellation', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const listeners = new Set<Parameters<AbortSignal['addEventListener']>[1]>();
+      const signal = {
+        aborted: false,
+        addEventListener(_type: string, listener: Parameters<AbortSignal['addEventListener']>[1]) {
+          if (typeof listener === 'function') {
+            listener.call(this, new Event('abort'));
+          } else {
+            listener.handleEvent(new Event('abort'));
+          }
+          listeners.add(listener);
+        },
+        removeEventListener(_type: string, listener: Parameters<AbortSignal['addEventListener']>[1]) {
+          listeners.delete(listener);
+        },
+      } as AbortSignal;
+      let rejected = false;
+      void sleep(25, signal).catch(() => {
+        rejected = true;
+      });
+      await Promise.resolve();
+
+      expect(rejected).toBe(true);
+      expect(listeners.size).toBe(0);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('value utilities', () => {

--- a/tests/internal/utils.test.ts
+++ b/tests/internal/utils.test.ts
@@ -99,6 +99,75 @@ describe('environment and request utilities', () => {
       vi.useRealTimers();
     }
   });
+
+  test('rejects even when structural signal cleanup throws', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const controller = new AbortController();
+      let listener: Parameters<AbortSignal['addEventListener']>[1] | undefined;
+      const signal = new Proxy(controller.signal, {
+        get(target, property) {
+          if (property === 'addEventListener') {
+            return (_type: string, next: Parameters<AbortSignal['addEventListener']>[1]) => {
+              listener = next;
+            };
+          }
+          if (property === 'removeEventListener') {
+            return () => {
+              throw new Error('listener cleanup failed');
+            };
+          }
+          return Reflect.get(target, property, target);
+        },
+      });
+      let rejected = false;
+      void sleep(25, signal).catch(() => {
+        rejected = true;
+      });
+
+      controller.abort();
+      expect(() => {
+        if (typeof listener === 'function') {
+          listener.call(signal, new Event('abort'));
+        } else {
+          listener?.handleEvent(new Event('abort'));
+        }
+      }).not.toThrow();
+      await Promise.resolve();
+
+      expect(rejected).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('rejects when a structural signal aborts during listener registration', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const controller = new AbortController();
+      const signal = new Proxy(controller.signal, {
+        get(target, property) {
+          if (property === 'addEventListener') {
+            return () => controller.abort(new Error('aborted during registration'));
+          }
+          return Reflect.get(target, property, target);
+        },
+      });
+      let rejected = false;
+      void sleep(25, signal).catch(() => {
+        rejected = true;
+      });
+      await Promise.resolve();
+
+      expect(rejected).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('value utilities', () => {


### PR DESCRIPTION
## Summary
- Make `sleep` accept optional `AbortSignal`s and clear its timer on abort.
- Pass the request signal(s) through `retryRequest` backoff so abort during `Retry-After` / default backoff settles promptly instead of waiting the full delay.
- Preserve abort `cause` via `APIUserAbortError`.

Fixes #2580.

## Test plan
- [x] `vitest run --config vitest.config.mts tests/internal/utils.test.ts tests/client-behavior.test.ts` (74 passed)