### PR TITLE
fix: preserve suppressed workload authorization

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1550,7 +1550,7 @@ export class OpenAI {
     if (this._workloadIdentityAuth && !this.#x509Fetch && schemes.bearerAuth) {
       const headers = init.headers as Headers;
       const authHeader = headers.get('Authorization');
-      if (!authHeader || authHeader === `Bearer ${WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER}`) {
+      if (authHeader === `Bearer ${WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER}`) {
         const token = await this._workloadIdentityAuth.getToken();
         headers.set('Authorization', `Bearer ${token}`);
       }

--- a/tests/lib/workload-identity.test.ts
+++ b/tests/lib/workload-identity.test.ts
@@ -92,6 +92,60 @@ describe('OpenAI with Workload Identity', () => {
     expect(apiRequestHeaders!.get('Authorization')).toBe('Bearer exchanged-access-token');
   });
 
+  test.each([
+    ['default null', { Authorization: null }, undefined, null],
+    ['default empty', { Authorization: '' }, undefined, ''],
+    ['request null', undefined, { Authorization: null }, null],
+    ['request empty', undefined, { Authorization: '' }, ''],
+    ['request null over default', { Authorization: 'Bearer default' }, { aUtHoRiZaTiOn: null }, null],
+    ['request empty over default', { Authorization: 'Bearer default' }, { authorization: '' }, ''],
+    ['default replacement', { Authorization: 'Bearer replacement' }, undefined, 'Bearer replacement'],
+    [
+      'request replacement',
+      { Authorization: null },
+      { Authorization: 'Bearer replacement' },
+      'Bearer replacement',
+    ],
+    ['default undefined', { Authorization: undefined }, undefined, 'Bearer exchanged-access-token'],
+    [
+      'request undefined',
+      { Authorization: 'Bearer default' },
+      { Authorization: undefined },
+      'Bearer default',
+    ],
+    ['native empty', undefined, new Headers({ Authorization: '' }), ''],
+    [
+      'workload placeholder',
+      undefined,
+      { Authorization: 'Bearer workload-identity-auth' },
+      'Bearer exchanged-access-token',
+    ],
+  ] as const)('preserves merged Authorization: %s', async (_name, defaultHeaders, headers, expected) => {
+    const authorizations: (string | null)[] = [];
+    global.fetch = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.toString() === 'https://auth.openai.com/oauth/token') {
+        return Response.json({
+          access_token: 'exchanged-access-token',
+          issued_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+          token_type: 'Bearer',
+          expires_in: 3600,
+        });
+      }
+      if (url.toString() === 'https://api.openai.com/v1/models') {
+        authorizations.push(new Headers(init?.headers).get('Authorization'));
+        return Response.json({ data: [] });
+      }
+      throw new Error('Unexpected request');
+    }) as typeof fetch;
+
+    const client = new OpenAI({ ...createTestClientOptions(), defaultHeaders });
+    await client.get('/models', { headers });
+    // Repeat with the credential cache populated by the first request.
+    await client.get('/models', { headers });
+
+    expect(authorizations).toEqual([expected, expected]);
+  });
+
   test('does not satisfy admin-only auth with workload identity', async () => {
     global.fetch = vi.fn(async () => new Response('Unexpected request', { status: 500 })) as typeof fetch;
 


### PR DESCRIPTION
Preserve explicit null and empty `Authorization` overrides from client defaults and request headers by resolving only the SDK workload-identity placeholder at dispatch.

Supersedes #2689 with a one-line production fix and 12 focused cases in the existing workload-identity suite. The cases cover client/request overrides, case-insensitive precedence, replacement credentials, undefined values, native Headers, and placeholder resolution. Each case makes two requests to check the result with a populated credential cache.

### Review scope

The acceptance criterion is that dispatch respects the final merged Authorization value, including explicit suppression. Credential-acquisition timing, 401 retry attribution, and transparent ownership through custom hooks/header copies should be evaluated as separate changes.

### Validation

- `./scripts/test tests/lib/workload-identity.test.ts tests/buildHeaders.test.ts`: 46 tests passed on Node 24.20.0 and exact minimum Node 22.0.0.
- `pnpm lint` and `pnpm exec tsc` passed with pnpm 11.5.1.
- `pnpm build` passed, including CJS/ESM core and provider import checks.
- Built CJS and ESM core imports also passed on Node 22.0.0.

Validation used synthetic credentials and in-memory fetch responses.
