### PR TITLE
fix(examples): avoid unhandled WebSocket rejections

### DIFF
--- a/examples/responses/websocket.ts
+++ b/examples/responses/websocket.ts
@@ -74,14 +74,6 @@ type RunTurnResult = {
   responseID: string;
 };
 
-type OpenableSocket = {
-  readyState: number;
-  on(event: 'open' | 'close', listener: () => void): void;
-  on(event: 'error', listener: (err: Error) => void): void;
-  off(event: 'open' | 'close', listener: () => void): void;
-  off(event: 'error', listener: (err: Error) => void): void;
-};
-
 type CLIArgs = {
   model: string;
   useBetaHeader: boolean;
@@ -293,39 +285,6 @@ const callTool = (name: ToolName, args: SKUArguments): ToolOutput => {
   };
 };
 
-const ensureSocketOpen = async (socket: OpenableSocket): Promise<void> => {
-  if (socket.readyState === 1) {
-    return;
-  }
-
-  await new Promise<void>((resolve, reject) => {
-    const onOpen = (): void => {
-      cleanup();
-      resolve();
-    };
-
-    const onError = (err: Error): void => {
-      cleanup();
-      reject(err);
-    };
-
-    const onClose = (): void => {
-      cleanup();
-      reject(new Error('WebSocket closed before opening.'));
-    };
-
-    const cleanup = (): void => {
-      socket.off('open', onOpen);
-      socket.off('error', onError);
-      socket.off('close', onClose);
-    };
-
-    socket.on('open', onOpen);
-    socket.on('error', onError);
-    socket.on('close', onClose);
-  });
-};
-
 const runResponse = async ({
   ws,
   model,
@@ -377,11 +336,6 @@ const runResponse = async ({
             callID: event.item.call_id,
           });
           return;
-        }
-
-        if (event.type === 'error') {
-          const message = 'error' in event ? event.error?.message : event.message;
-          throw new Error(message || 'WebSocket error event');
         }
 
         if (event.type === 'response.completed') {
@@ -504,8 +458,6 @@ const main = async (): Promise<void> => {
   const ws = new ResponsesWS(client, {
     headers: args.useBetaHeader ? { 'OpenAI-Beta': BETA_HEADER_VALUE } : undefined,
   });
-
-  await ensureSocketOpen(ws.socket);
 
   try {
     let previousResponseID: string | null = null;

--- a/tests/lib/websocket-example-close.test.ts
+++ b/tests/lib/websocket-example-close.test.ts
@@ -1,5 +1,7 @@
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import type {
@@ -8,13 +10,43 @@ import type {
   ResponsesClientEvent,
   ResponsesServerEvent,
 } from 'openai/resources/responses/responses';
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import { WebSocketServer } from 'ws';
 
 interface Reply {
   events: ResponsesServerEvent[];
   close?: 'clean' | 'abrupt';
 }
+
+const uncaughtErrorMarker = 'SYNTHETIC_UNCAUGHT_WEBSOCKET_ERROR';
+const observeUncaught = `process.on('uncaughtExceptionMonitor', () => {
+  process.stderr.write(${JSON.stringify(`${uncaughtErrorMarker}\n`)});
+});`;
+const apiErrors: { name: string; event: ResponsesServerEvent }[] = [
+  {
+    name: 'nested',
+    event: {
+      type: 'error',
+      error: {
+        code: 'invalid_request',
+        message: 'Synthetic API failure',
+        param: null,
+        type: 'invalid_request_error',
+      },
+      status: 400,
+    },
+  },
+  {
+    name: 'flat',
+    event: {
+      type: 'error',
+      code: 'invalid_request',
+      message: 'Synthetic API failure',
+      param: null,
+      sequence_number: 1,
+    },
+  },
+];
 
 const textEvent: ResponsesServerEvent = {
   type: 'response.output_text.delta',
@@ -51,15 +83,31 @@ function completed(responseID: string, output: Response['output'] = []): Respons
   };
 }
 
-async function runExample(reply: (request: ResponsesClientEvent, index: number) => Reply) {
-  const server = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+async function runExample(
+  reply: (request: ResponsesClientEvent, index: number) => Reply,
+  {
+    rejectUpgrade = false,
+    initialError,
+  }: { rejectUpgrade?: boolean; initialError?: ResponsesServerEvent } = {},
+) {
+  const server = new WebSocketServer({
+    host: '127.0.0.1',
+    port: 0,
+    verifyClient: () => !rejectUpgrade,
+  });
   await once(server, 'listening');
   const address = server.address();
   if (!address || typeof address === 'string') {
     throw new Error('Expected a local TCP address');
   }
   const requests: ResponsesClientEvent[] = [];
-  server.on('connection', (socket) => {
+  server.on('headers', (_headers, request) => {
+    if (initialError) {
+      // Deliver the HTTP upgrade and first error frame in the same transport write.
+      request.socket.cork();
+    }
+  });
+  server.on('connection', (socket, upgradeRequest) => {
     socket.on('message', (data) => {
       const request = JSON.parse(data.toString()) as ResponsesClientEvent;
       requests.push(request);
@@ -73,12 +121,22 @@ async function runExample(reply: (request: ResponsesClientEvent, index: number) 
         socket.terminate();
       }
     });
+    if (initialError) {
+      socket.send(JSON.stringify(initialError));
+      upgradeRequest.socket.uncork();
+    }
   });
 
   const root = process.cwd();
+  const fixture = mkdtempSync(path.join(tmpdir(), 'openai-websocket-example-'));
+  const observerPath = path.join(fixture, 'observe-uncaught.cjs');
+  writeFileSync(observerPath, observeUncaught);
   const child = spawn(
     process.execPath,
     [
+      // Observe crashes without handling them or changing Node's default failure behavior.
+      '--require',
+      observerPath,
       path.join(root, 'node_modules/ts-node/dist/bin.js'),
       '--swc',
       '-r',
@@ -111,6 +169,8 @@ async function runExample(reply: (request: ResponsesClientEvent, index: number) 
     expect(signal).toBeNull();
     expect(stdout + stderr).not.toContain('synthetic-example-key');
     expect(stdout + stderr).not.toContain('SYNTHETIC_PRIVATE_CLOSE_REASON');
+    expect(stderr).not.toContain(uncaughtErrorMarker);
+    expect(stderr).not.toContain('To resolve these unhandled rejection errors');
     return { exitCode, stdout, stderr, requests };
   } finally {
     child.kill();
@@ -120,6 +180,7 @@ async function runExample(reply: (request: ResponsesClientEvent, index: number) 
     const closed = once(server, 'close');
     server.close();
     await closed;
+    rmSync(fixture, { recursive: true, force: true });
   }
 }
 
@@ -173,25 +234,37 @@ test('completes all turns and closes normally without reporting an unfinished re
   ]);
 });
 
-test('preserves an API failure when the server closes immediately afterward', async () => {
-  const result = await runExample(() => ({
-    events: [
-      {
-        type: 'error',
-        error: {
-          code: 'invalid_request',
-          message: 'Synthetic API failure',
-          param: null,
-          type: 'invalid_request_error',
-        },
-        status: 400,
-      },
-    ],
-    close: 'clean',
-  }));
+describe.each(apiErrors)('$name API errors', ({ event }) => {
+  test.each([false, true])('handles the failure once when followed by a close: %s', async (close) => {
+    const result = await runExample(() => ({
+      events: [event],
+      ...(close ? { close: 'clean' as const } : {}),
+    }));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Synthetic API failure');
+    expect(result.stderr).not.toContain('WebSocket closed before the response completed.');
+    expect(result.requests).toHaveLength(1);
+    expect(result.stdout).not.toContain('Assistant:');
+    expect(result.stdout).not.toContain('=== Turn 2 ===');
+  });
+
+  test('handles a failure delivered with the opening handshake', async () => {
+    const result = await runExample(() => ({ events: [] }), { initialError: event });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('Synthetic API failure');
+    expect(result.requests.length).toBeLessThanOrEqual(1);
+    expect(result.stdout).not.toContain('Assistant:');
+    expect(result.stdout).not.toContain('=== Turn 2 ===');
+  });
+});
+
+test('handles an opening handshake rejection without an unhandled SDK error', async () => {
+  const result = await runExample(() => ({ events: [] }), { rejectUpgrade: true });
 
   expect(result.exitCode).toBe(1);
-  expect(result.stderr).toContain('Synthetic API failure');
-  expect(result.stderr).not.toContain('WebSocket closed before the response completed.');
-  expect(result.requests).toHaveLength(1);
+  expect(result.stderr).toContain('Unexpected server response: 401');
+  expect(result.requests).toHaveLength(0);
+  expect(result.stdout).not.toContain('Assistant:');
 });


### PR DESCRIPTION
## Summary

- Use the SDK's existing connecting-state send queue instead of a separate raw-socket opening waiter, so the example's response/error/close handlers are installed before connection events can arrive.
- Let the existing SDK `error` callback own protocol errors, rather than rejecting and removing that callback during generic event dispatch.
- Delete 48 example lines without changing the SDK, generated code, parsers, tools, models, or dependencies.

## Reproduction

For an API error frame, the SDK emits the generic `event` callback before its dedicated `error` callback. The example previously handled the generic event and removed its error listener, so the SDK then produced an unhandled rejection for the same failure. Opening handshake failures and an error frame delivered together with HTTP 101 exposed related listener gaps.

These cases already exited with status 1; the bug was the additional uncaught rejection and crash diagnostics. The fix retains normal failure exit codes, API-error precedence over a subsequent close, the six-request tool loop, and response-ID chaining. The first demo heading can now print while the connection is opening.

## Validation

- Extend the existing real-WebSocket fixture to ten cases. Seven regressions fail before the source change, while the three original successful/early-close controls pass. All ten pass afterward on exact Node 22.0.0, Node 24.19.0, and Node 26.7.0.
- The fixture observes `uncaughtExceptionMonitor` without handling exceptions or changing Node's default exit behavior. It covers flat/nested API errors, immediate closes, rejected upgrades, and HTTP 101 coalesced with an initial error frame.
- Independent checks execute the actual example against the freshly built public SDK: all 13 scenarios pass on each of those three runtimes, with zero uncaught failures. Before the fix, eight scenarios exhibited unhandled rejections; normal request counts and exit-code controls still passed.
- Full canonical handwritten suite: 7,890 tests pass across 208 files.
- Canonical build, formatting/lint, TypeScript 6, and whitespace checks pass. Independent adversarial review found no remaining issues.

The generated suite and remaining ecosystem/packaging checks run in CI.
