### PR TITLE
fix(examples): respect raw streaming proxy backpressure

### DIFF
--- a/examples/chat-completions/stream-to-client-raw.ts
+++ b/examples/chat-completions/stream-to-client-raw.ts
@@ -14,6 +14,7 @@
 // Remote HTTPS requests must include: Authorization: Bearer <OPENAI_EXAMPLE_AUTH_TOKEN>
 
 import { timingSafeEqual } from 'node:crypto';
+import { once } from 'node:events';
 import { readFileSync } from 'node:fs';
 import { createServer } from 'node:https';
 import OpenAI from 'openai';
@@ -138,6 +139,32 @@ function rethrowUnlessClientAbort(
   }
 }
 
+async function writeResponseChunk(
+  res: Response,
+  chunk: string,
+  disconnect: ReturnType<typeof watchClientDisconnect>,
+): Promise<void> {
+  if (res.write(chunk) === false && disconnect) {
+    try {
+      await once(res, 'drain', { signal: disconnect.signal });
+    } catch (error) {
+      if (
+        !disconnect.signal.aborted ||
+        typeof error !== 'object' ||
+        error === null ||
+        !('name' in error) ||
+        error.name !== 'AbortError' ||
+        !('code' in error) ||
+        error.code !== 'ABORT_ERR' ||
+        !('cause' in error) ||
+        error.cause !== disconnect.signal.reason
+      ) {
+        throw error;
+      }
+    }
+  }
+}
+
 const handleRequest = async (req: Request, res: Response) => {
   console.log('Received request:', req.body);
 
@@ -170,7 +197,7 @@ const handleRequest = async (req: Request, res: Response) => {
         break;
       }
 
-      res.write(chunk.choices[0]?.delta.content || '');
+      await writeResponseChunk(res, chunk.choices[0]?.delta.content || '', disconnect);
 
       if (disconnect?.signal.aborted || res.destroyed) {
         break;

--- a/tests/lib/streaming-example-backpressure.test.ts
+++ b/tests/lib/streaming-example-backpressure.test.ts
@@ -1,0 +1,198 @@
+import { setTimeout } from 'node:timers/promises';
+
+import { expect, test, vi } from 'vitest';
+
+import {
+  createRequest,
+  createResponse,
+  invoke,
+  loadExample,
+  loadPublicHTTPExample,
+} from './streaming-example-test-utils';
+
+const largeContentChunk = 'x'.repeat(256 * 1024);
+const largeContentChunkCount = 64;
+
+test('the raw example waits for drain before consuming another upstream chunk', async () => {
+  const runtime = loadExample('stream-to-client-raw.ts');
+  const request = createRequest();
+  const response = createResponse();
+  response.writeResult = false;
+
+  const pending = invoke(runtime, request, response);
+  await vi.waitFor(() => expect(response.listenerCount('drain')).toBe(1));
+
+  expect(runtime.generated).toBe(1);
+  expect(response.write).toHaveBeenCalledOnce();
+  expect(response.end).not.toHaveBeenCalled();
+
+  response.writeResult = true;
+  response.emit('drain');
+  await pending;
+
+  expect(runtime.generated).toBe(3);
+  expect(response.body).toBe('safe chunk'.repeat(3));
+  expect(response.end).toHaveBeenCalledOnce();
+  expect(runtime.signal?.aborted).toBe(false);
+  expect(runtime.consoleError).not.toHaveBeenCalled();
+  expect(request.listenerCount('aborted')).toBe(0);
+  expect(response.listenerCount('drain')).toBe(0);
+  expect(response.listenerCount('error')).toBe(0);
+  expect(response.listenerCount('close')).toBe(0);
+});
+
+test.each(['response close', 'request abort', 'close during write'] as const)(
+  'the raw example cancels a drain wait after %s',
+  async (event) => {
+    const runtime = loadExample('stream-to-client-raw.ts');
+    const request = createRequest();
+    const response = createResponse();
+    response.writeResult = false;
+    if (event === 'close during write') {
+      response.onWrite = () => response.destroy();
+    }
+
+    const pending = invoke(runtime, request, response);
+    if (event !== 'close during write') {
+      await vi.waitFor(() => expect(response.listenerCount('drain')).toBe(1));
+      if (event === 'response close') {
+        response.destroy();
+      } else {
+        request.emit('aborted');
+      }
+    }
+    await pending;
+
+    expect(runtime.signal?.aborted).toBe(true);
+    expect(runtime.generated).toBe(1);
+    expect(runtime.cancellations).toBe(1);
+    expect(response.end).not.toHaveBeenCalled();
+    expect(runtime.consoleError).not.toHaveBeenCalled();
+    expect(request.listenerCount('aborted')).toBe(0);
+    expect(response.listenerCount('drain')).toBe(0);
+    expect(response.listenerCount('error')).toBe(0);
+    expect(response.listenerCount('close')).toBe(0);
+  },
+);
+
+test.each(['write', 'drain wait'] as const)(
+  'the raw example reports a genuine response error during %s',
+  async (phase) => {
+    const failure = new Error(`intentional response ${phase} failure`);
+    const runtime = loadExample('stream-to-client-raw.ts');
+    const request = createRequest();
+    const response = createResponse();
+    response.writeResult = false;
+    if (phase === 'write') {
+      response.onWrite = () => {
+        throw failure;
+      };
+    }
+
+    const pending = invoke(runtime, request, response);
+    if (phase === 'drain wait') {
+      await vi.waitFor(() => expect(response.listenerCount('drain')).toBe(1));
+      response.emit('error', failure);
+    }
+    await pending;
+
+    expect(runtime.consoleError).toHaveBeenCalledExactlyOnceWith(failure);
+    expect(runtime.signal?.aborted).toBe(false);
+    expect(runtime.cancellations).toBe(1);
+    expect(response.destroy).toHaveBeenCalledOnce();
+    expect(response.end).not.toHaveBeenCalled();
+    expect(request.listenerCount('aborted')).toBe(0);
+    expect(response.listenerCount('drain')).toBe(0);
+    expect(response.listenerCount('error')).toBe(0);
+    expect(response.listenerCount('close')).toBe(0);
+  },
+);
+
+test.each(['response close', 'request abort'] as const)(
+  'the raw example preserves a response error immediately followed by %s',
+  async (event) => {
+    const failure = new Error('intentional response error before client disconnect');
+    const runtime = loadExample('stream-to-client-raw.ts');
+    const request = createRequest();
+    const response = createResponse();
+    response.writeResult = false;
+
+    const pending = invoke(runtime, request, response);
+    await vi.waitFor(() => expect(response.listenerCount('drain')).toBe(1));
+    response.emit('error', failure);
+    if (event === 'response close') {
+      response.destroy();
+    } else {
+      request.emit('aborted');
+    }
+    await pending;
+
+    expect(runtime.signal?.aborted).toBe(true);
+    expect(runtime.consoleError).toHaveBeenCalledExactlyOnceWith(failure);
+    expect(runtime.cancellations).toBe(1);
+    expect(response.end).not.toHaveBeenCalled();
+    expect(request.listenerCount('aborted')).toBe(0);
+    expect(response.listenerCount('drain')).toBe(0);
+    expect(response.listenerCount('error')).toBe(0);
+    expect(response.listenerCount('close')).toBe(0);
+  },
+);
+
+test.each(['resume', 'disconnect', 'upstream failure'] as const)(
+  'the raw example handles a paused real downstream client followed by %s',
+  async (mode) => {
+    const downstream = await loadPublicHTTPExample('stream-to-client-raw.ts', {
+      content: largeContentChunk,
+      contentCount: largeContentChunkCount,
+      terminalEvent:
+        mode === 'upstream failure'
+          ? { error: { message: 'intentional upstream failure after backpressure' } }
+          : 'done',
+    });
+    const { client, controller } = downstream;
+    try {
+      const incoming = await fetch(downstream.url, {
+        method: 'POST',
+        body: 'A synthetic prompt',
+        signal: controller.signal,
+      });
+      // Leave the actual HTTP response unread while the provider sends 16 MiB.
+      await vi.waitFor(() => expect(downstream.outgoing?.writableNeedDrain).toBe(true));
+      await setTimeout(100);
+      expect(downstream.routeFinished).toBe(false);
+      expect(downstream.outgoing?.writableNeedDrain).toBe(true);
+      expect(downstream.outgoing?.writableLength).toBeLessThan(largeContentChunk.length * 2);
+      expect(incoming.status).toBe(200);
+
+      if (mode === 'resume') {
+        expect(await incoming.text()).toBe(largeContentChunk.repeat(largeContentChunkCount));
+      } else if (mode === 'upstream failure') {
+        await expect(incoming.text()).rejects.toThrow();
+      } else {
+        controller.abort();
+      }
+      await vi.waitFor(() => expect(downstream.routeFinished).toBe(true));
+      expect(client.transport).toHaveBeenCalledOnce();
+      expect(client.upstreamClosed).toHaveLength(1);
+      await client.upstreamClosed[0];
+
+      if (mode === 'upstream failure') {
+        expect(client.runtime.consoleError).toHaveBeenCalledOnce();
+        expect(String(client.runtime.consoleError.mock.calls[0]?.[0])).toContain(
+          'intentional upstream failure after backpressure',
+        );
+        expect(downstream.outgoing?.destroyed).toBe(true);
+      } else {
+        expect(client.runtime.consoleError).not.toHaveBeenCalled();
+        expect(client.signal?.aborted).toBe(mode === 'disconnect');
+      }
+      expect(downstream.outgoing?.writableEnded).toBe(mode === 'resume');
+      expect(downstream.incomingRequest?.listenerCount('aborted')).toBe(0);
+      expect(downstream.outgoing?.listenerCount('drain')).toBe(0);
+      expect(downstream.outgoing?.listenerCount('error')).toBe(0);
+      expect(downstream.outgoing?.listenerCount('close')).toBe(0);
+    } finally {
+      await downstream.close();
+    }
+  },
+);

--- a/tests/lib/streaming-example-disconnect-security.test.ts
+++ b/tests/lib/streaming-example-disconnect-security.test.ts
@@ -1,405 +1,15 @@
-import { timingSafeEqual } from 'node:crypto';
-import { EventEmitter, once } from 'node:events';
-import { readFileSync } from 'node:fs';
-import { createServer } from 'node:http';
-import type { IncomingMessage, ServerResponse } from 'node:http';
-import { setTimeout } from 'node:timers/promises';
-import { runInNewContext } from 'node:vm';
-
-import ts from 'typescript';
 import { describe, expect, test, vi } from 'vitest';
 
-import OpenAI, { APIUserAbortError } from '../../src/index';
-
-const examples = ['stream-to-client-express.ts', 'stream-to-client-raw.ts'] as const;
-const largeContentChunk = 'x'.repeat(256 * 1024);
-const largeContentChunkCount = 64;
-
-type Example = (typeof examples)[number];
-interface Completion {
-  choices: [{ delta: { content: string } }];
-}
-type RouteHandler = (request: unknown, response: unknown) => Promise<void>;
-
-interface ExampleRuntime {
-  apiCalls: number;
-  aborts: number;
-  generated: number;
-  cancellations: number;
-  consoleError: ReturnType<typeof vi.fn>;
-  handler?: RouteHandler;
-  signal?: AbortSignal;
-  onProvider?: () => void;
-  pendingCreate: boolean;
-  pendingNext: boolean;
-  abortError?: Error;
-  rejectCreate?: (error: Error) => void;
-  rejectNext?: (error: Error) => void;
-}
-
-function createNodeHTTPEmitter(): EventEmitter {
-  // Node HTTP requests and responses expose EventEmitter lifecycle events.
-  // oxlint-disable-next-line unicorn/prefer-event-target
-  return new EventEmitter();
-}
-
-function createRequest() {
-  return Object.assign(createNodeHTTPEmitter(), {
-    body: 'Tell me why dogs are better than cats',
-    get: vi.fn(),
-  });
-}
-
-function createResponse() {
-  const response = Object.assign(createNodeHTTPEmitter(), {
-    body: '',
-    destroyed: false,
-    headersSent: false,
-    statusCode: 200,
-    writableEnded: false,
-    writeResult: true,
-    onWrite: null as (() => void) | null,
-  });
-
-  return Object.assign(response, {
-    header: vi.fn((_name: string, _value: string) => response),
-    status: vi.fn((code: number) => {
-      response.statusCode = code;
-      return response;
-    }),
-
-    write: vi.fn((chunk: unknown) => {
-      if (response.destroyed) {
-        throw new Error('Attempted to write to a destroyed socket');
-      }
-
-      response.headersSent = true;
-      response.body += String(chunk);
-      response.onWrite?.();
-      return response.writeResult;
-    }),
-
-    end: vi.fn((chunk?: string) => {
-      if (response.destroyed) {
-        throw new Error('Attempted to end a destroyed socket');
-      }
-
-      response.body += chunk ?? '';
-      response.headersSent = true;
-      response.writableEnded = true;
-      response.emit('finish');
-      return response;
-    }),
-
-    destroy: vi.fn(() => {
-      response.destroyed = true;
-      response.emit('close');
-      return response;
-    }),
-  });
-}
-
-function completionChunks(runtime: ExampleRuntime, encoded: boolean): AsyncIterable<string | Completion> {
-  return {
-    [Symbol.asyncIterator]() {
-      let index = 0;
-
-      return {
-        async next() {
-          if (encoded && runtime.pendingNext) {
-            runtime.pendingNext = false;
-            const deferred = new AbortController();
-            let failure: Error | undefined;
-            const pending = once(deferred.signal, 'abort').then(() => {
-              throw failure ?? new APIUserAbortError();
-            });
-
-            runtime.rejectNext = (error) => {
-              failure = error;
-              deferred.abort();
-            };
-            runtime.signal?.addEventListener(
-              'abort',
-              () => runtime.rejectNext?.(runtime.abortError ?? new APIUserAbortError()),
-              { once: true },
-            );
-            return pending;
-          }
-
-          if (index >= 3) {
-            return { done: true as const, value: undefined };
-          }
-
-          index += 1;
-          runtime.generated += 1;
-          return {
-            done: false as const,
-            value: encoded ? 'safe chunk' : { choices: [{ delta: { content: 'safe chunk' } }] },
-          };
-        },
-
-        async return() {
-          runtime.cancellations += 1;
-          return { done: true as const, value: undefined };
-        },
-      };
-    },
-  };
-}
-
-function loadExample(
-  filename: Example,
-  options: { withoutAbortController?: boolean; client?: new () => OpenAI } = {},
-): ExampleRuntime {
-  const runtime: ExampleRuntime = {
-    apiCalls: 0,
-    aborts: 0,
-    generated: 0,
-    cancellations: 0,
-    consoleError: vi.fn(),
-    pendingCreate: false,
-    pendingNext: false,
-  };
-
-  const app = {
-    use() {
-      return app;
-    },
-
-    post(_path: string, handler: RouteHandler) {
-      runtime.handler = handler;
-      return app;
-    },
-
-    listen() {
-      return app;
-    },
-  };
-
-  const express = Object.assign(() => app, {
-    text: () => (_request: unknown, _response: unknown, next: () => void) => next(),
-  });
-
-  function configureProvider(providerOptions?: { signal?: AbortSignal }): void {
-    runtime.apiCalls += 1;
-
-    if (providerOptions?.signal) {
-      runtime.signal = providerOptions.signal;
-      runtime.signal.addEventListener(
-        'abort',
-        () => {
-          runtime.aborts += 1;
-        },
-        { once: true },
-      );
-    }
-  }
-
-  class MockOpenAI {
-    static APIUserAbortError = APIUserAbortError;
-
-    readonly chat = {
-      completions: {
-        stream: (_body: unknown, providerOptions?: { signal?: AbortSignal }) => {
-          configureProvider(providerOptions);
-          runtime.onProvider?.();
-          return {
-            toReadableStream: () => completionChunks(runtime, true),
-          };
-        },
-
-        create: (_body: unknown, providerOptions?: { signal?: AbortSignal }) => {
-          configureProvider(providerOptions);
-          const chunks = completionChunks(runtime, false) as AsyncIterable<Completion>;
-
-          if (runtime.pendingCreate) {
-            const deferred = new AbortController();
-            let failure: Error | undefined;
-            const pending = once(deferred.signal, 'abort').then(() => {
-              throw failure ?? new APIUserAbortError();
-            });
-
-            runtime.rejectCreate = (error) => {
-              failure = error;
-              deferred.abort();
-            };
-            runtime.signal?.addEventListener(
-              'abort',
-              () => runtime.rejectCreate?.(runtime.abortError ?? new APIUserAbortError()),
-              { once: true },
-            );
-            runtime.onProvider?.();
-            return pending;
-          }
-
-          runtime.onProvider?.();
-          return Promise.resolve(chunks);
-        },
-      },
-    };
-  }
-
-  const source = readFileSync(`examples/chat-completions/${filename}`, 'utf-8');
-  const transpiled = ts.transpileModule(source, {
-    compilerOptions: {
-      esModuleInterop: true,
-      module: ts.ModuleKind.CommonJS,
-      target: ts.ScriptTarget.ES2022,
-    },
-    fileName: filename,
-  }).outputText;
-
-  function requireExampleModule(specifier: string): unknown {
-    if (specifier === 'openai') {
-      return { __esModule: true, default: options.client ?? MockOpenAI };
-    }
-    if (specifier === 'express') {
-      return { __esModule: true, default: express };
-    }
-    if (specifier === 'node:crypto') {
-      return { timingSafeEqual };
-    }
-    if (specifier === 'node:events') {
-      return { once };
-    }
-    if (specifier === 'node:fs') {
-      return { readFileSync: vi.fn() };
-    }
-    if (specifier === 'node:https') {
-      return { createServer: vi.fn() };
-    }
-
-    throw new Error(`Unexpected streaming example import: ${specifier}`);
-  }
-
-  const commonJS = { exports: {} };
-  const globals: Record<string, unknown> = {
-    Buffer,
-    console: { error: runtime.consoleError, log: vi.fn() },
-    exports: commonJS.exports,
-    module: commonJS,
-    process: { env: {} },
-    require: requireExampleModule,
-  };
-
-  if (!options.withoutAbortController) {
-    globals['AbortController'] = AbortController;
-  }
-
-  runInNewContext(transpiled, globals, { filename });
-  return runtime;
-}
-
-function invoke(runtime: ExampleRuntime, request: unknown, response: unknown): Promise<void> {
-  if (!runtime.handler) {
-    throw new Error('The streaming example did not register its Express route');
-  }
-
-  return runtime.handler(request, response);
-}
-
-async function loadPublicExample(
-  filename: Example,
-  mode: 'pending' | 'complete' | 'failure' | 'partial' | 'large' | 'large-failure' = 'pending',
-) {
-  const upstreamClosed: Promise<unknown[]>[] = [];
-  const upstream = createServer((_request, response) => {
-    upstreamClosed.push(once(response, 'close'));
-
-    if (mode === 'failure') {
-      response.writeHead(500, { 'Content-Type': 'application/json' });
-      response.end(JSON.stringify({ error: { message: 'intentional public upstream failure' } }));
-      return;
-    }
-
-    if (mode === 'pending' && filename === 'stream-to-client-raw.ts') {
-      return;
-    }
-
-    response.writeHead(200, { 'Content-Type': 'text/event-stream' });
-    response.flushHeaders();
-
-    if (mode === 'complete' || mode === 'partial' || mode === 'large' || mode === 'large-failure') {
-      const large = mode === 'large' || mode === 'large-failure';
-      const base = {
-        id: 'chatcmpl-public-loopback',
-        object: 'chat.completion.chunk',
-        created: 1,
-        model: 'gpt-test',
-      };
-      const content = {
-        ...base,
-        choices: [
-          {
-            index: 0,
-            delta: { role: 'assistant', content: large ? largeContentChunk : 'safe public chunk' },
-            finish_reason: null,
-          },
-        ],
-      };
-      const finished = {
-        ...base,
-        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
-      };
-      if (mode === 'partial') {
-        response.write(`data: ${JSON.stringify(content)}\n\n`);
-        return;
-      }
-      const contentEvents = `data: ${JSON.stringify(content)}\n\n`.repeat(large ? largeContentChunkCount : 1);
-      const endEvent =
-        mode === 'large-failure'
-          ? `data: ${JSON.stringify({ error: { message: 'intentional upstream failure after backpressure' } })}\n\n`
-          : `data: ${JSON.stringify(finished)}\n\ndata: [DONE]\n\n`;
-      response.end(contentEvents + endEvent);
-    }
-  });
-
-  const listening = once(upstream, 'listening');
-  upstream.listen(0, '127.0.0.1');
-  await listening;
-
-  const address = upstream.address();
-  if (address === null || typeof address === 'string') {
-    throw new Error('The public SDK loopback server has no local port');
-  }
-  const baseURL = `http://127.0.0.1:${address.port}/v1`;
-
-  let signal: AbortSignal | undefined;
-  let body: ReadableStream<Uint8Array> | null | undefined;
-  const transport = vi.fn<typeof fetch>(async (request, options) => {
-    signal = options?.signal ?? undefined;
-    const response = await fetch(request, options);
-    ({ body } = response);
-    return response;
-  });
-
-  const PublicOpenAI = OpenAI.bind(undefined, {
-    apiKey: 'public-sdk-loopback-test-key',
-    baseURL,
-    fetch: transport,
-    maxRetries: 0,
-  });
-
-  return {
-    runtime: loadExample(filename, { client: PublicOpenAI }),
-    transport,
-    upstream,
-    upstreamClosed,
-    get signal() {
-      return signal;
-    },
-    get body() {
-      return body;
-    },
-  };
-}
-
-async function closePublicExample(upstream: ReturnType<typeof createServer>): Promise<void> {
-  const closed = once(upstream, 'close');
-  upstream.closeAllConnections();
-  upstream.close();
-  await closed;
-}
+import { APIUserAbortError } from '../../src/index';
+import {
+  createRequest,
+  createResponse,
+  examples,
+  invoke,
+  loadExample,
+  loadPublicExample,
+  loadPublicHTTPExample,
+} from './streaming-example-test-utils';
 
 describe.each(examples)('%s upstream disconnect lifecycle', (filename) => {
   test('aborts upstream and closes its iterator as soon as the downstream socket closes', async () => {
@@ -534,219 +144,6 @@ test.each(examples)('%s does not rewrite an already-ended response after an erro
   expect(response.destroy).not.toHaveBeenCalled();
 });
 
-test('the raw example waits for drain before consuming another upstream chunk', async () => {
-  const runtime = loadExample('stream-to-client-raw.ts');
-  const request = createRequest();
-  const response = createResponse();
-  response.writeResult = false;
-
-  const pending = invoke(runtime, request, response);
-  await vi.waitFor(() => expect(response.listenerCount('drain')).toBe(1));
-
-  expect(runtime.generated).toBe(1);
-  expect(response.write).toHaveBeenCalledOnce();
-  expect(response.end).not.toHaveBeenCalled();
-
-  response.writeResult = true;
-  response.emit('drain');
-  await pending;
-
-  expect(runtime.generated).toBe(3);
-  expect(response.body).toBe('safe chunk'.repeat(3));
-  expect(response.end).toHaveBeenCalledOnce();
-  expect(runtime.signal?.aborted).toBe(false);
-  expect(runtime.consoleError).not.toHaveBeenCalled();
-  expect(request.listenerCount('aborted')).toBe(0);
-  expect(response.listenerCount('drain')).toBe(0);
-  expect(response.listenerCount('error')).toBe(0);
-  expect(response.listenerCount('close')).toBe(0);
-});
-
-test.each(['response close', 'request abort', 'close during write'] as const)(
-  'the raw example cancels a drain wait after %s',
-  async (event) => {
-    const runtime = loadExample('stream-to-client-raw.ts');
-    const request = createRequest();
-    const response = createResponse();
-    response.writeResult = false;
-    if (event === 'close during write') {
-      response.onWrite = () => response.destroy();
-    }
-
-    const pending = invoke(runtime, request, response);
-    if (event !== 'close during write') {
-      await vi.waitFor(() => expect(response.listenerCount('drain')).toBe(1));
-      if (event === 'response close') {
-        response.destroy();
-      } else {
-        request.emit('aborted');
-      }
-    }
-    await pending;
-
-    expect(runtime.signal?.aborted).toBe(true);
-    expect(runtime.generated).toBe(1);
-    expect(runtime.cancellations).toBe(1);
-    expect(response.end).not.toHaveBeenCalled();
-    expect(runtime.consoleError).not.toHaveBeenCalled();
-    expect(request.listenerCount('aborted')).toBe(0);
-    expect(response.listenerCount('drain')).toBe(0);
-    expect(response.listenerCount('error')).toBe(0);
-    expect(response.listenerCount('close')).toBe(0);
-  },
-);
-
-test.each(['write', 'drain wait'] as const)(
-  'the raw example reports a genuine response error during %s',
-  async (phase) => {
-    const failure = new Error(`intentional response ${phase} failure`);
-    const runtime = loadExample('stream-to-client-raw.ts');
-    const request = createRequest();
-    const response = createResponse();
-    response.writeResult = false;
-    if (phase === 'write') {
-      response.onWrite = () => {
-        throw failure;
-      };
-    }
-
-    const pending = invoke(runtime, request, response);
-    if (phase === 'drain wait') {
-      await vi.waitFor(() => expect(response.listenerCount('drain')).toBe(1));
-      response.emit('error', failure);
-    }
-    await pending;
-
-    expect(runtime.consoleError).toHaveBeenCalledExactlyOnceWith(failure);
-    expect(runtime.signal?.aborted).toBe(false);
-    expect(runtime.cancellations).toBe(1);
-    expect(response.destroy).toHaveBeenCalledOnce();
-    expect(response.end).not.toHaveBeenCalled();
-    expect(request.listenerCount('aborted')).toBe(0);
-    expect(response.listenerCount('drain')).toBe(0);
-    expect(response.listenerCount('error')).toBe(0);
-    expect(response.listenerCount('close')).toBe(0);
-  },
-);
-
-test.each(['response close', 'request abort'] as const)(
-  'the raw example preserves a response error immediately followed by %s',
-  async (event) => {
-    const failure = new Error('intentional response error before client disconnect');
-    const runtime = loadExample('stream-to-client-raw.ts');
-    const request = createRequest();
-    const response = createResponse();
-    response.writeResult = false;
-
-    const pending = invoke(runtime, request, response);
-    await vi.waitFor(() => expect(response.listenerCount('drain')).toBe(1));
-    response.emit('error', failure);
-    if (event === 'response close') {
-      response.destroy();
-    } else {
-      request.emit('aborted');
-    }
-    await pending;
-
-    expect(runtime.signal?.aborted).toBe(true);
-    expect(runtime.consoleError).toHaveBeenCalledExactlyOnceWith(failure);
-    expect(runtime.cancellations).toBe(1);
-    expect(response.end).not.toHaveBeenCalled();
-    expect(request.listenerCount('aborted')).toBe(0);
-    expect(response.listenerCount('drain')).toBe(0);
-    expect(response.listenerCount('error')).toBe(0);
-    expect(response.listenerCount('close')).toBe(0);
-  },
-);
-
-test.each(['resume', 'disconnect', 'upstream failure'] as const)(
-  'the raw example handles a paused real downstream client followed by %s',
-  async (mode) => {
-    const client = await loadPublicExample(
-      'stream-to-client-raw.ts',
-      mode === 'upstream failure' ? 'large-failure' : 'large',
-    );
-    let incomingRequest: IncomingMessage | undefined;
-    let outgoing: ServerResponse | undefined;
-    let routeFinished = false;
-    const downstream = createServer(async (request, response) => {
-      incomingRequest = request;
-      let body = '';
-      for await (const chunk of request) {
-        body += String(chunk);
-      }
-      outgoing = response;
-      const adaptedResponse = Object.assign(response, {
-        header(name: string, value: string) {
-          response.setHeader(name, value);
-          return response;
-        },
-        status(code: number) {
-          response.statusCode = code;
-          return response;
-        },
-      });
-      await invoke(client.runtime, Object.assign(request, { body }), adaptedResponse);
-      routeFinished = true;
-    });
-    const listening = once(downstream, 'listening');
-    downstream.listen(0, '127.0.0.1');
-    await listening;
-    const address = downstream.address();
-    if (address === null || typeof address === 'string') {
-      throw new Error('The downstream server has no local port');
-    }
-
-    const controller = new AbortController();
-    try {
-      const incoming = await fetch(`http://127.0.0.1:${address.port}`, {
-        method: 'POST',
-        body: 'A synthetic prompt',
-        signal: controller.signal,
-      });
-      // Leave the actual HTTP response unread while the provider sends 16 MiB.
-      await vi.waitFor(() => expect(outgoing?.writableNeedDrain).toBe(true));
-      await setTimeout(100);
-      expect(routeFinished).toBe(false);
-      expect(outgoing?.writableNeedDrain).toBe(true);
-      expect(outgoing?.writableLength).toBeLessThan(largeContentChunk.length * 2);
-      expect(incoming.status).toBe(200);
-
-      if (mode === 'resume') {
-        expect(await incoming.text()).toBe(largeContentChunk.repeat(largeContentChunkCount));
-      } else if (mode === 'upstream failure') {
-        await expect(incoming.text()).rejects.toThrow();
-      } else {
-        controller.abort();
-      }
-      await vi.waitFor(() => expect(routeFinished).toBe(true));
-      expect(client.transport).toHaveBeenCalledOnce();
-      expect(client.upstreamClosed).toHaveLength(1);
-      await client.upstreamClosed[0];
-
-      if (mode === 'upstream failure') {
-        expect(client.runtime.consoleError).toHaveBeenCalledOnce();
-        expect(String(client.runtime.consoleError.mock.calls[0]?.[0])).toContain(
-          'intentional upstream failure after backpressure',
-        );
-        expect(outgoing?.destroyed).toBe(true);
-      } else {
-        expect(client.runtime.consoleError).not.toHaveBeenCalled();
-        expect(client.signal?.aborted).toBe(mode === 'disconnect');
-      }
-      expect(outgoing?.writableEnded).toBe(mode === 'resume');
-      expect(incomingRequest?.listenerCount('aborted')).toBe(0);
-      expect(outgoing?.listenerCount('drain')).toBe(0);
-      expect(outgoing?.listenerCount('error')).toBe(0);
-      expect(outgoing?.listenerCount('close')).toBe(0);
-    } finally {
-      controller.abort();
-      await closePublicExample(downstream);
-      await closePublicExample(client.upstream);
-    }
-  },
-);
-
 test.each([
   ['stream-to-client-express.ts', 'response close'],
   ['stream-to-client-express.ts', 'request abort'],
@@ -755,7 +152,9 @@ test.each([
 ] as const)(
   'the public SDK aborts %s through the real loopback transport after %s',
   async (filename, event) => {
-    const client = await loadPublicExample(filename);
+    const client = await loadPublicExample(filename, {
+      pendingHeaders: filename === 'stream-to-client-raw.ts',
+    });
     const request = createRequest();
     const response = createResponse();
 
@@ -788,7 +187,7 @@ test.each([
       expect(request.listenerCount('aborted')).toBe(0);
       expect(response.listenerCount('close')).toBe(0);
     } finally {
-      await closePublicExample(client.upstream);
+      await client.close();
     }
   },
 );
@@ -796,7 +195,7 @@ test.each([
 test.each(examples)(
   'the public SDK completes %s through the real SSE loopback transport',
   async (filename) => {
-    const client = await loadPublicExample(filename, 'complete');
+    const client = await loadPublicExample(filename, { contentCount: 1, terminalEvent: 'done' });
     const request = createRequest();
     const response = createResponse();
 
@@ -810,13 +209,13 @@ test.each(examples)(
       expect(request.listenerCount('aborted')).toBe(0);
       expect(response.listenerCount('close')).toBe(0);
     } finally {
-      await closePublicExample(client.upstream);
+      await client.close();
     }
   },
 );
 
 test.each(examples)('the public SDK still reports genuine upstream failures from %s', async (filename) => {
-  const client = await loadPublicExample(filename, 'failure');
+  const client = await loadPublicExample(filename, { httpError: 'intentional public upstream failure' });
   const request = createRequest();
   const response = createResponse();
 
@@ -835,7 +234,7 @@ test.each(examples)('the public SDK still reports genuine upstream failures from
     expect(request.listenerCount('aborted')).toBe(0);
     expect(response.listenerCount('close')).toBe(0);
   } finally {
-    await closePublicExample(client.upstream);
+    await client.close();
   }
 });
 
@@ -847,41 +246,15 @@ test.each(
 )(
   '$filename finishes the real downstream HTTP connection after an upstream $mode',
   async ({ filename, mode }) => {
-    const client = await loadPublicExample(filename, mode);
-    let outgoing: ServerResponse | undefined;
-    let routeFinished = false;
-    const downstream = createServer(async (request, response) => {
-      let body = '';
-      for await (const chunk of request) {
-        body += String(chunk);
-      }
-      outgoing = response;
-      const adaptedResponse = Object.assign(response, {
-        header(name: string, value: string) {
-          response.setHeader(name, value);
-          return response;
-        },
-        status(code: number) {
-          response.statusCode = code;
-          return response;
-        },
-      });
-      await invoke(client.runtime, Object.assign(request, { body }), adaptedResponse);
-      routeFinished = true;
-    });
-    const listening = once(downstream, 'listening');
-    downstream.listen(0, '127.0.0.1');
-    await listening;
-    const address = downstream.address();
-    if (address === null || typeof address === 'string') {
-      throw new Error('The downstream server has no local port');
-    }
-
-    const controller = new AbortController();
+    const downstream = await loadPublicHTTPExample(
+      filename,
+      mode === 'failure' ? { httpError: 'intentional public upstream failure' } : { contentCount: 1 },
+    );
+    const { client, controller } = downstream;
     let receivedStatus: number | undefined;
     const result = (async () => {
       try {
-        const response = await fetch(`http://127.0.0.1:${address.port}`, {
+        const response = await fetch(downstream.url, {
           method: 'POST',
           body: 'A synthetic prompt',
           signal: controller.signal,
@@ -898,21 +271,19 @@ test.each(
         await vi.waitFor(() => expect(receivedStatus).toBe(200));
         client.upstream.closeAllConnections();
       }
-      await vi.waitFor(() => expect(routeFinished).toBe(true));
+      await vi.waitFor(() => expect(downstream.routeFinished).toBe(true));
       expect(client.runtime.consoleError).toHaveBeenCalledOnce();
       if (mode === 'failure') {
-        expect(outgoing?.writableEnded).toBe(true);
+        expect(downstream.outgoing?.writableEnded).toBe(true);
         expect(await result).toEqual({ status: 500, body: 'Internal Server Error' });
       } else {
-        expect(outgoing?.destroyed).toBe(true);
-        expect(outgoing?.writableEnded).toBe(false);
+        expect(downstream.outgoing?.destroyed).toBe(true);
+        expect(downstream.outgoing?.writableEnded).toBe(false);
         expect(await result).toHaveProperty('error');
       }
     } finally {
-      controller.abort();
+      await downstream.close();
       await result;
-      await closePublicExample(downstream);
-      await closePublicExample(client.upstream);
     }
   },
 );

--- a/tests/lib/streaming-example-disconnect-security.test.ts
+++ b/tests/lib/streaming-example-disconnect-security.test.ts
@@ -2,7 +2,8 @@ import { timingSafeEqual } from 'node:crypto';
 import { EventEmitter, once } from 'node:events';
 import { readFileSync } from 'node:fs';
 import { createServer } from 'node:http';
-import type { ServerResponse } from 'node:http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { setTimeout } from 'node:timers/promises';
 import { runInNewContext } from 'node:vm';
 
 import ts from 'typescript';
@@ -11,6 +12,8 @@ import { describe, expect, test, vi } from 'vitest';
 import OpenAI, { APIUserAbortError } from '../../src/index';
 
 const examples = ['stream-to-client-express.ts', 'stream-to-client-raw.ts'] as const;
+const largeContentChunk = 'x'.repeat(256 * 1024);
+const largeContentChunkCount = 64;
 
 type Example = (typeof examples)[number];
 interface Completion {
@@ -54,6 +57,7 @@ function createResponse() {
     headersSent: false,
     statusCode: 200,
     writableEnded: false,
+    writeResult: true,
     onWrite: null as (() => void) | null,
   });
 
@@ -72,7 +76,7 @@ function createResponse() {
       response.headersSent = true;
       response.body += String(chunk);
       response.onWrite?.();
-      return true;
+      return response.writeResult;
     }),
 
     end: vi.fn((chunk?: string) => {
@@ -255,6 +259,9 @@ function loadExample(
     if (specifier === 'node:crypto') {
       return { timingSafeEqual };
     }
+    if (specifier === 'node:events') {
+      return { once };
+    }
     if (specifier === 'node:fs') {
       return { readFileSync: vi.fn() };
     }
@@ -293,7 +300,7 @@ function invoke(runtime: ExampleRuntime, request: unknown, response: unknown): P
 
 async function loadPublicExample(
   filename: Example,
-  mode: 'pending' | 'complete' | 'failure' | 'partial' = 'pending',
+  mode: 'pending' | 'complete' | 'failure' | 'partial' | 'large' | 'large-failure' = 'pending',
 ) {
   const upstreamClosed: Promise<unknown[]>[] = [];
   const upstream = createServer((_request, response) => {
@@ -312,7 +319,8 @@ async function loadPublicExample(
     response.writeHead(200, { 'Content-Type': 'text/event-stream' });
     response.flushHeaders();
 
-    if (mode === 'complete' || mode === 'partial') {
+    if (mode === 'complete' || mode === 'partial' || mode === 'large' || mode === 'large-failure') {
+      const large = mode === 'large' || mode === 'large-failure';
       const base = {
         id: 'chatcmpl-public-loopback',
         object: 'chat.completion.chunk',
@@ -322,7 +330,11 @@ async function loadPublicExample(
       const content = {
         ...base,
         choices: [
-          { index: 0, delta: { role: 'assistant', content: 'safe public chunk' }, finish_reason: null },
+          {
+            index: 0,
+            delta: { role: 'assistant', content: large ? largeContentChunk : 'safe public chunk' },
+            finish_reason: null,
+          },
         ],
       };
       const finished = {
@@ -333,9 +345,12 @@ async function loadPublicExample(
         response.write(`data: ${JSON.stringify(content)}\n\n`);
         return;
       }
-      response.end(
-        `data: ${JSON.stringify(content)}\n\ndata: ${JSON.stringify(finished)}\n\ndata: [DONE]\n\n`,
-      );
+      const contentEvents = `data: ${JSON.stringify(content)}\n\n`.repeat(large ? largeContentChunkCount : 1);
+      const endEvent =
+        mode === 'large-failure'
+          ? `data: ${JSON.stringify({ error: { message: 'intentional upstream failure after backpressure' } })}\n\n`
+          : `data: ${JSON.stringify(finished)}\n\ndata: [DONE]\n\n`;
+      response.end(contentEvents + endEvent);
     }
   });
 
@@ -518,6 +533,219 @@ test.each(examples)('%s does not rewrite an already-ended response after an erro
   expect(response.end).toHaveBeenCalledOnce();
   expect(response.destroy).not.toHaveBeenCalled();
 });
+
+test('the raw example waits for drain before consuming another upstream chunk', async () => {
+  const runtime = loadExample('stream-to-client-raw.ts');
+  const request = createRequest();
+  const response = createResponse();
+  response.writeResult = false;
+
+  const pending = invoke(runtime, request, response);
+  await vi.waitFor(() => expect(response.listenerCount('drain')).toBe(1));
+
+  expect(runtime.generated).toBe(1);
+  expect(response.write).toHaveBeenCalledOnce();
+  expect(response.end).not.toHaveBeenCalled();
+
+  response.writeResult = true;
+  response.emit('drain');
+  await pending;
+
+  expect(runtime.generated).toBe(3);
+  expect(response.body).toBe('safe chunk'.repeat(3));
+  expect(response.end).toHaveBeenCalledOnce();
+  expect(runtime.signal?.aborted).toBe(false);
+  expect(runtime.consoleError).not.toHaveBeenCalled();
+  expect(request.listenerCount('aborted')).toBe(0);
+  expect(response.listenerCount('drain')).toBe(0);
+  expect(response.listenerCount('error')).toBe(0);
+  expect(response.listenerCount('close')).toBe(0);
+});
+
+test.each(['response close', 'request abort', 'close during write'] as const)(
+  'the raw example cancels a drain wait after %s',
+  async (event) => {
+    const runtime = loadExample('stream-to-client-raw.ts');
+    const request = createRequest();
+    const response = createResponse();
+    response.writeResult = false;
+    if (event === 'close during write') {
+      response.onWrite = () => response.destroy();
+    }
+
+    const pending = invoke(runtime, request, response);
+    if (event !== 'close during write') {
+      await vi.waitFor(() => expect(response.listenerCount('drain')).toBe(1));
+      if (event === 'response close') {
+        response.destroy();
+      } else {
+        request.emit('aborted');
+      }
+    }
+    await pending;
+
+    expect(runtime.signal?.aborted).toBe(true);
+    expect(runtime.generated).toBe(1);
+    expect(runtime.cancellations).toBe(1);
+    expect(response.end).not.toHaveBeenCalled();
+    expect(runtime.consoleError).not.toHaveBeenCalled();
+    expect(request.listenerCount('aborted')).toBe(0);
+    expect(response.listenerCount('drain')).toBe(0);
+    expect(response.listenerCount('error')).toBe(0);
+    expect(response.listenerCount('close')).toBe(0);
+  },
+);
+
+test.each(['write', 'drain wait'] as const)(
+  'the raw example reports a genuine response error during %s',
+  async (phase) => {
+    const failure = new Error(`intentional response ${phase} failure`);
+    const runtime = loadExample('stream-to-client-raw.ts');
+    const request = createRequest();
+    const response = createResponse();
+    response.writeResult = false;
+    if (phase === 'write') {
+      response.onWrite = () => {
+        throw failure;
+      };
+    }
+
+    const pending = invoke(runtime, request, response);
+    if (phase === 'drain wait') {
+      await vi.waitFor(() => expect(response.listenerCount('drain')).toBe(1));
+      response.emit('error', failure);
+    }
+    await pending;
+
+    expect(runtime.consoleError).toHaveBeenCalledExactlyOnceWith(failure);
+    expect(runtime.signal?.aborted).toBe(false);
+    expect(runtime.cancellations).toBe(1);
+    expect(response.destroy).toHaveBeenCalledOnce();
+    expect(response.end).not.toHaveBeenCalled();
+    expect(request.listenerCount('aborted')).toBe(0);
+    expect(response.listenerCount('drain')).toBe(0);
+    expect(response.listenerCount('error')).toBe(0);
+    expect(response.listenerCount('close')).toBe(0);
+  },
+);
+
+test.each(['response close', 'request abort'] as const)(
+  'the raw example preserves a response error immediately followed by %s',
+  async (event) => {
+    const failure = new Error('intentional response error before client disconnect');
+    const runtime = loadExample('stream-to-client-raw.ts');
+    const request = createRequest();
+    const response = createResponse();
+    response.writeResult = false;
+
+    const pending = invoke(runtime, request, response);
+    await vi.waitFor(() => expect(response.listenerCount('drain')).toBe(1));
+    response.emit('error', failure);
+    if (event === 'response close') {
+      response.destroy();
+    } else {
+      request.emit('aborted');
+    }
+    await pending;
+
+    expect(runtime.signal?.aborted).toBe(true);
+    expect(runtime.consoleError).toHaveBeenCalledExactlyOnceWith(failure);
+    expect(runtime.cancellations).toBe(1);
+    expect(response.end).not.toHaveBeenCalled();
+    expect(request.listenerCount('aborted')).toBe(0);
+    expect(response.listenerCount('drain')).toBe(0);
+    expect(response.listenerCount('error')).toBe(0);
+    expect(response.listenerCount('close')).toBe(0);
+  },
+);
+
+test.each(['resume', 'disconnect', 'upstream failure'] as const)(
+  'the raw example handles a paused real downstream client followed by %s',
+  async (mode) => {
+    const client = await loadPublicExample(
+      'stream-to-client-raw.ts',
+      mode === 'upstream failure' ? 'large-failure' : 'large',
+    );
+    let incomingRequest: IncomingMessage | undefined;
+    let outgoing: ServerResponse | undefined;
+    let routeFinished = false;
+    const downstream = createServer(async (request, response) => {
+      incomingRequest = request;
+      let body = '';
+      for await (const chunk of request) {
+        body += String(chunk);
+      }
+      outgoing = response;
+      const adaptedResponse = Object.assign(response, {
+        header(name: string, value: string) {
+          response.setHeader(name, value);
+          return response;
+        },
+        status(code: number) {
+          response.statusCode = code;
+          return response;
+        },
+      });
+      await invoke(client.runtime, Object.assign(request, { body }), adaptedResponse);
+      routeFinished = true;
+    });
+    const listening = once(downstream, 'listening');
+    downstream.listen(0, '127.0.0.1');
+    await listening;
+    const address = downstream.address();
+    if (address === null || typeof address === 'string') {
+      throw new Error('The downstream server has no local port');
+    }
+
+    const controller = new AbortController();
+    try {
+      const incoming = await fetch(`http://127.0.0.1:${address.port}`, {
+        method: 'POST',
+        body: 'A synthetic prompt',
+        signal: controller.signal,
+      });
+      // Leave the actual HTTP response unread while the provider sends 16 MiB.
+      await vi.waitFor(() => expect(outgoing?.writableNeedDrain).toBe(true));
+      await setTimeout(100);
+      expect(routeFinished).toBe(false);
+      expect(outgoing?.writableNeedDrain).toBe(true);
+      expect(outgoing?.writableLength).toBeLessThan(largeContentChunk.length * 2);
+      expect(incoming.status).toBe(200);
+
+      if (mode === 'resume') {
+        expect(await incoming.text()).toBe(largeContentChunk.repeat(largeContentChunkCount));
+      } else if (mode === 'upstream failure') {
+        await expect(incoming.text()).rejects.toThrow();
+      } else {
+        controller.abort();
+      }
+      await vi.waitFor(() => expect(routeFinished).toBe(true));
+      expect(client.transport).toHaveBeenCalledOnce();
+      expect(client.upstreamClosed).toHaveLength(1);
+      await client.upstreamClosed[0];
+
+      if (mode === 'upstream failure') {
+        expect(client.runtime.consoleError).toHaveBeenCalledOnce();
+        expect(String(client.runtime.consoleError.mock.calls[0]?.[0])).toContain(
+          'intentional upstream failure after backpressure',
+        );
+        expect(outgoing?.destroyed).toBe(true);
+      } else {
+        expect(client.runtime.consoleError).not.toHaveBeenCalled();
+        expect(client.signal?.aborted).toBe(mode === 'disconnect');
+      }
+      expect(outgoing?.writableEnded).toBe(mode === 'resume');
+      expect(incomingRequest?.listenerCount('aborted')).toBe(0);
+      expect(outgoing?.listenerCount('drain')).toBe(0);
+      expect(outgoing?.listenerCount('error')).toBe(0);
+      expect(outgoing?.listenerCount('close')).toBe(0);
+    } finally {
+      controller.abort();
+      await closePublicExample(downstream);
+      await closePublicExample(client.upstream);
+    }
+  },
+);
 
 test.each([
   ['stream-to-client-express.ts', 'response close'],

--- a/tests/lib/streaming-example-test-utils.ts
+++ b/tests/lib/streaming-example-test-utils.ts
@@ -1,0 +1,474 @@
+import { timingSafeEqual } from 'node:crypto';
+import { EventEmitter, once } from 'node:events';
+import { readFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { runInNewContext } from 'node:vm';
+
+import ts from 'typescript';
+import { vi } from 'vitest';
+
+import OpenAI, { APIUserAbortError } from '../../src/index';
+
+export const examples = ['stream-to-client-express.ts', 'stream-to-client-raw.ts'] as const;
+
+type Example = (typeof examples)[number];
+interface Completion {
+  choices: [{ delta: { content: string } }];
+}
+type RouteHandler = (request: unknown, response: unknown) => Promise<void>;
+
+interface ExampleRuntime {
+  apiCalls: number;
+  aborts: number;
+  generated: number;
+  cancellations: number;
+  consoleError: ReturnType<typeof vi.fn>;
+  handler?: RouteHandler;
+  signal?: AbortSignal;
+  onProvider?: () => void;
+  pendingCreate: boolean;
+  pendingNext: boolean;
+  abortError?: Error;
+  rejectCreate?: (error: Error) => void;
+  rejectNext?: (error: Error) => void;
+}
+
+function createNodeHTTPEmitter(): EventEmitter {
+  // Node HTTP requests and responses expose EventEmitter lifecycle events.
+  // oxlint-disable-next-line unicorn/prefer-event-target
+  return new EventEmitter();
+}
+
+export function createRequest() {
+  return Object.assign(createNodeHTTPEmitter(), {
+    body: 'Tell me why dogs are better than cats',
+    get: vi.fn(),
+  });
+}
+
+export function createResponse() {
+  const response = Object.assign(createNodeHTTPEmitter(), {
+    body: '',
+    destroyed: false,
+    headersSent: false,
+    statusCode: 200,
+    writableEnded: false,
+    writeResult: true,
+    onWrite: null as (() => void) | null,
+  });
+
+  return Object.assign(response, {
+    header: vi.fn((_name: string, _value: string) => response),
+    status: vi.fn((code: number) => {
+      response.statusCode = code;
+      return response;
+    }),
+
+    write: vi.fn((chunk: unknown) => {
+      if (response.destroyed) {
+        throw new Error('Attempted to write to a destroyed socket');
+      }
+
+      response.headersSent = true;
+      response.body += String(chunk);
+      response.onWrite?.();
+      return response.writeResult;
+    }),
+
+    end: vi.fn((chunk?: string) => {
+      if (response.destroyed) {
+        throw new Error('Attempted to end a destroyed socket');
+      }
+
+      response.body += chunk ?? '';
+      response.headersSent = true;
+      response.writableEnded = true;
+      response.emit('finish');
+      return response;
+    }),
+
+    destroy: vi.fn(() => {
+      response.destroyed = true;
+      response.emit('close');
+      return response;
+    }),
+  });
+}
+
+function completionChunks(runtime: ExampleRuntime, encoded: boolean): AsyncIterable<string | Completion> {
+  return {
+    [Symbol.asyncIterator]() {
+      let index = 0;
+
+      return {
+        async next() {
+          if (encoded && runtime.pendingNext) {
+            runtime.pendingNext = false;
+            const deferred = new AbortController();
+            let failure: Error | undefined;
+            const pending = (async () => {
+              await once(deferred.signal, 'abort');
+              throw failure ?? new APIUserAbortError();
+            })();
+
+            runtime.rejectNext = (error) => {
+              failure = error;
+              deferred.abort();
+            };
+            runtime.signal?.addEventListener(
+              'abort',
+              () => runtime.rejectNext?.(runtime.abortError ?? new APIUserAbortError()),
+              { once: true },
+            );
+            return pending;
+          }
+
+          if (index >= 3) {
+            return { done: true as const, value: undefined };
+          }
+
+          index += 1;
+          runtime.generated += 1;
+          return {
+            done: false as const,
+            value: encoded ? 'safe chunk' : { choices: [{ delta: { content: 'safe chunk' } }] },
+          };
+        },
+
+        async return() {
+          runtime.cancellations += 1;
+          return { done: true as const, value: undefined };
+        },
+      };
+    },
+  };
+}
+
+export function loadExample(
+  filename: Example,
+  options: { withoutAbortController?: boolean; client?: new () => OpenAI } = {},
+): ExampleRuntime {
+  const runtime: ExampleRuntime = {
+    apiCalls: 0,
+    aborts: 0,
+    generated: 0,
+    cancellations: 0,
+    consoleError: vi.fn(),
+    pendingCreate: false,
+    pendingNext: false,
+  };
+
+  const app = {
+    use() {
+      return app;
+    },
+
+    post(_path: string, handler: RouteHandler) {
+      runtime.handler = handler;
+      return app;
+    },
+
+    listen() {
+      return app;
+    },
+  };
+
+  const express = Object.assign(() => app, {
+    text: () => (_request: unknown, _response: unknown, next: () => void) => next(),
+  });
+
+  function configureProvider(providerOptions?: { signal?: AbortSignal }): void {
+    runtime.apiCalls += 1;
+
+    if (providerOptions?.signal) {
+      runtime.signal = providerOptions.signal;
+      runtime.signal.addEventListener(
+        'abort',
+        () => {
+          runtime.aborts += 1;
+        },
+        { once: true },
+      );
+    }
+  }
+
+  class MockOpenAI {
+    static APIUserAbortError = APIUserAbortError;
+
+    readonly chat = {
+      completions: {
+        stream: (_body: unknown, providerOptions?: { signal?: AbortSignal }) => {
+          configureProvider(providerOptions);
+          runtime.onProvider?.();
+          return {
+            toReadableStream: () => completionChunks(runtime, true),
+          };
+        },
+
+        create: (_body: unknown, providerOptions?: { signal?: AbortSignal }) => {
+          configureProvider(providerOptions);
+          const chunks = completionChunks(runtime, false) as AsyncIterable<Completion>;
+
+          if (runtime.pendingCreate) {
+            const deferred = new AbortController();
+            let failure: Error | undefined;
+            const pending = (async () => {
+              await once(deferred.signal, 'abort');
+              throw failure ?? new APIUserAbortError();
+            })();
+
+            runtime.rejectCreate = (error) => {
+              failure = error;
+              deferred.abort();
+            };
+            runtime.signal?.addEventListener(
+              'abort',
+              () => runtime.rejectCreate?.(runtime.abortError ?? new APIUserAbortError()),
+              { once: true },
+            );
+            runtime.onProvider?.();
+            return pending;
+          }
+
+          runtime.onProvider?.();
+          return Promise.resolve(chunks);
+        },
+      },
+    };
+  }
+
+  const source = readFileSync(`examples/chat-completions/${filename}`, 'utf-8');
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: {
+      esModuleInterop: true,
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName: filename,
+  }).outputText;
+
+  function requireExampleModule(specifier: string): unknown {
+    if (specifier === 'openai') {
+      return { __esModule: true, default: options.client ?? MockOpenAI };
+    }
+    if (specifier === 'express') {
+      return { __esModule: true, default: express };
+    }
+    if (specifier === 'node:crypto') {
+      return { timingSafeEqual };
+    }
+    if (specifier === 'node:events') {
+      return { once };
+    }
+    if (specifier === 'node:fs') {
+      return { readFileSync: vi.fn() };
+    }
+    if (specifier === 'node:https') {
+      return { createServer: vi.fn() };
+    }
+
+    throw new Error(`Unexpected streaming example import: ${specifier}`);
+  }
+
+  const commonJS = { exports: {} };
+  const globals: Record<string, unknown> = {
+    Buffer,
+    console: { error: runtime.consoleError, log: vi.fn() },
+    exports: commonJS.exports,
+    module: commonJS,
+    process: { env: {} },
+    require: requireExampleModule,
+  };
+
+  if (!options.withoutAbortController) {
+    globals['AbortController'] = AbortController;
+  }
+
+  runInNewContext(transpiled, globals, { filename });
+  return runtime;
+}
+
+export function invoke(runtime: ExampleRuntime, request: unknown, response: unknown): Promise<void> {
+  if (!runtime.handler) {
+    throw new Error('The streaming example did not register its Express route');
+  }
+
+  return runtime.handler(request, response);
+}
+
+interface UpstreamOptions {
+  pendingHeaders?: boolean;
+  httpError?: string;
+  content?: string;
+  contentCount?: number;
+  // Omit the terminal event to keep the SSE connection open.
+  terminalEvent?: 'done' | { error: { message: string } };
+}
+
+async function listen(server: ReturnType<typeof createServer>): Promise<string> {
+  const listening = once(server, 'listening');
+  server.listen(0, '127.0.0.1');
+  await listening;
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('The streaming example loopback server has no local port');
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function closeServer(server: ReturnType<typeof createServer>): Promise<void> {
+  const closed = once(server, 'close');
+  server.closeAllConnections();
+  server.close();
+  await closed;
+}
+
+export async function loadPublicExample(filename: Example, options: UpstreamOptions) {
+  const upstreamClosed: Promise<unknown[]>[] = [];
+  const upstream = createServer((_request, response) => {
+    upstreamClosed.push(once(response, 'close'));
+
+    if (options.httpError !== undefined) {
+      response.writeHead(500, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify({ error: { message: options.httpError } }));
+      return;
+    }
+    if (options.pendingHeaders) {
+      return;
+    }
+
+    response.writeHead(200, { 'Content-Type': 'text/event-stream' });
+    response.flushHeaders();
+    const base = {
+      id: 'chatcmpl-public-loopback',
+      object: 'chat.completion.chunk',
+      created: 1,
+      model: 'gpt-test',
+    };
+    const content = {
+      ...base,
+      choices: [
+        {
+          index: 0,
+          delta: { role: 'assistant', content: options.content ?? 'safe public chunk' },
+          finish_reason: null,
+        },
+      ],
+    };
+    const contentEvents = `data: ${JSON.stringify(content)}\n\n`.repeat(options.contentCount ?? 0);
+    if (options.terminalEvent === undefined) {
+      if (contentEvents) {
+        response.write(contentEvents);
+      }
+      return;
+    }
+
+    const finished = {
+      ...base,
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+    };
+    const endEvent =
+      options.terminalEvent === 'done'
+        ? `data: ${JSON.stringify(finished)}\n\ndata: [DONE]\n\n`
+        : `data: ${JSON.stringify(options.terminalEvent)}\n\n`;
+    response.end(contentEvents + endEvent);
+  });
+
+  const baseURL = `${await listen(upstream)}/v1`;
+  let signal: AbortSignal | undefined;
+  let body: ReadableStream<Uint8Array> | null | undefined;
+  const transport = vi.fn<typeof fetch>(async (request, requestOptions) => {
+    signal = requestOptions?.signal ?? undefined;
+    const response = await fetch(request, requestOptions);
+    ({ body } = response);
+    return response;
+  });
+
+  const PublicOpenAI = OpenAI.bind(undefined, {
+    apiKey: 'public-sdk-loopback-test-key',
+    baseURL,
+    fetch: transport,
+    maxRetries: 0,
+  });
+
+  let runtime: ExampleRuntime;
+  try {
+    runtime = loadExample(filename, { client: PublicOpenAI });
+  } catch (error) {
+    await closeServer(upstream);
+    throw error;
+  }
+
+  return {
+    runtime,
+    transport,
+    upstream,
+    upstreamClosed,
+    close: () => closeServer(upstream),
+    get signal() {
+      return signal;
+    },
+    get body() {
+      return body;
+    },
+  };
+}
+
+export async function loadPublicHTTPExample(filename: Example, options: UpstreamOptions) {
+  const client = await loadPublicExample(filename, options);
+  let incomingRequest: IncomingMessage | undefined;
+  let outgoing: ServerResponse | undefined;
+  let routeFinished = false;
+  const downstream = createServer(async (request, response) => {
+    incomingRequest = request;
+    let body = '';
+    for await (const chunk of request) {
+      body += String(chunk);
+    }
+    outgoing = response;
+    const adaptedResponse = Object.assign(response, {
+      header(name: string, value: string) {
+        response.setHeader(name, value);
+        return response;
+      },
+      status(code: number) {
+        response.statusCode = code;
+        return response;
+      },
+    });
+    await invoke(client.runtime, Object.assign(request, { body }), adaptedResponse);
+    routeFinished = true;
+  });
+  const controller = new AbortController();
+  let url: string;
+  try {
+    url = await listen(downstream);
+  } catch (error) {
+    await client.close();
+    throw error;
+  }
+
+  return {
+    client,
+    url,
+    controller,
+    get incomingRequest() {
+      return incomingRequest;
+    },
+    get outgoing() {
+      return outgoing;
+    },
+    get routeFinished() {
+      return routeFinished;
+    },
+    async close() {
+      controller.abort();
+      try {
+        await closeServer(downstream);
+      } finally {
+        await client.close();
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Respect `ServerResponse.write(false)` in the raw streaming proxy example by waiting for Node's `drain` event before reading another upstream chunk.
- Use the existing client-disconnect signal to cancel that wait, and suppress only the matching Node abort rejection. Preserve genuine write, drain, and upstream errors.
- Extend the existing example regression harness with backpressure, cleanup, same-tick error/disconnect races, and real HTTP transport coverage.

Only the raw example and its handwritten tests change. The Express streaming-helper example, authentication, TLS, origin checks, request handling, SDK runtime, and payload limits are unchanged.

## Reproduction

Send a synthetic 16 MiB streamed response through the actual raw-example route and built SDK to a paused local HTTP client. On main, the route consumes all 65 chunks while the client remains paused and queues roughly 14.9 MB in the response.

With this change, the same check pauses upstream consumption, peaks at 262,282 buffered bytes for 256 KiB chunks, and either delivers the complete 16 MiB after the client resumes or cancels the upstream request when the client disconnects. It leaves no drain, close, or error listeners behind. These are observed fixture results, not a new payload cap.

## Validation

- Original focused regressions: 7 failed / 38 passed before the production change.
- Independent adversarial review caught a genuine response-error/disconnect race in the first candidate. Both added error-first regression cases failed before the correction and pass afterward.
- Final four-suite example checks: 81 passed on exact Node 22.0.0, Node 24.19.0, and Node 26.2.0.
- Independent actual-route race/cancellation review: 18 checks passed across Node 22.0.0 and 24.19.0, including unrelated AbortError-shaped errors, synchronous write failures, and listener cleanup.
- Final actual-source, built-SDK HTTP proof passes on Node 22.0.0, 24.19.0, and 26.7.0: exact 16 MiB resume delivery, disconnect abort, bounded response queue, and cleanup.
- Full canonical handwritten suite: 7,811 tests passed across 205 files. Canonical formatting/lint, pinned TypeScript checking, CJS/ESM build, and `git diff --check` pass.

The generated resource suite and remaining platform integrations are left to CI.
