### PR TITLE
docs: add SECURITY.md to fix broken link in CONTRIBUTING.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately via email to security@openai.com. Do not disclose security vulnerabilities in public GitHub issues, discussions, or pull requests.
+
+We will acknowledge receipt of your report within 48 hours and will provide a more detailed response within 5 business days indicating the next steps in handling your report.
+
+## Supported Versions
+
+We provide security updates for the latest version of the `openai` Node.js library.


### PR DESCRIPTION
Fixes #2654. The CONTRIBUTING.md references SECURITY.md but the file did not exist, causing a 404. Added a security policy file at the repository root.