### PR TITLE
fix(examples): preserve background stream resume cursors

### DIFF
--- a/examples/responses/stream_background.ts
+++ b/examples/responses/stream_background.ts
@@ -12,9 +12,12 @@ async function main() {
   });
 
   let id: string | null = null;
+  let lastSequenceNumber = -1;
   let completed = false;
 
   for await (const event of runner) {
+    lastSequenceNumber = event.sequence_number;
+
     if (event.type === 'response.created') {
       id = event.response.id;
     }
@@ -41,7 +44,7 @@ async function main() {
 
   const runner2 = openai.responses.stream({
     response_id: id!,
-    starting_after: 10,
+    starting_after: lastSequenceNumber,
   });
 
   for await (const event of runner2) {

--- a/tests/lib/background-streaming-example.test.ts
+++ b/tests/lib/background-streaming-example.test.ts
@@ -155,7 +155,8 @@ test.each(cases)('$source: $status $name', async ({ chunks, resumed, partial, st
   const events = responseEvents(chunks, status, background);
   const nonterminal = status === 'queued' || status === 'in_progress';
   const body = `${events.map((event) => `data: ${JSON.stringify(event)}`).join('\n\n')}\n\n${nonterminal ? '' : 'data: [DONE]\n\n'}`;
-  const partialEvents = nonterminal ? events : events.slice(0, -1);
+  // Disconnect before the final delta as well as the terminal event.
+  const partialEvents = nonterminal ? events : events.slice(0, -2);
   const partialBody = `${partialEvents.map((event) => `data: ${JSON.stringify(event)}`).join('\n\n')}\n\n`;
   const requests: {
     method: string | undefined;
@@ -220,6 +221,8 @@ main();`,
         OPENAI_BASE_URL: `http://127.0.0.1:${address.port}/v1`,
         OPENAI_CUSTOM_HEADERS: undefined,
         OPENAI_LOG: undefined,
+        // Keep console-inspected event numbers plain for the sequence assertions.
+        FORCE_COLOR: undefined,
         TS_NODE_PROJECT: path.join(root, 'tsconfig.json'),
         DISABLE_V8_COMPILE_CACHE: '1',
       },
@@ -270,6 +273,10 @@ main();`,
     }
     if (source === 'example') {
       expect(stdout.includes('Interrupted. Continuing...')).toBe(resumed);
+      const seenSequences = [...stdout.matchAll(/sequence_number:\s*(?<sequence>\d+)/gu)].map((match) =>
+        Number(match.groups?.['sequence']),
+      );
+      expect(seenSequences).toEqual(events.map((event) => event.sequence_number));
     } else if (source === 'guide') {
       expect(stdout + stderr).not.toContain(privateErrorDetail);
     }


### PR DESCRIPTION
## Summary

- Resume the background-streaming example after the last event actually observed, matching the existing streaming guide, instead of always using `starting_after: 10`.
- Keep the deliberate interruption at event 10, completion handling, failure exit codes, request counts, and final response behavior unchanged.
- Strengthen the existing test fixture to check complete, ordered, duplicate-free event output. No SDK, generated code, parser, model, dependency, or documentation changes.

## Reproduction

When the first connection ends cleanly after event 3 and the replay contains events 0–12, the current example prints events `0, 1, 2, 3, 11, 12`. Its hard-coded cursor suppresses unseen text deltas 4–10. An interruption immediately after `response.created` similarly skips events 1–10.

The SDK still replays all events internally and produces a complete final response. This is an example-level event-continuity bug, not lost final-response data or a problem with the SDK accumulator. Tracking the last observed sequence uses the same small pattern already documented in `docs/streaming.md`.

## Validation

- Before the source change, three early-EOF example regressions fail while 31 existing controls pass. All 34 cases pass afterward on exact Node 22.0.0, Node 24.19.0, and Node 26.7.0.
- The first response now ends before both its final text delta and terminal event, so a complete final snapshot alone cannot make the regression pass. The test also checks exact event order and absence of duplicates.
- Execute the actual example against the built public SDK in nine loopback scenarios on each runtime: 27 checks pass. Early interruption, the intentional cutoff, completion before/at the cutoff, and initial/resumed failure cases retain their expected requests, exit codes, and complete successful final snapshots.
- Independent adversarial review verifies empty-stream/missing-ID behavior and finds no remaining issues. Its forced-color test exposed a fixture assumption; clearing inherited `FORCE_COLOR` in the child makes all 34 cases pass with a forced-color parent without adding an ANSI parser.
- Full canonical handwritten suite: **7,884 tests pass across 208 files**. CJS/ESM build and imports, formatting/lint, pinned TypeScript 6, and whitespace checks pass.

The generated suite and remaining ecosystem/packaging checks run in CI. This is separate from the completion-reuse and final-status fixes in #2557 and #2600.
