### PR TITLE
fix(audio): only signal started recording processes

### DIFF
--- a/src/helpers/audio.ts
+++ b/src/helpers/audio.ts
@@ -158,7 +158,7 @@ function nodejsRecordAudio({ signal, device, timeout }: RecordAudioOptions = {})
       }
     };
     const stopRecording = () => {
-      if (!settled && ffmpeg) {
+      if (!settled && ffmpeg?.pid) {
         try {
           wasStopped ||= ffmpeg.kill('SIGTERM');
         } catch (error) {
@@ -291,7 +291,7 @@ function nodejsRecordAudio({ signal, device, timeout }: RecordAudioOptions = {})
       }
 
       try {
-        if (!wasStopped) {
+        if (!wasStopped && ffmpeg?.pid) {
           ffmpeg?.kill('SIGTERM');
         }
       } catch {

--- a/tests/helpers/audio-recording-device.test.ts
+++ b/tests/helpers/audio-recording-device.test.ts
@@ -29,6 +29,7 @@ describe.each([
     runtime.platform = platform;
     const output = Buffer.from('synthetic audio');
     const ffmpeg = Object.assign(new ChildProcess(), {
+      pid: 123,
       stdout: new PassThrough(),
       kill: vi.fn(),
     });

--- a/tests/helpers/audio-recording-process-ownership.test.ts
+++ b/tests/helpers/audio-recording-process-ownership.test.ts
@@ -1,0 +1,143 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+const root = process.cwd();
+const probe = String.raw`
+const childProcess = require('node:child_process');
+const { getEventListeners } = require('node:events');
+const { setTimeout: delay } = require('node:timers/promises');
+const scenario = process.env.AUDIO_SCENARIO;
+let receivedSigterms = 0;
+const kills = [];
+process.on('SIGTERM', () => { receivedSigterms += 1; });
+console.error = () => {};
+if (scenario.startsWith('synthetic')) {
+  const nativeSpawn = childProcess.spawn;
+  childProcess.spawn = (command, args, options) => {
+    if (command !== 'ffmpeg') throw new Error('Unexpected recording command');
+    const child = nativeSpawn(process.execPath, ['-e', 'process.stdout.write("synthetic WAV bytes")'], options);
+    const nativeKill = child.kill;
+    child.kill = function(signal) {
+      kills.push({ pid: this.pid, signal });
+      return nativeKill.call(this, signal);
+    };
+    return child;
+  };
+}
+const { recordAudio } = require('openai/helpers/audio');
+const caller = new AbortController();
+if (scenario.includes('pre-aborted')) caller.abort();
+if (scenario === 'setup failure') {
+  Object.defineProperty(caller.signal, 'addEventListener', {
+    value() { throw new Error('synthetic caller-listener setup failure'); },
+  });
+}
+(async () => {
+  let outcome;
+  try {
+    const file = await recordAudio({ signal: caller.signal });
+    outcome = { name: file.name, type: file.type, content: await file.text() };
+  } catch (error) {
+    outcome = { code: error.code, message: error.message };
+  }
+  // Give any incorrectly sent process-group signal time to reach this owned wrapper.
+  await delay(50);
+  console.log(JSON.stringify({ receivedSigterms, listeners: getEventListeners(caller.signal, 'abort').length, kills, outcome }));
+})().catch(error => { console.error(error); process.exitCode = 1; });
+`;
+
+async function runRecorder(emptyPath: string, scenario: string) {
+  const child = spawn(
+    process.execPath,
+    [
+      path.join(root, 'node_modules/ts-node/dist/bin.js'),
+      '--swc',
+      '-r',
+      path.join(root, 'node_modules/tsconfig-paths/register.js'),
+      '-e',
+      probe,
+    ],
+    {
+      // A failed-spawn kill must never reach the test runner's process group.
+      detached: true,
+      cwd: root,
+      env: {
+        PATH: emptyPath,
+        AUDIO_SCENARIO: scenario,
+        TS_NODE_PROJECT: path.join(root, 'tsconfig.json'),
+        TS_NODE_TRANSPILE_ONLY: 'true',
+        DISABLE_V8_COMPILE_CACHE: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf-8').on('data', (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.setEncoding('utf-8').on('data', (chunk: string) => {
+    stderr += chunk;
+  });
+  const timeout = setTimeout(() => {
+    if (child.pid) {
+      child.kill('SIGKILL');
+    }
+  }, 10_000);
+  try {
+    const [code, signal] = await once(child, 'close');
+    return { code, signal, stdout, stderr };
+  } finally {
+    clearTimeout(timeout);
+    if (child.pid && child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGKILL');
+    }
+  }
+}
+
+const describeOnUnix = process.platform === 'win32' ? describe.skip : describe;
+describeOnUnix('recordAudio subprocess ownership', () => {
+  test.each([
+    'missing ffmpeg',
+    'pre-aborted caller',
+    'setup failure',
+    'synthetic success',
+    'synthetic pre-aborted caller',
+  ])('preserves its caller process after %s', async (scenario) => {
+    const emptyPath = await mkdtemp(path.join(tmpdir(), 'openai-recording-path-'));
+    try {
+      const result = await runRecorder(emptyPath, scenario);
+      expect(result.signal).toBeNull();
+      expect(result.code).toBe(0);
+      expect(result.stderr).toBe('');
+      const recorded = JSON.parse(result.stdout);
+      expect(recorded.receivedSigterms).toBe(0);
+      expect(recorded.listeners).toBe(0);
+      if (scenario.startsWith('synthetic')) {
+        expect(recorded.outcome).toMatchObject({
+          name: 'audio.wav',
+          type: 'audio/wav',
+        });
+        if (scenario === 'synthetic success') {
+          expect(recorded.outcome.content).toBe('synthetic WAV bytes');
+          expect(recorded.kills).toEqual([]);
+        } else {
+          expect(recorded.kills).toHaveLength(1);
+          expect(recorded.kills[0].pid).toBeGreaterThan(0);
+          expect(recorded.kills[0].signal).toBe('SIGTERM');
+        }
+      } else if (scenario === 'setup failure') {
+        expect(recorded.outcome).toEqual({ message: 'synthetic caller-listener setup failure' });
+      } else {
+        expect(recorded.outcome).toEqual({ code: 'ENOENT', message: 'spawn ffmpeg ENOENT' });
+      }
+    } finally {
+      await rm(emptyPath, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/helpers/audio-recording.test.ts
+++ b/tests/helpers/audio-recording.test.ts
@@ -10,8 +10,9 @@ vi.mock('node:child_process', () => ({ spawn: vi.fn() }));
 const spawnMock = spawn as MockedFunction<typeof spawn>;
 const devicePrefix = ['darwin', 'win32', 'cygwin'].includes(process.platform) ? '' : 'hw';
 
-function mockFfmpeg() {
+function mockFfmpeg(started = true) {
   const ffmpeg = Object.assign(new EventEmitter(), {
+    pid: started ? 123 : undefined,
     stdout: new PassThrough(),
     stderr: new PassThrough(),
     kill: vi.fn().mockReturnValue(true),
@@ -342,6 +343,37 @@ describe('recordAudio', () => {
 
     await expect(recordAudio()).rejects.toThrow('ffmpeg was not found');
   });
+
+  test.each(['an already-aborted caller', 'a caller-listener setup failure'] as const)(
+    'does not signal a process without a PID after %s',
+    async (scenario) => {
+      const ffmpeg = mockFfmpeg(false);
+      const caller = new AbortController();
+      const spawnFailure = new Error('ffmpeg could not start');
+      const setupFailure = new Error('caller listener could not be installed');
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      if (scenario === 'an already-aborted caller') {
+        caller.abort();
+      } else {
+        vi.spyOn(caller.signal, 'addEventListener').mockImplementationOnce(() => {
+          throw setupFailure;
+        });
+      }
+
+      const recording = recordAudio({ signal: caller.signal });
+      const rejection = expect(recording).rejects.toBe(
+        scenario === 'an already-aborted caller' ? spawnFailure : setupFailure,
+      );
+      expect(() => ffmpeg.emit('error', spawnFailure)).not.toThrow();
+      ffmpeg.emit('close', -2);
+      await rejection;
+
+      expect(ffmpeg.kill).not.toHaveBeenCalled();
+      expect(getEventListeners(caller.signal, 'abort')).toHaveLength(0);
+      expect(ffmpeg.stdout.listenerCount('data')).toBe(0);
+      expect(() => ffmpeg.emit('error', spawnFailure)).not.toThrow();
+    },
+  );
 
   test('terminates ffmpeg when recording setup fails after it starts', async () => {
     const ffmpeg = mockFfmpeg();


### PR DESCRIPTION
## Summary

- Only signal a recording process when its native child-process object has a PID.
- Apply the same guard to ordinary recording cancellation and setup-error cleanup.
- Keep recording errors, stop semantics, captured WAV data, device/timeout options, and playback unchanged.

The production change is two conditions in the handwritten audio helper. Tests model successful child processes with a PID and cover the real failed-spawn boundary; no generated files, dependencies, or public types change.

## Reproduction

With FFmpeg unavailable, an already-aborted caller signal reaches `ChildProcess.kill('SIGTERM')` before the unsuccessful spawn has a PID. That can signal the calling process group instead of a recorder. The setup-error cleanup path has the same problem if installing the caller's abort listener throws.

The native regression imports the public helper inside a detached, owned wrapper and gives it a freshly created empty executable-search directory. No FFmpeg or microphone is used. On the unchanged source, both native failure cases receive an unwanted signal; normal missing-command and real positive-PID controls pass.

## Validation

- Focused regressions before the production change: 4 failed / 55 passed.
- Full canonical handwritten suite: 7,807 tests passed across 206 files.
- Focused recording/device/playback checks pass on exact Node 22.0.0, Node 24.19.0, and Node 26.2.0.
- Built public CJS and ESM checks pass all 36 cases across Node 22.0.0, 24.19.0, and 26.7.0, including default signal disposition, original ENOENT/setup errors, complete synthetic WAV data, and cancellation of an actual positive-PID child.
- All 651 published declaration files are byte-identical to main. Repository TypeScript 6, published-source TypeScript 4.9/6, CJS/ESM build, canonical formatting/lint, and `git diff --check` pass.
- Independent adversarial review verifies original-error identity, late process-error handling, kill-failure behavior, listener cleanup, and normal recording/playback controls. A scheduling-dependent test assertion was corrected and rechecked with an intentional parent scheduling delay.

Native process-group regressions are POSIX-only; the portable mock-based guards and existing controls remain enabled elsewhere. Local native validation was on macOS. Generated and remaining integration tests are left to CI.
