### PR TITLE
fix(test): reject HTTP errors in mock health checks

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -10,7 +10,7 @@ YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
 function steady_is_running() {
-  curl --silent "http://127.0.0.1:4010/_x-steady/health" >/dev/null 2>&1
+  curl --silent --fail "http://127.0.0.1:4010/_x-steady/health" >/dev/null 2>&1
 }
 
 kill_server_on_port() {

--- a/tests/test-script-cleanup.test.ts
+++ b/tests/test-script-cleanup.test.ts
@@ -57,6 +57,7 @@ describeBash('scripts/test mock-server cleanup', () => {
       STARTUP_EXIT: '0',
       PAUSE_STARTUP: 'false',
       REUSE_HEALTHY: 'false',
+      HEALTH_STATUS: '200',
       JEST_EXIT: '0',
     };
     for (const directory of ['scripts', 'bin', 'node_modules/.bin']) {
@@ -65,7 +66,16 @@ describeBash('scripts/test mock-server cleanup', () => {
     for (const file of ['scripts/test', 'scripts/generated-test-patterns.json']) {
       copyFileSync(path.join(repoRoot, file), path.join(fixture, file));
     }
-    writeExecutable('bin/curl', 'bash', '[ "$REUSE_HEALTHY" = true ] || [ -f "$FIXTURE_ROOT/mock.ready" ]');
+    writeExecutable(
+      'bin/curl',
+      'bash',
+      `[ "$REUSE_HEALTHY" = true ] || [ -f "$FIXTURE_ROOT/mock.ready" ] || exit 1
+# curl treats HTTP error responses as failures only when --fail is enabled.
+for option in "$@"; do
+  if [ "$option" = --fail ] && [ "$HEALTH_STATUS" -ge 400 ]; then exit 22; fi
+done
+exit 0`,
+    );
     writeExecutable('bin/lsof', 'bash', 'touch "$FIXTURE_ROOT/lsof.called"\ncat "$FIXTURE_ROOT/server.pid"');
     writeExecutable('node_modules/.bin/jest', 'bash', 'touch "$FIXTURE_ROOT/jest.called"\nexit "$JEST_EXIT"');
     writeExecutable(
@@ -137,6 +147,20 @@ child.once('message', () => {
 
   test('does not kill an unrelated process when mock startup fails', async () => {
     await startExistingProcess();
+    env['STARTUP_EXIT'] = '23';
+
+    runTests(23);
+
+    expect(existsSync(path.join(fixture, 'mock.called'))).toBe(true);
+    expect(existsSync(path.join(fixture, 'jest.called'))).toBe(false);
+    expect(existsSync(path.join(fixture, 'lsof.called'))).toBe(false);
+    expect(isRunning(fixturePid())).toBe(true);
+  });
+
+  test.each([404, 503])('rejects HTTP %i health responses before running Jest', async (status) => {
+    await startExistingProcess();
+    env['REUSE_HEALTHY'] = 'true';
+    env['HEALTH_STATUS'] = String(status);
     env['STARTUP_EXIT'] = '23';
 
     runTests(23);

--- a/tests/test-script-cleanup.test.ts
+++ b/tests/test-script-cleanup.test.ts
@@ -76,7 +76,8 @@ describeBash('scripts/test mock-server cleanup', () => {
 const http = require('node:http');
 const root = process.env.FIXTURE_ROOT;
 fs.writeFileSync(root + '/server.pid', String(process.pid));
-const server = http.createServer((_request, response) => {
+const server = http.createServer((request, response) => {
+  fs.appendFileSync(root + '/health.requests', request.url + '\\n');
   response.writeHead(Number(process.env.HEALTH_STATUS));
   response.end();
 });
@@ -136,15 +137,16 @@ child.once('message', () => {
   }
 
   function useNativeHealthProbe(): void {
-    rmSync(path.join(fixture, 'bin/curl'));
-    const scriptPath = path.join(fixture, 'scripts/test');
-    const script = readFileSync(scriptPath, 'utf-8');
-    writeFileSync(
-      scriptPath,
-      script.replace(
-        'http://127.0.0.1:4010/_x-steady/health',
-        readFileSync(path.join(fixture, 'health.url'), 'utf-8'),
-      ),
+    const curl = spawnSync('bash', ['-c', 'command -v curl'], { encoding: 'utf-8' });
+    expect(curl.error).toBeUndefined();
+    expect(curl.status).toBe(0);
+    env['NATIVE_CURL'] = curl.stdout.trim();
+    env['HEALTH_PORT'] = new URL(readFileSync(path.join(fixture, 'health.url'), 'utf-8')).port;
+    // Keep the wrapper and its curl options intact, redirecting only the connection to our isolated server.
+    writeExecutable(
+      'bin/curl',
+      'bash',
+      `exec "$NATIVE_CURL" --disable --noproxy '*' --max-time 5 --connect-to "127.0.0.1:4010:127.0.0.1:$HEALTH_PORT" "$@"`,
     );
   }
 
@@ -184,6 +186,7 @@ child.once('message', () => {
 
     runTests(exitCode);
 
+    expect(readFileSync(path.join(fixture, 'health.requests'), 'utf-8')).toContain('/_x-steady/health\n');
     expect(existsSync(path.join(fixture, 'mock.called'))).toBe(startsMock);
     expect(existsSync(path.join(fixture, 'jest.called'))).toBe(runsJest);
     expect(existsSync(path.join(fixture, 'lsof.called'))).toBe(false);

--- a/tests/test-script-cleanup.test.ts
+++ b/tests/test-script-cleanup.test.ts
@@ -66,27 +66,29 @@ describeBash('scripts/test mock-server cleanup', () => {
     for (const file of ['scripts/test', 'scripts/generated-test-patterns.json']) {
       copyFileSync(path.join(repoRoot, file), path.join(fixture, file));
     }
-    writeExecutable(
-      'bin/curl',
-      'bash',
-      `[ "$REUSE_HEALTHY" = true ] || [ -f "$FIXTURE_ROOT/mock.ready" ] || exit 1
-# curl treats HTTP error responses as failures only when --fail is enabled.
-for option in "$@"; do
-  if [ "$option" = --fail ] && [ "$HEALTH_STATUS" -ge 400 ]; then exit 22; fi
-done
-exit 0`,
-    );
+    writeExecutable('bin/curl', 'bash', '[ "$REUSE_HEALTHY" = true ] || [ -f "$FIXTURE_ROOT/mock.ready" ]');
     writeExecutable('bin/lsof', 'bash', 'touch "$FIXTURE_ROOT/lsof.called"\ncat "$FIXTURE_ROOT/server.pid"');
     writeExecutable('node_modules/.bin/jest', 'bash', 'touch "$FIXTURE_ROOT/jest.called"\nexit "$JEST_EXIT"');
     writeExecutable(
       'server.cjs',
       'node',
       `const fs = require('node:fs');
+const http = require('node:http');
 const root = process.env.FIXTURE_ROOT;
-process.on('SIGTERM', () => { fs.writeFileSync(root + '/server.stopped', 'SIGTERM'); process.exit(0); });
 fs.writeFileSync(root + '/server.pid', String(process.pid));
-setInterval(() => {}, 1000);
-process.send('ready');`,
+const server = http.createServer((_request, response) => {
+  response.writeHead(Number(process.env.HEALTH_STATUS));
+  response.end();
+});
+process.on('SIGTERM', () => {
+  fs.writeFileSync(root + '/server.stopped', 'SIGTERM');
+  server.close(() => process.exit(0));
+});
+server.listen(0, '127.0.0.1', () => {
+  const address = server.address();
+  fs.writeFileSync(root + '/health.url', 'http://127.0.0.1:' + address.port + '/_x-steady/health');
+  process.send('ready');
+});`,
     );
     writeExecutable(
       'scripts/mock',
@@ -133,6 +135,19 @@ child.once('message', () => {
     await once(existingProcess, 'message');
   }
 
+  function useNativeHealthProbe(): void {
+    rmSync(path.join(fixture, 'bin/curl'));
+    const scriptPath = path.join(fixture, 'scripts/test');
+    const script = readFileSync(scriptPath, 'utf-8');
+    writeFileSync(
+      scriptPath,
+      script.replace(
+        'http://127.0.0.1:4010/_x-steady/health',
+        readFileSync(path.join(fixture, 'health.url'), 'utf-8'),
+      ),
+    );
+  }
+
   function runTests(expectedExit: number): void {
     const result = spawnSync('bash', [path.join(fixture, 'scripts/test'), '--showConfig'], {
       cwd: fixture,
@@ -157,16 +172,20 @@ child.once('message', () => {
     expect(isRunning(fixturePid())).toBe(true);
   });
 
-  test.each([404, 503])('rejects HTTP %i health responses before running Jest', async (status) => {
-    await startExistingProcess();
-    env['REUSE_HEALTHY'] = 'true';
+  test.each([
+    { status: 200, exitCode: 0, startsMock: false, runsJest: true },
+    { status: 404, exitCode: 23, startsMock: true, runsJest: false },
+    { status: 503, exitCode: 23, startsMock: true, runsJest: false },
+  ])('handles a real HTTP $status health response', async ({ status, exitCode, startsMock, runsJest }) => {
     env['HEALTH_STATUS'] = String(status);
+    await startExistingProcess();
+    useNativeHealthProbe();
     env['STARTUP_EXIT'] = '23';
 
-    runTests(23);
+    runTests(exitCode);
 
-    expect(existsSync(path.join(fixture, 'mock.called'))).toBe(true);
-    expect(existsSync(path.join(fixture, 'jest.called'))).toBe(false);
+    expect(existsSync(path.join(fixture, 'mock.called'))).toBe(startsMock);
+    expect(existsSync(path.join(fixture, 'jest.called'))).toBe(runsJest);
     expect(existsSync(path.join(fixture, 'lsof.called'))).toBe(false);
     expect(isRunning(fixturePid())).toBe(true);
   });


### PR DESCRIPTION
## Summary

Add `curl --fail` to the handwritten test wrapper's Steady health probe, matching the mock launcher's health check. HTTP 404 or 503 responses now enter the existing startup path instead of being treated as a healthy mock and allowing generated tests to run.

## Regression coverage

The existing cleanup fixture serves synthetic HTTP 200, 404, and 503 responses on an ephemeral loopback port. It runs a byte-copied `scripts/test` through native curl, forwarding only the connection to that port and recording requests to the health endpoint.

HTTP 200 reuses the server and runs Jest. HTTP 404/503 trigger startup, preserve its failure status, and never run Jest or the port-cleanup command. Removing `--fail` makes both error-status regressions fail while the HTTP 200 control passes.

## Validation

- Cleanup and routing suites: 37/37 pass on exact Node 22.0.0, Node 24.20.0, and Node 26.8.1.
- Full canonical handwritten suite: 7,803 tests pass across 205 files with writable pnpm caches.
- TypeScript, build, generated-file lint, pinned format/lint checks across all tracked files, Bash syntax, and whitespace checks pass.
- Canonical `pnpm lint` reports only the untracked Symphony prompt artifact `.symphony/prompts/attempt.md`; tracked repository files pass unchanged lint rules.

The process fixture remains POSIX-only. Local validation ran on Linux.

Symphony-Work-Item: work_item:github:openai:openai-node:2667
