### PR TITLE
fix: preserve streamed API error classification

### DIFF
--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -9,6 +9,10 @@ import type { OpenAI } from '../client';
 
 type Bytes = string | ArrayBuffer | Uint8Array | null | undefined;
 
+function isTransportAbortError(error: unknown): boolean {
+  return !(error instanceof APIError) && isAbortError(error);
+}
+
 type StreamTeeQueue<Item> = {
   readonly length: number;
   readonly canceled: boolean;
@@ -168,7 +172,7 @@ export class Stream<Item> implements AsyncIterable<Item> {
         // Abort errors and cleanup failures after the completion sentinel are non-fatal.
         if (
           receivedCompletionSentinel ||
-          isAbortError(e) ||
+          isTransportAbortError(e) ||
           (controller.signal.aborted && e === controller.signal.reason)
         ) {
           return;

--- a/tests/lib/streaming-named-error-events.test.ts
+++ b/tests/lib/streaming-named-error-events.test.ts
@@ -327,3 +327,59 @@ describe('named SSE provider errors', () => {
     expect(logger.error).not.toHaveBeenCalled();
   });
 });
+
+describe.each([
+  { name: 'unnamed wrapped', event: undefined, wrapped: true },
+  { name: 'named wrapped', event: 'error', wrapped: true },
+  { name: 'named flat', event: 'error', wrapped: false },
+])('$name API errors resembling transport cancellation', ({ event, wrapped }) => {
+  const payload = { ...providerError, message: 'Provider failure: FetchRequestCanceledException' };
+
+  test.each(['exported stream', 'public request', 'chat helper'] as const)(
+    'preserves the provider error through %s',
+    async (surface) => {
+      const response = responseForWire(record(event, wrapped ? { error: payload } : payload));
+      let failure: unknown;
+      if (surface === 'chat helper') {
+        const client = new OpenAI({
+          apiKey: 'sk-synthetic-stream-error',
+          maxRetries: 0,
+          fetch: async () => response,
+        });
+        failure = await client.chat.completions
+          .stream({ model: 'gpt-synthetic', messages: [] })
+          .finalChatCompletion()
+          .then(
+            () => null,
+            (error: unknown) => error,
+          );
+      } else {
+        const stream =
+          surface === 'exported stream'
+            ? Stream.fromSSEResponse(response, new AbortController())
+            : await publicStream(publicSurfaces[0], response);
+        failure = await rejection(stream);
+      }
+
+      expect(failure).toBeInstanceOf(APIError);
+      expect(failure).toMatchObject({ ...payload, error: payload, requestID });
+    },
+  );
+});
+
+test.each([
+  { name: 'AbortError', failure: new DOMException('Synthetic transport cancellation', 'AbortError') },
+  { name: 'Expo', failure: new Error('expo.modules.fetch.FetchRequestCanceledException') },
+])('preserves transport cancellation handling for $name', async ({ failure }) => {
+  const response = new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.error(failure);
+      },
+    }),
+    { headers: { 'content-type': 'text/event-stream' } },
+  );
+  const stream = Stream.fromSSEResponse(response, new AbortController());
+
+  expect(await collect(stream)).toEqual([]);
+});


### PR DESCRIPTION
Streaming API errors now bypass the transport-abort heuristic, so an API error containing a cancellation marker still reaches callers with its original message, code, and request ID. Actual AbortError/Expo cancellations, explicit abort reasons, and completion-sentinel cleanup retain their existing behavior.

Validation:
- Nine public regressions fail before the fix across exported streams, raw requests, and the chat helper, with named/unnamed and flat/wrapped errors.
- 147 focused tests pass on Node 24.20.0 and exact minimum Node 22.0.0; the final Node 24 run passes after the predicate extraction and test formatting.
- Canonical lint, TypeScript checking, build/import checks, and built CJS/ESM error-propagation checks on Node 22.0.0 pass.
