### PR TITLE
fix(assistants): reject root IDs in run-step deltas

### DIFF
--- a/src/lib/AssistantStream.ts
+++ b/src/lib/AssistantStream.ts
@@ -525,6 +525,13 @@ export class AssistantStream
       throw new OpenAIError('Received assistant run-step event with an invalid run-step ID');
     }
 
+    if (event.event === 'thread.run.step.delta') {
+      const delta = event.data.delta;
+      if (delta && hasOwn(delta, 'id')) {
+        throw new OpenAIError('Run-step deltas must not contain an id field');
+      }
+    }
+
     if (event.event === 'thread.run.step.created') {
       if (this.#activeRunStepID !== undefined) {
         throw new OpenAIError(
@@ -842,10 +849,14 @@ export class AssistantStream
           throw new Error('Received a RunStepDelta before creation of a snapshot');
         }
 
-        const data = event.data;
+        const delta = event.data.delta;
 
-        if (data.delta) {
-          const accumulated = accumulateAssistantStreamDelta(snapshot, data.delta, true) as Runs.RunStep;
+        if (delta) {
+          // Raw-event listeners can replace or modify the delta after initial validation.
+          if (hasOwn(delta, 'id')) {
+            throw new OpenAIError('Run-step deltas must not contain an id field');
+          }
+          const accumulated = accumulateAssistantStreamDelta(snapshot, delta, true) as Runs.RunStep;
           this.#runStepSnapshots[runStepID] = accumulated;
         }
 

--- a/tests/lib/assistant-stream-run-step-identity-security.test.ts
+++ b/tests/lib/assistant-stream-run-step-identity-security.test.ts
@@ -83,6 +83,104 @@ function toolCallDelta(id: string) {
 }
 
 describe('AssistantStream run-step identity security', () => {
+  describe.each([
+    ['SSE', publicAssistantStream],
+    ['serialized stream', assistantStream],
+  ] as const)('%s run-step delta identity', (_transport, createStream) => {
+    test.each(['replacement', '', null, 123])(
+      'rejects a root id containing %j before raw dispatch',
+      async (id) => {
+        const step = runStep('step_original');
+        const created = { event: 'thread.run.step.created', data: step };
+        const runner = createStream([
+          created,
+          {
+            event: 'thread.run.step.delta',
+            data: { id: step.id, delta: { id, metadata: { changed: true } } },
+          },
+          completedRun(),
+        ]);
+        const rawEvent = vi.fn();
+        const stepDelta = vi.fn();
+        runner.on('event', rawEvent);
+        runner.on('runStepDelta', stepDelta);
+
+        await expect(runner.done()).rejects.toThrow('Run-step deltas must not contain an id field');
+
+        expect(rawEvent).toHaveBeenCalledTimes(1);
+        expect(stepDelta).not.toHaveBeenCalled();
+        expect(runner.currentEvent()).toEqual(created);
+        expect(runner.currentRunStepSnapshot()).toEqual(step);
+      },
+    );
+
+    test.each(['mutate', 'replace'] as const)(
+      'rejects a root id introduced by a raw listener: %s',
+      async (mode) => {
+        const step = runStep('step_original');
+        const runner = createStream([
+          { event: 'thread.run.step.created', data: step },
+          toolCallDelta(step.id),
+          completedRun(),
+        ]);
+        const stepDelta = vi.fn();
+        const toolCreated = vi.fn();
+        runner.on('event', (event) => {
+          if (event.event === 'thread.run.step.delta') {
+            const delta = Object.assign(mode === 'mutate' ? event.data.delta : {}, event.data.delta, {
+              id: 'listener_id',
+            });
+            event.data.delta = delta;
+          }
+        });
+        runner.on('runStepDelta', stepDelta);
+        runner.on('toolCallCreated', toolCreated);
+
+        await expect(runner.done()).rejects.toThrow('Run-step deltas must not contain an id field');
+
+        expect(stepDelta).not.toHaveBeenCalled();
+        expect(toolCreated).not.toHaveBeenCalled();
+        expect(runner.currentRunStepSnapshot()).toEqual(step);
+      },
+    );
+
+    test('preserves valid delta identity, nested tool IDs, and extension fields', async () => {
+      const step = runStep('step_original');
+      const delta = {
+        metadata: { marker: 'retained' },
+        step_details: {
+          type: 'tool_calls',
+          tool_calls: [{ index: 0, id: '_suffix', function: { arguments: ' updated' } }],
+        },
+      };
+      const runner = createStream([
+        { event: 'thread.run.step.created', data: step },
+        { event: 'thread.run.step.delta', data: { id: step.id, delta } },
+        completedRun(),
+      ]);
+      let rawDelta: unknown;
+      runner.on('event', (event) => {
+        if (event.event === 'thread.run.step.delta') {
+          rawDelta = event.data.delta;
+        }
+      });
+      const stepDelta = vi.fn();
+      runner.on('runStepDelta', stepDelta);
+
+      await runner.done();
+
+      expect(stepDelta).toHaveBeenCalledTimes(1);
+      expect(stepDelta.mock.calls[0]?.[0]).toBe(rawDelta);
+      expect(stepDelta.mock.calls[0]?.[1]).toMatchObject({
+        id: step.id,
+        metadata: { marker: 'retained' },
+        step_details: {
+          tool_calls: [{ id: 'call_trusted_suffix', function: { arguments: '{"to":"trusted"} updated' } }],
+        },
+      });
+    });
+  });
+
   test.each(['step_trusted', 'step_foreign'])(
     'rejects creation of %s while a trusted run step remains active',
     async (injectedID) => {


### PR DESCRIPTION
Supersedes #2685.

Run-step deltas must not carry a root `id`. Reject that field before raw-event dispatch and recheck the captured delta immediately before accumulation, so an ordinary raw listener cannot introduce it between validation and merging. A listener-added root ID rejects the event instead of being silently stripped.

This keeps run-step identity out of delta accumulation while preserving valid callback objects, nested tool-call IDs, extension properties, and existing alias handling. The production change is 14 additions and 3 deletions in `AssistantStream.ts`.

## Scope

The security guarantee covers decoded SSE/NDJSON protocol data. The pre-merge check also covers ordinary listener additions and replacements. It follows the repository's [documented distinction between protocol data and executable application authority](https://github.com/openai/openai-node/blob/80ce89f355ddb2ea74e48da0284a85d536597446/docs/architecture/security-model.md#L90); arbitrary hostile getters, Proxies, and callback code running with application authority are outside this change's security guarantee.

## Validation

- Added 14 focused cases covering both byte-decoding entrypoints: rejection before raw dispatch, listener-added/replaced root IDs, and preservation of valid callback identity, nested IDs, and extension fields.
- All 278 tests across the seven AssistantStream suites pass on Node 24.20.0 using `./scripts/test tests/lib/AssistantStream.test.ts tests/lib/assistant-stream`.
- All 51 run-step identity tests pass on exact minimum Node 22.0.0.
- Canonical `pnpm lint`, full `pnpm exec tsc`, and `pnpm build` pass with the pinned dependencies.
- Built AssistantStream CJS/ESM imports pass on Node 22.0.0 and 24.20.0.
- One independent static review found no actionable issues within the stated scope.

Validation uses focused rejection tests; the original heap-exhaustion experiment was not rerun.
