### PR TITLE
fix(embeddings): validate response collection before decoding

### DIFF
--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -46,8 +46,8 @@ export function createEmbedding(
   loggerFor(client).debug('embeddings/decoding base64 embeddings from base64');
 
   return response._thenUnwrap((data) => {
-    if (data && data.data) {
-      const embeddings = data.data;
+    const embeddings = data?.data;
+    if (embeddings !== undefined) {
       if (!Array.isArray(embeddings)) {
         throw new TypeError('Expected embeddings response data to be an array');
       }

--- a/src/lib/embeddings.ts
+++ b/src/lib/embeddings.ts
@@ -48,6 +48,9 @@ export function createEmbedding(
   return response._thenUnwrap((data) => {
     if (data && data.data) {
       const embeddings = data.data;
+      if (!Array.isArray(embeddings)) {
+        throw new TypeError('Expected embeddings response data to be an array');
+      }
       const { length } = embeddings;
       // Preserve the original iteration length and skip sparse-array holes.
       for (let index = 0; index < length; index += 1) {

--- a/tests/lib/embeddings.test.ts
+++ b/tests/lib/embeddings.test.ts
@@ -11,6 +11,18 @@ const incompleteVectors = [1, 2, 3, 5, 6, 7].map((byteLength) => ({
   encoded: Buffer.alloc(byteLength).toString('base64'),
 }));
 const request = { input: 'hello', model: 'text-embedding-3-small' } as const;
+const nonArrayCollections = [
+  { length: 3 },
+  { length: 0 },
+  { 0: { embedding: encodedVector }, length: 1 },
+  'invalid',
+  1,
+  true,
+  null,
+  0,
+  false,
+  '',
+];
 
 function createClient(base64Embedding = encodedVector): OpenAI {
   return new OpenAI({
@@ -48,14 +60,7 @@ function makeFixtureClient(): OpenAI {
 }
 
 describe('resource embeddings', () => {
-  test.each([
-    { length: 3 },
-    { length: 0 },
-    { 0: { embedding: encodedVector }, length: 1 },
-    'invalid',
-    1,
-    true,
-  ])('rejects a non-array response collection: %j', async (data) => {
+  test.each(nonArrayCollections)('rejects a non-array response collection: %j', async (data) => {
     const client = new OpenAI({
       apiKey: 'test-key',
       fetch: async () => Response.json({ data }),
@@ -66,16 +71,26 @@ describe('resource embeddings', () => {
     );
   });
 
-  test.each(['float', 'base64'] as const)('preserves explicit %s response passthrough', async (encoding) => {
-    const data = { length: 3 };
+  describe.each(['float', 'base64'] as const)('explicit %s encoding', (encoding) => {
+    test.each(nonArrayCollections)('preserves response passthrough: %j', async (data) => {
+      const client = new OpenAI({
+        apiKey: 'test-key',
+        fetch: async () => Response.json({ data }),
+      });
+
+      await expect(client.embeddings.create({ ...request, encoding_format: encoding })).resolves.toEqual({
+        data,
+      });
+    });
+  });
+
+  test.each([{}, { data: [] }])('preserves an absent or empty response collection: %j', async (body) => {
     const client = new OpenAI({
       apiKey: 'test-key',
-      fetch: async () => Response.json({ data }),
+      fetch: async () => Response.json(body),
     });
 
-    await expect(client.embeddings.create({ ...request, encoding_format: encoding })).resolves.toEqual({
-      data,
-    });
+    await expect(client.embeddings.create(request)).resolves.toEqual(body);
   });
 
   test.each(incompleteVectors)('default rejects $byteLength decoded embedding bytes', async ({ encoded }) => {

--- a/tests/lib/embeddings.test.ts
+++ b/tests/lib/embeddings.test.ts
@@ -48,6 +48,36 @@ function makeFixtureClient(): OpenAI {
 }
 
 describe('resource embeddings', () => {
+  test.each([
+    { length: 3 },
+    { length: 0 },
+    { 0: { embedding: encodedVector }, length: 1 },
+    'invalid',
+    1,
+    true,
+  ])('rejects a non-array response collection: %j', async (data) => {
+    const client = new OpenAI({
+      apiKey: 'test-key',
+      fetch: async () => Response.json({ data }),
+    });
+
+    await expect(client.embeddings.create(request)).rejects.toThrow(
+      'Expected embeddings response data to be an array',
+    );
+  });
+
+  test.each(['float', 'base64'] as const)('preserves explicit %s response passthrough', async (encoding) => {
+    const data = { length: 3 };
+    const client = new OpenAI({
+      apiKey: 'test-key',
+      fetch: async () => Response.json({ data }),
+    });
+
+    await expect(client.embeddings.create({ ...request, encoding_format: encoding })).resolves.toEqual({
+      data,
+    });
+  });
+
   test.each(incompleteVectors)('default rejects $byteLength decoded embedding bytes', async ({ encoded }) => {
     await expect(createClient(encoded).embeddings.create(request)).rejects.toBeInstanceOf(RangeError);
   });


### PR DESCRIPTION
The default embeddings decoder now rejects non-array `data` before reading its length. Previously, array-like response objects could drive iteration using an unchecked length. Real arrays retain the existing sparse-entry, captured-length, and numeric-vector behavior; explicit encoding formats still return the original response.

Initial local validation at `269c5f3f`:
- Six malformed-response cases failed before the fix through public `OpenAI.embeddings.create()` with JSON responses; explicit-encoding controls passed.
- All 43 embedding helper/request tests pass on Node 24.20.0 and the minimum supported Node 22.0.0.
- Repository lint, TypeScript checking, and production CJS/ESM build pass.
- Independent review found no remaining issues.

Generated API-resource tests were not run: the pinned mock-server setup stalled fetching JSR dependency metadata.

The follow-up also rejects falsy non-array collections and adds corresponding default/explicit-encoding controls. CI passes at `63daff58`.
