### PR TITLE
fix(format): ignore missing literal file-list paths

### DIFF
--- a/scripts/fast-format
+++ b/scripts/fast-format
@@ -29,7 +29,13 @@ node ./scripts/lint-generated.cjs --fix --file-list "$FILE_LIST"
 
 echo "==> Running oxlint --fix"
 # Match the generated linter's line-based input, without letting xargs split paths.
-FILES="$(sed -e $'s/\r$//' -e '/^$/d' "$FILE_LIST")"
+# Only pass existing literal files; missing paths can be interpreted as globs.
+FILES="$(while IFS= read -r file || [ -n "$file" ]; do
+    file="${file%$'\r'}"
+    if [ -f "$file" ]; then
+        printf '%s\n' "$file"
+    fi
+done < "$FILE_LIST")"
 LINT_FILES="$(printf '%s\n' "$FILES" | grep -E '\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$' || true)"
 if [ -n "$LINT_FILES" ]; then
    printf '%s\n' "$LINT_FILES" | tr '\n' '\0' | xargs -0 ./node_modules/.bin/oxlint --fix --no-error-on-unmatched-pattern --

--- a/tests/fast-format-file-list.test.ts
+++ b/tests/fast-format-file-list.test.ts
@@ -54,18 +54,25 @@ describeBash('fast-format file lists', () => {
     withFormatFixture((root) => fastFormat(root, list));
   });
 
-  test.each(['selected.ts', 'with spaces.ts', "with'quote.ts", 'with"quote.ts', '-leading-dash.ts'])(
-    'formats the exact listed path %s',
-    (filename) => {
-      withFormatFixture((root) => {
-        writeFileSync(path.join(root, filename), source);
+  test.each([
+    'selected.ts',
+    'with spaces.ts',
+    'with\ttab.ts',
+    "with'quote.ts",
+    'with"quote.ts',
+    '-leading-dash.ts',
+    '[u]nrelated.ts',
+    '*.ts',
+    '{unrelated,other}.ts',
+  ])('formats the exact listed path %s', (filename) => {
+    withFormatFixture((root) => {
+      writeFileSync(path.join(root, filename), source);
 
-        fastFormat(root, `${filename}\n`);
+      fastFormat(root, `${filename}\n`);
 
-        expect(readFileSync(path.join(root, filename), 'utf-8')).toBe(formattedSource);
-      });
-    },
-  );
+      expect(readFileSync(path.join(root, filename), 'utf-8')).toBe(formattedSource);
+    });
+  });
 
   test('ignores blank lines and accepts CRLF and a final path without a newline', () => {
     withFormatFixture((root) => {
@@ -94,7 +101,20 @@ describeBash('fast-format file lists', () => {
     });
   });
 
-  test('does not format unrelated files when listed paths no longer exist', () => {
-    withFormatFixture((root) => fastFormat(root, 'deleted.ts\n'));
+  test.each(['deleted.ts', '[u]nrelated.ts', '*.ts', '{unrelated,other}.ts'])(
+    'does not format unrelated files when listed path %s no longer exists',
+    (filename) => {
+      withFormatFixture((root) => fastFormat(root, filename));
+    },
+  );
+
+  test('formats existing files alongside missing literal paths', () => {
+    withFormatFixture((root) => {
+      writeFileSync(path.join(root, 'selected.ts'), source);
+
+      fastFormat(root, '[u]nrelated.ts\nselected.ts\n{unrelated,other}.ts\n*.ts');
+
+      expect(readFileSync(path.join(root, 'selected.ts'), 'utf-8')).toBe(formattedSource);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Filter the line-based `fast-format` input to existing literal files before passing the shared list to Oxlint and Oxfmt.
- Keep the existing handling of spaces, tabs, quotes, leading dashes, CRLF, and a final line without a newline. Existing filenames containing glob characters still work as literal filenames.
- Change only the handwritten wrapper and its existing regression fixture. No generated code, SDK behavior, dependencies, or lockfiles change.

## Reproduction

With `unrelated.ts` present and `[u]nrelated.ts` absent, a file list containing only `[u]nrelated.ts` causes both native tools to interpret the missing filename as a glob and modify `unrelated.ts`. Missing `*.ts` and brace-looking filenames similarly modify files that were never listed. The commands still exit successfully.

The wrapper now checks each literal path once at the shared input boundary. Missing paths are skipped before either tool sees them; no glob parser or per-tool workaround is added. Regular-file symlinks retain their behavior. Directories and directory symlinks are ignored, consistent with the documented one-file-path-per-line input.

## Validation

- Extend the existing native-CLI fixture from 11 to 19 cases. Against the unchanged base wrapper, four regressions fail while 15 controls pass. All 19 pass afterward on exact Node 22.0.0, Node 24.19.0, and Node 26.7.0.
- Independently execute the actual wrapper with the pinned Oxlint/Oxfmt binaries: three missing glob-looking paths modify unlisted files before the change; all eight literal/deleted-path cases pass afterward.
- Independent adversarial review compares 17 baseline/current scenarios, including broken symlinks, existing literal metacharacters, backslashes, leading dashes, spaces, tabs, regular-file symlinks, CRLF, and missing final newlines, using Bash 3.2 and the pinned native tools. No remaining findings.
- Full canonical handwritten suite: **7,892 tests pass across 208 files**. An initial run hit local `ENOSPC`; the complete rerun passed after disk space was restored.
- Canonical formatting/lint, pinned TypeScript 6, Bash syntax, and whitespace checks pass.

The generated suite and remaining ecosystem/packaging checks run in CI.
