### PR TITLE
fix(examples): avoid extra requests for empty tool calls

### DIFF
--- a/examples/chat-completions/tool-calls-stream.ts
+++ b/examples/chat-completions/tool-calls-stream.ts
@@ -147,7 +147,7 @@ async function main() {
     messages.push(message);
 
     // If there are no tool calls, we're done and can exit this loop
-    if (!message.tool_calls) {
+    if (!message.tool_calls?.length) {
       return;
     }
 

--- a/tests/lib/streaming-example-nontty.test.ts
+++ b/tests/lib/streaming-example-nontty.test.ts
@@ -10,9 +10,17 @@ import type {
 import { expect, test } from 'vitest';
 
 const examples = ['function-call-stream.ts', 'function-call-stream-raw.ts', 'tool-calls-stream.ts'] as const;
+const cases = [
+  ...examples.map((filename) => ({ filename, hasToolCall: true, emptyToolCalls: false })),
+  { filename: 'tool-calls-stream.ts', hasToolCall: true, emptyToolCalls: true },
+  { filename: 'tool-calls-stream.ts', hasToolCall: false, emptyToolCalls: false },
+  { filename: 'tool-calls-stream.ts', hasToolCall: false, emptyToolCalls: true },
+];
 
-test.each(examples)('%s completes a tool round trip with redirected stdout', async (filename) => {
+test.each(cases)('$filename (tool=$hasToolCall, empty=$emptyToolCalls)', async (scenario) => {
+  const { filename, hasToolCall, emptyToolCalls } = scenario;
   const usesTools = filename === 'tool-calls-stream.ts';
+  const expectedRequests = hasToolCall ? 2 : 1;
   const requests: ChatCompletionCreateParamsStreaming[] = [];
   const server = createServer((request, response) => {
     let body = '';
@@ -21,9 +29,18 @@ test.each(examples)('%s completes a tool round trip with redirected stdout', asy
     });
     request.on('end', () => {
       requests.push(JSON.parse(body) as ChatCompletionCreateParamsStreaming);
+      if (requests.length > expectedRequests) {
+        // Bound unintended extra rounds without relying on the child timeout.
+        response.writeHead(400, { 'content-type': 'application/json' });
+        response.end(JSON.stringify({ error: { message: 'Unexpected extra completion request.' } }));
+        return;
+      }
       let deltas: ChatCompletionChunk.Choice.Delta[];
-      if (requests.length > 1) {
-        deltas = [{ role: 'assistant', content: 'Synthetic ' }, { content: 'recommendation.' }];
+      if (requests.length > 1 || !hasToolCall) {
+        deltas = [
+          { role: 'assistant', content: 'Synthetic ', ...(emptyToolCalls ? { tool_calls: [] } : {}) },
+          { content: 'recommendation.' },
+        ];
       } else if (usesTools) {
         deltas = [
           {
@@ -46,14 +63,18 @@ test.each(examples)('%s completes a tool round trip with redirected stdout', asy
         ];
       }
 
+      let finishReason: ChatCompletionChunk.Choice['finish_reason'] = 'stop';
+      if (hasToolCall && requests.length === 1) {
+        finishReason = usesTools ? 'tool_calls' : 'function_call';
+      }
       response.writeHead(200, { 'Content-Type': 'text/event-stream' });
-      for (const delta of deltas) {
+      for (const [index, delta] of deltas.entries()) {
         const chunk: ChatCompletionChunk = {
           id: 'chatcmpl_example',
           object: 'chat.completion.chunk',
           created: 1,
           model: 'gpt-3.5-turbo',
-          choices: [{ index: 0, delta, finish_reason: null }],
+          choices: [{ index: 0, delta, finish_reason: index === deltas.length - 1 ? finishReason : null }],
         };
         response.write(`data: ${JSON.stringify(chunk)}\n\n`);
       }
@@ -102,14 +123,18 @@ test.each(examples)('%s completes a tool round trip with redirected stdout', asy
   try {
     const [exitCode, signal] = await once(child, 'close');
     expect(signal).toBeNull();
+    expect(requests).toHaveLength(expectedRequests);
     expect(stderr).toBe('');
     expect(exitCode).toBe(0);
     expect(stdout).toContain('Synthetic recommendation.');
     expect(stdout.match(/Synthetic /gu)).toHaveLength(1);
     expect(stdout).not.toContain('\u001B[');
     expect(stdout).not.toContain('synthetic-example-key');
-    expect(requests).toHaveLength(2);
     expect(requests[0]?.stream).toBe(true);
+    if (!hasToolCall) {
+      expect(requests[0]?.messages).toHaveLength(2);
+      return;
+    }
     const messages = requests[1]?.messages;
     expect(messages).toHaveLength(4);
     const result = messages?.[3];


### PR DESCRIPTION
## Summary

- Stop the raw tool-calling example when the collected tool-call array is empty, using the same length check as the SDK's tool runner.
- Keep the check after the stream is fully reduced. The reducer, model, streaming delay, output, SDK, generated code, and dependencies are unchanged.
- Extend the existing redirected-output fixture to cover omitted and empty tool-call arrays, both for direct answers and after a valid tool round trip.

## Reproduction

A completed assistant response with `finish_reason: 'stop'` and `tool_calls: []` leaves an empty array in the example's collected message. Because an empty array is truthy, the old guard falls through, executes zero tools, and starts another completion request.

The actual example sends an unwanted second POST for a direct answer, or a third POST after one valid tool round trip. Omitted tool calls correctly stop after one or two requests. The reproduction server rejects the first unwanted request with a non-retryable HTTP 400, so the failure is bounded and does not rely on a process timeout. Repeated empty-array answers could otherwise keep the request loop running.

## Validation

- Expand the existing executable fixture from three to six cases. Against the unchanged example, the two empty-array regressions fail their exact request-count assertions while four controls pass. All six pass afterward on exact Node 22.0.0, Node 24.19.0, and Node 26.7.0.
- Execute the actual example against the built public SDK in four scenarios on each runtime: all 12 checks pass with exact request counts `1, 1, 2, 2`, natural successful exits, and final text printed once.
- Fragmented function arguments, tool-call IDs, and tool results remain unchanged; both legacy function examples retain their redirected-output controls.
- Full canonical handwritten suite: **7,887 tests pass across 208 files**. CJS/ESM build and imports, formatting/lint, pinned TypeScript 6, and whitespace checks pass.
- Independent adversarial review found no remaining issues. The guard remains after complete stream reduction, preserving non-empty tool calls and avoiding changes to the custom reducer.

The generated suite and remaining ecosystem/packaging checks run in CI.
