### PR TITLE
test: isolate line-ending fixture from commit signing

### DIFF
--- a/tests/oxlint-config.test.ts
+++ b/tests/oxlint-config.test.ts
@@ -49,6 +49,8 @@ test('formats an existing CRLF checkout after the LF policy is pulled', () => {
     runGit(['init', '--quiet']);
     runGit(['config', 'user.email', 'line-endings@example.com']);
     runGit(['config', 'user.name', 'Line Endings Test']);
+    // Keep synthetic fixture commits independent of the developer's signing agent.
+    runGit(['config', 'commit.gpgsign', 'false']);
     runGit(['config', 'core.autocrlf', 'true']);
     runGit(['config', 'core.safecrlf', 'false']);
 


### PR DESCRIPTION
## Summary

Keep the disposable Git commits in the CRLF checkout test independent of a contributor's commit-signing setup.

The fixture already supplies a synthetic Git identity, but inherits `commit.gpgsign=true`. An unavailable SSH/GPG signer can therefore fail the test before it exercises formatting. Set `commit.gpgsign=false` in the temporary fixture repository's local configuration.

This is two added lines in one handwritten test file, including the explanatory comment. All line-ending assertions, commits, cleanup, production code, and real-repository signing settings remain unchanged.

## Validation

- Deterministic before/after reproduction through the canonical test command with a private synthetic global configuration: signing enabled, `/usr/bin/false` as the signer, and a synthetic key identifier. Main fails at the first fixture commit; the fix passes under the identical configuration without using a real signer.
- The focused regression passes on Node 22.22.3, 24.19.0, and 26.7.0.
- Full handwritten suite: 7,884 tests across 208 files pass on Node 24.19.0 with ordinary globally enabled signing and no command-level signing override.
- Canonical formatting, lint, TypeScript 6, and diff checks pass.
- Independent native-Git checks verify the fixture-local override and successful disposable commits while the synthetic global configuration and actual source repository's local signing configuration remain unchanged. Adversarial review found no further issue.

The exact Node 22.0.0 probe gets past the commits but encounters the existing Oxfmt TypeScript-config loader requirement. Repository tooling continues to target Node 24; no SDK runtime requirement changes.
