### PR TITLE
fix(ecosystem): preserve retry delays in parallel workers

### DIFF
--- a/ecosystem-tests/cli.ts
+++ b/ecosystem-tests/cli.ts
@@ -870,6 +870,7 @@ async function main() {
                       '--skip-pack',
                       '--noCleanup',
                       `--retry=${args.retry}`,
+                      `--retryDelay=${args.retryDelay}`,
                       ...(args.live ? ['--live'] : []),
                       ...(args.verbose ? ['--verbose'] : []),
                       ...(args.deploy ? ['--deploy'] : []),

--- a/tests/ecosystem-cli.test.ts
+++ b/tests/ecosystem-cli.test.ts
@@ -269,10 +269,16 @@ describe('ecosystem test CLI', () => {
   });
 
   test.each([
-    { name: 'sequential', options: [], packageOption: '--fromNpm' },
-    { name: 'explicit worker count', options: ['--jobs=2'], packageOption: '--fromNpm' },
-    { name: 'parallel', options: ['--parallel'], packageOption: '--from-npm' },
-  ])('installs the selected local package in $name mode', ({ options, packageOption }) => {
+    { name: 'sequential', options: [], packageOption: '--fromNpm', retryDelay: 7 },
+    { name: 'explicit worker count', options: ['--jobs=2'], packageOption: '--fromNpm', retryDelay: 25 },
+    { name: 'parallel', options: ['--parallel'], packageOption: '--from-npm', retryDelay: 0 },
+    {
+      name: 'default-delay parallel',
+      options: ['--parallel'],
+      packageOption: '--from-npm',
+      retryDelay: undefined,
+    },
+  ])('installs and retries a local package in $name mode', ({ options, packageOption, retryDelay }) => {
     const fixture = mkdtempSync(path.join(tmpdir(), 'openai-node-ecosystem-cli-'));
     const dependency = path.join(fixture, 'selected package = fixture');
     const projects = ['node-js', 'cloudflare-worker'];
@@ -317,18 +323,30 @@ describe('ecosystem test CLI', () => {
           [
             "const fs = require('node:fs');",
             "const { version } = require('openai/package.json');",
+            "const firstAttempt = !fs.existsSync('installed-version.txt');",
             "fs.writeFileSync('installed-version.txt', version);",
+            'if (firstAttempt) process.exit(1);',
           ].join('\n'),
         );
       }
 
       const result = runCli(
-        [...projects, `${packageOption}=${dependency}`, '--noCleanup', ...options],
+        [
+          ...projects,
+          `${packageOption}=${dependency}`,
+          '--noCleanup',
+          '--retry=1',
+          ...(retryDelay === undefined ? [] : [`--retryDelay=${retryDelay}`]),
+          ...options,
+        ],
         fixture,
       );
 
       expect(result.error, result.stdout + result.stderr).toBeUndefined();
       expect(result.status, result.stdout + result.stderr).toBe(0);
+      expect((result.stdout + result.stderr).match(/next retry in \d+ms/gu)).toEqual(
+        projects.map(() => `next retry in ${retryDelay ?? 1000}ms`),
+      );
       for (const project of projects) {
         expect(
           readFileSync(path.join(fixture, 'ecosystem-tests', project, 'installed-version.txt'), 'utf-8'),


### PR DESCRIPTION
## Summary

Forward `--retryDelay` to parallel ecosystem-test workers alongside `--retry`. The parent already parses this option, but workers previously reverted to the 1,000 ms default for ordinary project retries.

This is one production-line addition. It preserves explicit `0`, custom delays, and the existing default without changing retry counts, option parsing, credentials, cleanup, or SDK code.

## Regression coverage

Strengthen the existing offline local-package fixture so each project fails its first typecheck and then succeeds. It runs the actual CLI, actual pnpm worker processes, and real local npm installations, and still verifies the selected package version.

- Before the fix: `--jobs=2 --retryDelay=25` and `--parallel --retryDelay=0` both report 1,000 ms project retries. The sequential custom-delay and parallel default-delay controls pass: two failures, two passes.
- After the fix: all four cases use the expected delay and complete successfully.

## Validation

- Four focused cases pass on Node 22.22.3, 24.19.0, and 26.7.0.
- Full handwritten suite: 7,885 tests across 208 files pass on Node 24.19.0.
- Canonical formatting and lint checks, TypeScript 6, and the typechecked CLI `--help` entrypoint pass.
- An independent before/after CLI probe confirms the actual worker arguments and exactly two project attempts in five scenarios, including custom, zero, default, sequential, and explicit-worker-count controls.
- Independent adversarial review checked zero/default preservation, both worker-selection modes, argument-array safety, retry-count behavior, and fixture scope; no further changes were needed.

The first full run encountered an unrelated local SSH-signing-agent failure in a temporary Git fixture. The focused fixture and full suite passed with commit signing disabled only for synthetic test commits in that command's environment; repository signing configuration is unchanged.

Exact Node 22.0.0 cannot load this existing CLI's pinned ESM yargs dependency on either main or this branch. Repository tooling targets Node 24; this change does not alter the consumer SDK's Node 22.0.0 floor.
