### PR TITLE
fix(test): use a monotonic Steady lock timeout

### DIFF
--- a/scripts/steady/cache.cjs
+++ b/scripts/steady/cache.cjs
@@ -6,13 +6,14 @@ const { spawn } = require('node:child_process');
 const { randomUUID } = require('node:crypto');
 const { setInterval: interval } = require('node:timers/promises');
 const { once } = require('node:events');
+const { performance } = require('node:perf_hooks');
 
 const MAX_IDLE_MS = 30 * 24 * 60 * 60 * 1000;
 
 // Serialize lease changes and pruning, never the commands using the cache.
 async function locked(cache, action, signal) {
   const lock = path.join(cache, '.lifecycle-lock');
-  const deadline = Date.now() + 10_000;
+  const deadline = performance.now() + 10_000;
   for await (const tick of interval(50, undefined, { signal })) {
     void tick;
     try {
@@ -22,7 +23,7 @@ async function locked(cache, action, signal) {
       if (error.code !== 'EEXIST') {
         throw error;
       }
-      if (Date.now() >= deadline) {
+      if (performance.now() >= deadline) {
         throw new Error(`Steady cache is locked. If no install or mock is running, remove ${lock}.`, {
           cause: error,
         });

--- a/tests/steady-cache-clock.test.ts
+++ b/tests/steady-cache-clock.test.ts
@@ -1,0 +1,136 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { vi } from 'vitest';
+
+const wrapperPath = path.join(process.cwd(), 'scripts/steady/cache.cjs');
+
+describe('Steady cache lock clock corrections', () => {
+  let fixture: string;
+  let cache: string;
+  let lock: string;
+  let running: ReturnType<typeof startWrapper> | undefined;
+
+  beforeEach(() => {
+    fixture = realpathSync(mkdtempSync(path.join(tmpdir(), 'steady-cache-clock-')));
+    cache = path.join(fixture, 'cache');
+    lock = path.join(cache, '.lifecycle-lock');
+    mkdirSync(lock, { recursive: true });
+    writeFileSync(path.join(lock, 'owner'), 'another cache user');
+    writeFileSync(path.join(fixture, 'command.cjs'), "console.log('CHILD_EXECUTED');\n");
+    writeFileSync(
+      path.join(fixture, 'clock.cjs'),
+      `const fs = require('node:fs');
+const path = require('node:path');
+const { performance } = require('node:perf_hooks');
+const wallNow = Date.now;
+const monotonicNow = performance.now.bind(performance);
+const backward = process.env.STEADY_TEST_CLOCK === 'backward';
+let shifted = false;
+if (backward) {
+  Object.defineProperty(performance, 'now', { value: () => monotonicNow() * 100 });
+}
+// Establish the deadline before applying the wall-clock correction.
+process.on('newListener', (event) => {
+  if (event === 'SIGTERM') setImmediate(() => {
+    Date.now = () => wallNow() + (backward ? -60_000 : 60_000);
+    shifted = true;
+    console.log('CLOCK_SHIFTED');
+  });
+});
+// Observe a real failed acquisition after the clock step; preserve its result.
+const mkdir = fs.mkdirSync;
+fs.mkdirSync = (...args) => {
+  try {
+    return mkdir(...args);
+  } catch (error) {
+    if (shifted && args[0] === path.join(process.argv[2], '.lifecycle-lock') && error.code === 'EEXIST') {
+      console.log('LOCK_CONTENDED');
+    }
+    throw error;
+  }
+};
+`,
+    );
+  });
+
+  afterEach(async () => {
+    if (running) {
+      if (running.child.exitCode === null && running.child.signalCode === null) {
+        running.child.kill('SIGKILL');
+      }
+      await running.closed;
+      running = undefined;
+    }
+    rmSync(fixture, { recursive: true, force: true });
+  });
+
+  function startWrapper(direction: 'backward' | 'forward') {
+    const child = spawn(
+      process.execPath,
+      [
+        '-r',
+        path.join(fixture, 'clock.cjs'),
+        wrapperPath,
+        cache,
+        path.join(cache, 'source-synthetic'),
+        path.join(cache, 'deno-synthetic'),
+        path.join(cache, 'deps-synthetic'),
+        process.execPath,
+        path.join(fixture, 'command.cjs'),
+      ],
+      { env: { ...process.env, STEADY_TEST_CLOCK: direction }, stdio: 'pipe' },
+    );
+    let output = '';
+    let errors = '';
+    child.stdout.on('data', (chunk) => {
+      output += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      errors += chunk;
+    });
+    child.stdin.end();
+    const closed = once(child, 'close');
+    const result = { child, closed, output: () => output, errors: () => errors };
+    running = result;
+    return result;
+  }
+
+  test('expires the acquisition budget despite a backward wall-clock correction', async () => {
+    const wrapper = startWrapper('backward');
+    await vi.waitFor(() => expect(wrapper.output()).toContain('CLOCK_SHIFTED'), { timeout: 5000 });
+
+    // Only the monotonic clock is accelerated; the real lock stays occupied.
+    await vi.waitFor(() => expect(wrapper.child.exitCode).toBe(1), { timeout: 2000 });
+
+    await expect(wrapper.closed).resolves.toEqual([1, null]);
+    expect(wrapper.errors()).toContain('Steady cache is locked.');
+    expect(wrapper.output()).not.toContain('CHILD_EXECUTED');
+    expect(readFileSync(path.join(lock, 'owner'), 'utf-8')).toBe('another cache user');
+    expect(readdirSync(path.join(cache, '.leases'))).toEqual([]);
+  });
+
+  test('does not expire the acquisition budget after a forward wall-clock correction', async () => {
+    const wrapper = startWrapper('forward');
+    await vi.waitFor(() => expect(wrapper.output()).toContain('LOCK_CONTENDED'), { timeout: 5000 });
+    expect(readFileSync(path.join(lock, 'owner'), 'utf-8')).toBe('another cache user');
+    rmSync(lock, { recursive: true });
+
+    await expect(wrapper.closed).resolves.toEqual([0, null]);
+    expect(wrapper.output()).toContain('CHILD_EXECUTED');
+    expect(wrapper.errors()).not.toContain('Steady cache is locked.');
+    expect(readdirSync(path.join(cache, '.leases'))).toEqual([]);
+    expect(existsSync(lock)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Use Node's monotonic clock for the Steady cache lock's existing 10-second acquisition budget.
- Add two regression tests through the actual cache CLI for backward and forward wall-clock corrections. The test preloads and child program are static; paths and clock direction are passed as data.
- Keep the 50-ms polling interval, cancellation, lease ownership, separate cleanup acquisition, and wall-clock file-aging timestamps unchanged. No generated files, SDK runtime code, dependency pins, or cache policy changes.

## Reproduction

On current main, hold the lifecycle lock and release it after 12 real seconds. With no clock adjustment, the wrapper rejects the command with its existing lock-timeout error. With a single 60-second backward `Date.now()` correction after the acquisition deadline is established, the same wrapper incorrectly launches the command after roughly 12.1 seconds and exits successfully.

This unaccelerated command-boundary reproduction fails before the fix on Node 22.0.0, 24.19.0, and 26.7.0. After the fix, both the normal-clock and corrected-clock cases reject late execution on all three runtimes, preserve the existing owner's lock until it is released, and leave no leases. The separate cleanup lock explains why the final process exit occurs after the fixture releases the lock; that lifecycle behavior is not changed here.

## Validation

- Both new regressions failed before the production change and passed afterward.
- New clock and existing cancellation tests: 8 passed on Node 22.0.0, 22.22.3, 24.19.0, and 26.7.0. An independent reviewer also repeated the clock tests five times successfully.
- Canonical cache expiry, active-lease, and cleanup checks passed on Node 22.0.0, 24.19.0, and 26.7.0.
- Full canonical handwritten suite on the final files: 7,800 tests passed across 205 files.
- Canonical lint/format, TypeScript checking, CJS/ESM build, and `git diff --check` passed.
- Independent adversarial review found no security, compatibility, lock-ownership, cancellation, or regression-test issues. Windows was reviewed for path/spawn compatibility but not executed locally; the generated suite will run in CI.

This is separate from #2657's file-processing timeout and retains #2636's Steady cancellation behavior.
