### PR TITLE
fix(responses): validate indexed response collections

### DIFF
--- a/src/internal/responses/response-accumulator.ts
+++ b/src/internal/responses/response-accumulator.ts
@@ -153,6 +153,7 @@ function validateArrayIndex(
   allowAppend = false,
 ): void {
   if (
+    !Array.isArray(collection) ||
     !Number.isSafeInteger(index) ||
     index < 0 ||
     index > collection.length ||

--- a/tests/lib/ResponseStream.test.ts
+++ b/tests/lib/ResponseStream.test.ts
@@ -383,6 +383,88 @@ describe('.stream()', () => {
     );
   });
 
+  describe.each(['SSE', 'serialized stream'])('%s shell output collections', (transport) => {
+    function shellStream(commands: unknown, commandIndex: number, eventType: 'delta' | 'done') {
+      const events = [
+        {
+          type: 'response.created',
+          sequence_number: 0,
+          response: {
+            ...makeResponse(),
+            output: [
+              {
+                id: 'sh_123',
+                type: 'shell_call',
+                call_id: 'call_123',
+                status: 'in_progress',
+                action: { commands },
+              },
+              {
+                id: 'sho_123',
+                type: 'shell_call_output',
+                call_id: 'call_123',
+                status: 'in_progress',
+                output: [],
+              },
+            ],
+          },
+        },
+        {
+          type: `response.shell_call_output_content.${eventType}`,
+          sequence_number: 1,
+          item_id: 'sho_123',
+          output_index: 1,
+          command_index: commandIndex,
+          ...(eventType === 'delta'
+            ? { delta: { stdout: 'result' } }
+            : { output: [{ stdout: 'result', stderr: '', outcome: { type: 'exit', exit_code: 0 } }] }),
+        },
+      ];
+      if (transport === 'serialized stream') {
+        const encoder = new TextEncoder();
+        return ResponseStream.fromReadableStream(
+          ReadableStreamFrom(events.map((event) => encoder.encode(`${JSON.stringify(event)}\n`))),
+        );
+      }
+      const client = new OpenAI({
+        apiKey: 'test-key',
+        fetch: async () =>
+          new Response(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(''), {
+            headers: { 'content-type': 'text/event-stream' },
+          }),
+      });
+      return client.responses.stream({ model: 'gpt-4o', input: 'test' });
+    }
+
+    it.each(['delta', 'done'] as const)(
+      'rejects an array-like command collection before %s',
+      async (type) => {
+      const stream = shellStream({ length: 4, 3: 'echo test' }, 3, type);
+      const emitted = vi.fn();
+      stream.on(`response.shell_call_output_content.${type}`, emitted);
+
+      await expect(stream.finalResponse()).rejects.toThrow('missing command at index 3');
+      expect(emitted).not.toHaveBeenCalled();
+      },
+    );
+
+    it.each(['delta', 'done'] as const)('preserves large command arrays for %s', async (type) => {
+      const commandIndex = 100_000;
+      const stream = shellStream(
+        Array.from({ length: commandIndex + 1 }, () => 'echo test'),
+        commandIndex,
+        type,
+      );
+      const response = await stream.finalResponse();
+      const output = response.output[1];
+      expect(output?.type).toBe('shell_call_output');
+      if (output?.type === 'shell_call_output') {
+        expect(output.output).toHaveLength(commandIndex + 1);
+        expect(output.output[commandIndex]?.stdout).toBe('result');
+      }
+    });
+  });
+
   it('replays hosted shell events, dispatches typed listeners, and preserves each command output', async () => {
     const events: ResponseStreamEvent[] = [
       {

--- a/tests/lib/ResponseStream.test.ts
+++ b/tests/lib/ResponseStream.test.ts
@@ -439,12 +439,12 @@ describe('.stream()', () => {
     it.each(['delta', 'done'] as const)(
       'rejects an array-like command collection before %s',
       async (type) => {
-      const stream = shellStream({ length: 4, 3: 'echo test' }, 3, type);
-      const emitted = vi.fn();
-      stream.on(`response.shell_call_output_content.${type}`, emitted);
+        const stream = shellStream({ length: 4, 3: 'echo test' }, 3, type);
+        const emitted = vi.fn();
+        stream.on(`response.shell_call_output_content.${type}`, emitted);
 
-      await expect(stream.finalResponse()).rejects.toThrow('missing command at index 3');
-      expect(emitted).not.toHaveBeenCalled();
+        await expect(stream.finalResponse()).rejects.toThrow('missing command at index 3');
+        expect(emitted).not.toHaveBeenCalled();
       },
     );
 


### PR DESCRIPTION
Response accumulation now verifies that an indexed collection is an array before trusting its length. This prevents malformed shell command objects from being accepted as command arrays and driving output allocation. Existing index rules and support for large valid arrays remain unchanged.

Validation:
- Four public SSE/replay cases covering shell-output delta and done events fail before the fix and pass after it.
- Four controls preserve genuine 100,001-command arrays.
- All 246 Responses streaming and accumulator tests pass on Node 24.20.0 and the minimum supported Node 22.0.0.
- Repository lint, TypeScript checking, and production CJS/ESM build pass.
- Independent review completed.

Generated API-resource tests were not run: the pinned mock-server setup stalled fetching JSR dependency metadata.
