### PR TITLE
fix: isolate realtime connection credentials

### DIFF
--- a/src/beta/realtime/websocket.ts
+++ b/src/beta/realtime/websocket.ts
@@ -1,3 +1,4 @@
+import { getRealtimeAPIKey, resolveRealtimeAPIKey } from '../../internal/realtime-credentials';
 import type { AzureOpenAI } from '../../index';
 import { assertBedrockWebSocketOrigin } from '../../internal/bedrock';
 import { OpenAI } from '../../index';
@@ -181,15 +182,18 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
       onURL?: (url: URL) => void;
       /** Indicates the token was resolved by the factory just before connecting. @internal */
       __resolvedApiKey?: boolean;
+      /** Credential captured by an async factory for this connection. @internal */
+      __apiKey?: string | null;
     },
     client?: Pick<OpenAI, 'apiKey' | 'baseURL'>,
   ) {
     super();
+    let apiKey = getRealtimeAPIKey(client, props.__apiKey);
     const hasProvider = typeof (client as any)?._options?.apiKey === 'function';
     const dangerouslyAllowBrowser =
       props.dangerouslyAllowBrowser ??
       (client as any)?._options?.dangerouslyAllowBrowser ??
-      (client?.apiKey?.startsWith('ek_') ? true : null);
+      (apiKey?.startsWith('ek_') ? true : null);
     if (!dangerouslyAllowBrowser && isRunningInBrowserOrBrowserWorker()) {
       throw new OpenAIError(
         "It looks like you're running in a browser-like environment.\n\nThis is disabled by default, as it risks exposing your secret API credentials to attackers.\n\nYou can avoid this error by creating an ephemeral session token:\nhttps://platform.openai.com/docs/api-reference/realtime-sessions\n",
@@ -197,6 +201,9 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     }
 
     client ??= new OpenAI({ dangerouslyAllowBrowser });
+    if (apiKey === undefined) {
+      apiKey = client.apiKey;
+    }
 
     if (hasProvider && !props?.__resolvedApiKey) {
       throw new Error(
@@ -215,12 +222,12 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     const azure = isAzure(client);
     const protocols = [
       'realtime',
-      ...(azure ? [] : [`openai-insecure-api-key.${client.apiKey}`]),
+      ...(azure ? [] : [`openai-insecure-api-key.${apiKey}`]),
       'openai-beta.realtime-v1',
     ];
 
     this.socket = azure
-      ? createAzureWebSocket(this.url, client.apiKey, props.__resolvedApiKey === true, protocols)
+      ? createAzureWebSocket(this.url, apiKey, props.__resolvedApiKey === true, protocols)
       : new WebSocket(this.url.toString(), protocols);
 
     this.socket.addEventListener('message', (websocketEvent: MessageEvent) => {
@@ -280,10 +287,13 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     const url = buildRealtimeURL(client, props);
     assertTrustedRealtimeURL(client, url);
     assertBedrockWebSocketOrigin(client, url);
-    const resolvedApiKey = await client._callApiKey();
+    const { apiKey, isProvider: resolvedApiKey } = await resolveRealtimeAPIKey(client);
     assertTrustedRealtimeURL(client, url);
     assertBedrockWebSocketOrigin(client, url);
-    return new OpenAIRealtimeWebSocket({ ...props, __resolvedApiKey: resolvedApiKey }, client);
+    return new OpenAIRealtimeWebSocket(
+      { ...props, __resolvedApiKey: resolvedApiKey, __apiKey: apiKey },
+      client,
+    );
   }
 
   /**
@@ -307,8 +317,7 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
       dangerouslyAllowBrowser?: boolean;
     } = {},
   ): Promise<OpenAIRealtimeWebSocket> {
-    const isApiKeyProvider = await client._callApiKey();
-    const apiKey = client.apiKey;
+    const { apiKey, isProvider: isApiKeyProvider } = await resolveRealtimeAPIKey(client);
     if (!apiKey) {
       throw new Error('Azure OpenAI Realtime requires an API key');
     }
@@ -322,6 +331,7 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
         model: deploymentName,
         ...(dangerouslyAllowBrowser === undefined ? {} : { dangerouslyAllowBrowser }),
         __resolvedApiKey: isApiKeyProvider,
+        __apiKey: apiKey,
       },
       client,
     );

--- a/src/beta/realtime/ws.ts
+++ b/src/beta/realtime/ws.ts
@@ -1,3 +1,4 @@
+import { resolveRealtimeAPIKey } from '../../internal/realtime-credentials';
 import * as WS from 'ws';
 import { assertBedrockWebSocketOrigin } from '../../internal/bedrock';
 import { protectWebSocketOptionsFromCredentialRedirects } from '../../internal/ws';
@@ -51,11 +52,14 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
 
       /** Indicates that a function-based credential was resolved by an async factory. @internal */
       __resolvedApiKey?: boolean;
+      /** Credential captured by an async factory for this connection. @internal */
+      __apiKey?: string | null;
     },
     client?: Pick<OpenAI, 'apiKey' | 'baseURL'>,
   ) {
     super();
     client ??= new OpenAI();
+    const apiKey = props.__apiKey === undefined ? client.apiKey : props.__apiKey;
     const hasProvider = typeof (client as any)?._options?.apiKey === 'function';
     if (hasProvider && !props.__resolvedApiKey) {
       throw new Error(
@@ -71,7 +75,7 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
     const headers = {
       'User-Agent': `${client.constructor.name}/JS ${VERSION}`,
       ...props.options?.headers,
-      ...(isAzure(client) && !props.__resolvedApiKey ? {} : { Authorization: `Bearer ${client.apiKey}` }),
+      ...(isAzure(client) && !props.__resolvedApiKey ? {} : { Authorization: `Bearer ${apiKey}` }),
       'OpenAI-Beta': 'realtime=v1',
     };
 
@@ -140,10 +144,10 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
     const url = buildRealtimeURL(client, props);
     assertTrustedRealtimeURL(client, url);
     assertBedrockWebSocketOrigin(client, url);
-    const resolvedApiKey = await client._callApiKey();
+    const { apiKey, isProvider: resolvedApiKey } = await resolveRealtimeAPIKey(client);
     assertTrustedRealtimeURL(client, url);
     assertBedrockWebSocketOrigin(client, url);
-    return new OpenAIRealtimeWS({ ...props, __resolvedApiKey: resolvedApiKey }, client);
+    return new OpenAIRealtimeWS({ ...props, __resolvedApiKey: resolvedApiKey, __apiKey: apiKey }, client);
   }
 
   /**
@@ -167,8 +171,7 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
       options?: WS.ClientOptions | undefined;
     } = {},
   ): Promise<OpenAIRealtimeWS> {
-    const isApiKeyProvider = await client._callApiKey();
-    const apiKey = client.apiKey;
+    const { apiKey, isProvider: isApiKeyProvider } = await resolveRealtimeAPIKey(client);
     if (!apiKey) {
       throw new Error('Azure OpenAI Realtime requires an API key');
     }
@@ -187,6 +190,7 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
           },
         },
         __resolvedApiKey: isApiKeyProvider,
+        __apiKey: apiKey,
       },
       client,
     );

--- a/src/client.ts
+++ b/src/client.ts
@@ -849,11 +849,25 @@ export class OpenAI {
     return Errors.APIError.generate(status, normalizedError, message, headers);
   }
 
-  async _callApiKey(): Promise<boolean> {
-    if (this._provider) return false;
+  /**
+   * Resolves a function-based API key and retains the resolved value on this client.
+   * Returns whether a provider was invoked. Internal callers can capture this
+   * invocation's key before another request updates the shared `apiKey` property.
+   * Overrides should forward `capture` or invoke it with their own resolved key
+   * to preserve connection-local credentials in concurrent Realtime factories.
+   * @internal
+   */
+  async _callApiKey(capture?: (apiKey: string | null) => void): Promise<boolean> {
+    if (this._provider) {
+      capture?.(this.apiKey);
+      return false;
+    }
 
     const apiKey = this._options.apiKey;
-    if (typeof apiKey !== 'function') return false;
+    if (typeof apiKey !== 'function') {
+      capture?.(this.apiKey);
+      return false;
+    }
 
     let token: unknown;
     try {
@@ -873,6 +887,7 @@ export class OpenAI {
       );
     }
     this.apiKey = token;
+    capture?.(this.apiKey);
     return true;
   }
 

--- a/src/internal/realtime-credentials.ts
+++ b/src/internal/realtime-credentials.ts
@@ -1,0 +1,27 @@
+import type { OpenAI } from '../client';
+
+/** Selects a captured credential without treating an explicit null as absent. @internal */
+export function getRealtimeAPIKey(
+  client: Pick<OpenAI, 'apiKey'> | undefined,
+  captured: string | null | undefined,
+): string | null | undefined {
+  return captured === undefined ? client?.apiKey : captured;
+}
+
+/**
+ * Captures the key belonging to this factory invocation while retaining the
+ * existing boolean credential-hook contract. Legacy overrides that do not
+ * capture a key keep their shared-property behavior and remain responsible for
+ * synchronizing concurrent credential updates.
+ * @internal
+ */
+export async function resolveRealtimeAPIKey(client: Pick<OpenAI, 'apiKey' | '_callApiKey'>): Promise<{
+  apiKey: string | null;
+  isProvider: boolean;
+}> {
+  let apiKey: string | null | undefined;
+  const isProvider = await client._callApiKey((resolved) => {
+    apiKey = resolved;
+  });
+  return { apiKey: apiKey === undefined ? client.apiKey : apiKey, isProvider };
+}

--- a/src/realtime/websocket.ts
+++ b/src/realtime/websocket.ts
@@ -1,3 +1,4 @@
+import { getRealtimeAPIKey, resolveRealtimeAPIKey } from '../internal/realtime-credentials';
 import type { AzureOpenAI } from '../index';
 import { assertBedrockWebSocketOrigin } from '../internal/bedrock';
 import { OpenAI } from '../index';
@@ -175,15 +176,18 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
       onURL?: (url: URL) => void;
       /** Indicates the token was resolved by the factory just before connecting. @internal */
       __resolvedApiKey?: boolean;
+      /** Credential captured by an async factory for this connection. @internal */
+      __apiKey?: string | null;
     },
     client?: Pick<OpenAI, 'apiKey' | 'baseURL'>,
   ) {
     super();
+    let apiKey = getRealtimeAPIKey(client, props.__apiKey);
     const hasProvider = typeof (client as any)?._options?.apiKey === 'function';
     const dangerouslyAllowBrowser =
       props.dangerouslyAllowBrowser ??
       (client as any)?._options?.dangerouslyAllowBrowser ??
-      (client?.apiKey?.startsWith('ek_') ? true : null);
+      (apiKey?.startsWith('ek_') ? true : null);
     if (!dangerouslyAllowBrowser && isRunningInBrowserOrBrowserWorker()) {
       throw new OpenAIError(
         "It looks like you're running in a browser-like environment.\n\nThis is disabled by default, as it risks exposing your secret API credentials to attackers.\n\nYou can avoid this error by creating an ephemeral session token:\nhttps://platform.openai.com/docs/api-reference/realtime-sessions\n",
@@ -191,6 +195,9 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     }
 
     client ??= new OpenAI({ dangerouslyAllowBrowser });
+    if (apiKey === undefined) {
+      apiKey = client.apiKey;
+    }
 
     if (hasProvider && !props?.__resolvedApiKey) {
       throw new Error(
@@ -209,10 +216,10 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     assertBedrockWebSocketOrigin(client, this.url);
 
     const azure = isAzure(client);
-    const protocols = ['realtime', ...(azure ? [] : [`openai-insecure-api-key.${client.apiKey}`])];
+    const protocols = ['realtime', ...(azure ? [] : [`openai-insecure-api-key.${apiKey}`])];
 
     this.socket = azure
-      ? createAzureWebSocket(this.url, client.apiKey, props.__resolvedApiKey === true, protocols)
+      ? createAzureWebSocket(this.url, apiKey, props.__resolvedApiKey === true, protocols)
       : new WebSocket(this.url.toString(), protocols);
 
     this.socket.addEventListener('message', (websocketEvent: MessageEvent) => {
@@ -269,7 +276,7 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
       dangerouslyAllowBrowser?: boolean;
     },
   ): Promise<OpenAIRealtimeWebSocket> {
-    const resolvedApiKey = await client._callApiKey();
+    const { apiKey, isProvider: resolvedApiKey } = await resolveRealtimeAPIKey(client);
     const url = buildRealtimeURL(client, props);
     assertBedrockWebSocketOrigin(client, url);
     return new OpenAIRealtimeWebSocket(
@@ -277,6 +284,7 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
         ...props,
         buildRealtimeURL: () => url,
         __resolvedApiKey: resolvedApiKey,
+        __apiKey: apiKey,
       },
       client,
     );
@@ -301,8 +309,7 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     } = {},
   ): Promise<OpenAIRealtimeWebSocket> {
     const connection = getAzureRealtimeConnection(client, options);
-    const isApiKeyProvider = await client._callApiKey();
-    const apiKey = client.apiKey;
+    const { apiKey, isProvider: isApiKeyProvider } = await resolveRealtimeAPIKey(client);
     if (!apiKey) {
       throw new Error('Azure OpenAI Realtime requires an API key');
     }
@@ -312,6 +319,7 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
         ...connection,
         ...(dangerouslyAllowBrowser === undefined ? {} : { dangerouslyAllowBrowser }),
         __resolvedApiKey: isApiKeyProvider,
+        __apiKey: apiKey,
       },
       client,
     );

--- a/src/realtime/ws.ts
+++ b/src/realtime/ws.ts
@@ -1,3 +1,4 @@
+import { resolveRealtimeAPIKey } from '../internal/realtime-credentials';
 import * as WS from 'ws';
 import { assertBedrockWebSocketOrigin } from '../internal/bedrock';
 import { protectWebSocketOptionsFromCredentialRedirects } from '../internal/ws';
@@ -46,11 +47,14 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
 
       /** Indicates that a function-based credential was resolved by an async factory. @internal */
       __resolvedApiKey?: boolean;
+      /** Credential captured by an async factory for this connection. @internal */
+      __apiKey?: string | null;
     },
     client?: Pick<OpenAI, 'apiKey' | 'baseURL'>,
   ) {
     super();
     client ??= new OpenAI();
+    const apiKey = props.__apiKey === undefined ? client.apiKey : props.__apiKey;
     const hasProvider = typeof (client as any)?._options?.apiKey === 'function';
     if (hasProvider && !props.__resolvedApiKey) {
       throw new Error(
@@ -65,7 +69,7 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
     const headers = {
       'User-Agent': `${client.constructor.name}/JS ${VERSION}`,
       ...props.options?.headers,
-      ...(isAzure(client) && !props.__resolvedApiKey ? {} : { Authorization: `Bearer ${client.apiKey}` }),
+      ...(isAzure(client) && !props.__resolvedApiKey ? {} : { Authorization: `Bearer ${apiKey}` }),
     };
 
     this.socket = new WS.WebSocket(
@@ -130,7 +134,7 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
       options?: WS.ClientOptions | undefined;
     },
   ): Promise<OpenAIRealtimeWS> {
-    const resolvedApiKey = await client._callApiKey();
+    const { apiKey, isProvider: resolvedApiKey } = await resolveRealtimeAPIKey(client);
     const url = buildRealtimeURL(client, props);
     assertBedrockWebSocketOrigin(client, url);
     return new OpenAIRealtimeWS(
@@ -138,6 +142,7 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
         ...props,
         buildRealtimeURL: () => url,
         __resolvedApiKey: resolvedApiKey,
+        __apiKey: apiKey,
       },
       client,
     );
@@ -162,8 +167,7 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
     } = {},
   ): Promise<OpenAIRealtimeWS> {
     const connection = getAzureRealtimeConnection(client, props);
-    const isApiKeyProvider = await client._callApiKey();
-    const apiKey = client.apiKey;
+    const { apiKey, isProvider: isApiKeyProvider } = await resolveRealtimeAPIKey(client);
     if (!apiKey) {
       throw new Error('Azure OpenAI Realtime requires an API key');
     }
@@ -178,6 +182,7 @@ export class OpenAIRealtimeWS extends OpenAIRealtimeEmitter {
           },
         },
         __resolvedApiKey: isApiKeyProvider,
+        __apiKey: apiKey,
       },
       client,
     );

--- a/tests/realtime-connection-credentials.test.ts
+++ b/tests/realtime-connection-credentials.test.ts
@@ -1,0 +1,231 @@
+import { vi } from 'vitest';
+import OpenAI, { AzureOpenAI } from 'openai';
+import { OpenAIRealtimeWS as StableNodeRealtime } from 'openai/realtime/ws';
+import { OpenAIRealtimeWebSocket as StableNativeRealtime } from 'openai/realtime/websocket';
+import { OpenAIRealtimeWS as BetaNodeRealtime } from 'openai/beta/realtime/ws';
+import { OpenAIRealtimeWebSocket as BetaNativeRealtime } from 'openai/beta/realtime/websocket';
+
+const { MockSocket, sockets } = vi.hoisted(() => {
+  const instances: Socket[] = [];
+  class Socket {
+    readonly url: string | URL;
+    readonly headers: Record<string, string>;
+    readonly protocols: string[];
+
+    constructor(
+      url: string | URL,
+      options: string[] | { headers: Record<string, string>; protocols?: string[] },
+    ) {
+      this.url = url;
+      this.headers = Array.isArray(options) ? {} : options.headers;
+      this.protocols = Array.isArray(options) ? options : (options.protocols ?? []);
+      instances.push(this);
+    }
+
+    on() {
+      return this;
+    }
+    addEventListener() {
+      return this;
+    }
+  }
+  return { MockSocket: Socket, sockets: instances };
+});
+
+vi.mock('ws', () => ({ WebSocket: MockSocket }));
+
+const surfaces = [
+  { name: 'stable ws', Realtime: StableNodeRealtime },
+  { name: 'beta ws', Realtime: BetaNodeRealtime },
+  { name: 'stable native', Realtime: StableNativeRealtime },
+  { name: 'beta native', Realtime: BetaNativeRealtime },
+] as const;
+
+function credential(connection: { socket: unknown }): string | undefined {
+  const socket = connection.socket as InstanceType<typeof MockSocket>;
+  return (
+    socket.headers['Authorization']?.replace(/^Bearer /u, '') ??
+    socket.headers['api-key'] ??
+    socket.protocols.find((protocol) => protocol.startsWith('openai-insecure-api-key.'))?.slice(24)
+  );
+}
+
+function clientFor(azure: boolean, apiKey: string | (() => Promise<string>)) {
+  return azure
+    ? new AzureOpenAI({
+        ...(typeof apiKey === 'function' ? { azureADTokenProvider: apiKey } : { apiKey }),
+        apiVersion: '2024-10-01-preview',
+        baseURL: 'https://azure.example/openai/',
+        deployment: 'synthetic-deployment',
+      })
+    : new OpenAI({ apiKey, baseURL: 'https://api.example/v1/' });
+}
+
+beforeEach(() => {
+  sockets.length = 0;
+  vi.stubGlobal('WebSocket', MockSocket);
+  // Explicit undefined removes any inherited Azure credential.
+  // oxlint-disable-next-line unicorn/no-useless-undefined
+  vi.stubEnv('AZURE_OPENAI_API_KEY', undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe.each(surfaces)('$name connection credentials', ({ Realtime }) => {
+  describe.each([false, true])('Azure: %s', (azure) => {
+    const connect = (client: OpenAI) =>
+      azure ? Realtime.azure(client as AzureOpenAI) : Realtime.create(client, { model: 'gpt-realtime' });
+
+    test('keeps simultaneously resolved provider credentials with their initiating connections', async () => {
+      let calls = 0;
+      const client = clientFor(azure, async () => {
+        calls += 1;
+        return `synthetic-token-${calls}`;
+      });
+
+      const connections = await Promise.all([connect(client), connect(client)]);
+
+      expect(connections.map(credential)).toEqual(['synthetic-token-1', 'synthetic-token-2']);
+      expect(calls).toBe(2);
+      expect(client.apiKey).toBe('synthetic-token-2');
+    });
+
+    test('keeps credentials associated when pending providers settle in reverse order', async () => {
+      const providers: ((token: string) => void)[] = [];
+      const client = clientFor(
+        azure,
+        () =>
+          // eslint-disable-next-line promise/avoid-new -- Control provider settlement order to reproduce the race.
+          new Promise<string>((resolve) => {
+            providers.push(resolve);
+          }),
+      );
+      const first = connect(client);
+      const second = connect(client);
+      expect(providers).toHaveLength(2);
+
+      const [resolveFirst, resolveSecond] = providers;
+      if (!resolveFirst || !resolveSecond) {
+        throw new Error('Expected both credential providers to start');
+      }
+      resolveSecond('synthetic-token-2');
+      resolveFirst('synthetic-token-1');
+      const connections = await Promise.all([first, second]);
+
+      expect(connections.map(credential)).toEqual(['synthetic-token-1', 'synthetic-token-2']);
+    });
+
+    test('preserves static credential authentication', async () => {
+      const connection = await connect(clientFor(azure, 'synthetic-static-key'));
+
+      expect(credential(connection)).toBe('synthetic-static-key');
+      if (azure) {
+        expect(sockets[0]?.headers).toHaveProperty('api-key', 'synthetic-static-key');
+        expect(sockets[0]?.headers).not.toHaveProperty('Authorization');
+      }
+    });
+
+    test('opens no socket for a failed provider while another provider succeeds', async () => {
+      let calls = 0;
+      const client = clientFor(azure, async () => {
+        calls += 1;
+        return calls === 1 ? '' : 'synthetic-valid-token';
+      });
+
+      const results = await Promise.allSettled([connect(client), connect(client)]);
+
+      expect(results[0]?.status).toBe('rejected');
+      expect(results[1]?.status).toBe('fulfilled');
+      expect(sockets).toHaveLength(1);
+      if (results[1]?.status === 'fulfilled') {
+        expect(credential(results[1].value)).toBe('synthetic-valid-token');
+      }
+    });
+
+    test('preserves a legacy no-argument credential hook', async () => {
+      const client = clientFor(azure, 'synthetic-static-key');
+      const hook = vi.spyOn(client, '_callApiKey').mockImplementation(async () => {
+        client.apiKey = 'synthetic-legacy-key';
+        return true;
+      });
+
+      expect(credential(await connect(client))).toBe('synthetic-legacy-key');
+      expect(hook).toHaveBeenCalledTimes(1);
+    });
+
+    test('preserves per-connection credentials through a forwarding hook override', async () => {
+      let calls = 0;
+      const client = clientFor(azure, async () => {
+        calls += 1;
+        return `synthetic-token-${calls}`;
+      });
+      const original = client._callApiKey.bind(client);
+      const hook = vi.spyOn(client, '_callApiKey').mockImplementation((capture) => original(capture));
+
+      const connections = await Promise.all([connect(client), connect(client)]);
+
+      expect(connections.map(credential)).toEqual(['synthetic-token-1', 'synthetic-token-2']);
+      expect(hook).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+test.each([false, true])('preserves the no-argument credential-hook contract (Azure: %s)', async (azure) => {
+  const staticClient = clientFor(azure, 'synthetic-static-key');
+  const providerClient = clientFor(azure, async () => 'synthetic-provider-key');
+
+  await expect(staticClient._callApiKey()).resolves.toBe(false);
+  await expect(providerClient._callApiKey()).resolves.toBe(true);
+  expect(staticClient.apiKey).toBe('synthetic-static-key');
+  expect(providerClient.apiKey).toBe('synthetic-provider-key');
+});
+
+describe.each([
+  { name: 'stable', Realtime: StableNativeRealtime },
+  { name: 'beta', Realtime: BetaNativeRealtime },
+])('$name native browser credentials', ({ Realtime }) => {
+  test('checks each resolved credential before permitting browser authentication', async () => {
+    let calls = 0;
+    const client = clientFor(false, async () => {
+      calls += 1;
+      return calls === 1 ? 'synthetic-permanent-key' : 'ek_synthetic';
+    });
+    vi.stubGlobal('window', { document: {} });
+    vi.stubGlobal('navigator', {});
+
+    const results = await Promise.allSettled([
+      Realtime.create(client, { model: 'gpt-realtime' }),
+      Realtime.create(client, { model: 'gpt-realtime' }),
+    ]);
+
+    expect(results[0]?.status).toBe('rejected');
+    expect(results[1]?.status).toBe('fulfilled');
+    expect(sockets).toHaveLength(1);
+    if (results[1]?.status === 'fulfilled') {
+      expect(credential(results[1].value)).toBe('ek_synthetic');
+    }
+  });
+});
+
+describe.each([
+  { name: 'ws', Realtime: StableNodeRealtime },
+  { name: 'native', Realtime: StableNativeRealtime },
+])('stable $name custom URL callbacks', ({ Realtime }) => {
+  test('keeps the resolved key while passing the actual client to the URL callback', async () => {
+    const client = clientFor(false, async () => 'synthetic-resolved-key');
+    const buildRealtimeURL = vi.fn((receivedClient: Pick<OpenAI, 'apiKey' | 'baseURL'>) => {
+      expect(receivedClient).toBe(client);
+      client.apiKey = 'synthetic-callback-key';
+      return new URL('wss://api.example/custom');
+    });
+
+    const connection = await Realtime.create(client, { model: 'gpt-realtime', buildRealtimeURL });
+
+    expect(credential(connection)).toBe('synthetic-resolved-key');
+    expect(buildRealtimeURL).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Concurrent Realtime factories now retain the API credential returned for each connection. Stable and beta transports use that captured value for WebSocket authentication and native browser eligibility, so a later provider response or URL callback cannot replace a connection’s credential.

`_callApiKey()` keeps its boolean return and `client.apiKey` update. An optional internal capture callback supplies the connection-local value without replacing the client or bypassing its URL/security hooks. Legacy overrides that ignore capture retain their existing shared-property behavior; overrides must forward the callback to obtain the same concurrency isolation.

Validation:
- 20 regressions fail before the change across stable/beta × native/`ws` × OpenAI/Azure, browser eligibility, and custom URL callbacks.
- Controls cover static and Azure auth modes, provider failures, legacy/forwarding overrides, and the no-argument credential-hook contract.
- 481 tests across eight transport/authentication suites pass on Node 24.20.0 and exact minimum Node 22.0.0, including 54 new cases.
- Canonical lint, TypeScript checking, build/import checks, and published-source TypeScript 4.9/6 checks pass.
