### PR TITLE
chore: validate comment-only review integration

### DIFF
--- a/.github/review-integration-validation.md
+++ b/.github/review-integration-validation.md
@@ -1,0 +1,5 @@
+# Review integration validation
+
+This temporary document provides a harmless change for validating a comment-only pull request review.
+
+No SDK behavior or exported API changes are proposed. This draft is intended for validation and should be closed without merging.


### PR DESCRIPTION
This draft provides a harmless documentation change for validating a comment-only pull request review. It changes no SDK behavior or exported APIs.

Validation: inspected the single Markdown fixture; no executable code is changed.

Please leave this PR unmerged. It will be closed after validation.