### PR TITLE
fix: preserve request credentials and authentication hooks

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -44,6 +44,26 @@ const client = new OpenAI({
 This also works with an OAuth bearer-token provider for a compatible endpoint;
 see the [Azure v1 example](azure.md#v1-api).
 
+For HTTP requests, the SDK resolves the credential while constructing authentication
+headers and uses that invocation's result directly. Each retry resolves a fresh
+credential. `client.apiKey` still exposes the most recently resolved value, but it
+is shared across requests and must not be used to select a concurrent request's
+credential. Static credentials continue to use the current `client.apiKey` value.
+
+#### Subclass authentication hooks
+
+Function credentials are resolved after `prepareOptions` and request URL/body
+construction. Calling `buildRequest` directly also resolves a function credential.
+Default and request headers retain their existing precedence over SDK authentication.
+
+Subclasses that previously customized HTTP credentials through `_callApiKey` or
+assigned `this.apiKey` after `super.prepareOptions()` should override
+`resolveAPIKey()` and return the credential instead. Overrides of `authHeaders`
+or `bearerAuth` can continue to return custom authentication headers. Delegating
+hooks keep their existing arguments; no request context needs to be forwarded.
+`_callApiKey` remains available with its existing boolean return and capture callback
+for Realtime and direct callers, but ordinary HTTP authentication no longer calls it.
+
 ### Environment and client configuration
 
 The client reads these optional environment variables when their corresponding

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -63,6 +63,13 @@ Preparation hooks that supply a credential without delegating to `super` retain
 control of that credential. Changes to `this.apiKey` inside authentication hooks
 are also honored.
 
+For direct builds, authentication hooks can explicitly assign `null` to suppress
+a function credential. With custom credential hooks, the SDK observes writes to
+configurable `apiKey` properties using an accessor; existing getters and setters
+continue to run. Subclasses that make `apiKey` non-configurable should return
+custom authentication headers instead. Ordinary clients keep their existing
+property descriptors.
+
 `_callApiKey` overrides can forward the existing optional `capture` callback to
 preserve the credential belonging to their invocation. Legacy overrides that omit
 it retain their shared-property behavior. Custom hooks that write `this.apiKey`

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -71,7 +71,9 @@ custom authentication headers instead. Ordinary clients keep their existing
 property descriptors.
 
 `_callApiKey` overrides can forward the existing optional `capture` callback to
-preserve the credential belonging to their invocation. Legacy overrides that omit
+preserve the credential belonging to their invocation. Changes to `this.apiKey`
+after the delegated call are honored; an explicit replacement passed to `capture`
+takes precedence over the shared property. Legacy overrides that omit
 it retain their shared-property behavior. Custom hooks that write `this.apiKey`
 remain responsible for coordinating concurrent writes. Prepared credentials are
 discarded when request construction finishes or fails.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -44,8 +44,8 @@ const client = new OpenAI({
 This also works with an OAuth bearer-token provider for a compatible endpoint;
 see the [Azure v1 example](azure.md#v1-api).
 
-For HTTP requests, the SDK keeps each credential resolution associated with its
-request and uses that invocation's result directly. Each retry resolves a fresh
+With the SDK's default HTTP authentication hooks, each function-credential result
+stays associated with its request. Each retry resolves a fresh
 credential. `client.apiKey` still exposes the most recently resolved value, but it
 is shared across requests and must not be used to select a concurrent request's
 credential. Static credentials continue to use the current `client.apiKey` value.
@@ -59,8 +59,15 @@ Default and request headers retain their existing precedence over SDK authentica
 Existing bearer-token subclasses that customize `_callApiKey`, or assign
 `this.apiKey` after `super.prepareOptions()`, remain supported. Overrides of
 `authHeaders` or `bearerAuth` can continue to return custom authentication headers.
-Delegating hooks keep their existing arguments; no request context needs to be
-forwarded.
+Preparation hooks that supply a credential without delegating to `super` retain
+control of that credential. Changes to `this.apiKey` inside authentication hooks
+are also honored.
+
+`_callApiKey` overrides can forward the existing optional `capture` callback to
+preserve the credential belonging to their invocation. Legacy overrides that omit
+it retain their shared-property behavior. Custom hooks that write `this.apiKey`
+remain responsible for coordinating concurrent writes. Prepared credentials are
+discarded when request construction finishes or fails.
 
 `AzureOpenAI` uses the inherited function-credential lifecycle for
 `azureADTokenProvider`, but a static `apiKey` uses Azure's `api-key` header. For

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -64,11 +64,11 @@ control of that credential. Changes to `this.apiKey` inside authentication hooks
 are also honored.
 
 For direct builds, authentication hooks can explicitly assign `null` to suppress
-a function credential. With custom credential hooks, the SDK observes writes to
-configurable `apiKey` properties using an accessor; existing getters and setters
-continue to run. Subclasses that make `apiKey` non-configurable should return
-custom authentication headers instead. Ordinary clients keep their existing
-property descriptors.
+a function credential. With custom credential hooks, the SDK temporarily observes
+writes to configurable `apiKey` properties while building the request; existing
+getters and setters continue to run, and the original property descriptor is
+restored when the build settles. Subclasses that make `apiKey` non-configurable
+should return custom authentication headers instead.
 
 `_callApiKey` overrides can forward the existing optional `capture` callback to
 preserve the credential belonging to their invocation. Legacy overrides that omit

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -69,6 +69,11 @@ it retain their shared-property behavior. Custom hooks that write `this.apiKey`
 remain responsible for coordinating concurrent writes. Prepared credentials are
 discarded when request construction finishes or fails.
 
+When concurrent requests use custom `authHeaders` or `bearerAuth` hooks, pass a
+distinct request-options object to each invocation. If two such hooks overlap on
+the same options object before authentication finishes, the SDK rejects the later
+request rather than risk associating one request's credential with the other.
+
 `AzureOpenAI` uses the inherited function-credential lifecycle for
 `azureADTokenProvider`, but a static `apiKey` uses Azure's `api-key` header. For
 an Azure subclass that refreshes API keys, override

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -66,8 +66,9 @@ are also honored.
 For direct builds, authentication hooks can explicitly assign `null` to suppress
 a function credential. With custom credential hooks, the SDK observes writes to
 configurable `apiKey` properties using an accessor; existing getters and setters
-continue to run. Subclasses that make `apiKey` non-configurable should return
-custom authentication headers instead. Ordinary clients keep their existing
+continue to run. On extensible clients, inherited accessors are observed on the
+client instance without changing the shared prototype. Subclasses that make `apiKey` non-configurable
+should return custom authentication headers instead. Ordinary clients keep their existing
 property descriptors.
 
 `_callApiKey` overrides can forward the existing optional `capture` callback to
@@ -82,6 +83,11 @@ When concurrent requests use custom `authHeaders` or `bearerAuth` hooks, pass a
 distinct request-options object to each invocation. If two such hooks overlap on
 the same options object before authentication finishes, the SDK rejects the later
 request rather than risk associating one request's credential with the other.
+Use distinct options objects also when a custom `prepareOptions` awaits before
+delegating to `super.prepareOptions`. If several requests with the same options
+remain active when that delegation resumes, the SDK rejects the ambiguous
+preparation before invoking the credential provider. Synchronous delegation
+continues to retain its request's credential context.
 
 `AzureOpenAI` uses the inherited function-credential lifecycle for
 `azureADTokenProvider`, but a static `apiKey` uses Azure's `api-key` header. For

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -56,13 +56,46 @@ Function credentials are resolved after `prepareOptions` and request URL/body
 construction. Calling `buildRequest` directly also resolves a function credential.
 Default and request headers retain their existing precedence over SDK authentication.
 
-Subclasses that previously customized HTTP credentials through `_callApiKey` or
+For bearer-token authentication, subclasses that customized HTTP credentials through `_callApiKey` or
 assigned `this.apiKey` after `super.prepareOptions()` should override
 `resolveAPIKey()` and return the credential instead. Overrides of `authHeaders`
 or `bearerAuth` can continue to return custom authentication headers. Delegating
 hooks keep their existing arguments; no request context needs to be forwarded.
 `_callApiKey` remains available with its existing boolean return and capture callback
 for Realtime and direct callers, but ordinary HTTP authentication no longer calls it.
+
+`AzureOpenAI` uses `resolveAPIKey()` for `azureADTokenProvider`, but a static
+`apiKey` uses Azure's `api-key` header without calling `resolveAPIKey()` or
+`bearerAuth()`. For an Azure subclass that refreshes API keys, override
+`authHeaders()` instead. Delegate to Azure first to preserve security-scheme
+selection, then replace its `api-key` value:
+
+```ts
+import { AzureOpenAI } from 'openai';
+
+class RotatingAzureOpenAI extends AzureOpenAI {
+  protected override async authHeaders(
+    options: Parameters<AzureOpenAI['buildRequest']>[0],
+    schemes?: { bearerAuth?: boolean; adminAPIKeyAuth?: boolean },
+  ) {
+    const headers = await super.authHeaders(options, schemes);
+    if (headers?.values.has('api-key')) {
+      const apiKey = process.env['AZURE_OPENAI_API_KEY'];
+      if (!apiKey) {
+        throw new Error('Missing AZURE_OPENAI_API_KEY');
+      }
+      headers.values.set('api-key', apiKey);
+    }
+    return headers;
+  }
+}
+
+const client = new RotatingAzureOpenAI(); // Configure Azure environment variables as usual.
+```
+
+This example reads the current API key during header construction and leaves
+`client.apiKey` unchanged. Default and request headers still take precedence.
+See the [Azure guide](azure.md) for endpoint and API-version configuration.
 
 ### Environment and client configuration
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -44,29 +44,27 @@ const client = new OpenAI({
 This also works with an OAuth bearer-token provider for a compatible endpoint;
 see the [Azure v1 example](azure.md#v1-api).
 
-For HTTP requests, the SDK resolves the credential while constructing authentication
-headers and uses that invocation's result directly. Each retry resolves a fresh
+For HTTP requests, the SDK keeps each credential resolution associated with its
+request and uses that invocation's result directly. Each retry resolves a fresh
 credential. `client.apiKey` still exposes the most recently resolved value, but it
 is shared across requests and must not be used to select a concurrent request's
 credential. Static credentials continue to use the current `client.apiKey` value.
 
 #### Subclass authentication hooks
 
-Function credentials are resolved after `prepareOptions` and request URL/body
-construction. Calling `buildRequest` directly also resolves a function credential.
+Function credentials continue to resolve through `prepareOptions` and `_callApiKey`.
+Calling `buildRequest` directly also resolves a function credential.
 Default and request headers retain their existing precedence over SDK authentication.
 
-For bearer-token authentication, subclasses that customized HTTP credentials through `_callApiKey` or
-assigned `this.apiKey` after `super.prepareOptions()` should override
-`resolveAPIKey()` and return the credential instead. Overrides of `authHeaders`
-or `bearerAuth` can continue to return custom authentication headers. Delegating
-hooks keep their existing arguments; no request context needs to be forwarded.
-`_callApiKey` remains available with its existing boolean return and capture callback
-for Realtime and direct callers, but ordinary HTTP authentication no longer calls it.
+Existing bearer-token subclasses that customize `_callApiKey`, or assign
+`this.apiKey` after `super.prepareOptions()`, remain supported. Overrides of
+`authHeaders` or `bearerAuth` can continue to return custom authentication headers.
+Delegating hooks keep their existing arguments; no request context needs to be
+forwarded.
 
-`AzureOpenAI` uses `resolveAPIKey()` for `azureADTokenProvider`, but a static
-`apiKey` uses Azure's `api-key` header without calling `resolveAPIKey()` or
-`bearerAuth()`. For an Azure subclass that refreshes API keys, override
+`AzureOpenAI` uses the inherited function-credential lifecycle for
+`azureADTokenProvider`, but a static `apiKey` uses Azure's `api-key` header. For
+an Azure subclass that refreshes API keys, override
 `authHeaders()` instead. Delegate to Azure first to preserve security-scheme
 selection, then replace its `api-key` value:
 

--- a/src/azure.ts
+++ b/src/azure.ts
@@ -3,6 +3,7 @@ import type { NullableHeaders } from './internal/headers';
 import { buildHeaders } from './internal/headers';
 import * as Errors from './error';
 import type { FinalRequestOptions } from './internal/request-options';
+import { markCredentialHooksSafe } from './internal/request-options';
 import { hasOwn, isObj, readEnv } from './internal/utils';
 import { path } from './internal/utils/path';
 import { OpenAI } from './client';
@@ -148,7 +149,7 @@ export class AzureOpenAI extends OpenAI {
 
     this.apiVersion = apiVersion;
     this.deploymentName = deployment;
-    this.markCredentialHooksSafe(AzureOpenAI.prototype.authHeaders, AzureOpenAI.prototype.buildRequest);
+    super[markCredentialHooksSafe](AzureOpenAI.prototype.authHeaders, AzureOpenAI.prototype.buildRequest);
   }
 
   /** Clones this client with Azure options; OpenAI data residency remains unsupported. */

--- a/src/azure.ts
+++ b/src/azure.ts
@@ -148,6 +148,7 @@ export class AzureOpenAI extends OpenAI {
 
     this.apiVersion = apiVersion;
     this.deploymentName = deployment;
+    this.markCredentialHooksSafe(AzureOpenAI.prototype.authHeaders, AzureOpenAI.prototype.buildRequest);
   }
 
   /** Clones this client with Azure options; OpenAI data residency remains unsupported. */

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -236,6 +236,10 @@ export class BedrockOpenAI extends OpenAI {
     const configuredBaseURL = this._options.baseURL ?? this.baseURL;
     assertBedrockRequestOrigin(configuredBaseURL, this.buildURL(options.path, null, options.defaultBaseURL));
 
+    const security = options.__security ?? { bearerAuth: true };
+    if (security.adminAPIKeyAuth && !security.bearerAuth) {
+      await this.prepareAPIKey(options);
+    }
     await super.prepareOptions(options);
   }
 
@@ -244,7 +248,6 @@ export class BedrockOpenAI extends OpenAI {
     context: { url: string; options: FinalRequestOptions },
   ): Promise<void> {
     const configuredBaseURL = this._options.baseURL ?? this.baseURL;
-    // Credentials now resolve during header construction, after prepareOptions.
     assertBedrockRequestOrigin(
       configuredBaseURL,
       this.buildURL(context.options.path, null, context.options.defaultBaseURL),
@@ -259,7 +262,8 @@ export class BedrockOpenAI extends OpenAI {
     schemes?: { bearerAuth?: boolean; adminAPIKeyAuth?: boolean },
   ): Promise<NullableHeaders | undefined> {
     const security = schemes ?? { bearerAuth: true, adminAPIKeyAuth: true };
-    const credential = security.bearerAuth || security.adminAPIKeyAuth ? await this.resolveAPIKey() : null;
+    const credential =
+      security.bearerAuth || security.adminAPIKeyAuth ? await this.resolvedAPIKey(opts) : null;
     if ((security.bearerAuth || security.adminAPIKeyAuth) && credential !== null) {
       assertValidBedrockBearerCredential(credential);
       try {

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -12,7 +12,12 @@ import type { RequestInit } from './internal/builtin-types';
 import type { NullableHeaders } from './internal/headers';
 import { buildHeaders } from './internal/headers';
 import type { FinalRequestOptions, RequestOptions } from './internal/request-options';
-import { prepareAPIKey, resolvedAPIKey } from './internal/request-options';
+import {
+  markCredentialHooksSafe,
+  prepareAPIKey,
+  resolvedAPIKey,
+  validateOptionsBeforePreparation,
+} from './internal/request-options';
 import { readEnv } from './internal/utils';
 import { addOutputText } from './lib/ResponsesParser';
 import type { ResponseStreamParams } from './lib/responses/ResponseStream';
@@ -224,7 +229,7 @@ export class BedrockOpenAI extends OpenAI {
 
     this.bedrockTokenProvider = bedrockTokenProvider;
     this.responses = restoreBedrockStreamOutputText(new API.Responses(this));
-    this.markCredentialHooksSafe(
+    super[markCredentialHooksSafe](
       BedrockOpenAI.prototype.buildURL,
       BedrockOpenAI.prototype.prepareOptions,
       BedrockOpenAI.prototype.authHeaders,
@@ -243,7 +248,7 @@ export class BedrockOpenAI extends OpenAI {
     return url;
   }
 
-  protected override validateOptionsBeforePreparation(options: FinalRequestOptions): void {
+  protected override [validateOptionsBeforePreparation](options: FinalRequestOptions): void {
     const configuredBaseURL = this._options.baseURL ?? this.baseURL;
     assertBedrockRequestOrigin(configuredBaseURL, this.buildURL(options.path, null, options.defaultBaseURL));
   }

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -12,6 +12,7 @@ import type { RequestInit } from './internal/builtin-types';
 import type { NullableHeaders } from './internal/headers';
 import { buildHeaders } from './internal/headers';
 import type { FinalRequestOptions, RequestOptions } from './internal/request-options';
+import { prepareAPIKey } from './internal/request-options';
 import { readEnv } from './internal/utils';
 import { addOutputText } from './lib/ResponsesParser';
 import type { ResponseStreamParams } from './lib/responses/ResponseStream';
@@ -250,7 +251,7 @@ export class BedrockOpenAI extends OpenAI {
   protected override async prepareOptions(options: FinalRequestOptions): Promise<void> {
     const security = options.__security ?? { bearerAuth: true };
     if (security.adminAPIKeyAuth && !security.bearerAuth) {
-      await this.prepareAPIKey(options);
+      await this[prepareAPIKey](options);
     }
     await super.prepareOptions(options);
   }

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -266,10 +266,6 @@ export class BedrockOpenAI extends OpenAI {
     context: { url: string; options: FinalRequestOptions },
   ): Promise<void> {
     const configuredBaseURL = this._options.baseURL ?? this.baseURL;
-    assertBedrockRequestOrigin(
-      configuredBaseURL,
-      this.buildURL(context.options.path, null, context.options.defaultBaseURL),
-    );
     assertBedrockRequestOrigin(configuredBaseURL, context.url);
     await super.prepareRequest(request, context);
     request.redirect = 'manual';

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -219,6 +219,7 @@ export class BedrockOpenAI extends OpenAI {
 
     this.bedrockTokenProvider = bedrockTokenProvider;
     this.responses = restoreBedrockStreamOutputText(new API.Responses(this));
+    this.markCredentialHooksSafe(BedrockOpenAI.prototype.prepareOptions, BedrockOpenAI.prototype.authHeaders);
   }
 
   /** Builds and validates the request URL before preparing its body or resolving credentials. */
@@ -232,10 +233,12 @@ export class BedrockOpenAI extends OpenAI {
     return url;
   }
 
-  protected override async prepareOptions(options: FinalRequestOptions): Promise<void> {
+  protected override validateOptionsBeforePreparation(options: FinalRequestOptions): void {
     const configuredBaseURL = this._options.baseURL ?? this.baseURL;
     assertBedrockRequestOrigin(configuredBaseURL, this.buildURL(options.path, null, options.defaultBaseURL));
+  }
 
+  protected override async prepareOptions(options: FinalRequestOptions): Promise<void> {
     const security = options.__security ?? { bearerAuth: true };
     if (security.adminAPIKeyAuth && !security.bearerAuth) {
       await this.prepareAPIKey(options);

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -12,7 +12,7 @@ import type { RequestInit } from './internal/builtin-types';
 import type { NullableHeaders } from './internal/headers';
 import { buildHeaders } from './internal/headers';
 import type { FinalRequestOptions, RequestOptions } from './internal/request-options';
-import { prepareAPIKey } from './internal/request-options';
+import { prepareAPIKey, resolvedAPIKey } from './internal/request-options';
 import { readEnv } from './internal/utils';
 import { addOutputText } from './lib/ResponsesParser';
 import type { ResponseStreamParams } from './lib/responses/ResponseStream';
@@ -276,7 +276,7 @@ export class BedrockOpenAI extends OpenAI {
   ): Promise<NullableHeaders | undefined> {
     const security = schemes ?? { bearerAuth: true, adminAPIKeyAuth: true };
     const credential =
-      security.bearerAuth || security.adminAPIKeyAuth ? await this.resolvedAPIKey(opts) : null;
+      security.bearerAuth || security.adminAPIKeyAuth ? await this[resolvedAPIKey](opts) : null;
     if ((security.bearerAuth || security.adminAPIKeyAuth) && credential !== null) {
       assertValidBedrockBearerCredential(credential);
       try {

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -6,6 +6,7 @@ import {
   assertBedrockRequestOrigin,
   assertValidBedrockBearerCredential,
   brand_privateBedrockClient,
+  registerBedrockClientOrigin,
 } from './internal/bedrock';
 import type { RequestInit } from './internal/builtin-types';
 import type { NullableHeaders } from './internal/headers';
@@ -180,13 +181,16 @@ export class BedrockOpenAI extends OpenAI {
     }
 
     const configuredBaseURL = baseURL?.trim() ? baseURL : deriveBedrockBaseURL(awsRegion);
+    const normalizedBaseURL = normalizeBedrockBaseURL(configuredBaseURL);
 
     super({
       apiKey: bedrockTokenProvider ?? apiKey,
       adminAPIKey: null,
-      baseURL: normalizeBedrockBaseURL(configuredBaseURL),
+      baseURL: normalizedBaseURL,
       ...opts,
     });
+
+    registerBedrockClientOrigin(this, normalizedBaseURL);
 
     let currentApiKey = this.apiKey;
     Object.defineProperty(this, 'apiKey', {
@@ -228,14 +232,8 @@ export class BedrockOpenAI extends OpenAI {
     defaultBaseURL?: string | undefined,
   ): string {
     const url = super.buildURL(path, query, defaultBaseURL);
-    this.validateRequestURL(url);
-    return url;
-  }
-
-  /** Validates the final URL returned by request construction, including subclass overrides. */
-  protected override validateRequestURL(url: string): void {
-    super.validateRequestURL(url);
     assertBedrockRequestOrigin(this._options.baseURL ?? this.baseURL, url);
+    return url;
   }
 
   protected override async prepareOptions(options: FinalRequestOptions): Promise<void> {

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -228,8 +228,14 @@ export class BedrockOpenAI extends OpenAI {
     defaultBaseURL?: string | undefined,
   ): string {
     const url = super.buildURL(path, query, defaultBaseURL);
-    assertBedrockRequestOrigin(this._options.baseURL ?? this.baseURL, url);
+    this.validateRequestURL(url);
     return url;
+  }
+
+  /** Validates the final URL returned by request construction, including subclass overrides. */
+  protected override validateRequestURL(url: string): void {
+    super.validateRequestURL(url);
+    assertBedrockRequestOrigin(this._options.baseURL ?? this.baseURL, url);
   }
 
   protected override async prepareOptions(options: FinalRequestOptions): Promise<void> {

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -221,6 +221,17 @@ export class BedrockOpenAI extends OpenAI {
     this.responses = restoreBedrockStreamOutputText(new API.Responses(this));
   }
 
+  /** Builds and validates the request URL before preparing its body or resolving credentials. */
+  override buildURL(
+    path: string,
+    query: Record<string, unknown> | null | undefined,
+    defaultBaseURL?: string | undefined,
+  ): string {
+    const url = super.buildURL(path, query, defaultBaseURL);
+    assertBedrockRequestOrigin(this._options.baseURL ?? this.baseURL, url);
+    return url;
+  }
+
   protected override async prepareOptions(options: FinalRequestOptions): Promise<void> {
     const configuredBaseURL = this._options.baseURL ?? this.baseURL;
     assertBedrockRequestOrigin(configuredBaseURL, this.buildURL(options.path, null, options.defaultBaseURL));
@@ -262,7 +273,7 @@ export class BedrockOpenAI extends OpenAI {
       }
     }
 
-    return super.authHeaders(opts, security);
+    return undefined;
   }
 
   /** Clones this client while preserving its refreshable Bedrock token provider when appropriate. */

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -12,12 +12,7 @@ import type { RequestInit } from './internal/builtin-types';
 import type { NullableHeaders } from './internal/headers';
 import { buildHeaders } from './internal/headers';
 import type { FinalRequestOptions, RequestOptions } from './internal/request-options';
-import {
-  markCredentialHooksSafe,
-  prepareAPIKey,
-  resolvedAPIKey,
-  validateOptionsBeforePreparation,
-} from './internal/request-options';
+import { markCredentialHooksSafe, prepareAPIKey, resolvedAPIKey } from './internal/request-options';
 import { readEnv } from './internal/utils';
 import { addOutputText } from './lib/ResponsesParser';
 import type { ResponseStreamParams } from './lib/responses/ResponseStream';
@@ -248,12 +243,10 @@ export class BedrockOpenAI extends OpenAI {
     return url;
   }
 
-  protected override [validateOptionsBeforePreparation](options: FinalRequestOptions): void {
+  protected override async prepareOptions(options: FinalRequestOptions): Promise<void> {
     const configuredBaseURL = this._options.baseURL ?? this.baseURL;
     assertBedrockRequestOrigin(configuredBaseURL, this.buildURL(options.path, null, options.defaultBaseURL));
-  }
 
-  protected override async prepareOptions(options: FinalRequestOptions): Promise<void> {
     const security = options.__security ?? { bearerAuth: true };
     if (security.adminAPIKeyAuth && !security.bearerAuth) {
       await this[prepareAPIKey](options);

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -265,12 +265,7 @@ export class BedrockOpenAI extends OpenAI {
     request: RequestInit,
     context: { url: string; options: FinalRequestOptions },
   ): Promise<void> {
-    const configuredBaseURL = this._options.baseURL ?? this.baseURL;
-    assertBedrockRequestOrigin(
-      configuredBaseURL,
-      this.buildURL(context.options.path, null, context.options.defaultBaseURL),
-    );
-    assertBedrockRequestOrigin(configuredBaseURL, context.url);
+    assertBedrockRequestOrigin(this._options.baseURL ?? this.baseURL, context.url);
     await super.prepareRequest(request, context);
     request.redirect = 'manual';
   }

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -290,7 +290,7 @@ export class BedrockOpenAI extends OpenAI {
       }
     }
 
-    return undefined;
+    return security.bearerAuth ? await super.authHeaders(opts, security) : undefined;
   }
 
   /** Clones this client while preserving its refreshable Bedrock token provider when appropriate. */

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -224,6 +224,7 @@ export class BedrockOpenAI extends OpenAI {
     this.bedrockTokenProvider = bedrockTokenProvider;
     this.responses = restoreBedrockStreamOutputText(new API.Responses(this));
     this.markCredentialHooksSafe(
+      BedrockOpenAI.prototype.buildURL,
       BedrockOpenAI.prototype.prepareOptions,
       BedrockOpenAI.prototype.authHeaders,
       BedrockOpenAI.prototype.prepareRequest,

--- a/src/bedrock.ts
+++ b/src/bedrock.ts
@@ -225,20 +225,20 @@ export class BedrockOpenAI extends OpenAI {
     const configuredBaseURL = this._options.baseURL ?? this.baseURL;
     assertBedrockRequestOrigin(configuredBaseURL, this.buildURL(options.path, null, options.defaultBaseURL));
 
-    const security = options.__security ?? { bearerAuth: true };
-    if (security.adminAPIKeyAuth && !security.bearerAuth) {
-      await this._callApiKey();
-    }
-
     await super.prepareOptions(options);
-    assertBedrockRequestOrigin(configuredBaseURL, this.buildURL(options.path, null, options.defaultBaseURL));
   }
 
   protected override async prepareRequest(
     request: RequestInit,
     context: { url: string; options: FinalRequestOptions },
   ): Promise<void> {
-    assertBedrockRequestOrigin(this._options.baseURL ?? this.baseURL, context.url);
+    const configuredBaseURL = this._options.baseURL ?? this.baseURL;
+    // Credentials now resolve during header construction, after prepareOptions.
+    assertBedrockRequestOrigin(
+      configuredBaseURL,
+      this.buildURL(context.options.path, null, context.options.defaultBaseURL),
+    );
+    assertBedrockRequestOrigin(configuredBaseURL, context.url);
     await super.prepareRequest(request, context);
     request.redirect = 'manual';
   }
@@ -248,7 +248,7 @@ export class BedrockOpenAI extends OpenAI {
     schemes?: { bearerAuth?: boolean; adminAPIKeyAuth?: boolean },
   ): Promise<NullableHeaders | undefined> {
     const security = schemes ?? { bearerAuth: true, adminAPIKeyAuth: true };
-    const credential = this.apiKey;
+    const credential = security.bearerAuth || security.adminAPIKeyAuth ? await this.resolveAPIKey() : null;
     if ((security.bearerAuth || security.adminAPIKeyAuth) && credential !== null) {
       assertValidBedrockBearerCredential(credential);
       try {

--- a/src/client.ts
+++ b/src/client.ts
@@ -499,8 +499,9 @@ export class OpenAI {
     }
   >();
   #lastProviderAPIKey: string | null | undefined;
-  #capturingBaseAPIKey = false;
+  #baseAPIKeyCapture: ((apiKey: string | null) => void) | undefined;
   #preparedAPIKeys = new WeakMap<FinalRequestOptions, PreparedAPIKey>();
+  #activeCredentialOptions = new WeakSet<FinalRequestOptions>();
   #synchronousCredentialAttempt: APIKeyPreparationAttempt | undefined;
   #safeCredentialHooks = new Set<Function>([
     OpenAI.prototype._callApiKey,
@@ -906,11 +907,12 @@ export class OpenAI {
     apiKey: string | null,
   ): void {
     if (!capture) return;
-    this.#capturingBaseAPIKey = true;
+    const previousCapture = this.#baseAPIKeyCapture;
+    this.#baseAPIKeyCapture = capture;
     try {
       capture(apiKey);
     } finally {
-      this.#capturingBaseAPIKey = false;
+      this.#baseAPIKeyCapture = previousCapture;
     }
   }
 
@@ -944,16 +946,17 @@ export class OpenAI {
       }
     };
     let captured = false;
-    await this._callApiKey((apiKey) => {
+    const captureAPIKey = (apiKey: string | null) => {
       captured = true;
-      const capturedByBase = this.#capturingBaseAPIKey;
+      const capturedByBase = this.#baseAPIKeyCapture === captureAPIKey;
       remember({
         apiKey,
         tracksClientValue: apiKey === this.apiKey,
         allowClientOverride: this.hasCustomRequestCredentialHooks(),
         explicitCapture: !this.#safeCredentialHooks.has(this._callApiKey) && !capturedByBase,
       });
-    });
+    };
+    await this._callApiKey(captureAPIKey);
     if (!captured) {
       remember({
         apiKey: this.apiKey,
@@ -1293,12 +1296,23 @@ export class OpenAI {
     retriesRemaining: number | null,
     retryOfRequestLogID: string | undefined,
   ): Promise<APIResponseProps> {
-    const options = await optionsInput;
+    const inputOptions = await optionsInput;
+    // A request hook may recursively or concurrently reuse its caller's options.
+    // Give only those overlapping attempts a distinct WeakMap identity while
+    // forwarding all reads and writes to the original object.
+    const options =
+      this.hasCustomCredentialHooks() && this.#activeCredentialOptions.has(inputOptions)
+        ? new Proxy(inputOptions, {
+            get: (target, property) => Reflect.get(target, property, target),
+            set: (target, property, value) => Reflect.set(target, property, value, target),
+          })
+        : inputOptions;
     const maxRetries = options.maxRetries ?? this.maxRetries;
     if (retriesRemaining == null) {
       retriesRemaining = maxRetries;
     }
 
+    this.#activeCredentialOptions.add(options);
     const x509Authentication = this.#x509Authentication;
     x509Authentication?.beginRequestPreparation();
     const preparationAttempt: APIKeyPreparationAttempt = {};
@@ -1315,6 +1329,7 @@ export class OpenAI {
       await preparation;
     } catch (error) {
       this.#preparedAPIKeys.delete(options);
+      this.#activeCredentialOptions.delete(options);
       throw error;
     }
     let preparedAPIKey = preparationAttempt.prepared ?? this.#preparedAPIKeys.get(options);
@@ -1329,6 +1344,7 @@ export class OpenAI {
       }
     } catch (error) {
       this.#preparedAPIKeys.delete(options);
+      this.#activeCredentialOptions.delete(options);
       throw error;
     }
 
@@ -1384,6 +1400,7 @@ export class OpenAI {
     } catch (error) {
       apiKeyBuildContext.active = false;
       this.#preparedAPIKeys.delete(options);
+      this.#activeCredentialOptions.delete(options);
       x509Authentication?.retireRequestBody();
       if (
         x509Authentication &&
@@ -1400,6 +1417,7 @@ export class OpenAI {
       }
       throw error;
     }
+    this.#activeCredentialOptions.delete(options);
     const { req, url } = built;
     const timeout = x509Authentication
       ? Math.min(built.timeout, x509Authentication.requestSnapshot().timeout)

--- a/src/client.ts
+++ b/src/client.ts
@@ -977,7 +977,7 @@ export class OpenAI {
     if (attempts.length === 0) this.#apiKeyPreparationAttempts.delete(options);
   }
 
-  protected async prepareAPIKey(options: FinalRequestOptions): Promise<void> {
+  protected async [Opts.prepareAPIKey](options: FinalRequestOptions): Promise<void> {
     const attempt = this.#synchronousCredentialAttempt ?? this.currentAPIKeyPreparationAttempt(options);
     const remember = (prepared: PreparedAPIKey) => {
       if (attempt) {
@@ -1092,7 +1092,7 @@ export class OpenAI {
 
     const security = options.__security ?? { bearerAuth: true };
     if (security.bearerAuth) {
-      await this.prepareAPIKey(options);
+      await this[Opts.prepareAPIKey](options);
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -251,6 +251,7 @@ import {
   ChatCompletionsPage,
 } from './resources/chat/completions/completions';
 import { type Fetch } from './internal/builtin-types';
+import { assertBedrockClientRequestOrigin } from './internal/bedrock';
 import { isRunningInBrowser } from './internal/detect-platform';
 import { HeadersLike, NullableHeaders, buildHeaders } from './internal/headers';
 import { configureProvider, type Provider, type ProviderRuntime } from './internal/provider';
@@ -746,9 +747,6 @@ export class OpenAI {
   protected defaultQuery(): Record<string, string | undefined> | undefined {
     return this._options.defaultQuery;
   }
-
-  /** Validates the final routed URL before constructing a body or authentication headers. */
-  protected validateRequestURL(url: string): void {}
 
   protected validateHeaders(
     { values, nulls }: NullableHeaders,
@@ -1814,7 +1812,7 @@ export class OpenAI {
     const { method, path, query, defaultBaseURL } = options;
 
     const url = this.buildURL(path!, query as Record<string, unknown>, defaultBaseURL);
-    this.validateRequestURL(url);
+    assertBedrockClientRequestOrigin(this, url);
     x509Authentication?.snapshotAPIURL(url);
     const explicitTimeout = 'timeout' in options;
     if (explicitTimeout) validatePositiveInteger('timeout', options.timeout);

--- a/src/client.ts
+++ b/src/client.ts
@@ -306,6 +306,10 @@ type APIKeyBuildContext = {
   prepared: PreparedAPIKey | undefined;
   active: boolean;
 };
+type APIKeyWriteObservation = {
+  depth: number;
+  restore: () => boolean;
+};
 type InternalBuildProperties = {
   retryCount?: number;
   [preparedAPIKeyContext]?: APIKeyBuildContext;
@@ -506,9 +510,8 @@ export class OpenAI {
   #lastProviderAPIKey: string | null | undefined;
   #apiKeyWriteVersion = 0;
   #lastProviderAPIKeyWriteVersion = 0;
-  #apiKeyWriteObserver: ((apiKey: string | null) => void) | undefined;
-  #apiKeyWriteObservationDepth = 0;
-  #restoreAPIKeyWriteDescriptor: (() => void) | undefined;
+  #writingProviderAPIKey = false;
+  #apiKeyWriteObservations = new Map<Function, APIKeyWriteObservation>();
   #baseAPIKeyCapture: { apiKey: string | null } | undefined;
   #apiKeyPreparationAttempts = new WeakMap<FinalRequestOptions, APIKeyPreparationAttempt[]>();
   #synchronousCredentialAttempt: APIKeyPreparationAttempt | undefined;
@@ -910,7 +913,12 @@ export class OpenAI {
     }
 
     const resolved = await this.resolveAPIKeyProvider(apiKey);
-    this.apiKey = resolved;
+    this.#writingProviderAPIKey = true;
+    try {
+      this.apiKey = resolved;
+    } finally {
+      this.#writingProviderAPIKey = false;
+    }
     this.#lastProviderAPIKeyWriteVersion = this.#apiKeyWriteVersion;
     if (capture) {
       const currentAPIKey = this.apiKey;
@@ -1014,10 +1022,12 @@ export class OpenAI {
 
   #observeAPIKeyWrites(): (() => void) | undefined {
     if (typeof this._options.apiKey !== 'function' || !this.hasCustomRequestCredentialHooks()) return;
-    if (this.#apiKeyWriteObservationDepth) {
-      if (Object.getOwnPropertyDescriptor(this, 'apiKey')?.set !== this.#apiKeyWriteObserver) return;
-      this.#apiKeyWriteObservationDepth++;
-      return () => this.#releaseAPIKeyWriteObserver();
+    const ownDescriptor = Object.getOwnPropertyDescriptor(this, 'apiKey');
+    const activeObserver = ownDescriptor?.set;
+    const activeObservation = activeObserver ? this.#apiKeyWriteObservations.get(activeObserver) : undefined;
+    if (activeObserver && activeObservation) {
+      activeObservation.depth++;
+      return this.#releaseAPIKeyWriteObserver(activeObserver, activeObservation);
     }
     let owner: object | null = this;
     let descriptor: PropertyDescriptor | undefined;
@@ -1025,19 +1035,18 @@ export class OpenAI {
       descriptor = Object.getOwnPropertyDescriptor(owner, 'apiKey');
       if (!descriptor) owner = Object.getPrototypeOf(owner);
     }
-    if (
-      !descriptor?.configurable ||
-      (this.#apiKeyWriteObserver && descriptor.set === this.#apiKeyWriteObserver)
-    ) {
-      return;
-    }
+    if (!descriptor?.configurable) return;
 
     const client = this;
     const inherited = owner !== this;
+    if (inherited && !Object.isExtensible(this)) return;
     let getter = descriptor.get;
     let setter = descriptor.set;
     let dataValue: { apiKey: string | null } | undefined;
+    let dataWrittenToClient = false;
     let observer: (this: OpenAI, next: string | null) => void;
+    let observedDescriptor: PropertyDescriptor;
+    let observation: APIKeyWriteObservation;
     const targetsClient = (receiver: OpenAI) => {
       if (receiver === client) return true;
       try {
@@ -1051,11 +1060,51 @@ export class OpenAI {
       dataValue = { apiKey: descriptor.value };
       getter = () => dataValue!.apiKey;
       setter = function (this: OpenAI, next: string | null) {
-        if (targetsClient(this)) {
-          dataValue!.apiKey = next;
-        } else if (!Reflect.set(dataValue!, 'apiKey', next, this)) {
+        const observesClient = targetsClient(this);
+        const current = Object.getOwnPropertyDescriptor(client, 'apiKey');
+        if (
+          current &&
+          current.get === observedDescriptor.get &&
+          current.set === observer &&
+          current.configurable
+        ) {
+          if (inherited) {
+            Reflect.deleteProperty(client, 'apiKey');
+          } else {
+            Object.defineProperty(client, 'apiKey', {
+              ...descriptor,
+              value: dataValue!.apiKey,
+              enumerable: current.enumerable ?? false,
+            });
+          }
+          let writeSucceeded = false;
+          try {
+            if (!Reflect.set(client, 'apiKey', next, this)) {
+              throw new TypeError('Cannot assign to read only property apiKey');
+            }
+            writeSucceeded = true;
+          } finally {
+            const after = Object.getOwnPropertyDescriptor(client, 'apiKey');
+            if (after && 'value' in after) dataValue!.apiKey = after.value;
+            if (
+              (!writeSucceeded ||
+                !observesClient ||
+                client.#writingProviderAPIKey ||
+                observation.depth > 1) &&
+              ((!after && inherited && Object.isExtensible(client)) ||
+                (after && 'value' in after && after.configurable && after.writable))
+            ) {
+              observedDescriptor.enumerable = after?.enumerable ?? observedDescriptor.enumerable ?? false;
+              Object.defineProperty(client, 'apiKey', observedDescriptor);
+            }
+          }
+          if (observesClient) dataWrittenToClient = true;
+          return;
+        }
+        if (!Reflect.set(dataValue!, 'apiKey', next, observesClient ? dataValue! : this)) {
           throw new TypeError('Cannot assign to read only property apiKey');
         }
+        if (observesClient) dataWrittenToClient = true;
       };
     }
     if (!setter) return;
@@ -1065,43 +1114,63 @@ export class OpenAI {
       originalSetter.call(this, next);
       if (observesClient) client.#apiKeyWriteVersion++;
     };
-    const observedDescriptor: PropertyDescriptor = {
+    observedDescriptor = {
       ...(getter && { get: getter }),
       set: observer,
       enumerable: descriptor.enumerable ?? false,
       configurable: descriptor.configurable,
     };
     Object.defineProperty(this, 'apiKey', observedDescriptor);
-    this.#apiKeyWriteObserver = observer;
-    this.#apiKeyWriteObservationDepth = 1;
-    this.#restoreAPIKeyWriteDescriptor = () => {
-      const current = Object.getOwnPropertyDescriptor(this, 'apiKey');
-      if (
-        current?.get !== observedDescriptor.get ||
-        current?.set !== observer ||
-        current.enumerable !== observedDescriptor.enumerable ||
-        current.configurable !== observedDescriptor.configurable
-      ) {
-        return;
-      }
-      if (inherited) {
-        Reflect.deleteProperty(this, 'apiKey');
-      } else if (dataValue) {
-        Object.defineProperty(this, 'apiKey', { ...descriptor, value: dataValue.apiKey });
-      } else {
-        Object.defineProperty(this, 'apiKey', descriptor);
-      }
+    observation = {
+      depth: 1,
+      restore: () => {
+        const current = Object.getOwnPropertyDescriptor(this, 'apiKey');
+        if (current?.set !== observer) return true;
+        if (current.get !== observedDescriptor.get || !current.configurable) return false;
+        if (inherited) {
+          if (dataValue && dataWrittenToClient) {
+            Object.defineProperty(this, 'apiKey', {
+              value: dataValue.apiKey,
+              writable: true,
+              enumerable: true,
+              configurable: true,
+            });
+          } else {
+            Reflect.deleteProperty(this, 'apiKey');
+          }
+        } else if (dataValue) {
+          Object.defineProperty(this, 'apiKey', {
+            ...descriptor,
+            value: dataValue.apiKey,
+            enumerable: current.enumerable ?? false,
+          });
+        } else {
+          Object.defineProperty(this, 'apiKey', {
+            ...descriptor,
+            enumerable: current.enumerable ?? false,
+          });
+        }
+        return true;
+      },
     };
-    return () => this.#releaseAPIKeyWriteObserver();
+    this.#apiKeyWriteObservations.set(observer, observation);
+    return this.#releaseAPIKeyWriteObserver(observer, observation);
   }
 
-  #releaseAPIKeyWriteObserver(): void {
-    if (--this.#apiKeyWriteObservationDepth > 0) return;
-    this.#apiKeyWriteObservationDepth = 0;
-    const restore = this.#restoreAPIKeyWriteDescriptor;
-    this.#restoreAPIKeyWriteDescriptor = undefined;
-    this.#apiKeyWriteObserver = undefined;
-    restore?.();
+  #releaseAPIKeyWriteObserver(observer: Function, observation: APIKeyWriteObservation): () => void {
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      if (--observation.depth > 0) return;
+      observation.depth = 0;
+      if (observation.restore()) this.#apiKeyWriteObservations.delete(observer);
+    };
+  }
+
+  #consumeAPIKeyWrite(): void {
+    this.#lastProviderAPIKey = this.apiKey;
+    this.#lastProviderAPIKeyWriteVersion = this.#apiKeyWriteVersion;
   }
 
   protected async [Opts.prepareAPIKey](options: FinalRequestOptions): Promise<void> {
@@ -1123,13 +1192,10 @@ export class OpenAI {
       });
     };
     await this._callApiKey(captureAPIKey);
+    const postDelegationWrite =
+      !this.#safeCredentialHooks.has(this._callApiKey) && this.apiKey !== this.#lastProviderAPIKey;
     const prepared = attempt?.prepared;
-    if (
-      prepared &&
-      !prepared.explicitCapture &&
-      !this.#safeCredentialHooks.has(this._callApiKey) &&
-      this.apiKey !== this.#lastProviderAPIKey
-    ) {
+    if (prepared && !prepared.explicitCapture && postDelegationWrite) {
       prepared.apiKey = this.apiKey;
       prepared.tracksClientValue = true;
     }
@@ -1141,6 +1207,7 @@ export class OpenAI {
         explicitCapture: false,
       });
     }
+    if (postDelegationWrite) this.#consumeAPIKeyWrite();
   }
 
   protected async [Opts.resolvedAPIKey](options: FinalRequestOptions): Promise<string | null> {
@@ -1178,10 +1245,9 @@ export class OpenAI {
       capturedByBase = this.#baseAPIKeyCapture?.apiKey === apiKey;
     });
     const explicitCapture = captured && !this.#safeCredentialHooks.has(this._callApiKey) && !capturedByBase;
-    const postDelegationOverride =
-      !explicitCapture &&
-      !this.#safeCredentialHooks.has(this._callApiKey) &&
-      this.apiKey !== this.#lastProviderAPIKey;
+    const postDelegationWrite =
+      !this.#safeCredentialHooks.has(this._callApiKey) && this.apiKey !== this.#lastProviderAPIKey;
+    const postDelegationOverride = !explicitCapture && postDelegationWrite;
     const apiKey = captured && !postDelegationOverride ? resolved : this.apiKey;
     if (attempt) {
       attempt.prepared = {
@@ -1191,6 +1257,7 @@ export class OpenAI {
         explicitCapture,
       };
     }
+    if (postDelegationWrite) this.#consumeAPIKeyWrite();
     return apiKey;
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -480,6 +480,11 @@ export class OpenAI {
       continueRequest?: <T>(operation: () => Promise<T>) => Promise<T>;
     }
   >();
+  #apiKeyResolution = 0;
+  #preparedAPIKeys = new WeakMap<
+    FinalRequestOptions,
+    { apiKey: string | null; resolution: number; tracksClientValue: boolean }
+  >();
   protected idempotencyHeader?: string;
   protected _options: ClientOptions;
   private _provider: ProviderRuntime | undefined;
@@ -813,7 +818,7 @@ export class OpenAI {
           : await authentication.getToken();
       return buildHeaders([{ Authorization: `Bearer ${token}` }]);
     }
-    const apiKey = await this.resolveAPIKey();
+    const apiKey = await this.resolvedAPIKey(opts);
     if (apiKey == null) {
       return undefined;
     }
@@ -866,24 +871,41 @@ export class OpenAI {
     }
 
     this.apiKey = await this.resolveAPIKeyProvider(apiKey);
+    this.#apiKeyResolution += 1;
     capture?.(this.apiKey);
     return true;
   }
 
-  /**
-   * Resolves the credential for the current authentication header construction.
-   * Overrides return their credential directly; callers use the returned value,
-   * since another request can update the shared `apiKey` property after an await.
-   */
-  protected async resolveAPIKey(): Promise<string | null> {
-    const apiKey = this._options.apiKey;
-    if (this._provider || typeof apiKey !== 'function') {
-      return this.apiKey;
+  protected async prepareAPIKey(options: FinalRequestOptions): Promise<void> {
+    let captured = false;
+    await this._callApiKey((apiKey) => {
+      captured = true;
+      this.#preparedAPIKeys.set(options, {
+        apiKey,
+        resolution: this.#apiKeyResolution,
+        tracksClientValue: apiKey === this.apiKey,
+      });
+    });
+    if (!captured) {
+      this.#preparedAPIKeys.set(options, {
+        apiKey: this.apiKey,
+        resolution: this.#apiKeyResolution,
+        tracksClientValue: true,
+      });
     }
+  }
 
-    this.apiKey = await this.resolveAPIKeyProvider(apiKey);
-    // Preserve provider-specific getters before yielding the captured credential.
-    return this.apiKey;
+  protected async resolvedAPIKey(options: FinalRequestOptions): Promise<string | null> {
+    const prepared = this.#preparedAPIKeys.get(options);
+    if (prepared) return prepared.apiKey;
+
+    let resolved = this.apiKey;
+    let captured = false;
+    await this._callApiKey((apiKey) => {
+      captured = true;
+      resolved = apiKey;
+    });
+    return captured ? resolved : this.apiKey;
   }
 
   private async resolveAPIKeyProvider(apiKey: ApiKeySetter): Promise<string> {
@@ -932,9 +954,15 @@ export class OpenAI {
 
   /**
    * Used as a callback for mutating the given `FinalRequestOptions` object.
-   * Function credentials are resolved later, when authentication headers are built.
    */
-  protected async prepareOptions(options: FinalRequestOptions): Promise<void> {}
+  protected async prepareOptions(options: FinalRequestOptions): Promise<void> {
+    if (this._provider) return;
+
+    const security = options.__security ?? { bearerAuth: true };
+    if (security.bearerAuth) {
+      await this.prepareAPIKey(options);
+    }
+  }
 
   /**
    * Used as a callback for mutating the given `RequestInit` object.
@@ -1184,6 +1212,15 @@ export class OpenAI {
     const x509Authentication = this.#x509Authentication;
     x509Authentication?.beginRequestPreparation();
     await this.prepareOptions(options);
+    const preparedAPIKey = this.#preparedAPIKeys.get(options);
+    if (
+      preparedAPIKey?.tracksClientValue &&
+      preparedAPIKey.resolution === this.#apiKeyResolution &&
+      preparedAPIKey.apiKey !== this.apiKey
+    ) {
+      // Preserve subclasses that assign `this.apiKey` after `super.prepareOptions()`.
+      this.#preparedAPIKeys.set(options, { ...preparedAPIKey, apiKey: this.apiKey });
+    }
 
     x509Authentication?.beginRequestPlanning();
     let built: { req: FinalizedRequestInit; url: string; timeout: number };

--- a/src/client.ts
+++ b/src/client.ts
@@ -747,6 +747,9 @@ export class OpenAI {
     return this._options.defaultQuery;
   }
 
+  /** Validates the final routed URL before constructing a body or authentication headers. */
+  protected validateRequestURL(url: string): void {}
+
   protected validateHeaders(
     { values, nulls }: NullableHeaders,
     schemes: { bearerAuth?: boolean; adminAPIKeyAuth?: boolean } = {
@@ -1811,6 +1814,7 @@ export class OpenAI {
     const { method, path, query, defaultBaseURL } = options;
 
     const url = this.buildURL(path!, query as Record<string, unknown>, defaultBaseURL);
+    this.validateRequestURL(url);
     x509Authentication?.snapshotAPIURL(url);
     const explicitTimeout = 'timeout' in options;
     if (explicitTimeout) validatePositiveInteger('timeout', options.timeout);

--- a/src/client.ts
+++ b/src/client.ts
@@ -503,6 +503,9 @@ export class OpenAI {
     }
   >();
   #lastProviderAPIKey: string | null | undefined;
+  #apiKeyWriteVersion = 0;
+  #lastProviderAPIKeyWriteVersion = 0;
+  #apiKeyWriteObserver: ((apiKey: string | null) => void) | undefined;
   #baseAPIKeyCapture: { apiKey: string | null } | undefined;
   #apiKeyPreparationAttempts = new WeakMap<FinalRequestOptions, APIKeyPreparationAttempt[]>();
   #synchronousCredentialAttempt: APIKeyPreparationAttempt | undefined;
@@ -902,6 +905,7 @@ export class OpenAI {
 
     const resolved = await this.resolveAPIKeyProvider(apiKey);
     this.apiKey = resolved;
+    this.#lastProviderAPIKeyWriteVersion = this.#apiKeyWriteVersion;
     if (capture) {
       const currentAPIKey = this.apiKey;
       this.#lastProviderAPIKey = currentAPIKey;
@@ -996,6 +1000,44 @@ export class OpenAI {
     if (attempts.length === 0) this.#apiKeyPreparationAttempts.delete(options);
   }
 
+  #observeAPIKeyWrites(): void {
+    if (typeof this._options.apiKey !== 'function' || !this.hasCustomRequestCredentialHooks()) return;
+    const descriptor = Object.getOwnPropertyDescriptor(this, 'apiKey');
+    if (
+      !descriptor?.configurable ||
+      (this.#apiKeyWriteObserver && descriptor.set === this.#apiKeyWriteObserver)
+    ) {
+      return;
+    }
+
+    const client = this;
+    let getter = descriptor.get;
+    let setter = descriptor.set;
+    if ('value' in descriptor) {
+      if (!descriptor.writable) return;
+      const value: { apiKey: string | null } = { apiKey: descriptor.value };
+      getter = () => value.apiKey;
+      setter = function (this: OpenAI, next: string | null) {
+        if (!Reflect.set(value, 'apiKey', next, this === client ? value : this)) {
+          throw new TypeError('Cannot assign to read only property apiKey');
+        }
+      };
+    }
+    if (!setter) return;
+    const originalSetter = setter;
+    const observer = function (this: OpenAI, next: string | null) {
+      originalSetter.call(this, next);
+      if (this === client) client.#apiKeyWriteVersion++;
+    };
+    Object.defineProperty(this, 'apiKey', {
+      ...(getter && { get: getter }),
+      set: observer,
+      enumerable: descriptor.enumerable ?? false,
+      configurable: descriptor.configurable,
+    });
+    this.#apiKeyWriteObserver = observer;
+  }
+
   protected async [Opts.prepareAPIKey](options: FinalRequestOptions): Promise<void> {
     const attempt = this.#synchronousCredentialAttempt ?? this.currentAPIKeyPreparationAttempt(options);
     const remember = (prepared: PreparedAPIKey) => {
@@ -1042,8 +1084,9 @@ export class OpenAI {
     }
     if (
       this.hasCustomRequestCredentialHooks() &&
-      this.apiKey !== null &&
-      this.apiKey !== this.#lastProviderAPIKey
+      (this.apiKey !== null
+        ? this.apiKey !== this.#lastProviderAPIKey
+        : this.#apiKeyWriteVersion > this.#lastProviderAPIKeyWriteVersion)
     ) {
       // Direct builds historically let credential hooks select `this.apiKey` without
       // invoking the configured provider through `prepareOptions`.
@@ -1948,6 +1991,8 @@ export class OpenAI {
     inputOptions: FinalRequestOptions,
     properties: { retryCount?: number } = {},
   ): Promise<{ req: FinalizedRequestInit; url: string; timeout: number }> {
+    // A hook can intentionally assign the function credential's initial null value.
+    this.#observeAPIKeyWrites();
     const { retryCount = 0 } = properties;
     const internalProperties = properties as InternalBuildProperties;
     const apiKeyContext = internalProperties[preparedAPIKeyContext];

--- a/src/client.ts
+++ b/src/client.ts
@@ -1770,6 +1770,12 @@ export class OpenAI {
       x509Headers,
       x509Timeout: explicitTimeout ? options.timeout : undefined,
       x509Tenant,
+    }).catch((error) => {
+      if (isStreamingBody && body !== options.body && !x509Authentication) {
+        // Retire the SDK-created adapter without delaying or masking the header error.
+        void Shims.CancelReadableStream(body).catch(() => undefined);
+      }
+      throw error;
     });
 
     const req: FinalizedRequestInit = {

--- a/src/client.ts
+++ b/src/client.ts
@@ -513,7 +513,7 @@ export class OpenAI {
   #writingProviderAPIKey = false;
   #apiKeyWriteObservations = new Map<Function, APIKeyWriteObservation>();
   #apiKeyBuildObservationDepth = 0;
-  #deferredAPIKeyWriteObserverReleases: Array<() => void> = [];
+  #deferredAPIKeyWriteObserver: { observer: Function; release: () => void } | undefined;
   #baseAPIKeyCapture: { apiKey: string | null } | undefined;
   #apiKeyPreparationAttempts = new WeakMap<FinalRequestOptions, APIKeyPreparationAttempt[]>();
   #synchronousCredentialAttempt: APIKeyPreparationAttempt | undefined;
@@ -916,9 +916,20 @@ export class OpenAI {
 
     const resolved = await this.resolveAPIKeyProvider(apiKey);
     if (this.#apiKeyBuildObservationDepth > 0) {
-      const releaseAPIKeyWriteObserver = this.#observeAPIKeyWrites();
-      if (releaseAPIKeyWriteObserver) {
-        this.#deferredAPIKeyWriteObserverReleases.push(releaseAPIKeyWriteObserver);
+      const activeObserver = Object.getOwnPropertyDescriptor(this, 'apiKey')?.set;
+      if (
+        !this.#deferredAPIKeyWriteObserver ||
+        this.#deferredAPIKeyWriteObserver.observer !== activeObserver
+      ) {
+        this.#deferredAPIKeyWriteObserver?.release();
+        this.#deferredAPIKeyWriteObserver = undefined;
+        const release = this.#observeAPIKeyWrites();
+        const observer = Object.getOwnPropertyDescriptor(this, 'apiKey')?.set;
+        if (release && observer && this.#apiKeyWriteObservations.has(observer)) {
+          this.#deferredAPIKeyWriteObserver = { observer, release };
+        } else {
+          release?.();
+        }
       }
     }
     this.#writingProviderAPIKey = true;
@@ -1182,19 +1193,29 @@ export class OpenAI {
   }
 
   protected async [Opts.prepareAPIKey](options: FinalRequestOptions): Promise<void> {
-    if (!this.#synchronousCredentialAttempt) {
-      let requestSeen = false;
+    let attempt = this.#synchronousCredentialAttempt;
+    if (!attempt) {
+      let requestAttempt: APIKeyPreparationAttempt | undefined;
+      let buildSeen = false;
       for (const candidate of this.#apiKeyPreparationAttempts.get(options) ?? []) {
-        if (candidate.kind !== 'request') continue;
-        if (requestSeen) {
+        if (candidate.kind === 'build') {
+          buildSeen = true;
+          continue;
+        }
+        if (requestAttempt) {
           throw new Errors.OpenAIError(
             'Cannot safely resolve credentials for overlapping requests that share the same options object after a preparation hook awaits before delegating. Pass a distinct options object to each request.',
           );
         }
-        requestSeen = true;
+        requestAttempt = candidate;
       }
+      if (requestAttempt && buildSeen) {
+        throw new Errors.OpenAIError(
+          'Cannot safely resolve credentials for overlapping requests that share the same options object after a preparation hook awaits before delegating. Pass a distinct options object to each request.',
+        );
+      }
+      attempt = requestAttempt ?? this.currentAPIKeyPreparationAttempt(options);
     }
-    const attempt = this.#synchronousCredentialAttempt ?? this.currentAPIKeyPreparationAttempt(options);
     const remember = (prepared: PreparedAPIKey) => {
       if (attempt) {
         attempt.prepared = prepared;
@@ -2161,16 +2182,17 @@ export class OpenAI {
   ): Promise<{ req: FinalizedRequestInit; url: string; timeout: number }> {
     // A hook can intentionally assign the function credential's initial null value.
     this.#apiKeyBuildObservationDepth++;
-    const releaseAPIKeyWriteObserver = this.#observeAPIKeyWrites();
+    let releaseAPIKeyWriteObserver: (() => void) | undefined;
     try {
+      releaseAPIKeyWriteObserver = this.#observeAPIKeyWrites();
       return await this.#buildRequest(inputOptions, properties);
     } finally {
       releaseAPIKeyWriteObserver?.();
       this.#apiKeyBuildObservationDepth--;
       if (this.#apiKeyBuildObservationDepth === 0) {
-        for (const release of this.#deferredAPIKeyWriteObserverReleases.splice(0).reverse()) {
-          release();
-        }
+        const deferredAPIKeyWriteObserver = this.#deferredAPIKeyWriteObserver;
+        this.#deferredAPIKeyWriteObserver = undefined;
+        deferredAPIKeyWriteObserver?.release();
       }
     }
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -506,6 +506,8 @@ export class OpenAI {
   #apiKeyWriteVersion = 0;
   #lastProviderAPIKeyWriteVersion = 0;
   #apiKeyWriteObserver: ((apiKey: string | null) => void) | undefined;
+  #apiKeyWriteObservationDepth = 0;
+  #restoreAPIKeyWriteDescriptor: (() => void) | undefined;
   #baseAPIKeyCapture: { apiKey: string | null } | undefined;
   #apiKeyPreparationAttempts = new WeakMap<FinalRequestOptions, APIKeyPreparationAttempt[]>();
   #synchronousCredentialAttempt: APIKeyPreparationAttempt | undefined;
@@ -1000,9 +1002,19 @@ export class OpenAI {
     if (attempts.length === 0) this.#apiKeyPreparationAttempts.delete(options);
   }
 
-  #observeAPIKeyWrites(): void {
+  #observeAPIKeyWrites(): (() => void) | undefined {
     if (typeof this._options.apiKey !== 'function' || !this.hasCustomRequestCredentialHooks()) return;
-    const descriptor = Object.getOwnPropertyDescriptor(this, 'apiKey');
+    if (this.#apiKeyWriteObservationDepth) {
+      if (Object.getOwnPropertyDescriptor(this, 'apiKey')?.set !== this.#apiKeyWriteObserver) return;
+      this.#apiKeyWriteObservationDepth++;
+      return () => this.#releaseAPIKeyWriteObserver();
+    }
+    let owner: object | null = this;
+    let descriptor: PropertyDescriptor | undefined;
+    while (owner && !descriptor) {
+      descriptor = Object.getOwnPropertyDescriptor(owner, 'apiKey');
+      if (!descriptor) owner = Object.getPrototypeOf(owner);
+    }
     if (
       !descriptor?.configurable ||
       (this.#apiKeyWriteObserver && descriptor.set === this.#apiKeyWriteObserver)
@@ -1011,31 +1023,75 @@ export class OpenAI {
     }
 
     const client = this;
+    const inherited = owner !== this;
     let getter = descriptor.get;
     let setter = descriptor.set;
+    let dataValue: { apiKey: string | null } | undefined;
+    let observer: (this: OpenAI, next: string | null) => void;
+    const targetsClient = (receiver: OpenAI) => {
+      if (receiver === client) return true;
+      try {
+        return Object.getOwnPropertyDescriptor(receiver, 'apiKey')?.set === observer;
+      } catch {
+        return false;
+      }
+    };
     if ('value' in descriptor) {
       if (!descriptor.writable) return;
-      const value: { apiKey: string | null } = { apiKey: descriptor.value };
-      getter = () => value.apiKey;
+      dataValue = { apiKey: descriptor.value };
+      getter = () => dataValue!.apiKey;
       setter = function (this: OpenAI, next: string | null) {
-        if (!Reflect.set(value, 'apiKey', next, this === client ? value : this)) {
+        if (targetsClient(this)) {
+          dataValue!.apiKey = next;
+        } else if (!Reflect.set(dataValue!, 'apiKey', next, this)) {
           throw new TypeError('Cannot assign to read only property apiKey');
         }
       };
     }
     if (!setter) return;
     const originalSetter = setter;
-    const observer = function (this: OpenAI, next: string | null) {
+    observer = function (this: OpenAI, next: string | null) {
+      const observesClient = targetsClient(this);
       originalSetter.call(this, next);
-      if (this === client) client.#apiKeyWriteVersion++;
+      if (observesClient) client.#apiKeyWriteVersion++;
     };
-    Object.defineProperty(this, 'apiKey', {
+    const observedDescriptor: PropertyDescriptor = {
       ...(getter && { get: getter }),
       set: observer,
       enumerable: descriptor.enumerable ?? false,
       configurable: descriptor.configurable,
-    });
+    };
+    Object.defineProperty(this, 'apiKey', observedDescriptor);
     this.#apiKeyWriteObserver = observer;
+    this.#apiKeyWriteObservationDepth = 1;
+    this.#restoreAPIKeyWriteDescriptor = () => {
+      const current = Object.getOwnPropertyDescriptor(this, 'apiKey');
+      if (
+        current?.get !== observedDescriptor.get ||
+        current?.set !== observer ||
+        current.enumerable !== observedDescriptor.enumerable ||
+        current.configurable !== observedDescriptor.configurable
+      ) {
+        return;
+      }
+      if (inherited) {
+        Reflect.deleteProperty(this, 'apiKey');
+      } else if (dataValue) {
+        Object.defineProperty(this, 'apiKey', { ...descriptor, value: dataValue.apiKey });
+      } else {
+        Object.defineProperty(this, 'apiKey', descriptor);
+      }
+    };
+    return () => this.#releaseAPIKeyWriteObserver();
+  }
+
+  #releaseAPIKeyWriteObserver(): void {
+    if (--this.#apiKeyWriteObservationDepth > 0) return;
+    this.#apiKeyWriteObservationDepth = 0;
+    const restore = this.#restoreAPIKeyWriteDescriptor;
+    this.#restoreAPIKeyWriteDescriptor = undefined;
+    this.#apiKeyWriteObserver = undefined;
+    restore?.();
   }
 
   protected async [Opts.prepareAPIKey](options: FinalRequestOptions): Promise<void> {
@@ -1992,7 +2048,18 @@ export class OpenAI {
     properties: { retryCount?: number } = {},
   ): Promise<{ req: FinalizedRequestInit; url: string; timeout: number }> {
     // A hook can intentionally assign the function credential's initial null value.
-    this.#observeAPIKeyWrites();
+    const releaseAPIKeyWriteObserver = this.#observeAPIKeyWrites();
+    try {
+      return await this.#buildRequest(inputOptions, properties);
+    } finally {
+      releaseAPIKeyWriteObserver?.();
+    }
+  }
+
+  async #buildRequest(
+    inputOptions: FinalRequestOptions,
+    properties: { retryCount?: number } = {},
+  ): Promise<{ req: FinalizedRequestInit; url: string; timeout: number }> {
     const { retryCount = 0 } = properties;
     const internalProperties = properties as InternalBuildProperties;
     const apiKeyContext = internalProperties[preparedAPIKeyContext];

--- a/src/client.ts
+++ b/src/client.ts
@@ -845,7 +845,7 @@ export class OpenAI {
           : await authentication.getToken();
       return buildHeaders([{ Authorization: `Bearer ${token}` }]);
     }
-    const apiKey = await this.resolvedAPIKey(opts);
+    const apiKey = await this[Opts.resolvedAPIKey](opts);
     if (apiKey == null) {
       return undefined;
     }
@@ -1006,7 +1006,7 @@ export class OpenAI {
     }
   }
 
-  protected async resolvedAPIKey(options: FinalRequestOptions): Promise<string | null> {
+  protected async [Opts.resolvedAPIKey](options: FinalRequestOptions): Promise<string | null> {
     const prepared = this.currentAPIKeyPreparationAttempt(options)?.prepared;
     if (prepared) {
       if (prepared.explicitCapture) return prepared.apiKey;

--- a/src/client.ts
+++ b/src/client.ts
@@ -287,6 +287,24 @@ function isRunningInBrowserOrBrowserWorker(): boolean {
 
 const WORKLOAD_IDENTITY_API_KEY_PLACEHOLDER = 'workload-identity-auth';
 const inheritedDataResidencySelection = Symbol('inheritedDataResidencySelection');
+const preparedAPIKeyContext = Symbol('preparedAPIKeyContext');
+type PreparedAPIKey = {
+  apiKey: string | null;
+  tracksClientValue: boolean;
+  allowClientOverride: boolean;
+  explicitCapture: boolean;
+};
+
+type APIKeyPreparationAttempt = { prepared?: PreparedAPIKey };
+type APIKeyBuildContext = {
+  owner: OpenAI;
+  prepared: PreparedAPIKey | undefined;
+  active: boolean;
+};
+type InternalBuildProperties = {
+  retryCount?: number;
+  [preparedAPIKeyContext]?: APIKeyBuildContext;
+};
 type InternalClientOptions = ClientOptions & { [inheritedDataResidencySelection]?: boolean };
 
 export type ApiKeySetter = () => Promise<string>;
@@ -480,11 +498,17 @@ export class OpenAI {
       continueRequest?: <T>(operation: () => Promise<T>) => Promise<T>;
     }
   >();
-  #apiKeyResolution = 0;
-  #preparedAPIKeys = new WeakMap<
-    FinalRequestOptions,
-    { apiKey: string | null; resolution: number; tracksClientValue: boolean }
-  >();
+  #lastProviderAPIKey: string | null | undefined;
+  #capturingBaseAPIKey = false;
+  #preparedAPIKeys = new WeakMap<FinalRequestOptions, PreparedAPIKey>();
+  #synchronousCredentialAttempt: APIKeyPreparationAttempt | undefined;
+  #safeCredentialHooks = new Set<Function>([
+    OpenAI.prototype._callApiKey,
+    OpenAI.prototype.prepareOptions,
+    OpenAI.prototype.authHeaders,
+    OpenAI.prototype.bearerAuth,
+    OpenAI.prototype.buildRequest,
+  ]);
   protected idempotencyHeader?: string;
   protected _options: ClientOptions;
   private _provider: ProviderRuntime | undefined;
@@ -866,38 +890,102 @@ export class OpenAI {
   async _callApiKey(capture?: (apiKey: string | null) => void): Promise<boolean> {
     const apiKey = this._options.apiKey;
     if (this._provider || typeof apiKey !== 'function') {
-      capture?.(this.apiKey);
+      this.captureBaseAPIKey(capture, this.apiKey);
       return false;
     }
 
-    this.apiKey = await this.resolveAPIKeyProvider(apiKey);
-    this.#apiKeyResolution += 1;
-    capture?.(this.apiKey);
+    const resolved = await this.resolveAPIKeyProvider(apiKey);
+    this.apiKey = resolved;
+    this.#lastProviderAPIKey = this.apiKey;
+    this.captureBaseAPIKey(capture, this.apiKey);
     return true;
   }
 
+  private captureBaseAPIKey(
+    capture: ((apiKey: string | null) => void) | undefined,
+    apiKey: string | null,
+  ): void {
+    if (!capture) return;
+    this.#capturingBaseAPIKey = true;
+    try {
+      capture(apiKey);
+    } finally {
+      this.#capturingBaseAPIKey = false;
+    }
+  }
+
+  protected markCredentialHooksSafe(...hooks: Function[]): void {
+    for (const hook of hooks) this.#safeCredentialHooks.add(hook);
+  }
+
+  private hasCustomCredentialHooks(): boolean {
+    return ![
+      this._callApiKey,
+      this.prepareOptions,
+      this.authHeaders,
+      this.bearerAuth,
+      this.buildRequest,
+    ].every((hook) => this.#safeCredentialHooks.has(hook));
+  }
+
+  private hasCustomRequestCredentialHooks(): boolean {
+    return ![this.prepareOptions, this.authHeaders, this.bearerAuth, this.buildRequest].every((hook) =>
+      this.#safeCredentialHooks.has(hook),
+    );
+  }
+
   protected async prepareAPIKey(options: FinalRequestOptions): Promise<void> {
+    const attempt = this.#synchronousCredentialAttempt;
+    const remember = (prepared: PreparedAPIKey) => {
+      if (attempt) {
+        attempt.prepared = prepared;
+      } else {
+        this.#preparedAPIKeys.set(options, prepared);
+      }
+    };
     let captured = false;
     await this._callApiKey((apiKey) => {
       captured = true;
-      this.#preparedAPIKeys.set(options, {
+      const capturedByBase = this.#capturingBaseAPIKey;
+      remember({
         apiKey,
-        resolution: this.#apiKeyResolution,
         tracksClientValue: apiKey === this.apiKey,
+        allowClientOverride: this.hasCustomRequestCredentialHooks(),
+        explicitCapture: !this.#safeCredentialHooks.has(this._callApiKey) && !capturedByBase,
       });
     });
     if (!captured) {
-      this.#preparedAPIKeys.set(options, {
+      remember({
         apiKey: this.apiKey,
-        resolution: this.#apiKeyResolution,
         tracksClientValue: true,
+        allowClientOverride: this.hasCustomRequestCredentialHooks(),
+        explicitCapture: false,
       });
     }
   }
 
   protected async resolvedAPIKey(options: FinalRequestOptions): Promise<string | null> {
     const prepared = this.#preparedAPIKeys.get(options);
-    if (prepared) return prepared.apiKey;
+    if (prepared) {
+      if (prepared.explicitCapture) return prepared.apiKey;
+      if (
+        prepared.allowClientOverride &&
+        prepared.tracksClientValue &&
+        this.apiKey !== this.#lastProviderAPIKey
+      ) {
+        return this.apiKey;
+      }
+      return prepared.apiKey;
+    }
+    if (
+      this.hasCustomRequestCredentialHooks() &&
+      this.apiKey !== null &&
+      this.apiKey !== this.#lastProviderAPIKey
+    ) {
+      // Direct builds historically let credential hooks select `this.apiKey` without
+      // invoking the configured provider through `prepareOptions`.
+      return this.apiKey;
+    }
 
     let resolved = this.apiKey;
     let captured = false;
@@ -907,6 +995,8 @@ export class OpenAI {
     });
     return captured ? resolved : this.apiKey;
   }
+
+  protected validateOptionsBeforePreparation(options: FinalRequestOptions): void {}
 
   private async resolveAPIKeyProvider(apiKey: ApiKeySetter): Promise<string> {
     let token: unknown;
@@ -1211,24 +1301,52 @@ export class OpenAI {
 
     const x509Authentication = this.#x509Authentication;
     x509Authentication?.beginRequestPreparation();
-    await this.prepareOptions(options);
-    const preparedAPIKey = this.#preparedAPIKeys.get(options);
-    if (
-      preparedAPIKey?.tracksClientValue &&
-      preparedAPIKey.resolution === this.#apiKeyResolution &&
-      preparedAPIKey.apiKey !== this.apiKey
-    ) {
-      // Preserve subclasses that assign `this.apiKey` after `super.prepareOptions()`.
-      this.#preparedAPIKeys.set(options, { ...preparedAPIKey, apiKey: this.apiKey });
+    const preparationAttempt: APIKeyPreparationAttempt = {};
+    let preparation: Promise<void>;
+    try {
+      this.validateOptionsBeforePreparation(options);
+      const previousAttempt = this.#synchronousCredentialAttempt;
+      this.#synchronousCredentialAttempt = preparationAttempt;
+      try {
+        preparation = this.prepareOptions(options);
+      } finally {
+        this.#synchronousCredentialAttempt = previousAttempt;
+      }
+      await preparation;
+    } catch (error) {
+      this.#preparedAPIKeys.delete(options);
+      throw error;
+    }
+    let preparedAPIKey = preparationAttempt.prepared ?? this.#preparedAPIKeys.get(options);
+    try {
+      if (!preparedAPIKey && this.hasCustomCredentialHooks()) {
+        preparedAPIKey = {
+          apiKey: this.apiKey,
+          tracksClientValue: true,
+          allowClientOverride: true,
+          explicitCapture: false,
+        };
+      }
+    } catch (error) {
+      this.#preparedAPIKeys.delete(options);
+      throw error;
     }
 
     x509Authentication?.beginRequestPlanning();
     let built: { req: FinalizedRequestInit; url: string; timeout: number };
+    const apiKeyBuildContext: APIKeyBuildContext = { owner: this, prepared: preparedAPIKey, active: true };
     try {
+      if (preparedAPIKey && this.hasCustomRequestCredentialHooks()) {
+        // Preserve one-argument overrides that delegate the original options object.
+        this.#preparedAPIKeys.set(options, preparedAPIKey);
+      }
       const candidate = await this.buildRequest(options, {
         retryCount: maxRetries - retriesRemaining,
-      });
+        [preparedAPIKeyContext]: apiKeyBuildContext,
+      } as InternalBuildProperties);
       built = { req: candidate.req, url: candidate.url, timeout: candidate.timeout };
+      apiKeyBuildContext.active = false;
+      this.#preparedAPIKeys.delete(options);
       if (x509Authentication) {
         validatePositiveInteger('timeout', built.timeout);
         x509Authentication.authorizePlannedRequest(built.url, built.req, built.timeout);
@@ -1264,6 +1382,8 @@ export class OpenAI {
         this.validateHeaders(buildHeaders([supplied, built.req.headers]), security);
       }
     } catch (error) {
+      apiKeyBuildContext.active = false;
+      this.#preparedAPIKeys.delete(options);
       x509Authentication?.retireRequestBody();
       if (
         x509Authentication &&
@@ -1747,8 +1867,13 @@ export class OpenAI {
 
   async buildRequest(
     inputOptions: FinalRequestOptions,
-    { retryCount = 0 }: { retryCount?: number } = {},
+    properties: { retryCount?: number } = {},
   ): Promise<{ req: FinalizedRequestInit; url: string; timeout: number }> {
+    const { retryCount = 0 } = properties;
+    const internalProperties = properties as InternalBuildProperties;
+    const apiKeyContext = internalProperties[preparedAPIKeyContext];
+    const preparedAPIKey =
+      apiKeyContext?.owner === this && apiKeyContext.active ? apiKeyContext.prepared : undefined;
     if (this.#x509Authentication && !this.#x509Authentication.inRequest(this)) {
       const authentication = this.#x509Authentication;
       return await authentication.runRequest(async () => {
@@ -1804,6 +1929,7 @@ export class OpenAI {
       method,
       bodyHeaders,
       retryCount,
+      preparedAPIKey,
       x509Headers,
       x509Timeout: explicitTimeout ? options.timeout : undefined,
       x509Tenant,
@@ -1834,6 +1960,7 @@ export class OpenAI {
     method,
     bodyHeaders,
     retryCount,
+    preparedAPIKey,
     x509Headers,
     x509Timeout,
     x509Tenant,
@@ -1842,6 +1969,7 @@ export class OpenAI {
     method: HTTPMethod;
     bodyHeaders: HeadersLike;
     retryCount: number;
+    preparedAPIKey: PreparedAPIKey | undefined;
     x509Headers?: { defaultHeaders: NullableHeaders; requestHeaders: NullableHeaders } | undefined;
     x509Timeout: number | undefined;
     x509Tenant?: { organization: string | null; project: string | null } | undefined;
@@ -1854,6 +1982,17 @@ export class OpenAI {
 
     const helperMethod = options.__metadata?.['helperMethod'];
     const timeout = x509Headers ? x509Timeout : options.timeout;
+    let authenticationHeaders: NullableHeaders | undefined;
+    if (!this._provider && !this.#x509Authentication?.isPlanningRequest()) {
+      if (preparedAPIKey) this.#preparedAPIKeys.set(options, preparedAPIKey);
+      try {
+        authenticationHeaders = await this.authHeaders(options, options.__security ?? { bearerAuth: true });
+      } finally {
+        if (this.#preparedAPIKeys.get(options) === preparedAPIKey) {
+          this.#preparedAPIKeys.delete(options);
+        }
+      }
+    }
     const headers = buildHeaders([
       idempotencyHeaders,
       {
@@ -1866,9 +2005,7 @@ export class OpenAI {
         'OpenAI-Organization': x509Tenant ? x509Tenant.organization : this.organization,
         'OpenAI-Project': x509Tenant ? x509Tenant.project : this.project,
       },
-      this._provider || this.#x509Authentication?.isPlanningRequest()
-        ? undefined
-        : await this.authHeaders(options, options.__security ?? { bearerAuth: true }),
+      authenticationHeaders,
       x509Headers?.defaultHeaders ?? this._options.defaultHeaders,
       bodyHeaders,
       x509Headers?.requestHeaders ?? options.headers,

--- a/src/client.ts
+++ b/src/client.ts
@@ -296,7 +296,7 @@ type PreparedAPIKey = {
   explicitCapture: boolean;
 };
 
-type APIKeyPreparationAttempt = { prepared?: PreparedAPIKey };
+type APIKeyPreparationAttempt = { kind: 'request' | 'build'; prepared?: PreparedAPIKey | undefined };
 type APIKeyBuildContext = {
   owner: OpenAI;
   prepared: PreparedAPIKey | undefined;
@@ -961,9 +961,15 @@ export class OpenAI {
 
   private currentAPIKeyPreparationAttempt(
     options: FinalRequestOptions,
+    kind?: APIKeyPreparationAttempt['kind'],
   ): APIKeyPreparationAttempt | undefined {
     const attempts = this.#apiKeyPreparationAttempts.get(options);
-    return attempts?.[attempts.length - 1];
+    if (!attempts) return undefined;
+    for (let index = attempts.length - 1; index >= 0; index--) {
+      const attempt = attempts[index];
+      if (attempt && (!kind || attempt.kind === kind)) return attempt;
+    }
+    return undefined;
   }
 
   private removeAPIKeyPreparationAttempt(
@@ -1355,7 +1361,7 @@ export class OpenAI {
 
     const x509Authentication = this.#x509Authentication;
     x509Authentication?.beginRequestPreparation();
-    const preparationAttempt: APIKeyPreparationAttempt = {};
+    const preparationAttempt: APIKeyPreparationAttempt = { kind: 'request' };
     this.addAPIKeyPreparationAttempt(options, preparationAttempt);
     let preparation: Promise<void>;
     try {
@@ -2045,18 +2051,16 @@ export class OpenAI {
     const timeout = x509Headers ? x509Timeout : options.timeout;
     let authenticationHeaders: NullableHeaders | undefined;
     if (!this._provider && !this.#x509Authentication?.isPlanningRequest()) {
-      const currentAttempt = this.currentAPIKeyPreparationAttempt(options);
-      const temporaryAttempt =
-        preparedAPIKey && currentAttempt?.prepared !== preparedAPIKey
-          ? { prepared: preparedAPIKey }
-          : currentAttempt === undefined
-            ? {}
-            : undefined;
-      if (temporaryAttempt) this.addAPIKeyPreparationAttempt(options, temporaryAttempt);
+      // A build may inherit request preparation, but never another build's cached credential.
+      const buildAttempt: APIKeyPreparationAttempt = {
+        kind: 'build',
+        prepared: preparedAPIKey ?? this.currentAPIKeyPreparationAttempt(options, 'request')?.prepared,
+      };
+      this.addAPIKeyPreparationAttempt(options, buildAttempt);
       try {
         authenticationHeaders = await this.authHeaders(options, options.__security ?? { bearerAuth: true });
       } finally {
-        if (temporaryAttempt) this.removeAPIKeyPreparationAttempt(options, temporaryAttempt);
+        this.removeAPIKeyPreparationAttempt(options, buildAttempt);
       }
     }
     const headers = buildHeaders([

--- a/src/client.ts
+++ b/src/client.ts
@@ -297,8 +297,8 @@ export interface ClientOptions {
    *
    * - Accepts either a static string or an async function that resolves to a string.
    * - Defaults to process.env['OPENAI_API_KEY'].
-   * - When a function is provided, it is invoked before each request so you can rotate
-   *   or refresh credentials at runtime.
+   * - When a function is provided, it is invoked while building authentication headers
+   *   for each request attempt, including retries, so you can rotate credentials.
    * - The function must return a non-empty string; otherwise an OpenAIError is thrown.
    * - If the function throws, the error is wrapped in an OpenAIError with the original
    *   error available as `cause`.
@@ -813,10 +813,11 @@ export class OpenAI {
           : await authentication.getToken();
       return buildHeaders([{ Authorization: `Bearer ${token}` }]);
     }
-    if (this.apiKey == null) {
+    const apiKey = await this.resolveAPIKey();
+    if (apiKey == null) {
       return undefined;
     }
-    return buildHeaders([{ Authorization: `Bearer ${this.apiKey}` }]);
+    return buildHeaders([{ Authorization: `Bearer ${apiKey}` }]);
   }
 
   protected async adminAPIKeyAuth(opts: FinalRequestOptions): Promise<NullableHeaders | undefined> {
@@ -858,17 +859,34 @@ export class OpenAI {
    * @internal
    */
   async _callApiKey(capture?: (apiKey: string | null) => void): Promise<boolean> {
-    if (this._provider) {
-      capture?.(this.apiKey);
-      return false;
-    }
-
     const apiKey = this._options.apiKey;
-    if (typeof apiKey !== 'function') {
+    if (this._provider || typeof apiKey !== 'function') {
       capture?.(this.apiKey);
       return false;
     }
 
+    this.apiKey = await this.resolveAPIKeyProvider(apiKey);
+    capture?.(this.apiKey);
+    return true;
+  }
+
+  /**
+   * Resolves the credential for the current authentication header construction.
+   * Overrides return their credential directly; callers use the returned value,
+   * since another request can update the shared `apiKey` property after an await.
+   */
+  protected async resolveAPIKey(): Promise<string | null> {
+    const apiKey = this._options.apiKey;
+    if (this._provider || typeof apiKey !== 'function') {
+      return this.apiKey;
+    }
+
+    this.apiKey = await this.resolveAPIKeyProvider(apiKey);
+    // Preserve provider-specific getters before yielding the captured credential.
+    return this.apiKey;
+  }
+
+  private async resolveAPIKeyProvider(apiKey: ApiKeySetter): Promise<string> {
     let token: unknown;
     try {
       token = await apiKey();
@@ -886,9 +904,7 @@ export class OpenAI {
         `Expected 'apiKey' function argument to return a string but it returned ${token}`,
       );
     }
-    this.apiKey = token;
-    capture?.(this.apiKey);
-    return true;
+    return token;
   }
 
   buildURL(
@@ -916,15 +932,9 @@ export class OpenAI {
 
   /**
    * Used as a callback for mutating the given `FinalRequestOptions` object.
+   * Function credentials are resolved later, when authentication headers are built.
    */
-  protected async prepareOptions(options: FinalRequestOptions): Promise<void> {
-    if (this._provider) return;
-
-    const security = options.__security ?? { bearerAuth: true };
-    if (security.bearerAuth) {
-      await this._callApiKey();
-    }
-  }
+  protected async prepareOptions(options: FinalRequestOptions): Promise<void> {}
 
   /**
    * Used as a callback for mutating the given `RequestInit` object.

--- a/src/client.ts
+++ b/src/client.ts
@@ -500,7 +500,7 @@ export class OpenAI {
     }
   >();
   #lastProviderAPIKey: string | null | undefined;
-  #baseAPIKeyCapture: ((apiKey: string | null) => void) | undefined;
+  #baseAPIKeyCapture: { apiKey: string | null } | undefined;
   #apiKeyPreparationAttempts = new WeakMap<FinalRequestOptions, APIKeyPreparationAttempt[]>();
   #synchronousCredentialAttempt: APIKeyPreparationAttempt | undefined;
   #safeCredentialHooks = new Set<Function>([
@@ -914,7 +914,7 @@ export class OpenAI {
   ): void {
     if (!capture) return;
     const previousCapture = this.#baseAPIKeyCapture;
-    this.#baseAPIKeyCapture = capture;
+    this.#baseAPIKeyCapture = { apiKey };
     try {
       capture(apiKey);
     } finally {
@@ -984,7 +984,7 @@ export class OpenAI {
     let captured = false;
     const captureAPIKey = (apiKey: string | null) => {
       captured = true;
-      const capturedByBase = this.#baseAPIKeyCapture !== undefined && apiKey === this.#lastProviderAPIKey;
+      const capturedByBase = this.#baseAPIKeyCapture?.apiKey === apiKey;
       remember({
         apiKey,
         tracksClientValue: apiKey === this.apiKey,

--- a/src/client.ts
+++ b/src/client.ts
@@ -959,7 +959,8 @@ export class OpenAI {
   private currentAPIKeyPreparationAttempt(
     options: FinalRequestOptions,
   ): APIKeyPreparationAttempt | undefined {
-    return this.#apiKeyPreparationAttempts.get(options)?.at(-1);
+    const attempts = this.#apiKeyPreparationAttempts.get(options);
+    return attempts?.[attempts.length - 1];
   }
 
   private removeAPIKeyPreparationAttempt(

--- a/src/client.ts
+++ b/src/client.ts
@@ -1007,7 +1007,8 @@ export class OpenAI {
   }
 
   protected async resolvedAPIKey(options: FinalRequestOptions): Promise<string | null> {
-    const prepared = this.currentAPIKeyPreparationAttempt(options)?.prepared;
+    const attempt = this.currentAPIKeyPreparationAttempt(options);
+    const prepared = attempt?.prepared;
     if (prepared) {
       if (prepared.explicitCapture) return prepared.apiKey;
       if (
@@ -1031,11 +1032,22 @@ export class OpenAI {
 
     let resolved = this.apiKey;
     let captured = false;
+    let capturedByBase = false;
     await this._callApiKey((apiKey) => {
       captured = true;
       resolved = apiKey;
+      capturedByBase = this.#baseAPIKeyCapture?.apiKey === apiKey;
     });
-    return captured ? resolved : this.apiKey;
+    const apiKey = captured ? resolved : this.apiKey;
+    if (attempt) {
+      attempt.prepared = {
+        apiKey,
+        tracksClientValue: apiKey === this.apiKey,
+        allowClientOverride: this.hasCustomRequestCredentialHooks(),
+        explicitCapture: captured && !this.#safeCredentialHooks.has(this._callApiKey) && !capturedByBase,
+      };
+    }
+    return apiKey;
   }
 
   protected validateOptionsBeforePreparation(options: FinalRequestOptions): void {}
@@ -2037,7 +2049,9 @@ export class OpenAI {
       const temporaryAttempt =
         preparedAPIKey && currentAttempt?.prepared !== preparedAPIKey
           ? { prepared: preparedAPIKey }
-          : undefined;
+          : currentAttempt === undefined
+            ? {}
+            : undefined;
       if (temporaryAttempt) this.addAPIKeyPreparationAttempt(options, temporaryAttempt);
       try {
         authenticationHeaders = await this.authHeaders(options, options.__security ?? { bearerAuth: true });

--- a/src/client.ts
+++ b/src/client.ts
@@ -923,7 +923,7 @@ export class OpenAI {
     }
   }
 
-  protected markCredentialHooksSafe(...hooks: Function[]): void {
+  protected [Opts.markCredentialHooksSafe](...hooks: Function[]): void {
     for (const hook of hooks) this.#safeCredentialHooks.add(hook);
   }
 
@@ -1050,7 +1050,7 @@ export class OpenAI {
     return apiKey;
   }
 
-  protected validateOptionsBeforePreparation(options: FinalRequestOptions): void {}
+  protected [Opts.validateOptionsBeforePreparation](options: FinalRequestOptions): void {}
 
   private async resolveAPIKeyProvider(apiKey: ApiKeySetter): Promise<string> {
     let token: unknown;
@@ -1359,7 +1359,7 @@ export class OpenAI {
     this.addAPIKeyPreparationAttempt(options, preparationAttempt);
     let preparation: Promise<void>;
     try {
-      this.validateOptionsBeforePreparation(options);
+      this[Opts.validateOptionsBeforePreparation](options);
       const previousAttempt = this.#synchronousCredentialAttempt;
       this.#synchronousCredentialAttempt = preparationAttempt;
       try {

--- a/src/client.ts
+++ b/src/client.ts
@@ -251,7 +251,7 @@ import {
   ChatCompletionsPage,
 } from './resources/chat/completions/completions';
 import { type Fetch } from './internal/builtin-types';
-import { assertBedrockClientRequestOrigin } from './internal/bedrock';
+import { applyBedrockClientRequestRedirect, assertBedrockClientRequestOrigin } from './internal/bedrock';
 import { isRunningInBrowser } from './internal/detect-platform';
 import { HeadersLike, NullableHeaders, buildHeaders } from './internal/headers';
 import { configureProvider, type Provider, type ProviderRuntime } from './internal/provider';
@@ -508,6 +508,7 @@ export class OpenAI {
     OpenAI.prototype.prepareOptions,
     OpenAI.prototype.authHeaders,
     OpenAI.prototype.bearerAuth,
+    OpenAI.prototype.buildURL,
     OpenAI.prototype.buildRequest,
     OpenAI.prototype.prepareRequest,
   ]);
@@ -932,6 +933,7 @@ export class OpenAI {
       this.prepareOptions,
       this.authHeaders,
       this.bearerAuth,
+      this.buildURL,
       this.buildRequest,
       this.prepareRequest,
     ].every((hook) => this.#safeCredentialHooks.has(hook));
@@ -942,6 +944,7 @@ export class OpenAI {
       this.prepareOptions,
       this.authHeaders,
       this.bearerAuth,
+      this.buildURL,
       this.buildRequest,
       this.prepareRequest,
     ].every((hook) => this.#safeCredentialHooks.has(hook));
@@ -1996,6 +1999,7 @@ export class OpenAI {
       ...(((x509Authentication ? x509ClientFetchOptions : this.fetchOptions) as any) ?? {}),
       ...(((x509Authentication ? x509RequestFetchOptions : options.fetchOptions) as any) ?? {}),
     };
+    applyBedrockClientRequestRedirect(this, req);
 
     return { req, url, timeout: options.timeout };
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -299,6 +299,7 @@ type PreparedAPIKey = {
 type APIKeyPreparationAttempt = {
   kind: 'request' | 'build';
   prepared?: PreparedAPIKey | undefined;
+  customAuthentication?: boolean;
 };
 type APIKeyBuildContext = {
   owner: OpenAI;
@@ -809,6 +810,9 @@ export class OpenAI {
     ) {
       return await this.adminAPIKeyAuth(opts);
     }
+    if (schemes.bearerAuth && !this.#safeCredentialHooks.has(this.bearerAuth)) {
+      this.#markCustomAuthentication(opts);
+    }
     return buildHeaders([
       schemes.bearerAuth ? await this.bearerAuth(opts) : null,
       schemes.adminAPIKeyAuth ? await this.adminAPIKeyAuth(opts) : null,
@@ -957,14 +961,20 @@ export class OpenAI {
     ].every((hook) => this.#safeCredentialHooks.has(hook));
   }
 
-  private hasCustomAuthenticationDelegationHooks(schemes: {
-    bearerAuth?: boolean;
-    adminAPIKeyAuth?: boolean;
-  }): boolean {
-    return (
-      !this.#safeCredentialHooks.has(this.authHeaders) ||
-      (!!schemes.bearerAuth && !this.#safeCredentialHooks.has(this.bearerAuth))
+  #throwOverlappingAuthentication(): never {
+    throw new Errors.OpenAIError(
+      'Cannot safely resolve credentials for overlapping requests that share the same options object while an authentication hook is pending. Pass a distinct options object to each request.',
     );
+  }
+
+  #markCustomAuthentication(options: FinalRequestOptions): void {
+    let build: APIKeyPreparationAttempt | undefined;
+    for (const attempt of this.#apiKeyPreparationAttempts.get(options) ?? []) {
+      if (attempt.kind !== 'build') continue;
+      if (build) this.#throwOverlappingAuthentication();
+      build = attempt;
+    }
+    if (build) build.customAuthentication = true;
   }
 
   private addAPIKeyPreparationAttempt(options: FinalRequestOptions, attempt: APIKeyPreparationAttempt): void {
@@ -1057,6 +1067,16 @@ export class OpenAI {
       });
     };
     await this._callApiKey(captureAPIKey);
+    const prepared = attempt?.prepared;
+    if (
+      prepared &&
+      !prepared.explicitCapture &&
+      !this.#safeCredentialHooks.has(this._callApiKey) &&
+      this.apiKey !== this.#lastProviderAPIKey
+    ) {
+      prepared.apiKey = this.apiKey;
+      prepared.tracksClientValue = true;
+    }
     if (!captured) {
       remember({
         apiKey: this.apiKey,
@@ -1101,13 +1121,18 @@ export class OpenAI {
       resolved = apiKey;
       capturedByBase = this.#baseAPIKeyCapture?.apiKey === apiKey;
     });
-    const apiKey = captured ? resolved : this.apiKey;
+    const explicitCapture = captured && !this.#safeCredentialHooks.has(this._callApiKey) && !capturedByBase;
+    const postDelegationOverride =
+      !explicitCapture &&
+      !this.#safeCredentialHooks.has(this._callApiKey) &&
+      this.apiKey !== this.#lastProviderAPIKey;
+    const apiKey = captured && !postDelegationOverride ? resolved : this.apiKey;
     if (attempt) {
       attempt.prepared = {
         apiKey,
         tracksClientValue: apiKey === this.apiKey,
         allowClientOverride: this.hasCustomRequestCredentialHooks(),
-        explicitCapture: captured && !this.#safeCredentialHooks.has(this._callApiKey) && !capturedByBase,
+        explicitCapture,
       };
     }
     return apiKey;
@@ -2111,18 +2136,19 @@ export class OpenAI {
     let authenticationHeaders: NullableHeaders | undefined;
     if (!this._provider && !this.#x509Authentication?.isPlanningRequest()) {
       const security = options.__security ?? { bearerAuth: true };
+      const customAuthHeaders = !this.#safeCredentialHooks.has(this.authHeaders);
       if (
-        this.hasCustomAuthenticationDelegationHooks(security) &&
-        this.#apiKeyPreparationAttempts.get(options)?.some((attempt) => attempt.kind === 'build')
+        this.#apiKeyPreparationAttempts
+          .get(options)
+          ?.some((attempt) => attempt.kind === 'build' && (customAuthHeaders || attempt.customAuthentication))
       ) {
-        throw new Errors.OpenAIError(
-          'Cannot safely resolve credentials for overlapping requests that share the same options object while an authentication hook is pending. Pass a distinct options object to each request.',
-        );
+        this.#throwOverlappingAuthentication();
       }
       // A build may inherit request preparation, but never another build's cached credential.
       const buildAttempt: APIKeyPreparationAttempt = {
         kind: 'build',
         prepared: preparedAPIKey ?? this.currentAPIKeyPreparationAttempt(options, 'request')?.prepared,
+        customAuthentication: customAuthHeaders,
       };
       this.addAPIKeyPreparationAttempt(options, buildAttempt);
       try {

--- a/src/client.ts
+++ b/src/client.ts
@@ -296,7 +296,10 @@ type PreparedAPIKey = {
   explicitCapture: boolean;
 };
 
-type APIKeyPreparationAttempt = { kind: 'request' | 'build'; prepared?: PreparedAPIKey | undefined };
+type APIKeyPreparationAttempt = {
+  kind: 'request' | 'build';
+  prepared?: PreparedAPIKey | undefined;
+};
 type APIKeyBuildContext = {
   owner: OpenAI;
   prepared: PreparedAPIKey | undefined;
@@ -950,6 +953,16 @@ export class OpenAI {
     ].every((hook) => this.#safeCredentialHooks.has(hook));
   }
 
+  private hasCustomAuthenticationDelegationHooks(schemes: {
+    bearerAuth?: boolean;
+    adminAPIKeyAuth?: boolean;
+  }): boolean {
+    return (
+      !this.#safeCredentialHooks.has(this.authHeaders) ||
+      (!!schemes.bearerAuth && !this.#safeCredentialHooks.has(this.bearerAuth))
+    );
+  }
+
   private addAPIKeyPreparationAttempt(options: FinalRequestOptions, attempt: APIKeyPreparationAttempt): void {
     const attempts = this.#apiKeyPreparationAttempts.get(options);
     if (attempts) {
@@ -1013,7 +1026,8 @@ export class OpenAI {
   }
 
   protected async [Opts.resolvedAPIKey](options: FinalRequestOptions): Promise<string | null> {
-    const attempt = this.currentAPIKeyPreparationAttempt(options);
+    const attempt =
+      this.currentAPIKeyPreparationAttempt(options, 'build') ?? this.currentAPIKeyPreparationAttempt(options);
     const prepared = attempt?.prepared;
     if (prepared) {
       if (prepared.explicitCapture) return prepared.apiKey;
@@ -2051,6 +2065,15 @@ export class OpenAI {
     const timeout = x509Headers ? x509Timeout : options.timeout;
     let authenticationHeaders: NullableHeaders | undefined;
     if (!this._provider && !this.#x509Authentication?.isPlanningRequest()) {
+      const security = options.__security ?? { bearerAuth: true };
+      if (
+        this.hasCustomAuthenticationDelegationHooks(security) &&
+        this.#apiKeyPreparationAttempts.get(options)?.some((attempt) => attempt.kind === 'build')
+      ) {
+        throw new Errors.OpenAIError(
+          'Cannot safely resolve credentials for overlapping requests that share the same options object while an authentication hook is pending. Pass a distinct options object to each request.',
+        );
+      }
       // A build may inherit request preparation, but never another build's cached credential.
       const buildAttempt: APIKeyPreparationAttempt = {
         kind: 'build',
@@ -2058,7 +2081,7 @@ export class OpenAI {
       };
       this.addAPIKeyPreparationAttempt(options, buildAttempt);
       try {
-        authenticationHeaders = await this.authHeaders(options, options.__security ?? { bearerAuth: true });
+        authenticationHeaders = await this.authHeaders(options, security);
       } finally {
         this.removeAPIKeyPreparationAttempt(options, buildAttempt);
       }

--- a/src/client.ts
+++ b/src/client.ts
@@ -297,8 +297,8 @@ export interface ClientOptions {
    *
    * - Accepts either a static string or an async function that resolves to a string.
    * - Defaults to process.env['OPENAI_API_KEY'].
-   * - When a function is provided, it is invoked while building authentication headers
-   *   for each request attempt, including retries, so you can rotate credentials.
+   * - When a function is provided, it is invoked for each request attempt, including
+   *   retries, so you can rotate or refresh credentials at runtime.
    * - The function must return a non-empty string; otherwise an OpenAIError is thrown.
    * - If the function throws, the error is wrapped in an OpenAIError with the original
    *   error available as `cause`.
@@ -480,10 +480,19 @@ export class OpenAI {
       continueRequest?: <T>(operation: () => Promise<T>) => Promise<T>;
     }
   >();
-  #apiKeyResolution = 0;
+  // Replaced on each provider resolution to distinguish it from later hook mutations.
+  #apiKeyResolution: { apiKey: string | null } | undefined;
+  // Retained through preparation hooks and retired before dispatch, including failures.
   #preparedAPIKeys = new WeakMap<
     FinalRequestOptions,
-    { apiKey: string | null; resolution: number; tracksClientValue: boolean }
+    {
+      activeBuilds: number;
+      credential?: {
+        apiKey: string | null;
+        resolution: { apiKey: string | null } | undefined;
+        tracksClientValue: boolean;
+      };
+    }
   >();
   protected idempotencyHeader?: string;
   protected _options: ClientOptions;
@@ -870,34 +879,55 @@ export class OpenAI {
       return false;
     }
 
-    this.apiKey = await this.resolveAPIKeyProvider(apiKey);
-    this.#apiKeyResolution += 1;
-    capture?.(this.apiKey);
+    const resolved = await this.resolveAPIKeyProvider(apiKey);
+    this.apiKey = resolved;
+    const resolution = (this.#apiKeyResolution = { apiKey: resolved });
+    if (capture) {
+      const currentAPIKey = this.apiKey;
+      resolution.apiKey = currentAPIKey;
+      capture(currentAPIKey);
+    }
     return true;
   }
 
+  /** Captures a credential while preserving the existing preparation hook lifecycle. */
   protected async prepareAPIKey(options: FinalRequestOptions): Promise<void> {
+    const preparation = this.#preparedAPIKeys.get(options);
     let captured = false;
     await this._callApiKey((apiKey) => {
       captured = true;
-      this.#preparedAPIKeys.set(options, {
-        apiKey,
-        resolution: this.#apiKeyResolution,
-        tracksClientValue: apiKey === this.apiKey,
-      });
+      if (preparation) {
+        preparation.credential = {
+          apiKey,
+          resolution: this.#apiKeyResolution,
+          tracksClientValue: apiKey === this.apiKey,
+        };
+      }
     });
-    if (!captured) {
-      this.#preparedAPIKeys.set(options, {
+    if (!captured && preparation) {
+      preparation.credential = {
         apiKey: this.apiKey,
         resolution: this.#apiKeyResolution,
         tracksClientValue: true,
-      });
+      };
     }
   }
 
+  /** Reads the prepared credential, or resolves it when a request is built directly. */
   protected async resolvedAPIKey(options: FinalRequestOptions): Promise<string | null> {
-    const prepared = this.#preparedAPIKeys.get(options);
-    if (prepared) return prepared.apiKey;
+    const preparation = this.#preparedAPIKeys.get(options);
+    if (preparation) {
+      const prepared = preparation.credential;
+      const currentAPIKey = this.apiKey;
+      // Preserve hook mutations while keeping concurrent provider results isolated.
+      // A nondelegating preparation hook owns its credential choice too.
+      return !prepared ||
+        (prepared.tracksClientValue &&
+          (prepared.resolution === this.#apiKeyResolution ||
+            currentAPIKey !== this.#apiKeyResolution?.apiKey))
+        ? currentAPIKey
+        : prepared.apiKey;
+    }
 
     let resolved = this.apiKey;
     let captured = false;
@@ -1211,15 +1241,17 @@ export class OpenAI {
 
     const x509Authentication = this.#x509Authentication;
     x509Authentication?.beginRequestPreparation();
-    await this.prepareOptions(options);
-    const preparedAPIKey = this.#preparedAPIKeys.get(options);
-    if (
-      preparedAPIKey?.tracksClientValue &&
-      preparedAPIKey.resolution === this.#apiKeyResolution &&
-      preparedAPIKey.apiKey !== this.apiKey
-    ) {
-      // Preserve subclasses that assign `this.apiKey` after `super.prepareOptions()`.
-      this.#preparedAPIKeys.set(options, { ...preparedAPIKey, apiKey: this.apiKey });
+    const preparation = this.#preparedAPIKeys.get(options) ?? { activeBuilds: 0 };
+    preparation.activeBuilds += 1;
+    this.#preparedAPIKeys.set(options, preparation);
+    const finishPreparation = () => {
+      if (--preparation.activeBuilds === 0) this.#preparedAPIKeys.delete(options);
+    };
+    try {
+      await this.prepareOptions(options);
+    } catch (error) {
+      finishPreparation();
+      throw error;
     }
 
     x509Authentication?.beginRequestPlanning();
@@ -1264,6 +1296,7 @@ export class OpenAI {
         this.validateHeaders(buildHeaders([supplied, built.req.headers]), security);
       }
     } catch (error) {
+      finishPreparation();
       x509Authentication?.retireRequestBody();
       if (
         x509Authentication &&
@@ -1280,6 +1313,7 @@ export class OpenAI {
       }
       throw error;
     }
+    if (x509Authentication) finishPreparation();
     const { req, url } = built;
     const timeout = x509Authentication
       ? Math.min(built.timeout, x509Authentication.requestSnapshot().timeout)
@@ -1288,8 +1322,12 @@ export class OpenAI {
     let hasStreamingBody = options.__metadata?.['hasStreamingBody'] === true;
 
     if (!x509Authentication) {
-      await this.prepareRequest(req, { url, options });
-      await this._provider?.prepareRequest?.(req, { url, options });
+      try {
+        await this.prepareRequest(req, { url, options });
+        await this._provider?.prepareRequest?.(req, { url, options });
+      } finally {
+        finishPreparation();
+      }
     }
     x509Authentication?.adoptRequestHeaders(req);
     if (x509Authentication && X509WorkloadIdentityAuth.isStreamingRequestBody(req.body)) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1012,7 +1012,17 @@ export class OpenAI {
 
   #observeAPIKeyWrites(): void {
     if (typeof this._options.apiKey !== 'function' || !this.hasCustomRequestCredentialHooks()) return;
-    const descriptor = Object.getOwnPropertyDescriptor(this, 'apiKey');
+    let descriptor = Object.getOwnPropertyDescriptor(this, 'apiKey');
+    if (!descriptor) {
+      let prototype = Object.getPrototypeOf(this);
+      while (prototype) {
+        descriptor = Object.getOwnPropertyDescriptor(prototype, 'apiKey');
+        if (descriptor) break;
+        prototype = Object.getPrototypeOf(prototype);
+      }
+      // Shadow inherited accessors on this client without changing the shared prototype.
+      if (!descriptor || 'value' in descriptor || !Object.isExtensible(this)) return;
+    }
     if (
       !descriptor?.configurable ||
       (this.#apiKeyWriteObserver && descriptor.set === this.#apiKeyWriteObserver)
@@ -1049,6 +1059,18 @@ export class OpenAI {
   }
 
   protected async [Opts.prepareAPIKey](options: FinalRequestOptions): Promise<void> {
+    if (!this.#synchronousCredentialAttempt) {
+      let requestSeen = false;
+      for (const candidate of this.#apiKeyPreparationAttempts.get(options) ?? []) {
+        if (candidate.kind !== 'request') continue;
+        if (requestSeen) {
+          throw new Errors.OpenAIError(
+            'Cannot safely resolve credentials for overlapping requests that share the same options object after a preparation hook awaits before delegating. Pass a distinct options object to each request.',
+          );
+        }
+        requestSeen = true;
+      }
+    }
     const attempt = this.#synchronousCredentialAttempt ?? this.currentAPIKeyPreparationAttempt(options);
     const remember = (prepared: PreparedAPIKey) => {
       if (attempt) {

--- a/src/internal/bedrock.ts
+++ b/src/internal/bedrock.ts
@@ -7,6 +7,16 @@ import { readEnv } from './utils';
 /** Identifies legacy Bedrock clients without importing the client class into WebSocket modules. */
 export const brand_privateBedrockClient = Symbol.for('openai.privateBedrockClient');
 
+// The configured origin is fixed for the lifetime of each legacy client.
+const bedrockClientOrigins = new WeakMap<object, string>();
+
+/** Records the constructor-configured origin once, independently of overridable client hooks. */
+export function registerBedrockClientOrigin(client: object, baseURL: string): void {
+  if (!bedrockClientOrigins.has(client)) {
+    bedrockClientOrigins.set(client, new URL(baseURL).origin);
+  }
+}
+
 /** Selects the regional Amazon Bedrock endpoint and its matching SigV4 service. */
 export type BedrockEndpoint = 'mantle' | 'runtime';
 
@@ -241,6 +251,14 @@ export function assertBedrockRequestOrigin(baseURL: string, requestURL: string):
     throw new Errors.OpenAIError(
       `Bedrock request origin \`${requestOrigin}\` does not match the configured base URL origin \`${expectedOrigin}\`.`,
     );
+  }
+}
+
+/** Enforces the registered Bedrock origin at the final HTTP construction boundary. */
+export function assertBedrockClientRequestOrigin(client: object, requestURL: string): void {
+  const baseURL = bedrockClientOrigins.get(client);
+  if (baseURL !== undefined) {
+    assertBedrockRequestOrigin(baseURL, requestURL);
   }
 }
 

--- a/src/internal/bedrock.ts
+++ b/src/internal/bedrock.ts
@@ -262,6 +262,13 @@ export function assertBedrockClientRequestOrigin(client: object, requestURL: str
   }
 }
 
+/** Prevents automatic redirects after merging a legacy Bedrock client's fetch options. */
+export function applyBedrockClientRequestRedirect(client: object, request: FinalizedRequestInit): void {
+  if (bedrockClientOrigins.has(client)) {
+    request.redirect = 'manual';
+  }
+}
+
 /** Validates a final WebSocket URL before a legacy Bedrock client resolves or attaches credentials. */
 export function assertBedrockWebSocketOrigin(client: unknown, requestURL: URL): void {
   if (typeof client !== 'object' || client === null || !(brand_privateBedrockClient in client)) {

--- a/src/internal/request-options.ts
+++ b/src/internal/request-options.ts
@@ -7,6 +7,9 @@ import { type HeadersLike } from './headers';
 
 export type FinalRequestOptions = RequestOptions & { method: HTTPMethod; path: string };
 
+/** Names internal credential preparation without claiming a string-named subclass hook. */
+export const prepareAPIKey = Symbol('openai.prepareAPIKey');
+
 export type RequestOptions = {
   /**
    * The HTTP method for the request (e.g., 'get', 'post', 'put', 'delete').

--- a/src/internal/request-options.ts
+++ b/src/internal/request-options.ts
@@ -10,6 +10,9 @@ export type FinalRequestOptions = RequestOptions & { method: HTTPMethod; path: s
 /** Names internal credential preparation without claiming a string-named subclass hook. */
 export const prepareAPIKey = Symbol('openai.prepareAPIKey');
 
+/** Names internal credential resolution without claiming a string-named subclass hook. */
+export const resolvedAPIKey = Symbol('openai.resolvedAPIKey');
+
 export type RequestOptions = {
   /**
    * The HTTP method for the request (e.g., 'get', 'post', 'put', 'delete').

--- a/src/internal/request-options.ts
+++ b/src/internal/request-options.ts
@@ -13,6 +13,12 @@ export const prepareAPIKey = Symbol('openai.prepareAPIKey');
 /** Names internal credential resolution without claiming a string-named subclass hook. */
 export const resolvedAPIKey = Symbol('openai.resolvedAPIKey');
 
+/** Names internal request validation without claiming a string-named subclass hook. */
+export const validateOptionsBeforePreparation = Symbol('openai.validateOptionsBeforePreparation');
+
+/** Names internal credential-hook registration without claiming a string-named subclass helper. */
+export const markCredentialHooksSafe = Symbol('openai.markCredentialHooksSafe');
+
 export type RequestOptions = {
   /**
    * The HTTP method for the request (e.g., 'get', 'post', 'put', 'delete').

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -1,0 +1,275 @@
+/* oxlint-disable eslint/max-classes-per-file -- Separate subclass fixtures cover delegation and custom credential resolution. */
+import { vi } from 'vitest';
+
+import OpenAI, { AzureOpenAI, BedrockOpenAI } from 'openai';
+import type { ClientOptions } from 'openai';
+import type { RequestInfo, RequestInit } from 'openai/internal/builtin-types';
+import type { FinalRequestOptions } from 'openai/internal/request-options';
+
+const clients = ['OpenAI', 'Azure', 'Bedrock', 'Bedrock admin'] as const;
+type ClientKind = (typeof clients)[number];
+
+function clientFor(
+  kind: ClientKind,
+  apiKey: string | (() => Promise<string>),
+  overrides: Pick<ClientOptions, 'fetch' | 'defaultHeaders' | 'maxRetries'>,
+): OpenAI {
+  const options = {
+    baseURL: 'https://credentials.example/v1',
+    maxRetries: 0,
+    logLevel: 'off' as const,
+    ...overrides,
+  };
+  if (kind === 'Azure') {
+    return new AzureOpenAI({
+      ...options,
+      apiVersion: '2024-10-01-preview',
+      ...(typeof apiKey === 'function' ? { azureADTokenProvider: apiKey } : { apiKey }),
+    });
+  }
+  if (kind === 'Bedrock' || kind === 'Bedrock admin') {
+    return new BedrockOpenAI({
+      ...options,
+      ...(typeof apiKey === 'function' ? { bedrockTokenProvider: apiKey } : { apiKey }),
+    });
+  }
+  return new OpenAI({ ...options, apiKey, adminAPIKey: null });
+}
+
+function securityFor(kind: ClientKind) {
+  return kind === 'Bedrock admin' ? { adminAPIKeyAuth: true } : { bearerAuth: true };
+}
+
+function mockFetch() {
+  return vi.fn(async (_url: RequestInfo, _init?: RequestInit) => Response.json({ ok: true }));
+}
+
+function sentHeaders(fetch: ReturnType<typeof mockFetch>) {
+  return fetch.mock.calls.map(([, init]) => new Headers(init?.headers));
+}
+
+beforeEach(() => {
+  vi.stubEnv('AZURE_OPENAI_API_KEY', '');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe.each(clients)('%s HTTP credentials', (kind) => {
+  test('uses each callback result for its own concurrent request', async () => {
+    const provider = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce('synthetic-first')
+      .mockResolvedValueOnce('synthetic-second');
+    const fetch = mockFetch();
+    const client = clientFor(kind, provider, { fetch });
+
+    await Promise.all([
+      client.get('/first', { __security: securityFor(kind) }),
+      client.get('/second', { __security: securityFor(kind) }),
+    ]);
+
+    expect(provider).toHaveBeenCalledTimes(2);
+    expect(fetch.mock.calls.map(([url]) => new URL(String(url)).pathname)).toEqual([
+      '/v1/first',
+      '/v1/second',
+    ]);
+    expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
+      'Bearer synthetic-first',
+      'Bearer synthetic-second',
+    ]);
+    expect(client.apiKey).toBe('synthetic-second');
+  });
+
+  test('resolves a fresh callback result once per retry attempt', async () => {
+    const provider = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce('synthetic-initial')
+      .mockResolvedValueOnce('synthetic-retry');
+    const fetch = mockFetch().mockResolvedValueOnce(
+      Response.json({ error: { message: 'retry' } }, { status: 429, headers: { 'retry-after-ms': '0' } }),
+    );
+    const client = clientFor(kind, provider, { fetch, maxRetries: 1 });
+
+    await expect(client.get('/items', { __security: securityFor(kind) })).resolves.toEqual({ ok: true });
+
+    expect(provider).toHaveBeenCalledTimes(2);
+    expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
+      'Bearer synthetic-initial',
+      'Bearer synthetic-retry',
+    ]);
+    expect(sentHeaders(fetch).map((headers) => headers.get('x-stainless-retry-count'))).toEqual(['0', '1']);
+  });
+
+  test('resolves callbacks in direct buildRequest calls', async () => {
+    const provider = vi.fn(async () => 'synthetic-direct');
+    const fetch = mockFetch();
+    const client = clientFor(kind, provider, { fetch });
+
+    const { req } = await client.buildRequest({
+      method: 'get',
+      path: '/items',
+      __security: securityFor(kind),
+    });
+
+    expect(req.headers.get('authorization')).toBe('Bearer synthetic-direct');
+    expect(provider).toHaveBeenCalledTimes(1);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test('preserves updates to a static apiKey between requests', async () => {
+    const fetch = mockFetch();
+    const client = clientFor(kind, 'synthetic-original', { fetch });
+
+    await client.get('/items', { __security: securityFor(kind) });
+    client.apiKey = 'synthetic-updated';
+    await client.get('/items', { __security: securityFor(kind) });
+
+    const header = kind === 'Azure' ? 'api-key' : 'authorization';
+    const prefix = kind === 'Azure' ? '' : 'Bearer ';
+    expect(sentHeaders(fetch).map((headers) => headers.get(header))).toEqual([
+      `${prefix}synthetic-original`,
+      `${prefix}synthetic-updated`,
+    ]);
+  });
+
+  test('preserves default, request, and explicit null authorization precedence', async () => {
+    const provider = vi.fn(async () => 'synthetic-provider');
+    const fetch = mockFetch();
+    const client = clientFor(kind, provider, {
+      fetch,
+      defaultHeaders: { Authorization: 'Bearer synthetic-default' },
+    });
+
+    await client.get('/items', { __security: securityFor(kind) });
+    await client.get('/items', {
+      __security: securityFor(kind),
+      headers: { Authorization: 'Bearer synthetic-request' },
+    });
+    await client.get('/items', {
+      __security: securityFor(kind),
+      headers: { Authorization: null },
+    });
+
+    expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
+      'Bearer synthetic-default',
+      'Bearer synthetic-request',
+      null,
+    ]);
+    expect(provider).toHaveBeenCalledTimes(3);
+  });
+
+  test.each([
+    {
+      name: 'an empty result',
+      provider: async () => '',
+      message: "Expected 'apiKey' function argument to return a string",
+    },
+    {
+      name: 'a provider error',
+      provider: async () => {
+        throw new Error('synthetic provider failure');
+      },
+      message: "Failed to get token from 'apiKey' function",
+    },
+  ])('rejects $name without dispatch', async ({ provider, message }) => {
+    const fetch = mockFetch();
+    const client = clientFor(kind, provider, { fetch });
+
+    await expect(client.get('/items', { __security: securityFor(kind) })).rejects.toThrow(message);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+test('preserves one-argument delegating hooks and resolves credentials after options and body preparation', async () => {
+  const events: string[] = [];
+  class HookedOpenAI extends OpenAI {
+    protected override async prepareOptions(options: FinalRequestOptions) {
+      events.push('prepare');
+      options.headers = { 'x-prepared': 'yes' };
+      await super.prepareOptions(options);
+      events.push('prepared');
+    }
+
+    override async buildRequest(options: FinalRequestOptions) {
+      events.push('build');
+      return super.buildRequest(options);
+    }
+
+    protected override async authHeaders(options: FinalRequestOptions) {
+      events.push('auth');
+      const headers = await super.authHeaders(options);
+      headers?.values.set('x-auth-hook', 'yes');
+      return headers;
+    }
+  }
+  const provider = vi.fn(async () => {
+    events.push('credential');
+    return 'synthetic-hook';
+  });
+  const fetch = mockFetch();
+  const client = new HookedOpenAI({ apiKey: provider, adminAPIKey: null, fetch });
+
+  await client.post('/items', {
+    body: {
+      toJSON() {
+        events.push('body');
+        return { synthetic: true };
+      },
+    },
+  });
+
+  expect(events).toEqual(['prepare', 'prepared', 'build', 'body', 'auth', 'credential']);
+  expect(provider).toHaveBeenCalledTimes(1);
+  expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-hook');
+  expect(sentHeaders(fetch)[0]?.get('x-prepared')).toBe('yes');
+  expect(sentHeaders(fetch)[0]?.get('x-auth-hook')).toBe('yes');
+  expect(fetch.mock.calls[0]?.[1]?.body).toBe('{"synthetic":true}');
+});
+
+test('uses a Bedrock callback once when both security schemes are requested', async () => {
+  const provider = vi.fn(async () => 'synthetic-bedrock');
+  const fetch = mockFetch();
+  const client = clientFor('Bedrock', provider, { fetch });
+
+  await client.get('/items', { __security: { bearerAuth: true, adminAPIKeyAuth: true } });
+
+  expect(provider).toHaveBeenCalledTimes(1);
+  expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-bedrock');
+});
+
+test('supports resolver overrides returning concurrent credentials without mutating apiKey', async () => {
+  class CustomCredentials extends OpenAI {
+    resolutions = 0;
+
+    protected override async resolveAPIKey() {
+      this.resolutions += 1;
+      return `synthetic-resolved-${this.resolutions}`;
+    }
+  }
+  const fetch = mockFetch();
+  const client = new CustomCredentials({ apiKey: 'synthetic-configured', fetch });
+
+  await Promise.all([client.get('/first'), client.get('/second')]);
+
+  expect(client.resolutions).toBe(2);
+  expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
+    'Bearer synthetic-resolved-1',
+    'Bearer synthetic-resolved-2',
+  ]);
+  expect(client.apiKey).toBe('synthetic-configured');
+});
+
+test('does not resolve the OpenAI callback for admin-only requests', async () => {
+  const provider = vi.fn(async () => {
+    throw new Error('unused synthetic provider');
+  });
+  const fetch = mockFetch();
+  const client = new OpenAI({ apiKey: provider, adminAPIKey: 'synthetic-admin', fetch });
+
+  await client.get('/organization/projects', { __security: { adminAPIKeyAuth: true } });
+
+  expect(provider).not.toHaveBeenCalled();
+  expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-admin');
+});

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -589,6 +589,15 @@ test('keeps observing a direct hook after it resolves a provider credential', as
   expect(provider).toHaveBeenCalledTimes(1);
 });
 
+function preparationGate() {
+  let release!: () => void;
+  // oxlint-disable-next-line promise/avoid-new -- Gates select the order of asynchronous hook delegation.
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
 test('restarts credential observation when a direct hook writes before and after provider resolution', async () => {
   class Credentials extends OpenAI {
     protected override async authHeaders(options: FinalRequestOptions) {
@@ -606,6 +615,95 @@ test('restarts credential observation when a direct hook writes before and after
   );
 
   expect(provider).toHaveBeenCalledTimes(1);
+});
+
+test('retains a borrowed credential observer until every participating build settles', async () => {
+  const firstEntered = preparationGate();
+  const resolveFirstProvider = preparationGate();
+  const firstProviderResolved = preparationGate();
+  const finishFirst = preparationGate();
+  const secondEntered = preparationGate();
+  const finishSecond = preparationGate();
+  class Credentials extends OpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      if (options.path === '/first') {
+        this.apiKey = 'synthetic-prior';
+        firstEntered.release();
+        await resolveFirstProvider.promise;
+        await this._callApiKey();
+        firstProviderResolved.release();
+        await finishFirst.promise;
+        this.apiKey = null;
+        return super.authHeaders(options);
+      }
+      const headers = await super.authHeaders(options);
+      secondEntered.release();
+      await finishSecond.promise;
+      return headers;
+    }
+  }
+  let resolutions = 0;
+  const provider = vi.fn(async () => {
+    resolutions += 1;
+    return `synthetic-${resolutions}`;
+  });
+  const client = new Credentials({ apiKey: provider, adminAPIKey: null });
+  let firstError: unknown;
+  const first = (async () => {
+    try {
+      await client.buildRequest({ method: 'get', path: '/first' });
+    } catch (error) {
+      firstError = error;
+    }
+  })();
+  await firstEntered.promise;
+  const second = client.buildRequest({ method: 'get', path: '/second' });
+  await secondEntered.promise;
+  resolveFirstProvider.release();
+  await firstProviderResolved.promise;
+  finishSecond.release();
+  const secondResult = await second;
+  finishFirst.release();
+  await first;
+
+  expect(secondResult.req.headers.get('authorization')).toBe('Bearer synthetic-prior');
+  expect(firstError).toBeInstanceOf(Error);
+  expect((firstError as Error).message).toContain('Could not resolve authentication method');
+  expect(provider).toHaveBeenCalledTimes(1);
+  expect(client.apiKey).toBeNull();
+});
+
+test('restores credential observation after hook inspection throws during setup', async () => {
+  class Credentials extends OpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      return super.authHeaders(options);
+    }
+  }
+  const client = new Credentials({ apiKey: async () => 'synthetic-provider', adminAPIKey: null });
+  let fail = true;
+  Object.defineProperty(client, 'buildURL', {
+    configurable: true,
+    get() {
+      if (fail) {
+        fail = false;
+        throw new Error('synthetic hook lookup failure');
+      }
+      return OpenAI.prototype.buildURL;
+    },
+  });
+
+  await expect(client.buildRequest({ method: 'get', path: '/first' })).rejects.toThrow(
+    'synthetic hook lookup failure',
+  );
+  const { req } = await client.buildRequest({ method: 'get', path: '/second' });
+
+  expect(req.headers.get('authorization')).toBe('Bearer synthetic-provider');
+  expect(Object.getOwnPropertyDescriptor(client, 'apiKey')).toMatchObject({
+    value: 'synthetic-provider',
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
 });
 
 test('restores credential data-property metadata changed during a build', async () => {
@@ -1664,15 +1762,6 @@ test('does not resolve the OpenAI callback for admin-only requests', async () =>
   expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-admin');
 });
 
-function preparationGate() {
-  let release!: () => void;
-  // oxlint-disable-next-line promise/avoid-new -- Gates select the order of asynchronous hook delegation.
-  const promise = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  return { promise, release };
-}
-
 describe('delayed credential preparation', () => {
   test.each([true, false])('handles pre-delegation overlap with shared options: %s', async (shared) => {
     const entered = [preparationGate(), preparationGate()] as const;
@@ -1750,4 +1839,67 @@ describe('delayed credential preparation', () => {
       'Bearer synthetic-second',
     ]);
   });
+
+  test.each([true, false])(
+    'isolates delayed request preparation from a direct build with shared options: %s',
+    async (shared) => {
+      const preparationEntered = preparationGate();
+      const startPreparation = preparationGate();
+      const preparationDelegated = preparationGate();
+      const finishPreparation = preparationGate();
+      let resolveDirect!: (value: string) => void;
+      // oxlint-disable-next-line promise/avoid-new -- Hold the direct provider to select the write order.
+      const directProvider = new Promise<string>((resolve) => {
+        resolveDirect = resolve;
+      });
+      const directProviderEntered = preparationGate();
+      class DelayedPreparation extends OpenAI {
+        protected override async prepareOptions(options: FinalRequestOptions) {
+          preparationEntered.release();
+          await startPreparation.promise;
+          await super.prepareOptions(options);
+          preparationDelegated.release();
+          await finishPreparation.promise;
+        }
+      }
+      const provider = vi
+        .fn<() => Promise<string>>()
+        .mockImplementationOnce(() => {
+          directProviderEntered.release();
+          return directProvider;
+        })
+        .mockResolvedValueOnce('synthetic-normal');
+      const fetch = mockFetch();
+      const client = new DelayedPreparation({ apiKey: provider, adminAPIKey: null, fetch });
+      const options: FinalRequestOptions = { method: 'get', path: '/items' };
+      const normalSettled = preparationGate();
+      const normal = (async () => {
+        try {
+          return { value: await client.request(options) };
+        } catch (error) {
+          return { error: error as Error };
+        } finally {
+          normalSettled.release();
+        }
+      })();
+      await preparationEntered.promise;
+      const direct = client.buildRequest(shared ? options : { ...options });
+      await directProviderEntered.promise;
+      startPreparation.release();
+      await Promise.race([preparationDelegated.promise, normalSettled.promise]);
+      resolveDirect('synthetic-direct');
+      const directResult = await direct;
+      expect(directResult.req.headers.get('authorization')).toBe('Bearer synthetic-direct');
+      finishPreparation.release();
+
+      const result = await normal;
+      if ('error' in result) {
+        expect(shared).toBe(true);
+        expect(result.error.message).toContain('overlapping requests that share the same options object');
+        expect(fetch).not.toHaveBeenCalled();
+      } else {
+        expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-normal');
+      }
+    },
+  );
 });

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -239,7 +239,7 @@ test('preserves the credential failure when upload cleanup throws during a direc
 });
 
 test.each(clients)(
-  '%s gives overlapping direct builds separate credentials with shared options',
+  '%s rejects overlapping direct builds with shared options and a pending authentication hook',
   async (kind) => {
     let signalEntered!: () => void;
     let signalRelease!: () => void;
@@ -280,10 +280,7 @@ test.each(clients)(
         return headers;
       }
     }
-    const provider = vi
-      .fn<() => Promise<string>>()
-      .mockResolvedValueOnce('synthetic-first')
-      .mockResolvedValueOnce('synthetic-second');
+    const provider = vi.fn<() => Promise<string>>().mockResolvedValueOnce('synthetic-first');
     const fetch = mockFetch();
     const clientOptions = { baseURL: 'https://credentials.example/v1', fetch };
     let client: OpenAI;
@@ -303,28 +300,27 @@ test.each(clients)(
     const first = client.buildRequest(options);
     await entered;
     try {
-      const second = await client.buildRequest(options);
-      await fetch(second.url, second.req);
+      await expect(client.buildRequest(options)).rejects.toThrow(
+        'overlapping requests that share the same options object',
+      );
     } finally {
       signalRelease();
     }
     const built = await first;
     await fetch(built.url, built.req);
 
-    expect(seenOptions).toHaveLength(2);
+    expect(seenOptions).toHaveLength(1);
     expect(seenOptions[0]).toBe(options);
-    expect(seenOptions[1]).toBe(options);
     expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
-      'Bearer synthetic-second',
       'Bearer synthetic-first',
     ]);
-    expect(provider).toHaveBeenCalledTimes(2);
+    expect(provider).toHaveBeenCalledTimes(1);
 
-    provider.mockResolvedValueOnce('synthetic-third');
+    provider.mockResolvedValueOnce('synthetic-second');
     const subsequent = await client.buildRequest(options);
-    expect(subsequent.req.headers.get('authorization')).toBe('Bearer synthetic-third');
-    expect(provider).toHaveBeenCalledTimes(3);
-    expect(seenOptions[2]).toBe(options);
+    expect(subsequent.req.headers.get('authorization')).toBe('Bearer synthetic-second');
+    expect(provider).toHaveBeenCalledTimes(2);
+    expect(seenOptions[1]).toBe(options);
   },
 );
 
@@ -634,7 +630,7 @@ test('preserves post-prepare static keys through transparent _callApiKey overrid
   expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-selected-by-prepare');
 });
 
-test('keeps prepared credentials through overlapping async hooks sharing options', async () => {
+test('rejects ambiguous shared-options authentication before sending another request credential', async () => {
   let signalEntered!: () => void;
   let signalRelease!: () => void;
   // oxlint-disable promise/avoid-new -- These gates enforce the shared-options overlap.
@@ -667,15 +663,191 @@ test('keeps prepared credentials through overlapping async hooks sharing options
 
   const first = client.request(options);
   await entered;
-  await client.request(options);
+  await expect(client.request(options)).rejects.toThrow(
+    'overlapping requests that share the same options object',
+  );
   signalRelease();
   await first;
 
   expect(provider).toHaveBeenCalledTimes(2);
   expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
-    'Bearer synthetic-second',
     'Bearer synthetic-first',
   ]);
+});
+
+test('keeps repeated authentication delegation bound after rejecting shared-options overlap', async () => {
+  let releaseFirst!: () => void;
+  let signalFirstEntered!: () => void;
+  // oxlint-disable promise/avoid-new -- This gate overlaps another request between delegations.
+  const firstEntered = new Promise<void>((resolve) => {
+    signalFirstEntered = resolve;
+  });
+  const firstRelease = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  // oxlint-enable promise/avoid-new
+  class RepeatedHeaders extends OpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      await super.authHeaders(options);
+      signalFirstEntered();
+      await firstRelease;
+      return super.authHeaders(options);
+    }
+  }
+  const provider = vi
+    .fn<() => Promise<string>>()
+    .mockResolvedValueOnce('synthetic-first')
+    .mockResolvedValueOnce('synthetic-second');
+  const fetch = mockFetch();
+  const client = new RepeatedHeaders({ apiKey: provider, fetch });
+  const options: FinalRequestOptions = { method: 'get', path: '/items' };
+
+  const first = client.request(options);
+  await firstEntered;
+  await expect(client.request(options)).rejects.toThrow(
+    'overlapping requests that share the same options object',
+  );
+  releaseFirst();
+  await first;
+
+  expect(provider).toHaveBeenCalledTimes(2);
+  expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
+    'Bearer synthetic-first',
+  ]);
+});
+
+test('keeps an active build credential while a shared-options request pauses after preparation', async () => {
+  let releaseFirst!: () => void;
+  let releaseSecond!: () => void;
+  let finishFirst!: () => void;
+  let signalFirstEntered!: () => void;
+  let signalFirstDelegated!: () => void;
+  let signalSecondPrepared!: () => void;
+  // oxlint-disable promise/avoid-new -- These gates enforce the preparation/build overlap.
+  const firstEntered = new Promise<void>((resolve) => {
+    signalFirstEntered = resolve;
+  });
+  const firstRelease = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  const firstDelegated = new Promise<void>((resolve) => {
+    signalFirstDelegated = resolve;
+  });
+  const firstFinish = new Promise<void>((resolve) => {
+    finishFirst = resolve;
+  });
+  const secondPrepared = new Promise<void>((resolve) => {
+    signalSecondPrepared = resolve;
+  });
+  const secondRelease = new Promise<void>((resolve) => {
+    releaseSecond = resolve;
+  });
+  // oxlint-enable promise/avoid-new
+  class PausedPreparation extends OpenAI {
+    preparations = 0;
+    authentications = 0;
+
+    protected override async prepareOptions(options: FinalRequestOptions) {
+      this.preparations += 1;
+      await super.prepareOptions(options);
+      if (this.preparations === 2) {
+        signalSecondPrepared();
+        await secondRelease;
+      }
+    }
+
+    protected override async authHeaders(options: FinalRequestOptions) {
+      this.authentications += 1;
+      if (this.authentications === 1) {
+        signalFirstEntered();
+        await firstRelease;
+        const headers = await super.authHeaders(options);
+        signalFirstDelegated();
+        await firstFinish;
+        return headers;
+      }
+      return super.authHeaders(options);
+    }
+  }
+  const provider = vi
+    .fn<() => Promise<string>>()
+    .mockResolvedValueOnce('synthetic-first')
+    .mockResolvedValueOnce('synthetic-second');
+  const fetch = mockFetch();
+  const client = new PausedPreparation({ apiKey: provider, fetch, maxRetries: 0 });
+  const options: FinalRequestOptions = { method: 'get', path: '/items' };
+
+  const first = client.request(options);
+  await firstEntered;
+  const second = client.request(options);
+  await secondPrepared;
+  releaseFirst();
+  await firstDelegated;
+  releaseSecond();
+  await expect(second).rejects.toThrow('overlapping requests that share the same options object');
+  finishFirst();
+  await first;
+
+  expect(provider).toHaveBeenCalledTimes(2);
+  expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
+    'Bearer synthetic-first',
+  ]);
+});
+
+test.each([{}, { adminAPIKeyAuth: true }])(
+  'allows shared-options direct builds when a custom bearer hook is unused by security %o',
+  async (security) => {
+    let bearerCalls = 0;
+    class UnusedBearerHook extends OpenAI {
+      protected override async bearerAuth(options: FinalRequestOptions) {
+        bearerCalls += 1;
+        return super.bearerAuth(options);
+      }
+    }
+    const client = new UnusedBearerHook({ apiKey: 'synthetic-api', adminAPIKey: 'synthetic-admin' });
+    const options: FinalRequestOptions = {
+      method: 'get',
+      path: '/items',
+      __security: security,
+      headers: { authorization: security.adminAPIKeyAuth ? undefined : null },
+    };
+
+    const [first, second] = await Promise.all([client.buildRequest(options), client.buildRequest(options)]);
+
+    expect(first.req.headers.get('authorization')).toBe(
+      security.adminAPIKeyAuth ? 'Bearer synthetic-admin' : null,
+    );
+    expect(second.req.headers.get('authorization')).toBe(
+      security.adminAPIKeyAuth ? 'Bearer synthetic-admin' : null,
+    );
+    expect(bearerCalls).toBe(0);
+  },
+);
+
+test('Bedrock request preparation does not rebuild a stateful URL', async () => {
+  class StatefulBedrock extends BedrockOpenAI {
+    buildURLCalls = 0;
+
+    override buildURL(
+      path: string,
+      query: Record<string, unknown> | null | undefined,
+      defaultBaseURL?: string | undefined,
+    ): string {
+      this.buildURLCalls += 1;
+      if (this.buildURLCalls > 2) {
+        throw new Error('synthetic exhausted route');
+      }
+      return super.buildURL(path, query, defaultBaseURL);
+    }
+  }
+  const client = new StatefulBedrock({
+    baseURL: 'https://credentials.example/v1',
+    bedrockTokenProvider: async () => 'synthetic-provider',
+    fetch: mockFetch(),
+  });
+
+  await expect(client.get('/items')).resolves.toEqual({ ok: true });
+  expect(client.buildURLCalls).toBe(2);
 });
 
 test('preserves apiKey assignments after delegated prepareOptions', async () => {

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -984,6 +984,78 @@ test('Bedrock request preparation does not rebuild a stateful URL', async () => 
   expect(client.buildURLCalls).toBe(2);
 });
 
+describe.each(['request', 'direct build'] as const)('%s post-delegation credentials', (entrypoint) => {
+  test.each(['transform', 'clear', 'explicit capture'] as const)(
+    'preserves a _callApiKey override that uses %s',
+    async (behavior) => {
+      class PostDelegationCredentials extends OpenAI {
+        override async _callApiKey(capture?: (apiKey: string | null) => void) {
+          const result = await super._callApiKey(capture);
+          if (behavior === 'explicit capture') {
+            capture?.('synthetic-explicit');
+          }
+          this.apiKey = behavior === 'clear' ? null : 'synthetic-transformed';
+          return result;
+        }
+      }
+      const provider = vi.fn(async () => 'synthetic-provider');
+      const fetch = mockFetch();
+      const client = new PostDelegationCredentials({ apiKey: provider, adminAPIKey: null, fetch });
+      const getHeaders = async () => {
+        if (entrypoint === 'request') {
+          await client.get('/items');
+          return sentHeaders(fetch)[0];
+        }
+        const built = await client.buildRequest({ method: 'get', path: '/items' });
+        return built.req.headers;
+      };
+
+      if (behavior === 'clear') {
+        await expect(getHeaders()).rejects.toThrow('Could not resolve authentication method.');
+        expect(fetch).not.toHaveBeenCalled();
+      } else {
+        const headers = await getHeaders();
+        expect(headers?.get('authorization')).toBe(
+          behavior === 'explicit capture' ? 'Bearer synthetic-explicit' : 'Bearer synthetic-transformed',
+        );
+      }
+      expect(provider).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test('keeps concurrent credentials through transparent _callApiKey forwarding', async () => {
+    class DelegatingCredentials extends OpenAI {
+      override async _callApiKey(capture?: (apiKey: string | null) => void) {
+        const result = await super._callApiKey(capture);
+        return result;
+      }
+    }
+    const provider = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce('synthetic-first')
+      .mockResolvedValueOnce('synthetic-second');
+    const fetch = mockFetch();
+    const client = new DelegatingCredentials({ apiKey: provider, fetch });
+    let headers: Headers[];
+    if (entrypoint === 'request') {
+      await Promise.all([client.get('/first'), client.get('/second')]);
+      headers = sentHeaders(fetch);
+    } else {
+      const built = await Promise.all([
+        client.buildRequest({ method: 'get', path: '/first' }),
+        client.buildRequest({ method: 'get', path: '/second' }),
+      ]);
+      headers = built.map(({ req }) => req.headers);
+    }
+
+    expect(provider).toHaveBeenCalledTimes(2);
+    expect(headers.map((value) => value.get('authorization'))).toEqual([
+      'Bearer synthetic-first',
+      'Bearer synthetic-second',
+    ]);
+  });
+});
+
 test('preserves apiKey assignments after delegated prepareOptions', async () => {
   class PreparedCredentials extends OpenAI {
     protected override async prepareOptions(options: FinalRequestOptions) {

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -311,6 +311,11 @@ test.each(clients.flatMap((kind) => ['HTTP', 'direct'].map((mode) => ({ kind, mo
       protected async resolvedAPIKey(options: FinalRequestOptions): Promise<string | null> {
         return unrelatedHelper(options);
       }
+
+      // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK request validation.
+      protected validateOptionsBeforePreparation(options: FinalRequestOptions): void {
+        throw new Error(`synthetic unrelated validation helper for ${options.path}`);
+      }
     }
     class CustomAzureOpenAI extends AzureOpenAI {
       // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK authentication.
@@ -322,6 +327,11 @@ test.each(clients.flatMap((kind) => ['HTTP', 'direct'].map((mode) => ({ kind, mo
       protected async resolvedAPIKey(options: FinalRequestOptions): Promise<string | null> {
         return unrelatedHelper(options);
       }
+
+      // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK request validation.
+      protected validateOptionsBeforePreparation(options: FinalRequestOptions): void {
+        throw new Error(`synthetic unrelated validation helper for ${options.path}`);
+      }
     }
     class CustomBedrockOpenAI extends BedrockOpenAI {
       // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK authentication.
@@ -332,6 +342,11 @@ test.each(clients.flatMap((kind) => ['HTTP', 'direct'].map((mode) => ({ kind, mo
       // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK authentication.
       protected async resolvedAPIKey(options: FinalRequestOptions): Promise<string | null> {
         return unrelatedHelper(options);
+      }
+
+      // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK request validation.
+      protected validateOptionsBeforePreparation(options: FinalRequestOptions): void {
+        throw new Error(`synthetic unrelated validation helper for ${options.path}`);
       }
     }
     const provider = vi.fn(async () => 'synthetic-provider');
@@ -365,6 +380,44 @@ test.each(clients.flatMap((kind) => ['HTTP', 'direct'].map((mode) => ({ kind, mo
 
     expect(unrelatedHelper).not.toHaveBeenCalled();
     expect(provider).toHaveBeenCalledTimes(1);
+  },
+);
+
+test.each(['Azure', 'Bedrock'] as const)(
+  '%s construction ignores unrelated subclass credential-hook registration',
+  async (kind) => {
+    const unrelatedRegistration = vi.fn((_hooks: unknown[]) => {
+      throw new Error('synthetic unrelated registration helper');
+    });
+    class CustomAzureOpenAI extends AzureOpenAI {
+      // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must not be invoked by the base constructor.
+      protected markCredentialHooksSafe(...hooks: unknown[]): void {
+        unrelatedRegistration(hooks);
+      }
+    }
+    class CustomBedrockOpenAI extends BedrockOpenAI {
+      // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must not be invoked by the base constructor.
+      protected markCredentialHooksSafe(...hooks: unknown[]): void {
+        unrelatedRegistration(hooks);
+      }
+    }
+    const provider = vi.fn(async () => 'synthetic-provider');
+    const fetch = mockFetch();
+    const options = { baseURL: 'https://credentials.example/v1', fetch, maxRetries: 0 };
+    const client =
+      kind === 'Azure'
+        ? new CustomAzureOpenAI({
+            ...options,
+            azureADTokenProvider: provider,
+            apiVersion: '2024-10-01-preview',
+          })
+        : new CustomBedrockOpenAI({ ...options, bedrockTokenProvider: provider });
+
+    await expect(client.get('/items')).resolves.toEqual({ ok: true });
+
+    expect(unrelatedRegistration).not.toHaveBeenCalled();
+    expect(provider).toHaveBeenCalledTimes(1);
+    expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-provider');
   },
 );
 

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -299,6 +299,10 @@ test('supports _callApiKey overrides returning concurrent credentials without mu
   class CustomCredentials extends OpenAI {
     resolutions = 0;
 
+    protected override async prepareOptions(options: FinalRequestOptions) {
+      await super.prepareOptions(options);
+    }
+
     override async _callApiKey(capture?: (apiKey: string | null) => void) {
       this.resolutions += 1;
       capture?.(`synthetic-resolved-${this.resolutions}`);
@@ -331,6 +335,245 @@ test('preserves apiKey assignments after delegated prepareOptions', async () => 
   await client.get('/items');
 
   expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-prepared-/items');
+});
+
+test('preserves concurrent post-super prepareOptions assignments', async () => {
+  let signalFirstPrepared!: () => void;
+  let signalSecondPrepared!: () => void;
+  let signalFirstFetched!: () => void;
+  // oxlint-disable promise/avoid-new -- Each gate controls an intentional hook interleaving.
+  const firstPrepared = new Promise<void>((resolve) => {
+    signalFirstPrepared = resolve;
+  });
+  const secondPrepared = new Promise<void>((resolve) => {
+    signalSecondPrepared = resolve;
+  });
+  const firstFetched = new Promise<void>((resolve) => {
+    signalFirstFetched = resolve;
+  });
+  // oxlint-enable promise/avoid-new
+  class PreparedCredentials extends OpenAI {
+    protected override async prepareOptions(options: FinalRequestOptions) {
+      await super.prepareOptions(options);
+      if (options.path === '/first') {
+        signalFirstPrepared();
+        await secondPrepared;
+      } else {
+        signalSecondPrepared();
+        await firstFetched;
+      }
+      this.apiKey = `synthetic-prepared-${options.path}`;
+    }
+  }
+  const fetch = vi.fn(async (url: RequestInfo, _init?: RequestInit) => {
+    if (new URL(String(url)).pathname.endsWith('/first')) {
+      signalFirstFetched();
+    }
+    return Response.json({ ok: true });
+  });
+  const client = new PreparedCredentials({ apiKey: async () => 'synthetic-provider', fetch });
+
+  const first = client.get('/first');
+  await firstPrepared;
+  const second = client.get('/second');
+  await Promise.all([first, second]);
+
+  expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
+    'Bearer synthetic-prepared-/first',
+    'Bearer synthetic-prepared-/second',
+  ]);
+});
+
+test('preserves nondelegating prepareOptions credential assignments', async () => {
+  class PreparedCredentials extends OpenAI {
+    protected override async prepareOptions() {
+      this.apiKey = 'synthetic-prepared';
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-provider');
+  const fetch = mockFetch();
+  const client = new PreparedCredentials({ apiKey: provider, fetch });
+
+  await client.get('/items');
+
+  expect(provider).not.toHaveBeenCalled();
+  expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-prepared');
+});
+
+test('preserves credential assignments made by a delegating authHeaders hook', async () => {
+  class HeaderCredentials extends OpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      this.apiKey = 'synthetic-auth-hook';
+      return super.authHeaders(options);
+    }
+  }
+  const fetch = mockFetch();
+  const client = new HeaderCredentials({ apiKey: async () => 'synthetic-provider', fetch });
+
+  await client.get('/items');
+
+  expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-auth-hook');
+});
+
+test('preserves authHeaders credential assignments in a direct build', async () => {
+  class HeaderCredentials extends OpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      this.apiKey = 'synthetic-auth-hook';
+      return super.authHeaders(options);
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-provider');
+  const client = new HeaderCredentials({ apiKey: provider });
+
+  const { req } = await client.buildRequest({ method: 'get', path: '/items' });
+
+  expect(provider).not.toHaveBeenCalled();
+  expect(req.headers.get('authorization')).toBe('Bearer synthetic-auth-hook');
+});
+
+test('reuses a prepared credential through a delegating buildRequest clone', async () => {
+  class ClonedOptions extends OpenAI {
+    override async buildRequest(
+      options: FinalRequestOptions,
+      properties?: Parameters<OpenAI['buildRequest']>[1],
+    ) {
+      return super.buildRequest({ ...options }, properties);
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-provider');
+  const fetch = mockFetch();
+  const client = new ClonedOptions({ apiKey: provider, fetch });
+
+  await client.get('/items');
+
+  expect(provider).toHaveBeenCalledTimes(1);
+  expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-provider');
+});
+
+test('resolves a direct credential through a transparent buildRequest override', async () => {
+  class DelegatingBuild extends OpenAI {
+    override async buildRequest(options: FinalRequestOptions) {
+      return super.buildRequest(options);
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-provider');
+  const client = new DelegatingBuild({ apiKey: provider });
+
+  const { req } = await client.buildRequest({ method: 'get', path: '/items' });
+
+  expect(provider).toHaveBeenCalledTimes(1);
+  expect(req.headers.get('authorization')).toBe('Bearer synthetic-provider');
+});
+
+test('does not transfer a prepared credential through a build delegated to another client', async () => {
+  const backend = new OpenAI({ apiKey: 'synthetic-backend' });
+  class DelegatingBuild extends OpenAI {
+    // oxlint-disable-next-line eslint/class-methods-use-this -- This fixture deliberately delegates to another client.
+    override async buildRequest(options: FinalRequestOptions) {
+      return backend.buildRequest(options);
+    }
+  }
+  const fetch = mockFetch();
+  const client = new DelegatingBuild({ apiKey: 'synthetic-frontend', fetch });
+
+  await client.get('/items');
+
+  expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-backend');
+});
+
+test('isolates cloned builds when request proxies reject private metadata', async () => {
+  class ClonedOptions extends OpenAI {
+    override async buildRequest(
+      options: FinalRequestOptions,
+      properties?: Parameters<OpenAI['buildRequest']>[1],
+    ) {
+      return super.buildRequest({ ...options }, properties);
+    }
+  }
+  const provider = vi
+    .fn<() => Promise<string>>()
+    .mockResolvedValueOnce('synthetic-first')
+    .mockResolvedValueOnce('synthetic-second');
+  const fetch = mockFetch();
+  const client = new ClonedOptions({ apiKey: provider, fetch });
+  // oxlint-disable-next-line unicorn/consistent-function-scoping -- This helper is local to the proxy scenario.
+  const options = (path: string) =>
+    new Proxy<FinalRequestOptions>(
+      { method: 'get', path },
+      {
+        defineProperty(target, property, attributes) {
+          return typeof property === 'symbol' ? false : Reflect.defineProperty(target, property, attributes);
+        },
+      },
+    );
+
+  await Promise.all([client.request(options('/first')), client.request(options('/second'))]);
+
+  expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
+    'Bearer synthetic-first',
+    'Bearer synthetic-second',
+  ]);
+});
+
+test('retires prepared credentials after a request before a direct build', async () => {
+  const provider = vi
+    .fn<() => Promise<string>>()
+    .mockResolvedValueOnce('synthetic-request')
+    .mockResolvedValueOnce('synthetic-direct');
+  const fetch = mockFetch();
+  const client = new OpenAI({ apiKey: provider, fetch });
+  const options: FinalRequestOptions = { method: 'get', path: '/items' };
+
+  await client.request(options);
+  const { req } = await client.buildRequest(options);
+
+  expect(provider).toHaveBeenCalledTimes(2);
+  expect(req.headers.get('authorization')).toBe('Bearer synthetic-direct');
+});
+
+test('serializes credential preparation for concurrent calls sharing one options object', async () => {
+  const provider = vi
+    .fn<() => Promise<string>>()
+    .mockResolvedValueOnce('synthetic-first')
+    .mockResolvedValueOnce('synthetic-second');
+  const fetch = mockFetch();
+  const client = new OpenAI({ apiKey: provider, fetch });
+  const options: FinalRequestOptions = { method: 'get', path: '/items' };
+
+  await Promise.all([client.request(options), client.request(options)]);
+
+  expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
+    'Bearer synthetic-first',
+    'Bearer synthetic-second',
+  ]);
+});
+
+test('allows a prepareOptions hook to await a nested request with the same options', async () => {
+  class ReentrantPreparation extends OpenAI {
+    nested = false;
+
+    protected override async prepareOptions(options: FinalRequestOptions) {
+      if (!this.nested) {
+        this.nested = true;
+        await this.request(options);
+      }
+      await super.prepareOptions(options);
+    }
+  }
+  const provider = vi
+    .fn<() => Promise<string>>()
+    .mockResolvedValueOnce('synthetic-nested')
+    .mockResolvedValueOnce('synthetic-outer');
+  const fetch = mockFetch();
+  const client = new ReentrantPreparation({ apiKey: provider, fetch });
+  const options: FinalRequestOptions = { method: 'get', path: '/items' };
+
+  await client.request(options);
+
+  expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
+    'Bearer synthetic-nested',
+    'Bearer synthetic-outer',
+  ]);
 });
 
 test('does not resolve the OpenAI callback for admin-only requests', async () => {

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -182,7 +182,7 @@ describe.each(clients)('%s HTTP credentials', (kind) => {
   });
 
   test.each(['empty', 'rejected'] as const)(
-    'releases an upload iterator after a %s credential without waiting for cleanup',
+    'rejects a %s credential before starting an upload iterator',
     async (failure) => {
       const provider = vi.fn(async () => {
         if (failure === 'rejected') {
@@ -209,7 +209,7 @@ describe.each(clients)('%s HTTP credentials', (kind) => {
           : "Expected 'apiKey' function argument to return a string",
       );
 
-      expect(release).toHaveBeenCalledTimes(1);
+      expect(release).not.toHaveBeenCalled();
       expect(provider).toHaveBeenCalledTimes(1);
       expect(fetch).not.toHaveBeenCalled();
     },
@@ -238,7 +238,7 @@ test('preserves the credential failure when upload cleanup throws during a direc
   expect(release).toHaveBeenCalledTimes(1);
 });
 
-test('preserves one-argument delegating hooks and resolves credentials after options and body preparation', async () => {
+test('preserves one-argument delegating hooks and resolves credentials through options preparation', async () => {
   const events: string[] = [];
   class HookedOpenAI extends OpenAI {
     protected override async prepareOptions(options: FinalRequestOptions) {
@@ -276,7 +276,7 @@ test('preserves one-argument delegating hooks and resolves credentials after opt
     },
   });
 
-  expect(events).toEqual(['prepare', 'prepared', 'build', 'body', 'auth', 'credential']);
+  expect(events).toEqual(['prepare', 'credential', 'prepared', 'build', 'body', 'auth']);
   expect(provider).toHaveBeenCalledTimes(1);
   expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-hook');
   expect(sentHeaders(fetch)[0]?.get('x-prepared')).toBe('yes');
@@ -295,13 +295,14 @@ test('uses a Bedrock callback once when both security schemes are requested', as
   expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-bedrock');
 });
 
-test('supports resolver overrides returning concurrent credentials without mutating apiKey', async () => {
+test('supports _callApiKey overrides returning concurrent credentials without mutating apiKey', async () => {
   class CustomCredentials extends OpenAI {
     resolutions = 0;
 
-    protected override async resolveAPIKey() {
+    override async _callApiKey(capture?: (apiKey: string | null) => void) {
       this.resolutions += 1;
-      return `synthetic-resolved-${this.resolutions}`;
+      capture?.(`synthetic-resolved-${this.resolutions}`);
+      return true;
     }
   }
   const fetch = mockFetch();
@@ -315,6 +316,21 @@ test('supports resolver overrides returning concurrent credentials without mutat
     'Bearer synthetic-resolved-2',
   ]);
   expect(client.apiKey).toBe('synthetic-configured');
+});
+
+test('preserves apiKey assignments after delegated prepareOptions', async () => {
+  class PreparedCredentials extends OpenAI {
+    protected override async prepareOptions(options: FinalRequestOptions) {
+      await super.prepareOptions(options);
+      this.apiKey = `synthetic-prepared-${options.path}`;
+    }
+  }
+  const fetch = mockFetch();
+  const client = new PreparedCredentials({ apiKey: async () => 'synthetic-provider', fetch });
+
+  await client.get('/items');
+
+  expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-prepared-/items');
 });
 
 test('does not resolve the OpenAI callback for admin-only requests', async () => {

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -295,6 +295,51 @@ test('uses a Bedrock callback once when both security schemes are requested', as
   expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-bedrock');
 });
 
+test.each(clients)('%s ignores an unrelated subclass prepareAPIKey helper', async (kind) => {
+  const unrelatedHelper = vi.fn(async (_options: FinalRequestOptions) => {
+    throw new Error('synthetic unrelated subclass helper');
+  });
+  class CustomOpenAI extends OpenAI {
+    // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK authentication.
+    protected async prepareAPIKey(options: FinalRequestOptions): Promise<void> {
+      await unrelatedHelper(options);
+    }
+  }
+  class CustomAzureOpenAI extends AzureOpenAI {
+    // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK authentication.
+    protected async prepareAPIKey(options: FinalRequestOptions): Promise<void> {
+      await unrelatedHelper(options);
+    }
+  }
+  class CustomBedrockOpenAI extends BedrockOpenAI {
+    // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK authentication.
+    protected async prepareAPIKey(options: FinalRequestOptions): Promise<void> {
+      await unrelatedHelper(options);
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-provider');
+  const fetch = mockFetch();
+  const options = { baseURL: 'https://credentials.example/v1', fetch, maxRetries: 0 };
+  let client: OpenAI;
+  if (kind === 'Azure') {
+    client = new CustomAzureOpenAI({
+      ...options,
+      azureADTokenProvider: provider,
+      apiVersion: '2024-10-01-preview',
+    });
+  } else if (kind === 'OpenAI') {
+    client = new CustomOpenAI({ ...options, apiKey: provider, adminAPIKey: null });
+  } else {
+    client = new CustomBedrockOpenAI({ ...options, bedrockTokenProvider: provider });
+  }
+
+  await expect(client.get('/items', { __security: securityFor(kind) })).resolves.toEqual({ ok: true });
+
+  expect(unrelatedHelper).not.toHaveBeenCalled();
+  expect(provider).toHaveBeenCalledTimes(1);
+  expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-provider');
+});
+
 test('supports _callApiKey overrides returning concurrent credentials without mutating apiKey', async () => {
   class CustomCredentials extends OpenAI {
     resolutions = 0;

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -318,6 +318,32 @@ test('supports _callApiKey overrides returning concurrent credentials without mu
   expect(client.apiKey).toBe('synthetic-configured');
 });
 
+test('preserves transformed provider credentials across concurrent requests', async () => {
+  const provider = vi
+    .fn<() => Promise<string>>()
+    .mockResolvedValueOnce('synthetic-first')
+    .mockResolvedValueOnce('synthetic-second');
+  const fetch = mockFetch();
+  const client = new OpenAI({ apiKey: provider, fetch });
+  let currentAPIKey: string | null = null;
+  Object.defineProperty(client, 'apiKey', {
+    get() {
+      return currentAPIKey === null ? null : `transformed-${currentAPIKey}`;
+    },
+    set(value: string | null) {
+      currentAPIKey = value;
+    },
+  });
+
+  await Promise.all([client.get('/first'), client.get('/second')]);
+
+  expect(provider).toHaveBeenCalledTimes(2);
+  expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
+    'Bearer transformed-synthetic-first',
+    'Bearer transformed-synthetic-second',
+  ]);
+});
+
 test('preserves apiKey assignments after delegated prepareOptions', async () => {
   class PreparedCredentials extends OpenAI {
     protected override async prepareOptions(options: FinalRequestOptions) {
@@ -331,6 +357,167 @@ test('preserves apiKey assignments after delegated prepareOptions', async () => 
   await client.get('/items');
 
   expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-prepared-/items');
+});
+
+test('preserves credentials supplied by prepareOptions without delegation', async () => {
+  class PreparedCredentials extends OpenAI {
+    protected override async prepareOptions() {
+      this.apiKey = 'synthetic-prepared';
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-provider');
+  const fetch = mockFetch();
+  const client = new PreparedCredentials({ apiKey: provider, fetch });
+
+  await client.get('/items');
+
+  expect(provider).not.toHaveBeenCalled();
+  expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-prepared');
+});
+
+test('preserves a preparation hook key after another request resolves its credential', async () => {
+  class PreparedCredentials extends OpenAI {
+    protected override async prepareOptions(options: FinalRequestOptions) {
+      await super.prepareOptions(options);
+      if (options.path === '/outer') {
+        await this.get('/inner');
+        this.apiKey = 'synthetic-prepared';
+      }
+    }
+  }
+  const provider = vi
+    .fn<() => Promise<string>>()
+    .mockResolvedValueOnce('synthetic-outer')
+    .mockResolvedValueOnce('synthetic-inner');
+  const fetch = mockFetch();
+  const client = new PreparedCredentials({ apiKey: provider, fetch });
+
+  await client.get('/outer');
+
+  expect(provider).toHaveBeenCalledTimes(2);
+  expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
+    'Bearer synthetic-inner',
+    'Bearer synthetic-prepared',
+  ]);
+});
+
+test.each(['static', 'function'] as const)(
+  'preserves %s key updates in authentication hooks',
+  async (kind) => {
+    class HeaderCredentials extends OpenAI {
+      protected override async authHeaders(options: FinalRequestOptions) {
+        this.apiKey = 'synthetic-header-hook';
+        return super.authHeaders(options);
+      }
+    }
+    const fetch = mockFetch();
+    const client = new HeaderCredentials({
+      apiKey: kind === 'static' ? 'synthetic-initial' : async () => 'synthetic-provider',
+      fetch,
+    });
+
+    await client.get('/items');
+
+    expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-header-hook');
+  },
+);
+
+test.each(['success', 'preparation failure', 'build failure', 'request hook failure'] as const)(
+  'retires prepared credentials after %s',
+  async (outcome) => {
+    class PreparedCredentials extends OpenAI {
+      protected override async prepareOptions(options: FinalRequestOptions) {
+        await super.prepareOptions(options);
+        if (outcome === 'preparation failure') {
+          throw new Error('synthetic preparation failure');
+        }
+      }
+
+      protected override async prepareRequest(
+        request: RequestInit,
+        context: { url: string; options: FinalRequestOptions },
+      ) {
+        await super.prepareRequest(request, context);
+        if (outcome === 'request hook failure') {
+          throw new Error('synthetic request hook failure');
+        }
+      }
+    }
+    let resolutions = 0;
+    const provider = vi.fn(async () => {
+      resolutions += 1;
+      return `synthetic-${resolutions}`;
+    });
+    const client = new PreparedCredentials({ apiKey: provider, fetch: mockFetch() });
+    const options: FinalRequestOptions = {
+      method: 'post',
+      path: '/items',
+      body: {
+        toJSON() {
+          if (outcome === 'build failure') {
+            throw new Error('synthetic build failure');
+          }
+          return { synthetic: true };
+        },
+      },
+    };
+
+    await (outcome === 'success'
+      ? client.request(options)
+      : expect(client.request(options)).rejects.toThrow(`synthetic ${outcome}`));
+    delete options.body;
+    const { req } = await client.buildRequest(options);
+
+    expect(provider).toHaveBeenCalledTimes(2);
+    expect(req.headers.get('authorization')).toBe('Bearer synthetic-2');
+  },
+);
+
+test('preserves authentication delegated from prepareRequest without resolving twice', async () => {
+  class PreparedRequest extends OpenAI {
+    protected override async prepareRequest(
+      request: RequestInit,
+      context: { url: string; options: FinalRequestOptions },
+    ) {
+      const authentication = await this.authHeaders(context.options);
+      if (authentication) {
+        request.headers = authentication.values;
+      }
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-provider');
+  const fetch = mockFetch();
+  const client = new PreparedRequest({ apiKey: provider, fetch });
+
+  await client.get('/items');
+
+  expect(provider).toHaveBeenCalledTimes(1);
+  expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-provider');
+});
+
+test('keeps preparation alive while a nested request builds with the same options', async () => {
+  class NestedRequest extends OpenAI {
+    builds = 0;
+
+    override async buildRequest(options: FinalRequestOptions) {
+      this.builds += 1;
+      if (this.builds === 1) {
+        await this.request(options);
+      }
+      return super.buildRequest(options);
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-provider');
+  const fetch = mockFetch();
+  const client = new NestedRequest({ apiKey: provider, fetch });
+  const options: FinalRequestOptions = { method: 'get', path: '/items' };
+
+  await client.request(options);
+
+  expect(provider).toHaveBeenCalledTimes(2);
+  expect(fetch).toHaveBeenCalledTimes(2);
+  await client.buildRequest(options);
+  expect(provider).toHaveBeenCalledTimes(3);
 });
 
 test('does not resolve the OpenAI callback for admin-only requests', async () => {

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -295,50 +295,78 @@ test('uses a Bedrock callback once when both security schemes are requested', as
   expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-bedrock');
 });
 
-test.each(clients)('%s ignores an unrelated subclass prepareAPIKey helper', async (kind) => {
-  const unrelatedHelper = vi.fn(async (_options: FinalRequestOptions) => {
-    throw new Error('synthetic unrelated subclass helper');
-  });
-  class CustomOpenAI extends OpenAI {
-    // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK authentication.
-    protected async prepareAPIKey(options: FinalRequestOptions): Promise<void> {
-      await unrelatedHelper(options);
-    }
-  }
-  class CustomAzureOpenAI extends AzureOpenAI {
-    // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK authentication.
-    protected async prepareAPIKey(options: FinalRequestOptions): Promise<void> {
-      await unrelatedHelper(options);
-    }
-  }
-  class CustomBedrockOpenAI extends BedrockOpenAI {
-    // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK authentication.
-    protected async prepareAPIKey(options: FinalRequestOptions): Promise<void> {
-      await unrelatedHelper(options);
-    }
-  }
-  const provider = vi.fn(async () => 'synthetic-provider');
-  const fetch = mockFetch();
-  const options = { baseURL: 'https://credentials.example/v1', fetch, maxRetries: 0 };
-  let client: OpenAI;
-  if (kind === 'Azure') {
-    client = new CustomAzureOpenAI({
-      ...options,
-      azureADTokenProvider: provider,
-      apiVersion: '2024-10-01-preview',
+test.each(clients.flatMap((kind) => ['HTTP', 'direct'].map((mode) => ({ kind, mode }))))(
+  '$kind $mode ignores unrelated subclass credential helpers',
+  async ({ kind, mode }) => {
+    const unrelatedHelper = vi.fn(async (_options: FinalRequestOptions) => {
+      throw new Error('synthetic unrelated subclass helper');
     });
-  } else if (kind === 'OpenAI') {
-    client = new CustomOpenAI({ ...options, apiKey: provider, adminAPIKey: null });
-  } else {
-    client = new CustomBedrockOpenAI({ ...options, bedrockTokenProvider: provider });
-  }
+    class CustomOpenAI extends OpenAI {
+      // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK authentication.
+      protected async prepareAPIKey(options: FinalRequestOptions): Promise<void> {
+        await unrelatedHelper(options);
+      }
 
-  await expect(client.get('/items', { __security: securityFor(kind) })).resolves.toEqual({ ok: true });
+      // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK authentication.
+      protected async resolvedAPIKey(options: FinalRequestOptions): Promise<string | null> {
+        return unrelatedHelper(options);
+      }
+    }
+    class CustomAzureOpenAI extends AzureOpenAI {
+      // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK authentication.
+      protected async prepareAPIKey(options: FinalRequestOptions): Promise<void> {
+        await unrelatedHelper(options);
+      }
 
-  expect(unrelatedHelper).not.toHaveBeenCalled();
-  expect(provider).toHaveBeenCalledTimes(1);
-  expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-provider');
-});
+      // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK authentication.
+      protected async resolvedAPIKey(options: FinalRequestOptions): Promise<string | null> {
+        return unrelatedHelper(options);
+      }
+    }
+    class CustomBedrockOpenAI extends BedrockOpenAI {
+      // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK authentication.
+      protected async prepareAPIKey(options: FinalRequestOptions): Promise<void> {
+        await unrelatedHelper(options);
+      }
+
+      // oxlint-disable-next-line eslint/class-methods-use-this -- An existing instance helper must remain independent of SDK authentication.
+      protected async resolvedAPIKey(options: FinalRequestOptions): Promise<string | null> {
+        return unrelatedHelper(options);
+      }
+    }
+    const provider = vi.fn(async () => 'synthetic-provider');
+    const fetch = mockFetch();
+    const options = { baseURL: 'https://credentials.example/v1', fetch, maxRetries: 0 };
+    let client: OpenAI;
+    if (kind === 'Azure') {
+      client = new CustomAzureOpenAI({
+        ...options,
+        azureADTokenProvider: provider,
+        apiVersion: '2024-10-01-preview',
+      });
+    } else if (kind === 'OpenAI') {
+      client = new CustomOpenAI({ ...options, apiKey: provider, adminAPIKey: null });
+    } else {
+      client = new CustomBedrockOpenAI({ ...options, bedrockTokenProvider: provider });
+    }
+
+    if (mode === 'HTTP') {
+      await expect(client.get('/items', { __security: securityFor(kind) })).resolves.toEqual({ ok: true });
+      expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-provider');
+    } else {
+      const { req } = await client.buildRequest({
+        method: 'get',
+        path: '/items',
+        __security: securityFor(kind),
+      });
+      expect(req.headers.get('authorization')).toBe('Bearer synthetic-provider');
+      expect(fetch).not.toHaveBeenCalled();
+    }
+
+    expect(unrelatedHelper).not.toHaveBeenCalled();
+    expect(provider).toHaveBeenCalledTimes(1);
+  },
+);
 
 test('supports _callApiKey overrides returning concurrent credentials without mutating apiKey', async () => {
   class CustomCredentials extends OpenAI {

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -216,6 +216,140 @@ describe.each(clients)('%s HTTP credentials', (kind) => {
   );
 });
 
+test.each([
+  { kind: 'OpenAI', hook: 'authHeaders' },
+  { kind: 'OpenAI', hook: 'bearerAuth' },
+  { kind: 'Azure', hook: 'authHeaders' },
+  { kind: 'Azure', hook: 'bearerAuth' },
+] as const)('honors an initial null assignment in a direct $kind $hook hook', async ({ kind, hook }) => {
+  class NullOpenAI extends OpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      if (hook === 'authHeaders') {
+        this.apiKey = null;
+      }
+      return super.authHeaders(options);
+    }
+
+    protected override async bearerAuth(options: FinalRequestOptions) {
+      if (hook === 'bearerAuth') {
+        this.apiKey = null;
+      }
+      return super.bearerAuth(options);
+    }
+  }
+  class NullAzure extends AzureOpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      if (hook === 'authHeaders') {
+        this.apiKey = null;
+      }
+      return super.authHeaders(options);
+    }
+
+    protected override async bearerAuth(options: FinalRequestOptions) {
+      if (hook === 'bearerAuth') {
+        this.apiKey = null;
+      }
+      return super.bearerAuth(options);
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-provider');
+  const fetch = mockFetch();
+  const options = { baseURL: 'https://credentials.example/v1', adminAPIKey: null, fetch };
+  const client =
+    kind === 'Azure'
+      ? new NullAzure({ ...options, azureADTokenProvider: provider, apiVersion: '2024-10-01-preview' })
+      : new NullOpenAI({ ...options, apiKey: provider });
+
+  await expect(
+    client.buildRequest({ method: 'get', path: '/items', __security: { bearerAuth: true } }),
+  ).rejects.toThrow('Could not resolve authentication method.');
+
+  expect(client.apiKey).toBeNull();
+  expect(provider).not.toHaveBeenCalled();
+  expect(fetch).not.toHaveBeenCalled();
+});
+
+test('honors an initial null assignment through the Bedrock credential accessor', async () => {
+  class NullBedrock extends BedrockOpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      this.apiKey = null;
+      return super.authHeaders(options);
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-provider');
+  const fetch = mockFetch();
+  const client = new NullBedrock({
+    baseURL: 'https://credentials.example/v1',
+    bedrockTokenProvider: provider,
+    fetch,
+  });
+
+  await expect(client.buildRequest({ method: 'get', path: '/items' })).rejects.toThrow(
+    'Could not resolve authentication method.',
+  );
+
+  expect(client.apiKey).toBeNull();
+  expect(provider).not.toHaveBeenCalled();
+  expect(fetch).not.toHaveBeenCalled();
+});
+
+test('observes null writes after a subclass initializes its own apiKey field', async () => {
+  class NullCredentials extends OpenAI {
+    override apiKey: string | null = null;
+
+    protected override async authHeaders(options: FinalRequestOptions) {
+      this.apiKey = null;
+      return super.authHeaders(options);
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-provider');
+  const client = new NullCredentials({ apiKey: provider, adminAPIKey: null });
+
+  await expect(client.buildRequest({ method: 'get', path: '/items' })).rejects.toThrow(
+    'Could not resolve authentication method.',
+  );
+
+  expect(provider).not.toHaveBeenCalled();
+  expect(client.apiKey).toBeNull();
+});
+
+test('preserves a custom credential accessor while observing null writes across direct builds', async () => {
+  class NullCredentials extends OpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      this.apiKey = null;
+      return super.authHeaders(options);
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-provider');
+  const client = new NullCredentials({ apiKey: provider, adminAPIKey: null });
+  let value: string | null = null;
+  const getter = vi.fn(() => value);
+  const setter = vi.fn(function setter(this: OpenAI, nextValue: string | null) {
+    expect(this).toBe(client);
+    value = nextValue;
+  });
+  Object.defineProperty(client, 'apiKey', {
+    configurable: true,
+    enumerable: true,
+    get: getter,
+    set: setter,
+  });
+
+  await expect(client.buildRequest({ method: 'get', path: '/items' })).rejects.toThrow(
+    'Could not resolve authentication method.',
+  );
+  expect(setter).toHaveBeenCalledTimes(1);
+  await expect(client.buildRequest({ method: 'get', path: '/items' })).rejects.toThrow(
+    'Could not resolve authentication method.',
+  );
+
+  expect(setter).toHaveBeenCalledTimes(2);
+  expect(getter).toHaveBeenCalled();
+  expect(Object.getOwnPropertyDescriptor(client, 'apiKey')?.get).toBe(getter);
+  expect(provider).not.toHaveBeenCalled();
+  expect(client.apiKey).toBeNull();
+});
+
 test('preserves the credential failure when upload cleanup throws during a direct build', async () => {
   const failure = new OpenAIError('synthetic provider failure');
   const release = vi.fn(() => {

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -372,6 +372,25 @@ test('treats transformed base callbacks as request-local credential captures', a
   ]);
 });
 
+test('preserves post-prepare static keys through transparent _callApiKey overrides', async () => {
+  class PreparedCredentials extends OpenAI {
+    override async _callApiKey(capture?: (apiKey: string | null) => void) {
+      return super._callApiKey((apiKey) => capture?.(apiKey));
+    }
+
+    protected override async prepareOptions(options: FinalRequestOptions) {
+      await super.prepareOptions(options);
+      this.apiKey = 'synthetic-selected-by-prepare';
+    }
+  }
+  const fetch = mockFetch();
+  const client = new PreparedCredentials({ apiKey: 'synthetic-static', fetch });
+
+  await client.get('/items');
+
+  expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-selected-by-prepare');
+});
+
 test('keeps prepared credentials through overlapping async hooks sharing options', async () => {
   let signalEntered!: () => void;
   let signalRelease!: () => void;

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -346,8 +346,95 @@ test('preserves a custom credential accessor while observing null writes across 
   expect(setter).toHaveBeenCalledTimes(2);
   expect(getter).toHaveBeenCalled();
   expect(Object.getOwnPropertyDescriptor(client, 'apiKey')?.get).toBe(getter);
+  expect(Object.getOwnPropertyDescriptor(client, 'apiKey')?.set).toBe(setter);
   expect(provider).not.toHaveBeenCalled();
   expect(client.apiKey).toBeNull();
+});
+
+test('preserves an inherited credential accessor while observing null writes across direct builds', async () => {
+  const values = new WeakMap<OpenAI, string | null>();
+  const getter = vi.fn(function getter(this: OpenAI) {
+    return values.get(this) ?? null;
+  });
+  const setter = vi.fn(function setter(this: OpenAI, nextValue: string | null) {
+    values.set(this, nextValue);
+  });
+  class NullCredentials extends OpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      this.apiKey = null;
+      return super.authHeaders(options);
+    }
+  }
+  Object.defineProperty(NullCredentials.prototype, 'apiKey', {
+    configurable: true,
+    enumerable: true,
+    get: getter,
+    set: setter,
+  });
+  const provider = vi.fn(async () => 'synthetic-provider');
+  const client = new NullCredentials({ apiKey: provider, adminAPIKey: null });
+
+  await expect(client.buildRequest({ method: 'get', path: '/items' })).rejects.toThrow(
+    'Could not resolve authentication method.',
+  );
+  await expect(client.buildRequest({ method: 'get', path: '/items' })).rejects.toThrow(
+    'Could not resolve authentication method.',
+  );
+
+  expect(setter).toHaveBeenCalledTimes(3);
+  expect(getter).toHaveBeenCalled();
+  expect(Object.getOwnPropertyDescriptor(NullCredentials.prototype, 'apiKey')?.get).toBe(getter);
+  expect(Object.hasOwn(client, 'apiKey')).toBe(false);
+  expect(provider).not.toHaveBeenCalled();
+  expect(client.apiKey).toBeNull();
+});
+
+test.each(['direct', 'normal'] as const)(
+  'preserves credential writes through a proxy receiver during a %s request',
+  async (mode) => {
+    class ProxyCredentials extends OpenAI {
+      protected override async authHeaders(options: FinalRequestOptions) {
+        new Proxy(this, {}).apiKey = 'synthetic-hook';
+        return super.authHeaders(options);
+      }
+    }
+    const provider = vi.fn(async () => 'synthetic-provider');
+    const fetch = mockFetch();
+    const client = new ProxyCredentials({ apiKey: provider, adminAPIKey: null, fetch });
+
+    if (mode === 'direct') {
+      const { req } = await client.buildRequest({ method: 'get', path: '/items' });
+      expect(req.headers.get('authorization')).toBe('Bearer synthetic-hook');
+    } else {
+      await client.get('/items');
+      expect(new Headers(fetch.mock.calls[0]?.[1]?.headers).get('authorization')).toBe(
+        'Bearer synthetic-hook',
+      );
+    }
+  },
+);
+
+test('restores the ordinary apiKey data descriptor after observing a direct build', async () => {
+  class Credentials extends OpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      return super.authHeaders(options);
+    }
+  }
+  const client = new Credentials({ apiKey: async () => 'synthetic-provider', adminAPIKey: null });
+
+  await client.buildRequest({ method: 'get', path: '/items' });
+
+  const descriptor = Object.getOwnPropertyDescriptor(client, 'apiKey');
+  expect(descriptor).toMatchObject({
+    value: 'synthetic-provider',
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  const receiver = Object.freeze({ apiKey: 'synthetic-receiver' });
+  expect(Reflect.set(client, 'apiKey', 'synthetic-update', receiver)).toBe(false);
+  Object.defineProperty(client, 'apiKey', { writable: false });
+  expect(client.apiKey).toBe('synthetic-provider');
 });
 
 test('preserves the credential failure when upload cleanup throws during a direct build', async () => {

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -384,7 +384,7 @@ test('preserves an inherited credential accessor while observing null writes acr
   expect(setter).toHaveBeenCalledTimes(3);
   expect(getter).toHaveBeenCalled();
   expect(Object.getOwnPropertyDescriptor(NullCredentials.prototype, 'apiKey')?.get).toBe(getter);
-  expect(Object.hasOwn(client, 'apiKey')).toBe(false);
+  expect(Object.getOwnPropertyDescriptor(client, 'apiKey')).toBeUndefined();
   expect(provider).not.toHaveBeenCalled();
   expect(client.apiKey).toBeNull();
 });
@@ -451,7 +451,7 @@ test.each(['direct', 'normal'] as const)(
       await client.get('/items');
       expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-hook');
     }
-    expect(Object.hasOwn(client, 'apiKey')).toBe(false);
+    expect(Object.getOwnPropertyDescriptor(client, 'apiKey')).toBeUndefined();
   },
 );
 
@@ -589,6 +589,15 @@ test('keeps observing a direct hook after it resolves a provider credential', as
   expect(provider).toHaveBeenCalledTimes(1);
 });
 
+function preparationGate() {
+  let release!: () => void;
+  // oxlint-disable-next-line promise/avoid-new -- Gates select the order of asynchronous hook delegation.
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
 test('restarts credential observation when a direct hook writes before and after provider resolution', async () => {
   class Credentials extends OpenAI {
     protected override async authHeaders(options: FinalRequestOptions) {
@@ -606,6 +615,95 @@ test('restarts credential observation when a direct hook writes before and after
   );
 
   expect(provider).toHaveBeenCalledTimes(1);
+});
+
+test('retains a borrowed credential observer until every participating build settles', async () => {
+  const firstEntered = preparationGate();
+  const resolveFirstProvider = preparationGate();
+  const firstProviderResolved = preparationGate();
+  const finishFirst = preparationGate();
+  const secondEntered = preparationGate();
+  const finishSecond = preparationGate();
+  class Credentials extends OpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      if (options.path === '/first') {
+        this.apiKey = 'synthetic-prior';
+        firstEntered.release();
+        await resolveFirstProvider.promise;
+        await this._callApiKey();
+        firstProviderResolved.release();
+        await finishFirst.promise;
+        this.apiKey = null;
+        return super.authHeaders(options);
+      }
+      const headers = await super.authHeaders(options);
+      secondEntered.release();
+      await finishSecond.promise;
+      return headers;
+    }
+  }
+  let resolutions = 0;
+  const provider = vi.fn(async () => {
+    resolutions += 1;
+    return `synthetic-${resolutions}`;
+  });
+  const client = new Credentials({ apiKey: provider, adminAPIKey: null });
+  let firstError: unknown;
+  const first = (async () => {
+    try {
+      await client.buildRequest({ method: 'get', path: '/first' });
+    } catch (error) {
+      firstError = error;
+    }
+  })();
+  await firstEntered.promise;
+  const second = client.buildRequest({ method: 'get', path: '/second' });
+  await secondEntered.promise;
+  resolveFirstProvider.release();
+  await firstProviderResolved.promise;
+  finishSecond.release();
+  const secondResult = await second;
+  finishFirst.release();
+  await first;
+
+  expect(secondResult.req.headers.get('authorization')).toBe('Bearer synthetic-prior');
+  expect(firstError).toBeInstanceOf(Error);
+  expect((firstError as Error).message).toContain('Could not resolve authentication method');
+  expect(provider).toHaveBeenCalledTimes(1);
+  expect(client.apiKey).toBeNull();
+});
+
+test('restores credential observation after hook inspection throws during setup', async () => {
+  class Credentials extends OpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      return super.authHeaders(options);
+    }
+  }
+  const client = new Credentials({ apiKey: async () => 'synthetic-provider', adminAPIKey: null });
+  let fail = true;
+  Object.defineProperty(client, 'buildURL', {
+    configurable: true,
+    get() {
+      if (fail) {
+        fail = false;
+        throw new Error('synthetic hook lookup failure');
+      }
+      return OpenAI.prototype.buildURL;
+    },
+  });
+
+  await expect(client.buildRequest({ method: 'get', path: '/first' })).rejects.toThrow(
+    'synthetic hook lookup failure',
+  );
+  const { req } = await client.buildRequest({ method: 'get', path: '/second' });
+
+  expect(req.headers.get('authorization')).toBe('Bearer synthetic-provider');
+  expect(Object.getOwnPropertyDescriptor(client, 'apiKey')).toMatchObject({
+    value: 'synthetic-provider',
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
 });
 
 test('restores credential data-property metadata changed during a build', async () => {
@@ -1664,15 +1762,6 @@ test('does not resolve the OpenAI callback for admin-only requests', async () =>
   expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-admin');
 });
 
-function preparationGate() {
-  let release!: () => void;
-  // oxlint-disable-next-line promise/avoid-new -- Gates select the order of asynchronous hook delegation.
-  const promise = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  return { promise, release };
-}
-
 describe('delayed credential preparation', () => {
   test.each([true, false])('handles pre-delegation overlap with shared options: %s', async (shared) => {
     const entered = [preparationGate(), preparationGate()] as const;
@@ -1750,4 +1839,67 @@ describe('delayed credential preparation', () => {
       'Bearer synthetic-second',
     ]);
   });
+
+  test.each([true, false])(
+    'isolates delayed request preparation from a direct build with shared options: %s',
+    async (shared) => {
+      const preparationEntered = preparationGate();
+      const startPreparation = preparationGate();
+      const preparationDelegated = preparationGate();
+      const finishPreparation = preparationGate();
+      let resolveDirect!: (value: string) => void;
+      // oxlint-disable-next-line promise/avoid-new -- Hold the direct provider to select the write order.
+      const directProvider = new Promise<string>((resolve) => {
+        resolveDirect = resolve;
+      });
+      const directProviderEntered = preparationGate();
+      class DelayedPreparation extends OpenAI {
+        protected override async prepareOptions(options: FinalRequestOptions) {
+          preparationEntered.release();
+          await startPreparation.promise;
+          await super.prepareOptions(options);
+          preparationDelegated.release();
+          await finishPreparation.promise;
+        }
+      }
+      const provider = vi
+        .fn<() => Promise<string>>()
+        .mockImplementationOnce(() => {
+          directProviderEntered.release();
+          return directProvider;
+        })
+        .mockResolvedValueOnce('synthetic-normal');
+      const fetch = mockFetch();
+      const client = new DelayedPreparation({ apiKey: provider, adminAPIKey: null, fetch });
+      const options: FinalRequestOptions = { method: 'get', path: '/items' };
+      const normalSettled = preparationGate();
+      const normal = (async () => {
+        try {
+          return { value: await client.request(options) };
+        } catch (error) {
+          return { error: error as Error };
+        } finally {
+          normalSettled.release();
+        }
+      })();
+      await preparationEntered.promise;
+      const direct = client.buildRequest(shared ? options : { ...options });
+      await directProviderEntered.promise;
+      startPreparation.release();
+      await Promise.race([preparationDelegated.promise, normalSettled.promise]);
+      resolveDirect('synthetic-direct');
+      const directResult = await direct;
+      expect(directResult.req.headers.get('authorization')).toBe('Bearer synthetic-direct');
+      finishPreparation.release();
+
+      const result = await normal;
+      if ('error' in result) {
+        expect(shared).toBe(true);
+        expect(result.error.message).toContain('overlapping requests that share the same options object');
+        expect(fetch).not.toHaveBeenCalled();
+      } else {
+        expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-normal');
+      }
+    },
+  );
 });

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -238,6 +238,123 @@ test('preserves the credential failure when upload cleanup throws during a direc
   expect(release).toHaveBeenCalledTimes(1);
 });
 
+test.each(clients)(
+  '%s gives overlapping direct builds separate credentials with shared options',
+  async (kind) => {
+    let signalEntered!: () => void;
+    let signalRelease!: () => void;
+    // oxlint-disable promise/avoid-new -- Pause the first build after it has obtained authentication headers.
+    const entered = new Promise<void>((resolve) => {
+      signalEntered = resolve;
+    });
+    const release = new Promise<void>((resolve) => {
+      signalRelease = resolve;
+    });
+    // oxlint-enable promise/avoid-new
+    const seenOptions: FinalRequestOptions[] = [];
+    async function afterAuthentication(options: FinalRequestOptions) {
+      seenOptions.push(options);
+      if (seenOptions.length === 1) {
+        signalEntered();
+        await release;
+      }
+    }
+    class PausedOpenAI extends OpenAI {
+      protected override async authHeaders(options: FinalRequestOptions) {
+        const headers = await super.authHeaders(options, options.__security);
+        await afterAuthentication(options);
+        return headers;
+      }
+    }
+    class PausedAzure extends AzureOpenAI {
+      protected override async authHeaders(options: FinalRequestOptions) {
+        const headers = await super.authHeaders(options, options.__security);
+        await afterAuthentication(options);
+        return headers;
+      }
+    }
+    class PausedBedrock extends BedrockOpenAI {
+      protected override async authHeaders(options: FinalRequestOptions) {
+        const headers = await super.authHeaders(options, options.__security);
+        await afterAuthentication(options);
+        return headers;
+      }
+    }
+    const provider = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce('synthetic-first')
+      .mockResolvedValueOnce('synthetic-second');
+    const fetch = mockFetch();
+    const clientOptions = { baseURL: 'https://credentials.example/v1', fetch };
+    let client: OpenAI;
+    if (kind === 'Azure') {
+      client = new PausedAzure({
+        ...clientOptions,
+        azureADTokenProvider: provider,
+        apiVersion: '2024-10-01-preview',
+      });
+    } else if (kind === 'Bedrock' || kind === 'Bedrock admin') {
+      client = new PausedBedrock({ ...clientOptions, bedrockTokenProvider: provider });
+    } else {
+      client = new PausedOpenAI({ ...clientOptions, apiKey: provider, adminAPIKey: null });
+    }
+    const options: FinalRequestOptions = { method: 'get', path: '/items', __security: securityFor(kind) };
+
+    const first = client.buildRequest(options);
+    await entered;
+    try {
+      const second = await client.buildRequest(options);
+      await fetch(second.url, second.req);
+    } finally {
+      signalRelease();
+    }
+    const built = await first;
+    await fetch(built.url, built.req);
+
+    expect(seenOptions).toHaveLength(2);
+    expect(seenOptions[0]).toBe(options);
+    expect(seenOptions[1]).toBe(options);
+    expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
+      'Bearer synthetic-second',
+      'Bearer synthetic-first',
+    ]);
+    expect(provider).toHaveBeenCalledTimes(2);
+
+    provider.mockResolvedValueOnce('synthetic-third');
+    const subsequent = await client.buildRequest(options);
+    expect(subsequent.req.headers.get('authorization')).toBe('Bearer synthetic-third');
+    expect(provider).toHaveBeenCalledTimes(3);
+    expect(seenOptions[2]).toBe(options);
+  },
+);
+
+test('retires direct-build credentials when authHeaders rejects after delegation', async () => {
+  class RejectedHeaders extends OpenAI {
+    calls = 0;
+
+    protected override async authHeaders(options: FinalRequestOptions) {
+      const headers = await super.authHeaders(options);
+      this.calls += 1;
+      if (this.calls === 1) {
+        throw new Error('synthetic post-authentication failure');
+      }
+      return headers;
+    }
+  }
+  const provider = vi
+    .fn<() => Promise<string>>()
+    .mockResolvedValueOnce('synthetic-failed-build')
+    .mockResolvedValueOnce('synthetic-subsequent-build');
+  const client = new RejectedHeaders({ apiKey: provider, fetch: mockFetch() });
+  const options: FinalRequestOptions = { method: 'get', path: '/items' };
+
+  await expect(client.buildRequest(options)).rejects.toThrow('synthetic post-authentication failure');
+  const { req } = await client.buildRequest(options);
+
+  expect(req.headers.get('authorization')).toBe('Bearer synthetic-subsequent-build');
+  expect(provider).toHaveBeenCalledTimes(2);
+});
+
 test('preserves one-argument delegating hooks and resolves credentials through options preparation', async () => {
   const events: string[] = [];
   class HookedOpenAI extends OpenAI {

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -389,6 +389,72 @@ test('preserves an inherited credential accessor while observing null writes acr
   expect(client.apiKey).toBeNull();
 });
 
+test('preserves provider writes to an inherited writable credential property', async () => {
+  class Credentials extends OpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      return super.authHeaders(options);
+    }
+  }
+  Object.defineProperty(Credentials.prototype, 'apiKey', {
+    value: null,
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+  let resolutions = 0;
+  const provider = vi.fn(async () => {
+    resolutions += 1;
+    return `synthetic-${resolutions}`;
+  });
+  const client = new Credentials({ apiKey: provider, adminAPIKey: null });
+  delete (client as { apiKey?: string | null }).apiKey;
+
+  const first = await client.buildRequest({ method: 'get', path: '/items' });
+  expect(first.req.headers.get('authorization')).toBe('Bearer synthetic-1');
+  expect(Object.getOwnPropertyDescriptor(client, 'apiKey')).toEqual({
+    value: 'synthetic-1',
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  const second = await client.buildRequest({ method: 'get', path: '/items' });
+
+  expect(second.req.headers.get('authorization')).toBe('Bearer synthetic-2');
+  expect(provider).toHaveBeenCalledTimes(2);
+});
+
+test.each(['direct', 'normal'] as const)(
+  'preserves a nonextensible client with an inherited credential accessor during a %s request',
+  async (mode) => {
+    let value: string | null = null;
+    class Credentials extends OpenAI {
+      protected override async authHeaders(options: FinalRequestOptions) {
+        this.apiKey = 'synthetic-hook';
+        return super.authHeaders(options);
+      }
+    }
+    Object.defineProperty(Credentials.prototype, 'apiKey', {
+      configurable: true,
+      get: () => value,
+      set: (next: string | null) => {
+        value = next;
+      },
+    });
+    const fetch = mockFetch();
+    const client = new Credentials({ apiKey: async () => 'synthetic-provider', adminAPIKey: null, fetch });
+    Object.preventExtensions(client);
+
+    if (mode === 'direct') {
+      const { req } = await client.buildRequest({ method: 'get', path: '/items' });
+      expect(req.headers.get('authorization')).toBe('Bearer synthetic-hook');
+    } else {
+      await client.get('/items');
+      expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-hook');
+    }
+    expect(Object.hasOwn(client, 'apiKey')).toBe(false);
+  },
+);
+
 test.each(['direct', 'normal'] as const)(
   'preserves credential writes through a proxy receiver during a %s request',
   async (mode) => {
@@ -413,6 +479,134 @@ test.each(['direct', 'normal'] as const)(
     }
   },
 );
+
+test.each(['direct', 'normal'] as const)(
+  'preserves rejection from a credential Proxy receiver during a %s request',
+  async (mode) => {
+    class ProxyCredentials extends OpenAI {
+      protected override async authHeaders(options: FinalRequestOptions) {
+        new Proxy(this, { defineProperty: () => false }).apiKey = 'synthetic-denied';
+        return super.authHeaders(options);
+      }
+    }
+    const fetch = mockFetch();
+    const client = new ProxyCredentials({
+      apiKey: async () => 'synthetic-provider',
+      adminAPIKey: null,
+      fetch,
+    });
+    const request =
+      mode === 'direct' ? client.buildRequest({ method: 'get', path: '/items' }) : client.get('/items');
+
+    await expect(request).rejects.toBeInstanceOf(TypeError);
+    expect(fetch).not.toHaveBeenCalled();
+  },
+);
+
+test('observes a replacement credential descriptor during an overlapping build', async () => {
+  let entered!: () => void;
+  // oxlint-disable promise/avoid-new -- These gates hold the first descriptor generation open.
+  const ready = new Promise<void>((resolve) => {
+    entered = resolve;
+  });
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  // oxlint-enable promise/avoid-new
+  class Credentials extends OpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      if (options.path === '/first') {
+        Object.defineProperty(this, 'apiKey', {
+          value: null,
+          writable: true,
+          enumerable: true,
+          configurable: true,
+        });
+        entered();
+        await gate;
+      } else {
+        this.apiKey = null;
+      }
+      return super.authHeaders(options);
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-provider');
+  const client = new Credentials({ apiKey: provider, adminAPIKey: null });
+  const first = client.buildRequest({ method: 'get', path: '/first' }).then(
+    () => {},
+    () => {},
+  );
+  await ready;
+
+  try {
+    await expect(client.buildRequest({ method: 'get', path: '/second' })).rejects.toThrow(
+      'Could not resolve authentication method.',
+    );
+  } finally {
+    release();
+    await first;
+  }
+
+  expect(provider).not.toHaveBeenCalled();
+});
+
+test('keeps observing an outer build after a nested provider resolution', async () => {
+  class Credentials extends OpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      if (options.path === '/outer') {
+        await this.buildRequest({ method: 'get', path: '/inner' });
+        this.apiKey = null;
+      }
+      return super.authHeaders(options);
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-provider');
+  const client = new Credentials({ apiKey: provider, adminAPIKey: null });
+
+  await expect(client.buildRequest({ method: 'get', path: '/outer' })).rejects.toThrow(
+    'Could not resolve authentication method.',
+  );
+
+  expect(provider).toHaveBeenCalledTimes(1);
+});
+
+test('keeps observing a direct hook after it resolves a provider credential', async () => {
+  class Credentials extends OpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      await this._callApiKey();
+      this.apiKey = null;
+      return super.authHeaders(options);
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-provider');
+  const client = new Credentials({ apiKey: provider, adminAPIKey: null });
+
+  await expect(client.buildRequest({ method: 'get', path: '/items' })).rejects.toThrow(
+    'Could not resolve authentication method.',
+  );
+
+  expect(provider).toHaveBeenCalledTimes(1);
+});
+
+test('restores credential data-property metadata changed during a build', async () => {
+  class Credentials extends OpenAI {
+    protected override async authHeaders(options: FinalRequestOptions) {
+      Object.defineProperty(this, 'apiKey', { enumerable: false });
+      return super.authHeaders(options);
+    }
+  }
+  const client = new Credentials({ apiKey: async () => 'synthetic-provider', adminAPIKey: null });
+
+  await client.buildRequest({ method: 'get', path: '/items' });
+
+  expect(Object.getOwnPropertyDescriptor(client, 'apiKey')).toMatchObject({
+    value: 'synthetic-provider',
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+});
 
 test('restores the ordinary apiKey data descriptor after observing a direct build', async () => {
   class Credentials extends OpenAI {
@@ -1142,6 +1336,43 @@ describe.each(['request', 'direct build'] as const)('%s post-delegation credenti
     ]);
   });
 });
+
+test.each(['transform', 'clear', 'explicit capture'] as const)(
+  'refreshes direct credentials after a post-delegation %s write',
+  async (behavior) => {
+    class PostDelegationCredentials extends OpenAI {
+      override async _callApiKey(capture?: (apiKey: string | null) => void) {
+        const result = await super._callApiKey(capture);
+        if (behavior === 'explicit capture') {
+          capture?.('synthetic-explicit');
+        }
+        this.apiKey = behavior === 'clear' ? null : 'synthetic-transformed';
+        return result;
+      }
+    }
+    let resolutions = 0;
+    const provider = vi.fn(async () => {
+      resolutions += 1;
+      return `synthetic-${resolutions}`;
+    });
+    const client = new PostDelegationCredentials({ apiKey: provider, adminAPIKey: null });
+    const build = () => client.buildRequest({ method: 'get', path: '/items' });
+
+    if (behavior === 'clear') {
+      await expect(build()).rejects.toThrow('Could not resolve authentication method.');
+      await expect(build()).rejects.toThrow('Could not resolve authentication method.');
+    } else {
+      const first = await build();
+      const second = await build();
+      const expected =
+        behavior === 'explicit capture' ? 'Bearer synthetic-explicit' : 'Bearer synthetic-transformed';
+      expect(first.req.headers.get('authorization')).toBe(expected);
+      expect(second.req.headers.get('authorization')).toBe(expected);
+    }
+
+    expect(provider).toHaveBeenCalledTimes(2);
+  },
+);
 
 test('preserves apiKey assignments after delegated prepareOptions', async () => {
   class PreparedCredentials extends OpenAI {

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -322,6 +322,78 @@ test('supports _callApiKey overrides returning concurrent credentials without mu
   expect(client.apiKey).toBe('synthetic-configured');
 });
 
+test('treats transformed base callbacks as request-local credential captures', async () => {
+  class TransformedCredentials extends OpenAI {
+    protected override async prepareOptions(options: FinalRequestOptions) {
+      await super.prepareOptions(options);
+    }
+
+    override async _callApiKey(capture?: (apiKey: string | null) => void) {
+      return super._callApiKey((apiKey) => {
+        this.apiKey = `transformed-${apiKey}`;
+        capture?.(this.apiKey);
+      });
+    }
+  }
+  const provider = vi
+    .fn<() => Promise<string>>()
+    .mockResolvedValueOnce('synthetic-first')
+    .mockResolvedValueOnce('synthetic-second');
+  const fetch = mockFetch();
+  const client = new TransformedCredentials({ apiKey: provider, fetch });
+
+  await Promise.all([client.get('/first'), client.get('/second')]);
+
+  expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
+    'Bearer transformed-synthetic-first',
+    'Bearer transformed-synthetic-second',
+  ]);
+});
+
+test('keeps prepared credentials through overlapping async hooks sharing options', async () => {
+  let signalEntered!: () => void;
+  let signalRelease!: () => void;
+  // oxlint-disable promise/avoid-new -- These gates enforce the shared-options overlap.
+  const entered = new Promise<void>((resolve) => {
+    signalEntered = resolve;
+  });
+  const release = new Promise<void>((resolve) => {
+    signalRelease = resolve;
+  });
+  // oxlint-enable promise/avoid-new
+  class PausedHeaders extends OpenAI {
+    calls = 0;
+
+    protected override async authHeaders(options: FinalRequestOptions) {
+      this.calls += 1;
+      if (this.calls === 1) {
+        signalEntered();
+        await release;
+      }
+      return super.authHeaders(options);
+    }
+  }
+  const provider = vi
+    .fn<() => Promise<string>>()
+    .mockResolvedValueOnce('synthetic-first')
+    .mockResolvedValueOnce('synthetic-second');
+  const fetch = mockFetch();
+  const client = new PausedHeaders({ apiKey: provider, fetch });
+  const options: FinalRequestOptions = { method: 'get', path: '/items' };
+
+  const first = client.request(options);
+  await entered;
+  await client.request(options);
+  signalRelease();
+  await first;
+
+  expect(provider).toHaveBeenCalledTimes(2);
+  expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
+    'Bearer synthetic-second',
+    'Bearer synthetic-first',
+  ]);
+});
+
 test('preserves apiKey assignments after delegated prepareOptions', async () => {
   class PreparedCredentials extends OpenAI {
     protected override async prepareOptions(options: FinalRequestOptions) {

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -513,6 +513,30 @@ test.each(['static', 'function'] as const)(
   },
 );
 
+test.each(['static', 'function'] as const)('preserves %s key updates in buildURL overrides', async (kind) => {
+  class RoutingClient extends OpenAI {
+    override buildURL(
+      path: string,
+      query: Record<string, unknown> | null | undefined,
+      defaultBaseURL?: string,
+    ) {
+      this.apiKey = 'synthetic-routing-hook';
+      return super.buildURL(path, query, defaultBaseURL);
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-provider');
+  const fetch = mockFetch();
+  const client = new RoutingClient({
+    apiKey: kind === 'static' ? 'synthetic-static' : provider,
+    fetch,
+  });
+
+  await client.get('/items');
+
+  expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-routing-hook');
+  expect(provider).toHaveBeenCalledTimes(kind === 'static' ? 0 : 1);
+});
+
 test.each(['success', 'preparation failure', 'build failure', 'request hook failure'] as const)(
   'retires prepared credentials after %s',
   async (outcome) => {

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -350,6 +350,64 @@ test('preserves a custom credential accessor while observing null writes across 
   expect(client.apiKey).toBeNull();
 });
 
+test.each(['authHeaders', 'bearerAuth'] as const)(
+  'observes null writes through a prototype accessor in a direct %s hook',
+  async (hook) => {
+    class PrototypeCredentials extends OpenAI {}
+    class NullCredentials extends PrototypeCredentials {
+      protected override async authHeaders(options: FinalRequestOptions) {
+        if (hook === 'authHeaders') {
+          this.apiKey = null;
+        }
+        return super.authHeaders(options);
+      }
+
+      protected override async bearerAuth(options: FinalRequestOptions) {
+        if (hook === 'bearerAuth') {
+          this.apiKey = null;
+        }
+        return super.bearerAuth(options);
+      }
+    }
+    const values = new WeakMap<OpenAI, string | null>();
+    const getter = function getter(this: OpenAI) {
+      return values.get(this) ?? null;
+    };
+    const setter = vi.fn(function setter(this: OpenAI, value: string | null) {
+      values.set(this, value);
+    });
+    Object.defineProperty(PrototypeCredentials.prototype, 'apiKey', {
+      get: getter,
+      set: setter,
+      configurable: true,
+      enumerable: false,
+    });
+    const original = Object.getOwnPropertyDescriptor(PrototypeCredentials.prototype, 'apiKey');
+    const provider = vi.fn(async () => 'synthetic-provider');
+    const client = new NullCredentials({ apiKey: provider, adminAPIKey: null });
+    const sibling = new NullCredentials({ apiKey: provider, adminAPIKey: null });
+    Reflect.deleteProperty(client, 'apiKey');
+    Reflect.deleteProperty(sibling, 'apiKey');
+    values.set(sibling, 'synthetic-sibling');
+    setter.mockClear();
+
+    await expect(client.buildRequest({ method: 'get', path: '/items' })).rejects.toThrow(
+      'Could not resolve authentication method.',
+    );
+    await expect(client.buildRequest({ method: 'get', path: '/items' })).rejects.toThrow(
+      'Could not resolve authentication method.',
+    );
+
+    expect(provider).not.toHaveBeenCalled();
+    expect(setter).toHaveBeenCalledTimes(2);
+    expect(setter.mock.contexts).toEqual([client, client]);
+    expect(Object.getOwnPropertyDescriptor(client, 'apiKey')?.get).toBe(getter);
+    expect(Object.getOwnPropertyDescriptor(PrototypeCredentials.prototype, 'apiKey')).toEqual(original);
+    expect(Object.getOwnPropertyDescriptor(sibling, 'apiKey')).toBeUndefined();
+    expect(sibling.apiKey).toBe('synthetic-sibling');
+  },
+);
+
 test('preserves the credential failure when upload cleanup throws during a direct build', async () => {
   const failure = new OpenAIError('synthetic provider failure');
   const release = vi.fn(() => {
@@ -1267,4 +1325,92 @@ test('does not resolve the OpenAI callback for admin-only requests', async () =>
 
   expect(provider).not.toHaveBeenCalled();
   expect(sentHeaders(fetch)[0]?.get('authorization')).toBe('Bearer synthetic-admin');
+});
+
+function preparationGate() {
+  let release!: () => void;
+  // oxlint-disable-next-line promise/avoid-new -- Gates select the order of asynchronous hook delegation.
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
+describe('delayed credential preparation', () => {
+  test.each([true, false])('handles pre-delegation overlap with shared options: %s', async (shared) => {
+    const entered = [preparationGate(), preparationGate()] as const;
+    const releases = [preparationGate(), preparationGate()] as const;
+    const seenOptions: FinalRequestOptions[] = [];
+    class DelayedPreparation extends OpenAI {
+      protected override async prepareOptions(options: FinalRequestOptions) {
+        const index = seenOptions.push(options) - 1;
+        if (index === 0 || index === 1) {
+          entered[index].release();
+          await releases[index].promise;
+        }
+        return super.prepareOptions(options);
+      }
+    }
+    const provider = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce('synthetic-first')
+      .mockResolvedValueOnce('synthetic-second')
+      .mockResolvedValueOnce('synthetic-third');
+    const fetch = mockFetch();
+    const client = new DelayedPreparation({ apiKey: provider, fetch, maxRetries: 0 });
+    const options: FinalRequestOptions = { method: 'get', path: '/items' };
+    const secondOptions = shared ? options : { ...options };
+
+    const first = client.request(options);
+    await entered[0].promise;
+    const second = client.request(secondOptions);
+    await entered[1].promise;
+    releases[0].release();
+    try {
+      if (shared) {
+        await expect(first).rejects.toThrow('overlapping requests that share the same options object');
+        expect(provider).not.toHaveBeenCalled();
+        expect(fetch).not.toHaveBeenCalled();
+      } else {
+        await first;
+        expect(provider).toHaveBeenCalledTimes(1);
+      }
+    } finally {
+      releases[1].release();
+      await second;
+    }
+    await client.request(options);
+
+    expect(seenOptions[0]).toBe(options);
+    expect(seenOptions[1]).toBe(secondOptions);
+    expect(provider).toHaveBeenCalledTimes(shared ? 2 : 3);
+    expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual(
+      shared
+        ? ['Bearer synthetic-first', 'Bearer synthetic-second']
+        : ['Bearer synthetic-first', 'Bearer synthetic-second', 'Bearer synthetic-third'],
+    );
+  });
+
+  test('preserves shared-options captures when preparation delegates synchronously', async () => {
+    class DelegatingPreparation extends OpenAI {
+      protected override async prepareOptions(options: FinalRequestOptions) {
+        await super.prepareOptions(options);
+      }
+    }
+    const provider = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce('synthetic-first')
+      .mockResolvedValueOnce('synthetic-second');
+    const fetch = mockFetch();
+    const client = new DelegatingPreparation({ apiKey: provider, fetch, maxRetries: 0 });
+    const options: FinalRequestOptions = { method: 'get', path: '/items' };
+
+    await Promise.all([client.request(options), client.request(options)]);
+
+    expect(provider).toHaveBeenCalledTimes(2);
+    expect(sentHeaders(fetch).map((headers) => headers.get('authorization'))).toEqual([
+      'Bearer synthetic-first',
+      'Bearer synthetic-second',
+    ]);
+  });
 });

--- a/tests/http-request-credentials.test.ts
+++ b/tests/http-request-credentials.test.ts
@@ -1,7 +1,7 @@
 /* oxlint-disable eslint/max-classes-per-file -- Separate subclass fixtures cover delegation and custom credential resolution. */
 import { vi } from 'vitest';
 
-import OpenAI, { AzureOpenAI, BedrockOpenAI } from 'openai';
+import OpenAI, { AzureOpenAI, BedrockOpenAI, OpenAIError } from 'openai';
 import type { ClientOptions } from 'openai';
 import type { RequestInfo, RequestInit } from 'openai/internal/builtin-types';
 import type { FinalRequestOptions } from 'openai/internal/request-options';
@@ -180,6 +180,62 @@ describe.each(clients)('%s HTTP credentials', (kind) => {
     await expect(client.get('/items', { __security: securityFor(kind) })).rejects.toThrow(message);
     expect(fetch).not.toHaveBeenCalled();
   });
+
+  test.each(['empty', 'rejected'] as const)(
+    'releases an upload iterator after a %s credential without waiting for cleanup',
+    async (failure) => {
+      const provider = vi.fn(async () => {
+        if (failure === 'rejected') {
+          throw new Error('synthetic provider failure');
+        }
+        return '';
+      });
+      // oxlint-disable-next-line promise/avoid-new -- Pending iterator cleanup must not delay the authentication failure.
+      const release = vi.fn(() => new Promise<IteratorResult<Uint8Array>>(() => {}));
+      const body = {
+        [Symbol.asyncIterator]() {
+          return {
+            next: async () => ({ done: false, value: new Uint8Array([1]) }),
+            return: release,
+          };
+        },
+      };
+      const fetch = mockFetch();
+      const client = clientFor(kind, provider, { fetch });
+
+      await expect(client.post('/items', { body, __security: securityFor(kind) })).rejects.toThrow(
+        failure === 'rejected'
+          ? "Failed to get token from 'apiKey' function"
+          : "Expected 'apiKey' function argument to return a string",
+      );
+
+      expect(release).toHaveBeenCalledTimes(1);
+      expect(provider).toHaveBeenCalledTimes(1);
+      expect(fetch).not.toHaveBeenCalled();
+    },
+  );
+});
+
+test('preserves the credential failure when upload cleanup throws during a direct build', async () => {
+  const failure = new OpenAIError('synthetic provider failure');
+  const release = vi.fn(() => {
+    throw new Error('synthetic cleanup failure');
+  });
+  const body = {
+    [Symbol.iterator]() {
+      return this;
+    },
+    next: () => ({ done: false, value: new Uint8Array([1]) }),
+    return: release,
+  };
+  const client = new OpenAI({
+    apiKey: async () => {
+      throw failure;
+    },
+  });
+
+  await expect(client.buildRequest({ method: 'post', path: '/items', body })).rejects.toBe(failure);
+  expect(release).toHaveBeenCalledTimes(1);
 });
 
 test('preserves one-argument delegating hooks and resolves credentials after options and body preparation', async () => {

--- a/tests/lib/azure-subclass-authentication.test.ts
+++ b/tests/lib/azure-subclass-authentication.test.ts
@@ -1,0 +1,83 @@
+import { vi } from 'vitest';
+import { AzureOpenAI } from 'openai';
+import type { RequestInfo, RequestInit } from 'openai/internal/builtin-types';
+
+class RotatingAzureOpenAI extends AzureOpenAI {
+  protected override async authHeaders(
+    options: Parameters<AzureOpenAI['buildRequest']>[0],
+    schemes?: { bearerAuth?: boolean; adminAPIKeyAuth?: boolean },
+  ) {
+    const headers = await super.authHeaders(options, schemes);
+    if (headers?.values.has('api-key')) {
+      const apiKey = process.env['AZURE_OPENAI_API_KEY'];
+      if (!apiKey) {
+        throw new Error('Missing AZURE_OPENAI_API_KEY');
+      }
+      headers.values.set('api-key', apiKey);
+    }
+    return headers;
+  }
+}
+
+function mockFetch() {
+  return vi.fn(async (_url: RequestInfo, _init?: RequestInit) => Response.json({ ok: true }));
+}
+
+function clientFor(fetch: ReturnType<typeof mockFetch>) {
+  return new RotatingAzureOpenAI({
+    apiKey: 'synthetic-initial',
+    adminAPIKey: 'synthetic-admin',
+    baseURL: 'https://azure.example/openai',
+    apiVersion: '2024-10-01-preview',
+    maxRetries: 0,
+    fetch,
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+test('uses the documented Azure subclass hook to rotate api-key headers', async () => {
+  const fetch = mockFetch();
+  const client = clientFor(fetch);
+
+  vi.stubEnv('AZURE_OPENAI_API_KEY', 'synthetic-first');
+  await client.get('/items');
+  vi.stubEnv('AZURE_OPENAI_API_KEY', 'synthetic-second');
+  await client.get('/items');
+
+  const headers = fetch.mock.calls.map(([, init]) => new Headers(init?.headers));
+  expect(headers.map((value) => value.get('api-key'))).toEqual(['synthetic-first', 'synthetic-second']);
+  expect(headers.map((value) => value.get('authorization'))).toEqual([null, null]);
+  expect(fetch.mock.calls.map(([, init]) => init?.redirect)).toEqual(['manual', 'manual']);
+  expect(client.apiKey).toBe('synthetic-initial');
+});
+
+test('preserves default, request, and explicit null Azure api-key header precedence', async () => {
+  vi.stubEnv('AZURE_OPENAI_API_KEY', 'synthetic-provider');
+  const fetch = mockFetch();
+  const client = clientFor(fetch).withOptions({ defaultHeaders: { 'api-key': 'synthetic-default' } });
+
+  await client.get('/items');
+  await client.get('/items', { headers: { 'api-key': 'synthetic-request' } });
+  await client.get('/items', { headers: { 'api-key': null } });
+
+  expect(fetch.mock.calls.map(([, init]) => new Headers(init?.headers).get('api-key'))).toEqual([
+    'synthetic-default',
+    'synthetic-request',
+    null,
+  ]);
+});
+
+test('delegates admin-only authentication without resolving an Azure API key', async () => {
+  vi.stubEnv('AZURE_OPENAI_API_KEY', '');
+  const fetch = mockFetch();
+  const client = clientFor(fetch);
+
+  await client.get('/organization/projects', { __security: { adminAPIKeyAuth: true } });
+
+  const headers = new Headers(fetch.mock.calls[0]?.[1]?.headers);
+  expect(headers.get('authorization')).toBe('Bearer synthetic-admin');
+  expect(headers.has('api-key')).toBe(false);
+});

--- a/tests/lib/azure.test.ts
+++ b/tests/lib/azure.test.ts
@@ -1,7 +1,9 @@
+/* oxlint-disable eslint/max-classes-per-file -- Separate subclasses exercise active and bypassed bearer hooks. */
 import { vi } from 'vitest';
 import { AzureOpenAI, APIUserAbortError, OpenAIError, toStreamingFile } from 'openai';
 import type { AzureClientOptions } from 'openai';
 import type { RequestInit, RequestInfo, Response as FetchResponse } from 'openai/internal/builtin-types';
+import type { FinalRequestOptions } from 'openai/internal/request-options';
 
 const defaultFetch = fetch;
 
@@ -84,6 +86,80 @@ describe('instantiate azure client', () => {
         { retryCount: 1 },
       );
       expect(req.headers.get('x-stainless-retry-count')).toEqual('1');
+    });
+
+    test.each(['buildRequest', 'request'] as const)(
+      '%s allows shared options when static Azure authentication bypasses bearerAuth',
+      async (operation) => {
+        let bearerCalls = 0;
+        class CustomBearerClient extends AzureOpenAI {
+          protected override async bearerAuth(options: FinalRequestOptions) {
+            bearerCalls++;
+            return super.bearerAuth(options);
+          }
+        }
+        const client = new CustomBearerClient({
+          endpoint: 'https://azure.example.test',
+          apiKey: 'synthetic-azure-key',
+          apiVersion,
+          fetch: async (_url, init) => Response.json({ apiKey: new Headers(init?.headers).get('api-key') }),
+        });
+        const options: FinalRequestOptions = { method: 'get', path: '/models' };
+
+        if (operation === 'buildRequest') {
+          const builds = await Promise.all([client.buildRequest(options), client.buildRequest(options)]);
+          expect(builds.map(({ req }) => req.headers.get('api-key'))).toEqual([
+            'synthetic-azure-key',
+            'synthetic-azure-key',
+          ]);
+        } else {
+          const responses = await Promise.all([client.request(options), client.request(options)]);
+          expect(responses).toEqual([{ apiKey: 'synthetic-azure-key' }, { apiKey: 'synthetic-azure-key' }]);
+        }
+        expect(bearerCalls).toBe(0);
+      },
+    );
+
+    test('rejects shared options while Azure AD authentication is using a custom bearerAuth', async () => {
+      let enter!: () => void;
+      let release!: () => void;
+      // oxlint-disable promise/avoid-new -- Pause the active bearer hook before it delegates.
+      const entered = new Promise<void>((resolve) => (enter = resolve));
+      const paused = new Promise<void>((resolve) => (release = resolve));
+      // oxlint-enable promise/avoid-new
+      let bearerCalls = 0;
+      class PausedBearerClient extends AzureOpenAI {
+        protected override async bearerAuth(options: FinalRequestOptions) {
+          if (++bearerCalls === 1) {
+            enter();
+            await paused;
+          }
+          return super.bearerAuth(options);
+        }
+      }
+      const provider = vi
+        .fn<() => Promise<string>>()
+        .mockResolvedValueOnce('synthetic-first')
+        .mockResolvedValueOnce('synthetic-next');
+      const client = new PausedBearerClient({
+        endpoint: 'https://azure.example.test',
+        azureADTokenProvider: provider,
+        apiVersion,
+      });
+      const options: FinalRequestOptions = { method: 'get', path: '/models' };
+
+      const first = client.buildRequest(options);
+      await entered;
+      await expect(client.buildRequest(options)).rejects.toThrow(
+        'overlapping requests that share the same options object',
+      );
+      release();
+      const initial = await first;
+      const subsequent = await client.buildRequest(options);
+      expect(initial.req.headers.get('authorization')).toBe('Bearer synthetic-first');
+      expect(subsequent.req.headers.get('authorization')).toBe('Bearer synthetic-next');
+      expect(bearerCalls).toBe(2);
+      expect(provider).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/tests/lib/bedrock-http-credential-resolution.test.ts
+++ b/tests/lib/bedrock-http-credential-resolution.test.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable eslint/max-classes-per-file -- Separate subclass fixtures cover independent compatibility paths. */
 import { vi } from 'vitest';
 
 import { BedrockOpenAI } from 'openai';
@@ -71,4 +72,26 @@ test('validates the exact direct-build URL without resolving query values again'
   expect(readCursor).toHaveBeenCalledTimes(1);
   expect(req.headers.get('authorization')).toBe('Bearer synthetic-direct');
   expect(provider).toHaveBeenCalledTimes(1);
+});
+
+test('releases credential preparation after a subclass API-key getter failure', async () => {
+  class AlternatingCredentials extends BedrockOpenAI {
+    preparations = 0;
+
+    protected override async prepareOptions() {
+      this.preparations += 1;
+      this.apiKey = this.preparations === 1 ? 'synthetic\ninvalid' : 'synthetic-valid';
+    }
+  }
+  const client = new AlternatingCredentials({
+    baseURL,
+    apiKey: 'synthetic-configured',
+    fetch: async () => Response.json({ ok: true }),
+  });
+  const options = { method: 'get' as const, path: '/items' };
+
+  await expect(client.request(options)).rejects.toThrow('invalid HTTP header value');
+  await expect(client.request(options)).resolves.toEqual({ ok: true });
+
+  expect(client.preparations).toBe(2);
 });

--- a/tests/lib/bedrock-http-credential-resolution.test.ts
+++ b/tests/lib/bedrock-http-credential-resolution.test.ts
@@ -114,6 +114,39 @@ test('does not use a custom Bedrock bearer fallback for an admin-only request', 
   expect(client.bearerCalls).toBe(0);
 });
 
+test.each(['buildRequest', 'request'] as const)(
+  '%s allows shared options when static Bedrock authentication bypasses bearerAuth',
+  async (operation) => {
+    class CustomBearerClient extends BedrockOpenAI {
+      bearerCalls = 0;
+
+      protected override async bearerAuth(options: Parameters<BedrockOpenAI['buildRequest']>[0]) {
+        this.bearerCalls += 1;
+        return super.bearerAuth(options);
+      }
+    }
+    const fetch = vi.fn(async (_url: RequestInfo, _init?: RequestInit) => Response.json({ ok: true }));
+    const client = new CustomBearerClient({ baseURL, apiKey: 'synthetic-static', fetch });
+    const options = { method: 'get' as const, path: '/items' };
+    let headers: Headers[];
+    if (operation === 'buildRequest') {
+      const built = await Promise.all([client.buildRequest(options), client.buildRequest(options)]);
+      headers = built.map(({ req }) => req.headers);
+      expect(fetch).not.toHaveBeenCalled();
+    } else {
+      await Promise.all([client.request(options), client.request(options)]);
+      headers = fetch.mock.calls.map(([, init]) => new Headers(init?.headers));
+      expect(fetch).toHaveBeenCalledTimes(2);
+    }
+
+    expect(headers.map((header) => header.get('authorization'))).toEqual([
+      'Bearer synthetic-static',
+      'Bearer synthetic-static',
+    ]);
+    expect(client.bearerCalls).toBe(0);
+  },
+);
+
 test('validates a replaced buildURL result before direct-build body or credential effects', async () => {
   class ReplacedURL extends BedrockOpenAI {
     override buildURL(
@@ -233,6 +266,51 @@ test('dispatches the constructed Bedrock URL without rebuilding it during prepar
   expect(provider).toHaveBeenCalledTimes(1);
   expect(fetch).toHaveBeenCalledTimes(1);
   expect(fetch.mock.calls[0]?.[0]).toBe(`${baseURL}/items?cursor=synthetic&route=2`);
+  expect(fetch.mock.calls[0]?.[1]?.redirect).toBe('manual');
+  expect(new Headers(fetch.mock.calls[0]?.[1]?.headers).get('authorization')).toBe(
+    'Bearer synthetic-request',
+  );
+});
+
+test('initializes Bedrock routing before inherited URL validation', async () => {
+  const events: string[] = [];
+  class PreparedRouting extends BedrockOpenAI {
+    route: string | undefined;
+
+    protected override async prepareOptions(options: Parameters<BedrockOpenAI['buildRequest']>[0]) {
+      events.push('prepare');
+      this.route = '/prepared/items';
+      await super.prepareOptions(options);
+    }
+
+    override buildURL(
+      _path: string,
+      query: Record<string, unknown> | null | undefined,
+      defaultBaseURL?: string,
+    ) {
+      events.push('url');
+      if (this.route === undefined) {
+        throw new Error('Routing state has not been prepared.');
+      }
+      return super.buildURL(this.route, query, defaultBaseURL);
+    }
+  }
+  const provider = vi.fn(async () => {
+    events.push('credential');
+    return 'synthetic-request';
+  });
+  const fetch = vi.fn(async (_url: RequestInfo, _init?: RequestInit) => {
+    events.push('fetch');
+    return Response.json({ ok: true });
+  });
+  const client = new PreparedRouting({ baseURL, bedrockTokenProvider: provider, fetch });
+
+  await expect(client.get('/items')).resolves.toEqual({ ok: true });
+
+  expect(events).toEqual(['prepare', 'url', 'credential', 'url', 'fetch']);
+  expect(provider).toHaveBeenCalledTimes(1);
+  expect(fetch).toHaveBeenCalledTimes(1);
+  expect(fetch.mock.calls[0]?.[0]).toBe(`${baseURL}/prepared/items`);
   expect(fetch.mock.calls[0]?.[1]?.redirect).toBe('manual');
   expect(new Headers(fetch.mock.calls[0]?.[1]?.headers).get('authorization')).toBe(
     'Bearer synthetic-request',

--- a/tests/lib/bedrock-http-credential-resolution.test.ts
+++ b/tests/lib/bedrock-http-credential-resolution.test.ts
@@ -4,6 +4,7 @@ import { vi } from 'vitest';
 import { BedrockOpenAI } from 'openai';
 import * as bedrockInternal from 'openai/internal/bedrock';
 import type { RequestInfo, RequestInit } from 'openai/internal/builtin-types';
+import { buildHeaders } from 'openai/internal/headers';
 
 const baseURL = 'https://bedrock.example/openai/v1';
 const schemes = [
@@ -33,6 +34,84 @@ test.each(schemes)('treats a null Bedrock _callApiKey result as final with %j', 
   );
 
   expect(client.resolutions).toBe(1);
+});
+
+test.each([
+  { mode: 'request', delegates: false, __security: { bearerAuth: true } },
+  { mode: 'request', delegates: false, __security: { bearerAuth: true, adminAPIKeyAuth: true } },
+  { mode: 'request', delegates: true, __security: { bearerAuth: true } },
+  { mode: 'request', delegates: true, __security: { bearerAuth: true, adminAPIKeyAuth: true } },
+  { mode: 'direct', delegates: false, __security: { bearerAuth: true } },
+  { mode: 'direct', delegates: false, __security: { bearerAuth: true, adminAPIKeyAuth: true } },
+  { mode: 'direct', delegates: true, __security: { bearerAuth: true } },
+  { mode: 'direct', delegates: true, __security: { bearerAuth: true, adminAPIKeyAuth: true } },
+] as const)(
+  'uses a custom Bedrock bearer fallback after one null resolution: %j',
+  async ({ mode, delegates, __security }) => {
+    class FallbackCredentials extends BedrockOpenAI {
+      resolutions = 0;
+      bearerCalls = 0;
+
+      override async _callApiKey(capture?: (apiKey: string | null) => void) {
+        this.resolutions += 1;
+        this.apiKey = null;
+        capture?.(null);
+        return true;
+      }
+
+      protected override async bearerAuth(options: Parameters<BedrockOpenAI['buildRequest']>[0]) {
+        this.bearerCalls += 1;
+        const inherited = delegates ? await super.bearerAuth(options) : undefined;
+        return inherited ?? buildHeaders([{ Authorization: 'Bearer synthetic-fallback' }]);
+      }
+    }
+    const fetch = vi.fn(async (_url: RequestInfo, _init?: RequestInit) => Response.json({ ok: true }));
+    const client = new FallbackCredentials({ baseURL, apiKey: 'synthetic-configured', fetch });
+    if (mode === 'direct') {
+      client.apiKey = null;
+    }
+
+    let headers: Headers;
+    if (mode === 'request') {
+      await client.get('/items', { __security });
+      headers = new Headers(fetch.mock.calls[0]?.[1]?.headers);
+    } else {
+      const { req } = await client.buildRequest({ method: 'get', path: '/items', __security });
+      ({ headers } = req);
+    }
+
+    expect(headers.get('authorization')).toBe('Bearer synthetic-fallback');
+    expect(client.resolutions).toBe(1);
+    expect(client.bearerCalls).toBe(1);
+  },
+);
+
+test('does not use a custom Bedrock bearer fallback for an admin-only request', async () => {
+  class FallbackCredentials extends BedrockOpenAI {
+    resolutions = 0;
+    bearerCalls = 0;
+
+    override async _callApiKey(capture?: (apiKey: string | null) => void) {
+      this.resolutions += 1;
+      this.apiKey = null;
+      capture?.(null);
+      return true;
+    }
+
+    protected override async bearerAuth(options: Parameters<BedrockOpenAI['buildRequest']>[0]) {
+      this.bearerCalls += 1;
+      return super.bearerAuth(options);
+    }
+  }
+  const client = new FallbackCredentials({ baseURL, apiKey: 'synthetic-configured' });
+  client.apiKey = null;
+
+  await expect(
+    client.buildRequest({ method: 'get', path: '/items', __security: { adminAPIKeyAuth: true } }),
+  ).rejects.toThrow('Could not resolve authentication method.');
+
+  expect(client.resolutions).toBe(1);
+  expect(client.bearerCalls).toBe(0);
 });
 
 test('validates a replaced buildURL result before direct-build body or credential effects', async () => {

--- a/tests/lib/bedrock-http-credential-resolution.test.ts
+++ b/tests/lib/bedrock-http-credential-resolution.test.ts
@@ -1,0 +1,73 @@
+import { vi } from 'vitest';
+
+import { BedrockOpenAI } from 'openai';
+import * as bedrockInternal from 'openai/internal/bedrock';
+
+const baseURL = 'https://bedrock.example/openai/v1';
+const schemes = [
+  { bearerAuth: true },
+  { adminAPIKeyAuth: true },
+  { bearerAuth: true, adminAPIKeyAuth: true },
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test.each(schemes)('treats a null Bedrock resolver result as final with %j', async (__security) => {
+  class MissingCredentials extends BedrockOpenAI {
+    resolutions = 0;
+
+    protected override async resolveAPIKey() {
+      this.resolutions += 1;
+      return this.resolutions === 1 ? null : 'synthetic';
+    }
+  }
+  const client = new MissingCredentials({ baseURL, apiKey: 'synthetic-configured' });
+
+  await expect(client.buildRequest({ method: 'get', path: '/items', __security })).rejects.toThrow(
+    'Could not resolve authentication method.',
+  );
+
+  expect(client.resolutions).toBe(1);
+});
+
+test('validates the constructed URL before resolving credentials in a direct Bedrock build', async () => {
+  const provider = vi.fn(async () => 'synthetic-direct');
+  const client = new BedrockOpenAI({ baseURL, bedrockTokenProvider: provider });
+  const guardFailure = new Error('synthetic origin validation failure');
+  vi.spyOn(bedrockInternal, 'assertBedrockRequestOrigin').mockImplementation(() => {
+    throw guardFailure;
+  });
+
+  await expect(client.buildRequest({ method: 'get', path: '/items' })).rejects.toBe(guardFailure);
+
+  expect(provider).not.toHaveBeenCalled();
+});
+
+test('validates the exact direct-build URL without resolving query values again', async () => {
+  const provider = vi.fn(async () => 'synthetic-direct');
+  const client = new BedrockOpenAI({ baseURL, bedrockTokenProvider: provider });
+  const guard = vi.spyOn(bedrockInternal, 'assertBedrockRequestOrigin');
+  const readCursor = vi.fn(() => 'synthetic cursor');
+  const query = {
+    get cursor() {
+      return readCursor();
+    },
+  };
+
+  const { req, url } = await client.buildRequest({
+    method: 'get',
+    path: '/items',
+    query,
+    defaultBaseURL: 'https://default.example/v1',
+  });
+
+  expect(guard).toHaveBeenCalledTimes(1);
+  expect(guard).toHaveBeenCalledWith(baseURL, url);
+  expect(new URL(url).origin).toBe(new URL(baseURL).origin);
+  expect(new URL(url).searchParams.get('cursor')).toBe('synthetic cursor');
+  expect(readCursor).toHaveBeenCalledTimes(1);
+  expect(req.headers.get('authorization')).toBe('Bearer synthetic-direct');
+  expect(provider).toHaveBeenCalledTimes(1);
+});

--- a/tests/lib/bedrock-http-credential-resolution.test.ts
+++ b/tests/lib/bedrock-http-credential-resolution.test.ts
@@ -57,6 +57,32 @@ test('validates a replaced buildURL result before direct-build body or credentia
   expect(serializeBody).not.toHaveBeenCalled();
 });
 
+test('validates direct-build origins despite a nondelegating validateRequestURL method', async () => {
+  class CustomValidation extends BedrockOpenAI {
+    // oxlint-disable-next-line eslint/class-methods-use-this -- This instance hook intentionally bypasses inherited validation.
+    protected validateRequestURL(_url: string): void {}
+
+    // oxlint-disable-next-line eslint/class-methods-use-this -- This instance routing override intentionally skips the base builder.
+    override buildURL(path: string): string {
+      return path;
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-direct');
+  const serializeBody = vi.fn(() => ({ synthetic: true }));
+  const client = new CustomValidation({ baseURL, bedrockTokenProvider: provider });
+
+  await expect(
+    client.buildRequest({
+      method: 'post',
+      path: 'https://other.example/openai/v1/items',
+      body: { toJSON: serializeBody },
+    }),
+  ).rejects.toThrow('origin');
+
+  expect(provider).not.toHaveBeenCalled();
+  expect(serializeBody).not.toHaveBeenCalled();
+});
+
 test('validates the constructed URL before resolving credentials in a direct Bedrock build', async () => {
   const provider = vi.fn(async () => 'synthetic-direct');
   const client = new BedrockOpenAI({ baseURL, bedrockTokenProvider: provider });
@@ -73,7 +99,7 @@ test('validates the constructed URL before resolving credentials in a direct Bed
 test('validates the exact direct-build URL without resolving query values again', async () => {
   const provider = vi.fn(async () => 'synthetic-direct');
   const client = new BedrockOpenAI({ baseURL, bedrockTokenProvider: provider });
-  const guard = vi.spyOn(bedrockInternal, 'assertBedrockRequestOrigin');
+  const guard = vi.spyOn(bedrockInternal, 'assertBedrockClientRequestOrigin');
   const readCursor = vi.fn(() => 'synthetic cursor');
   const query = {
     get cursor() {
@@ -88,8 +114,8 @@ test('validates the exact direct-build URL without resolving query values again'
     defaultBaseURL: 'https://default.example/v1',
   });
 
-  expect(guard).toHaveBeenCalledTimes(2);
-  expect(guard).toHaveBeenCalledWith(baseURL, url);
+  expect(guard).toHaveBeenCalledTimes(1);
+  expect(guard).toHaveBeenCalledWith(client, url);
   expect(new URL(url).origin).toBe(new URL(baseURL).origin);
   expect(new URL(url).searchParams.get('cursor')).toBe('synthetic cursor');
   expect(readCursor).toHaveBeenCalledTimes(1);

--- a/tests/lib/bedrock-http-credential-resolution.test.ts
+++ b/tests/lib/bedrock-http-credential-resolution.test.ts
@@ -3,6 +3,7 @@ import { vi } from 'vitest';
 
 import { BedrockOpenAI } from 'openai';
 import * as bedrockInternal from 'openai/internal/bedrock';
+import type { RequestInfo, RequestInit } from 'openai/internal/builtin-types';
 
 const baseURL = 'https://bedrock.example/openai/v1';
 const schemes = [
@@ -122,3 +123,39 @@ test('validates the exact direct-build URL without resolving query values again'
   expect(req.headers.get('authorization')).toBe('Bearer synthetic-direct');
   expect(provider).toHaveBeenCalledTimes(1);
 });
+
+test.each(['default', 'client', 'request', 'both'] as const)(
+  'uses manual redirects for a direct Bedrock build with %s fetch options',
+  async (configuration) => {
+    const provider = vi.fn(async () => 'synthetic-direct');
+    const fetch = vi.fn(async (_url: RequestInfo, _init?: RequestInit) => Response.json({ ok: true }));
+    const client = new BedrockOpenAI({
+      baseURL,
+      bedrockTokenProvider: provider,
+      fetch,
+      ...(configuration === 'client' || configuration === 'both'
+        ? { fetchOptions: { redirect: 'follow' as const } }
+        : {}),
+    });
+
+    const { req, url } = await client.buildRequest({
+      method: 'get',
+      path: '/items',
+      ...(configuration === 'request' || configuration === 'both'
+        ? { fetchOptions: { redirect: 'follow' as const } }
+        : {}),
+    });
+
+    expect(req.redirect).toBe('manual');
+    expect(provider).toHaveBeenCalledTimes(1);
+    expect(fetch).not.toHaveBeenCalled();
+
+    await client.fetchWithTimeout(url, req, 1000, new AbortController());
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch.mock.calls[0]?.[1]?.redirect).toBe('manual');
+    expect(new Headers(fetch.mock.calls[0]?.[1]?.headers).get('authorization')).toBe(
+      'Bearer synthetic-direct',
+    );
+  },
+);

--- a/tests/lib/bedrock-http-credential-resolution.test.ts
+++ b/tests/lib/bedrock-http-credential-resolution.test.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable eslint/max-classes-per-file -- Separate subclass fixtures cover credential fallback and final URL validation. */
 import { vi } from 'vitest';
 
 import { BedrockOpenAI } from 'openai';
@@ -33,6 +34,29 @@ test.each(schemes)('treats a null Bedrock _callApiKey result as final with %j', 
   expect(client.resolutions).toBe(1);
 });
 
+test('validates a replaced buildURL result before direct-build body or credential effects', async () => {
+  class ReplacedURL extends BedrockOpenAI {
+    override buildURL(
+      path: string,
+      query: Record<string, unknown> | null | undefined,
+      defaultBaseURL?: string,
+    ) {
+      super.buildURL(path, query, defaultBaseURL);
+      return 'https://other.example/openai/v1/items';
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-direct');
+  const serializeBody = vi.fn(() => ({ synthetic: true }));
+  const client = new ReplacedURL({ baseURL, bedrockTokenProvider: provider });
+
+  await expect(
+    client.buildRequest({ method: 'post', path: '/items', body: { toJSON: serializeBody } }),
+  ).rejects.toThrow('origin');
+
+  expect(provider).not.toHaveBeenCalled();
+  expect(serializeBody).not.toHaveBeenCalled();
+});
+
 test('validates the constructed URL before resolving credentials in a direct Bedrock build', async () => {
   const provider = vi.fn(async () => 'synthetic-direct');
   const client = new BedrockOpenAI({ baseURL, bedrockTokenProvider: provider });
@@ -64,7 +88,7 @@ test('validates the exact direct-build URL without resolving query values again'
     defaultBaseURL: 'https://default.example/v1',
   });
 
-  expect(guard).toHaveBeenCalledTimes(1);
+  expect(guard).toHaveBeenCalledTimes(2);
   expect(guard).toHaveBeenCalledWith(baseURL, url);
   expect(new URL(url).origin).toBe(new URL(baseURL).origin);
   expect(new URL(url).searchParams.get('cursor')).toBe('synthetic cursor');

--- a/tests/lib/bedrock-http-credential-resolution.test.ts
+++ b/tests/lib/bedrock-http-credential-resolution.test.ts
@@ -203,6 +203,59 @@ test('validates the exact direct-build URL without resolving query values again'
   expect(provider).toHaveBeenCalledTimes(1);
 });
 
+test('dispatches the constructed Bedrock URL without rebuilding it during preparation', async () => {
+  class StatefulRouting extends BedrockOpenAI {
+    urlBuilds = 0;
+
+    override buildURL(
+      path: string,
+      query: Record<string, unknown> | null | undefined,
+      defaultBaseURL?: string,
+    ) {
+      this.urlBuilds += 1;
+      if (this.urlBuilds > 2) {
+        throw new Error('The URL has already been constructed.');
+      }
+      const url = new URL(super.buildURL(path, query, defaultBaseURL));
+      url.searchParams.set('route', String(this.urlBuilds));
+      return url.toString();
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-request');
+  const fetch = vi.fn(async (_url: RequestInfo, _init?: RequestInit) => Response.json({ ok: true }));
+  const client = new StatefulRouting({ baseURL, bedrockTokenProvider: provider, fetch });
+
+  await expect(
+    client.get('/items', { query: { cursor: 'synthetic' }, fetchOptions: { redirect: 'follow' } }),
+  ).resolves.toEqual({ ok: true });
+
+  expect(client.urlBuilds).toBe(2);
+  expect(provider).toHaveBeenCalledTimes(1);
+  expect(fetch).toHaveBeenCalledTimes(1);
+  expect(fetch.mock.calls[0]?.[0]).toBe(`${baseURL}/items?cursor=synthetic&route=2`);
+  expect(fetch.mock.calls[0]?.[1]?.redirect).toBe('manual');
+  expect(new Headers(fetch.mock.calls[0]?.[1]?.headers).get('authorization')).toBe(
+    'Bearer synthetic-request',
+  );
+});
+
+test('validates a replaced final Bedrock URL before normal request dispatch', async () => {
+  class ReplacedBuildResult extends BedrockOpenAI {
+    override async buildRequest(options: Parameters<BedrockOpenAI['buildRequest']>[0]) {
+      const built = await super.buildRequest(options);
+      return { ...built, url: 'https://other.example/openai/v1/items' };
+    }
+  }
+  const provider = vi.fn(async () => 'synthetic-request');
+  const fetch = vi.fn(async (_url: RequestInfo, _init?: RequestInit) => Response.json({ ok: true }));
+  const client = new ReplacedBuildResult({ baseURL, bedrockTokenProvider: provider, fetch });
+
+  await expect(client.get('/items')).rejects.toThrow('origin');
+
+  expect(provider).toHaveBeenCalledTimes(1);
+  expect(fetch).not.toHaveBeenCalled();
+});
+
 test.each(['default', 'client', 'request', 'both'] as const)(
   'uses manual redirects for a direct Bedrock build with %s fetch options',
   async (configuration) => {

--- a/tests/lib/bedrock-http-credential-resolution.test.ts
+++ b/tests/lib/bedrock-http-credential-resolution.test.ts
@@ -14,13 +14,14 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-test.each(schemes)('treats a null Bedrock resolver result as final with %j', async (__security) => {
+test.each(schemes)('treats a null Bedrock _callApiKey result as final with %j', async (__security) => {
   class MissingCredentials extends BedrockOpenAI {
     resolutions = 0;
 
-    protected override async resolveAPIKey() {
+    override async _callApiKey(capture?: (apiKey: string | null) => void) {
       this.resolutions += 1;
-      return this.resolutions === 1 ? null : 'synthetic';
+      capture?.(this.resolutions === 1 ? null : 'synthetic');
+      return true;
     }
   }
   const client = new MissingCredentials({ baseURL, apiKey: 'synthetic-configured' });

--- a/tests/lib/bedrock.test.ts
+++ b/tests/lib/bedrock.test.ts
@@ -657,7 +657,7 @@ describe('instantiate bedrock client', () => {
       expect(fetch).not.toHaveBeenCalled();
     });
 
-    test('rejects a path getter that changes the final request origin after preparation', async () => {
+    test('dispatches the captured safe URL without rereading a stateful path getter', async () => {
       const options: { method: 'get'; path: string } = { method: 'get', path: '/models' };
       let pathReads = 0;
       Object.defineProperty(options, 'path', {
@@ -670,9 +670,11 @@ describe('instantiate bedrock client', () => {
       const fetch = vi.fn(async (_url: RequestInfo, _init?: RequestInit) => jsonResponse());
       const client = new BedrockOpenAI({ baseURL: configuredBaseURL, apiKey: 'bedrock-token', fetch });
 
-      await expect(client.request(options)).rejects.toThrow(/request origin/i);
+      await client.request(options);
 
-      expect(fetch).not.toHaveBeenCalled();
+      expect(pathReads).toBe(3);
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(String(fetch.mock.calls[0]![0])).toBe('https://bedrock.example.com/openai/v1/models');
     });
 
     test('rejects a request path mutated in a later token-provider microtask', async () => {

--- a/tests/lib/bedrock.test.ts
+++ b/tests/lib/bedrock.test.ts
@@ -659,19 +659,23 @@ describe('instantiate bedrock client', () => {
 
     test('rejects a path getter that changes the final request origin after preparation', async () => {
       const options: { method: 'get'; path: string } = { method: 'get', path: '/models' };
-      let pathReads = 0;
+      let credentialPrepared = false;
       Object.defineProperty(options, 'path', {
         enumerable: true,
         get() {
-          pathReads += 1;
-          return pathReads <= 2 ? '/models' : 'https://attacker.example/exfiltrate';
+          return credentialPrepared ? 'https://attacker.example/exfiltrate' : '/models';
         },
       });
+      const bedrockTokenProvider = vi.fn(async () => {
+        credentialPrepared = true;
+        return 'synthetic-bedrock-token';
+      });
       const fetch = vi.fn(async (_url: RequestInfo, _init?: RequestInit) => jsonResponse());
-      const client = new BedrockOpenAI({ baseURL: configuredBaseURL, apiKey: 'bedrock-token', fetch });
+      const client = new BedrockOpenAI({ baseURL: configuredBaseURL, bedrockTokenProvider, fetch });
 
       await expect(client.request(options)).rejects.toThrow(/request origin/i);
 
+      expect(bedrockTokenProvider).toHaveBeenCalledTimes(1);
       expect(fetch).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes

Keep each default HTTP function-credential result associated with its request attempt, including retries, for OpenAI, Azure AD, and legacy Bedrock. Credentials resolve through the existing preparation hooks; subclasses do not need a new resolver method. Direct `buildRequest` calls also resolve function credentials.

Preserve static-key mutation, request/header precedence, and the Realtime capture contract. Internal credential preparation, resolution, validation, and registration use unique symbols so unrelated subclass helper names remain independent. Temporary build records are removed when authentication completes or fails.

Concurrent custom `authHeaders` or `bearerAuth` hooks must receive distinct options objects. If authentication hooks overlap on the same object, the later request is rejected before entering its hook, and the first retains its credential. Only custom hooks actually entered participate in this restriction; unused bearer hooks on Azure static-key and Bedrock credential paths do not prevent concurrent builds. Custom `prepareOptions` hooks that await before delegating must also use distinct options objects: ambiguous delayed preparation is rejected before credential resolution, while synchronous delegation retains its invocation context.

Direct authentication hooks can now assign `this.apiKey = null` without invoking the function provider afterward. For custom credential hooks, the SDK observes writes to configurable `apiKey` properties with an accessor while preserving existing getters and setter receivers. Configurable inherited accessors are observed on extensible client instances without mutating shared prototypes. Ordinary clients keep their data-property descriptors. Subclasses with non-configurable properties should return custom authentication headers. These details are documented in `docs/authentication.md`.

`_callApiKey` overrides can forward the capture callback and then transform or clear `this.apiKey`; the final value is honored unless the override explicitly captures a replacement. Transparent forwarding retains separate credentials for concurrent invocations.

Bedrock routing validation runs inside inherited `prepareOptions`, after a subclass initializes its routing state and before credential resolution. Request preparation validates the constructed URL without rebuilding it; existing origin checks and manual redirects are preserved.

## Remaining review work

Two selected findings remain open pending owner decisions about subclass compatibility:

- Cloning `buildRequest` overrides need a credential-context contract: require forwarding the existing second argument, or support one-argument clones through an approved invocation carrier.
- Authenticated direct Bedrock builds through custom `buildRequest` overrides need an enclosing finalization boundary or an explicit restriction on that override path.

These limitations are not resolved by this description and remain blockers before merge.

## Validation

Validated on `f4b4992a6bce8e8e8e44af2bd4aa346fd747b38b` with Node 24.20.0 and pnpm 11.5.1:

- Public-entrypoint regressions fail before the changes and pass afterward for ambiguous delayed preparation and explicit null writes through inherited accessors.
- Controls cover distinct-options concurrency, synchronous delegation, rejected-attempt cleanup/reuse, accessor receivers, and unchanged sibling/prototype behavior.
- Full handwritten suite: **8,268 tests pass across 215 suites**.
- **374 HTTP, Azure, Bedrock, and Realtime tests pass across six suites** on both Node 24.20.0 and exact minimum Node 22.0.0.
- Built CommonJS and ESM artifacts pass **28 selected-feedback checks per runtime** on Node 22.0.0 and 24.20.0.
- `pnpm exec tsc --noEmit` and `pnpm build` pass.
- Generated-file lint and Ultracite over every tracked file pass. Canonical `pnpm lint` fails only on formatting in the untracked Symphony prompt.
- Packed-package checks pass CommonJS, ESM, ES2020 browser bundling, TypeScript 4.9/current consumers, and packed-source checks.
- Main's trusted custom-code checker passes: **3,401 / 4,000 lines**; no budget change.
- A bounded independent review found no material issue in the delayed-preparation guard or inherited-accessor observation.

Generated tests could not start locally because the pinned Steady mock server is absent. All 49 checks on the incoming remote head were successful or skipped; CI must verify this update.

AI assistance: Codex was used to prepare and validate this patch.

Symphony-Work-Item: work_item:github:openai:openai-node:2700
