### PR TITLE
fix(test): reap Steady commands when lease creation fails

### DIFF
--- a/scripts/steady/cache.cjs
+++ b/scripts/steady/cache.cjs
@@ -32,7 +32,7 @@ async function locked(cache, action, signal) {
   }
   try {
     signal?.throwIfAborted();
-    return action();
+    return await action();
   } finally {
     fs.rmdirSync(lock);
   }
@@ -105,15 +105,29 @@ async function run(cache, selected, command, args) {
   try {
     const { exited } = await locked(
       cache,
-      () => {
+      async () => {
         prune(cache, selected);
         child = spawn(command, args, { stdio: 'inherit', env: { ...process.env, STEADY_CACHE_LEASE: '1' } });
-        fs.writeFileSync(
-          lease,
-          JSON.stringify({ pids: [process.pid, child.pid].filter(Boolean), entries: selected }),
-          { flag: 'wx' },
-        );
-        return { exited: once(child, 'exit') };
+        const exit = once(child, 'exit');
+        void exit.catch(() => {
+          // Rollback reports the lease error after the child has closed.
+        });
+        const { promise: closed, resolve } = Promise.withResolvers();
+        child.once('close', resolve);
+        try {
+          fs.writeFileSync(
+            lease,
+            JSON.stringify({ pids: [process.pid, child.pid].filter(Boolean), entries: selected }),
+            { flag: 'wx' },
+          );
+        } catch (error) {
+          if (child.pid !== undefined) {
+            child.kill('SIGKILL');
+          }
+          await closed;
+          throw error;
+        }
+        return { exited: exit };
       },
       pending.signal,
     );

--- a/tests/steady-cache-lease-failure.test.ts
+++ b/tests/steady-cache-lease-failure.test.ts
@@ -1,0 +1,180 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import {
+  accessSync,
+  chmodSync,
+  constants,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { vi } from 'vitest';
+
+const wrapperPath = path.join(process.cwd(), 'scripts/steady/cache.cjs');
+const testPermissions = process.platform === 'win32' || process.getuid?.() === 0 ? test.skip : test;
+
+describe('Steady cache lease persistence failure', () => {
+  let fixture: string;
+  let cache: string;
+  let leases: string;
+  let running: ReturnType<typeof startWrapper> | undefined;
+
+  beforeEach(() => {
+    fixture = realpathSync(mkdtempSync(path.join(tmpdir(), 'steady-cache-lease-failure-')));
+    cache = path.join(fixture, 'cache');
+    leases = path.join(cache, '.leases');
+    mkdirSync(leases, { recursive: true });
+    writeFileSync(
+      path.join(fixture, 'observe.cjs'),
+      `const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const spawn = childProcess.spawn;
+// Observe the real child without replacing spawning, filesystem writes, or events.
+childProcess.spawn = (...args) => {
+  const child = spawn(...args);
+  console.log('OWNED_CHILD_PID', child.pid ?? 'missing');
+  child.once('exit', () => {
+    console.log('LOCK_AT_CHILD_EXIT', fs.existsSync(path.join(process.argv[2], '.lifecycle-lock')));
+  });
+  return child;
+};
+`,
+    );
+    writeFileSync(
+      path.join(fixture, 'command.cjs'),
+      `console.log('COMMAND_READY', process.env.STEADY_CACHE_LEASE);
+process.stdin.once('end', () => process.exit(Number(process.argv[2])));
+process.stdin.resume();
+`,
+    );
+  });
+
+  afterEach(async () => {
+    try {
+      if (running) {
+        // Release even the unfixed wrapper's unprotected child and let it be reaped.
+        running.child.stdin.end();
+        await running.closed;
+        running = undefined;
+      }
+    } finally {
+      chmodSync(leases, 0o755);
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  function startWrapper(command = process.execPath, args = [path.join(fixture, 'command.cjs'), '0']) {
+    const child = spawn(
+      process.execPath,
+      [
+        '-r',
+        path.join(fixture, 'observe.cjs'),
+        wrapperPath,
+        cache,
+        path.join(cache, 'source-synthetic'),
+        path.join(cache, 'deno-synthetic'),
+        path.join(cache, 'deps-synthetic'),
+        command,
+        ...args,
+      ],
+      {
+        stdio: 'pipe',
+        // Contain a regression that signals a failed spawn before it has a PID.
+        detached: process.platform !== 'win32',
+        timeout: 10_000,
+        killSignal: 'SIGKILL',
+      },
+    );
+    let output = '';
+    let errors = '';
+    child.stdout.on('data', (chunk) => {
+      output += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      errors += chunk;
+    });
+    const closed = once(child, 'close');
+    const result = { child, closed, output: () => output, errors: () => errors };
+    running = result;
+    return result;
+  }
+
+  function makeLeasesReadOnly() {
+    chmodSync(leases, 0o555);
+    expect(() => accessSync(leases, constants.W_OK)).toThrow(/EACCES/u);
+  }
+
+  function expectCleanCache() {
+    expect(readdirSync(leases)).toEqual([]);
+    expect(existsSync(path.join(cache, '.lifecycle-lock'))).toBe(false);
+  }
+
+  testPermissions(
+    'reaps a started command before releasing its lock or reporting a lease write error',
+    async () => {
+      makeLeasesReadOnly();
+      const wrapper = startWrapper();
+
+      await vi.waitFor(() => expect(wrapper.errors()).toContain('EACCES'), { timeout: 5000 });
+      // The two output streams can be delivered independently; wait for the exit observation.
+      await vi.waitFor(() => expect(wrapper.output()).toContain('LOCK_AT_CHILD_EXIT true'), {
+        timeout: 2000,
+      });
+
+      const pid = Number(wrapper.output().match(/OWNED_CHILD_PID (?<pid>\d+)/u)?.groups?.['pid']);
+      expect(pid).toBeGreaterThan(0);
+      expect(() => process.kill(pid, 0)).toThrow(/ESRCH/u);
+      await expect(wrapper.closed).resolves.toEqual([1, null]);
+      expect(wrapper.errors()).toContain('.json');
+      expectCleanCache();
+    },
+  );
+
+  testPermissions(
+    'preserves the lease error when spawning also fails, without signaling a missing PID',
+    async () => {
+      makeLeasesReadOnly();
+      const wrapper = startWrapper(path.join(fixture, 'missing-command'), []);
+
+      await expect(wrapper.closed).resolves.toEqual([1, null]);
+      expect(wrapper.output()).toContain('OWNED_CHILD_PID missing');
+      expect(wrapper.errors()).toContain('EACCES');
+      expect(wrapper.errors()).not.toContain('ENOENT');
+      expectCleanCache();
+    },
+  );
+
+  test.each([0, 23])(
+    'keeps a writable lease without holding the lock and preserves exit code %i',
+    async (code) => {
+      const wrapper = startWrapper(process.execPath, [path.join(fixture, 'command.cjs'), String(code)]);
+      await vi.waitFor(() => expect(wrapper.output()).toContain('COMMAND_READY 1'), { timeout: 5000 });
+
+      expect(readdirSync(leases)).toHaveLength(1);
+      expect(existsSync(path.join(cache, '.lifecycle-lock'))).toBe(false);
+      wrapper.child.stdin.end();
+
+      await expect(wrapper.closed).resolves.toEqual([code, null]);
+      expect(wrapper.output()).toContain('LOCK_AT_CHILD_EXIT false');
+      expect(wrapper.errors()).toBe('');
+      expectCleanCache();
+    },
+  );
+
+  test('preserves a spawn error when the lease is writable', async () => {
+    const wrapper = startWrapper(path.join(fixture, 'missing-command'), []);
+
+    await expect(wrapper.closed).resolves.toEqual([1, null]);
+    expect(wrapper.output()).toContain('OWNED_CHILD_PID missing');
+    expect(wrapper.errors()).toContain('ENOENT');
+    expect(wrapper.errors()).not.toContain('EACCES');
+    expectCleanCache();
+  });
+});


### PR DESCRIPTION
## Summary

- If persisting a newly spawned Steady command's cache lease fails, terminate the owned child and wait for it to close before releasing the lifecycle lock or reporting the original filesystem error.
- Observe child exit/error and closure before writing the lease, and do not signal a failed spawn without a PID.
- Keep successful commands outside the lifecycle lock. Lease format, cache aging/pruning policy, ordinary exit codes, signal forwarding, and existing cancellation behavior are unchanged.

Only the handwritten cache wrapper and a focused regression-test module change. No generated files, SDK runtime, dependencies, or cache-policy changes.

## Reproduction

Make the existing `.leases` directory genuinely unwritable, then launch a command through the actual cache CLI. On main, the lease write reports `EACCES`, but the child remains running with `STEADY_CACHE_LEASE=1`, no lease, and the lifecycle lock already released. If spawning also fails, the abandoned child additionally emits an uncaught `ENOENT`.

The regression uses real filesystem permissions and real child processes, with a small observational preload to record child ownership and lock state. Before the source change, both failure cases fail and the three writable controls pass.

## Validation

- Five new CLI cases pass, covering lease-write failure with a live child or failed spawn, writable normal/nonzero exits, and writable spawn errors.
- New and existing cancellation/clock regressions: 13 passed on Node 22.0.0, 24.19.0, and 26.7.0. Offline cache-lifetime checks also pass on all three.
- Independent real-process checks verify the child is closed while the lock is held, the exact original filesystem error is preserved, failed spawns produce no unhandled errors, and normal concurrent commands still overlap and retain their exit codes.
- Full canonical handwritten suite: 7,805 tests passed across 206 files.
- Canonical formatting/lint, pinned TypeScript checking, CJS/ESM build, and `git diff --check` pass.
- Independent adversarial review covers process ownership, missing PIDs, spawn errors, lock lifetime, cleanup, cancellation, and runtime-floor compatibility.

The two permission-dependent cases skip Windows and root execution; the writable controls remain enabled. Local process/permission validation was on macOS. Generated and remaining integration tests are left to CI.
