### PR TITLE
fix(build): preserve declaration file import specifiers

### DIFF
--- a/scripts/_vendor/tsc-multi/src/transformer.ts
+++ b/scripts/_vendor/tsc-multi/src/transformer.ts
@@ -93,6 +93,11 @@ export function createTransformer<T extends ts.SourceFile | ts.Bundle>(
       return factory.createStringLiteral(`${node.text}/index${options.extname}`);
     }
 
+    // Declaration files have no emitted JavaScript counterpart.
+    if (node.text.endsWith('.d.ts') || node.text.endsWith('.d.mts') || node.text.endsWith('.d.cts')) {
+      return node;
+    }
+
     return factory.createStringLiteral(`${base}${options.extname}`);
   }
 

--- a/tests/tsc-multi-declaration-specifiers.test.ts
+++ b/tests/tsc-multi-declaration-specifiers.test.ts
@@ -1,0 +1,146 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import ts from 'typescript';
+
+const repoRoot = process.cwd();
+const cli = path.join(repoRoot, 'scripts/_vendor/tsc-multi/src/cli.ts');
+const register = createRequire(path.join(repoRoot, 'package.json')).resolve(
+  'ts-node/register/transpile-only',
+);
+
+describe('tsc-multi declaration-file specifiers', () => {
+  let fixture: string;
+
+  beforeEach(() => {
+    fixture = mkdtempSync(path.join(tmpdir(), 'openai-tsc-declaration-specifiers-'));
+  });
+
+  afterEach(() => {
+    rmSync(fixture, { recursive: true, force: true });
+  });
+
+  function writeFixture(relative: string, contents: string) {
+    const file = path.join(fixture, relative);
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, contents);
+  }
+
+  test.each([
+    { module: 'commonjs', extname: '.js', declaration: '.d.ts' },
+    { module: 'esnext', extname: '.mjs', declaration: '.d.mts' },
+  ])('preserves explicit declaration paths in $module output', ({ module, extname, declaration }) => {
+    writeFixture('types/plain.d.ts', 'export interface Plain { plain: true }');
+    writeFixture('types/module.d.mts', 'export interface Module { module: true }');
+    writeFixture('types/common.d.cts', 'export interface Common { common: true }');
+    writeFixture('src/value.ts', 'export const value = 7;');
+    for (const suffix of ['.d.ts', '.d.mts', '.d.cts']) {
+      writeFixture(`src/directory${suffix}/index.ts`, 'export const value = 8;');
+    }
+    writeFixture(
+      'src/index.ts',
+      [
+        "import type { Plain } from '../types/plain.d.ts';",
+        "import { value } from './value.js';",
+        'export interface UsesPlain { value: Plain }',
+        "export type { Plain } from '../types/plain.d.ts';",
+        "export type Module = import('../types/module.d.mts', { with: { 'resolution-mode': 'import' } }).Module;",
+        "export type Common = import('../types/common.d.cts').Common;",
+        'export const staticValue = value;',
+        "export { value as reexportedValue } from './value.js';",
+        "export async function dynamicValue() { return (await import('./value.js')).value; }",
+        "export { value as tsDirectoryValue } from './directory.d.ts';",
+        "export { value as mtsDirectoryValue } from './directory.d.mts';",
+        "export { value as ctsDirectoryValue } from './directory.d.cts';",
+      ].join('\n'),
+    );
+    writeFixture(
+      'tsconfig.json',
+      JSON.stringify({
+        compilerOptions: {
+          target: 'es2020',
+          moduleResolution: 'bundler',
+          declaration: true,
+          rootDir: 'src',
+          outDir: 'dist',
+          types: [],
+          strict: true,
+          skipLibCheck: true,
+        },
+        include: ['src/**/*.ts'],
+      }),
+    );
+    writeFixture(
+      'tsc-multi.json',
+      JSON.stringify({ projects: ['tsconfig.json'], targets: [{ module, extname }] }),
+    );
+
+    const build = spawnSync(process.execPath, ['-r', register, cli, '--cwd', fixture, '--maxWorkers', '1'], {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      timeout: 15_000,
+    });
+    expect(build.error).toBeUndefined();
+    expect(build.signal).toBeNull();
+    expect(build.status).toBe(0);
+    expect(build.stderr).toContain('Found 0 errors.');
+
+    const declarationPath = path.join(fixture, `dist/index${declaration}`);
+    const specifiers = ts
+      .preProcessFile(readFileSync(declarationPath, 'utf-8'))
+      .importedFiles.map(({ fileName }) => fileName);
+    expect(new Set(specifiers)).toEqual(
+      new Set([
+        '../types/plain.d.ts',
+        '../types/module.d.mts',
+        '../types/common.d.cts',
+        `./value${extname}`,
+        `./directory.d.ts/index${extname}`,
+        `./directory.d.mts/index${extname}`,
+        `./directory.d.cts/index${extname}`,
+      ]),
+    );
+
+    writeFixture(
+      'consumer.ts',
+      [
+        `import type { Plain, Module, Common } from './dist/index${extname}';`,
+        'const plain: Plain = { plain: true };',
+        'const module: Module = { module: true };',
+        'const common: Common = { common: true };',
+        'void [plain, module, common];',
+      ].join('\n'),
+    );
+    const consumer = ts.createProgram([path.join(fixture, 'consumer.ts')], {
+      target: ts.ScriptTarget.ES2020,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      noEmit: true,
+      strict: true,
+      types: [],
+    });
+    expect(ts.getPreEmitDiagnostics(consumer)).toEqual([]);
+
+    const artifact = path.join(fixture, `dist/index${extname}`);
+    const load =
+      module === 'commonjs'
+        ? `require(${JSON.stringify(artifact)})`
+        : `await import(${JSON.stringify(pathToFileURL(artifact).href)})`;
+    const runtime = spawnSync(
+      process.execPath,
+      [
+        ...(module === 'esnext' ? ['--input-type=module'] : []),
+        '-e',
+        `(async () => { const artifact = ${load}; console.log(JSON.stringify([artifact.staticValue, artifact.reexportedValue, await artifact.dynamicValue(), artifact.tsDirectoryValue, artifact.mtsDirectoryValue, artifact.ctsDirectoryValue])); })();`,
+      ],
+      { cwd: fixture, encoding: 'utf-8', timeout: 15_000 },
+    );
+    expect(runtime.error).toBeUndefined();
+    expect(runtime.signal).toBeNull();
+    expect(runtime.status).toBe(0);
+    expect(JSON.parse(runtime.stdout)).toEqual([7, 7, 7, 8, 8, 8]);
+  });
+});

--- a/tests/tsc-multi-declaration-specifiers.test.ts
+++ b/tests/tsc-multi-declaration-specifiers.test.ts
@@ -125,16 +125,17 @@ describe('tsc-multi declaration-file specifiers', () => {
     expect(ts.getPreEmitDiagnostics(consumer)).toEqual([]);
 
     const artifact = path.join(fixture, `dist/index${extname}`);
-    const load =
+    const program =
       module === 'commonjs'
-        ? `require(${JSON.stringify(artifact)})`
-        : `await import(${JSON.stringify(pathToFileURL(artifact).href)})`;
+        ? '(async () => { const artifact = require(process.argv[1]); console.log(JSON.stringify([artifact.staticValue, artifact.reexportedValue, await artifact.dynamicValue(), artifact.tsDirectoryValue, artifact.mtsDirectoryValue, artifact.ctsDirectoryValue])); })();'
+        : '(async () => { const artifact = await import(process.argv[1]); console.log(JSON.stringify([artifact.staticValue, artifact.reexportedValue, await artifact.dynamicValue(), artifact.tsDirectoryValue, artifact.mtsDirectoryValue, artifact.ctsDirectoryValue])); })();';
     const runtime = spawnSync(
       process.execPath,
       [
         ...(module === 'esnext' ? ['--input-type=module'] : []),
         '-e',
-        `(async () => { const artifact = ${load}; console.log(JSON.stringify([artifact.staticValue, artifact.reexportedValue, await artifact.dynamicValue(), artifact.tsDirectoryValue, artifact.mtsDirectoryValue, artifact.ctsDirectoryValue])); })();`,
+        program,
+        module === 'commonjs' ? artifact : pathToFileURL(artifact).href,
       ],
       { cwd: fixture, encoding: 'utf-8', timeout: 15_000 },
     );


### PR DESCRIPTION
## Summary

Preserve explicit `.d.ts`, `.d.mts`, and `.d.cts` module specifiers in the handwritten `tsc-multi` transformer. Declaration files have no corresponding emitted JavaScript file.

The current build appends `.js` or `.mjs` to these paths. For example, the published `internal/types.d.ts` imports `../../node_modules/undici/index.d.ts.js`, which does not exist. Its intentionally optional imports suppress resolution errors, so the corresponding `RequestInit` types silently become `never`.

This is observable through the public package: with TypeScript 6.0.3, current Node types, and Undici 8.9, a `ClientOptions['fetchOptions']` value containing an Undici `ProxyAgent` fails to compile before this fix and compiles afterward, in both ESM and CommonJS consumers.

## Scope and compatibility

- Five production lines in the existing transformer and one focused regression file. No generated SDK source, dependencies, lockfiles, or documentation recipes change.
- Preserve the existing directory-resolution branch before applying the declaration-file guard. A directory whose name ends in `.d.ts`, `.d.mts`, or `.d.cts` still resolves to its emitted `index.js`/`index.mjs`.
- Ordinary static, re-exported, and dynamic JavaScript imports keep their existing rewriting and runtime behavior.
- Optional Undici remains optional. Physically isolated package copies without Undici compile on TypeScript 4.9 and 6, before and after the fix.
- SDK-owned request-body overrides remain rejected. This does not loosen the public request-option restrictions.

The older TypeScript 4.9 resolver still does not resolve the SDK's existing explicit declaration imports in the tested Node/Undici lane; its pre-existing diagnostic is unchanged. This PR fixes the producer's invalid path rewriting, not that separate source-level compatibility issue.

## Regression coverage and review

The two real `tsc-multi` CLI/emitter tests build CommonJS and ESM artifacts, compile consumers of all three declaration suffixes, and execute static imports, re-exports, dynamic imports, and directories ending in declaration-like suffixes.

The original implementation fails the declaration-path checks. Adversarial review caught an initial guard ordering that broke declaration-named directories; the directory controls fail with that ordering and pass after preserving the existing resolution branch. No new resolver or parsing framework was added.

The runtime fixture uses static CJS/ESM loader programs and passes artifact paths as separate process arguments, rather than interpolating paths into JavaScript source.

## Verification

- Public-package before/after TypeScript matrix covers both module formats, optional dependency presence/absence, and rejection of SDK-owned body options. All lanes have zero dependency-declaration diagnostics.
- The existing TypeScript 4.9 Node/Undici diagnostic is unchanged; optional-dependency-absent TypeScript 4.9 consumers pass.
- Canonical build, full TypeScript checking, lint, and format checks pass.
- Canonical full handwritten suite: 7,751 tests across 204 files pass on Node 24.19.0.
- All 23 tsc-multi tests pass on Node 24.19.0; the new emitter/runtime cases also pass on Node 22.22.3 and 26.7.0.
- Full artifact comparison changes only `internal/types.d.ts`, `internal/types.d.mts`, and their source maps. All emitted runtime code is byte-identical.
