### PR TITLE
fix(examples): reject unsuccessful structured-tool responses

### DIFF
--- a/examples/responses/structured-outputs-tools.ts
+++ b/examples/responses/structured-outputs-tools.ts
@@ -44,6 +44,10 @@ async function main() {
     tools: [tool],
   });
 
+  if (rsp.status && rsp.status !== 'completed') {
+    throw new Error(`Response ended with status ${rsp.status}.`);
+  }
+
   console.log(rsp);
 
   const functionCall = rsp.output.find((item) => item.type === 'function_call');

--- a/tests/lib/structured-output-tool-example.test.ts
+++ b/tests/lib/structured-output-tool-example.test.ts
@@ -72,14 +72,31 @@ async function runExample(baseURL: string) {
   }
 }
 
-const cases: { name: string; output: ResponseOutputItem[]; succeeds: boolean }[] = [
-  { name: 'function call first', output: [toolCall], succeeds: true },
-  { name: 'message before function call', output: [message, toolCall], succeeds: true },
-  { name: 'message without a function call', output: [message], succeeds: false },
-  { name: 'empty output', output: [], succeeds: false },
+const cases: {
+  name: string;
+  status: Response['status'];
+  output: ResponseOutputItem[];
+  succeeds: boolean;
+}[] = [
+  { name: 'function call first', status: 'completed', output: [toolCall], succeeds: true },
+  {
+    name: 'message before function call',
+    status: 'completed',
+    output: [message, toolCall],
+    succeeds: true,
+  },
+  { name: 'message without a function call', status: 'completed', output: [message], succeeds: false },
+  { name: 'empty output', status: 'completed', output: [], succeeds: false },
+  { name: 'omitted response status', status: undefined, output: [toolCall], succeeds: true },
+  ...(['failed', 'incomplete', 'cancelled'] as const).map((status) => ({
+    name: `${status} response with a partial function call`,
+    status,
+    output: [{ ...toolCall, arguments: '{"table_name":', status: 'incomplete' as const }],
+    succeeds: false,
+  })),
 ];
 
-test.each(cases)('structured-output tool example: $name', async ({ output, succeeds }) => {
+test.each(cases)('structured-output tool example: $name', async ({ output, succeeds, status }) => {
   const requests: {
     method: string | undefined;
     url: string | undefined;
@@ -101,9 +118,9 @@ test.each(cases)('structured-output tool example: $name', async ({ output, succe
         id: 'resp_synthetic',
         object: 'response',
         created_at: 0,
-        status: 'completed',
-        error: null,
-        incomplete_details: null,
+        ...(status === undefined ? {} : { status }),
+        error: status === 'failed' ? { code: 'server_error', message: 'Synthetic response failure' } : null,
+        incomplete_details: status === 'incomplete' ? { reason: 'max_output_tokens' } : null,
         instructions: null,
         metadata: {},
         model: 'gpt-4o-2024-08-06',
@@ -149,8 +166,13 @@ test.each(cases)('structured-output tool example: $name', async ({ output, succe
       expect(result.stdout.trimEnd().endsWith(inspect(query))).toBe(true);
     } else {
       expect(result.code).toBe(1);
-      expect(result.stderr).toContain('Expected function call');
+      expect(result.stderr).toContain(
+        status && status !== 'completed' ? `Response ended with status ${status}.` : 'Expected function call',
+      );
       expect(result.stderr).not.toContain('TypeError');
+      if (status && status !== 'completed') {
+        expect(result.stdout).toBe('');
+      }
     }
   } finally {
     if (server.listening) {


### PR DESCRIPTION
## Summary

- Reject explicitly unsuccessful Responses statuses before the structured-output tool example prints or consumes a function call.
- Preserve completed responses, existing missing-tool errors, and the SDK's compatibility behavior for responses that omit `status`.
- Keep the fix to a three-line guard and the existing real-HTTP regression fixture. No SDK parsing, generated code, models, dependencies, or public types change.

## Reproduction

An HTTP 200 response can have `status: "failed"`, `"incomplete"`, or `"cancelled"` and still contain a partial function call. The SDK intentionally leaves that call's `parsed_arguments` as `null`, but this example previously printed `null` and exited successfully.

The example now exits with status 1 and an explicit response-status diagnostic before printing partial output. The guard mirrors the parser's existing completion policy rather than making the optional `status` field mandatory.

## Validation

- The existing loopback HTTP fixture now has eight cases: all four original controls, omitted-status success, and three unsuccessful responses with partial JSON arguments. Before the fix, the three new failure cases exited 0; all five controls passed. Afterward, all eight pass on exact Node 22.0.0, Node 24.19.0, and Node 26.7.0.
- Independent checks execute the actual example against the freshly built public CommonJS and ESM SDK entrypoints. All 48 cases pass across those three runtimes. Before the fix, both module formats reproduce the three unsuccessful-status failures while retaining their success/error controls.
- Full canonical handwritten suite: 7,888 tests pass across 208 files.
- Canonical build, formatting/lint, TypeScript 6, and `git diff --check` pass. The SDK source and dependency files are unchanged.
- Independent adversarial review covered omitted-status compatibility, error precedence, partial-output handling, synthetic credential isolation, process cleanup, and scope.

The generated resource suite and remaining ecosystem/packaging checks run in CI.
