### PR TITLE
ci: configure runner capacity and extend test timeout

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -10,6 +10,9 @@ trust boundaries, attacker capabilities, security objectives, exclusions,
 reportability, and severity. This policy adds no separate trust-boundary rules,
 exclusions, or severity guidance.
 
+For CI runner trust and isolation assumptions, see
+[CI runner configuration](../docs/architecture/security-model.md#ci-runner-configuration).
+
 ## Reporting a vulnerability
 
 Please report potential security vulnerabilities through OpenAI's

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   lint:
     timeout-minutes: 10
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review'
     permissions:
       contents: read
@@ -48,7 +48,7 @@ jobs:
   build:
     timeout-minutes: 5
     name: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review'
     permissions:
       contents: read
@@ -88,7 +88,7 @@ jobs:
 
   node_matrix:
     name: Read Node.js test matrix
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review'
     permissions:
       contents: read
@@ -113,8 +113,8 @@ jobs:
   test:
     name: test (${{ matrix.node-version }})
     needs: node_matrix
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review'
     continue-on-error: ${{ matrix.experimental }}
     permissions:
@@ -207,7 +207,7 @@ jobs:
     name: ${{ (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review') && 'test matrix' || 'test matrix (not run)' }}
     if: ${{ always() && (github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review') }}
     needs: [test, benchmarks, ecosystem_tests]
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-latest' }}
     permissions: {}
     steps:
       - name: Tests (all)
@@ -232,7 +232,7 @@ jobs:
   benchmarks:
     timeout-minutes: 20
     name: performance benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event_name == 'merge_group' || github.event.pull_request.head.repo.fork || github.event.action == 'ready_for_review'
     permissions:
       contents: read
@@ -267,7 +267,7 @@ jobs:
   examples:
     timeout-minutes: 30
     name: examples
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-latest' }}
     if: >-
       ${{
         github.repository == 'openai/openai-node' &&
@@ -321,7 +321,7 @@ jobs:
 
   ecosystem_tests:
     name: ecosystem tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 # Runs the repository's normal lint, build, test, benchmark, example, and ecosystem checks.
 # These checks catch generated-code, packaging, runtime, and integration
 # regressions; policy-document alignment lives in node-version-policy.yml.
+# SDK_GHA_RUNNER is trusted configuration for ephemeral GitHub-hosted capacity.
+# See docs/architecture/security-model.md#ci-runner-configuration.
 name: CI
 on:
   push:
@@ -267,7 +269,8 @@ jobs:
   examples:
     timeout-minutes: 30
     name: examples
-    runs-on: ${{ vars.SDK_GHA_RUNNER || 'ubuntu-latest' }}
+    # Keep live credentials independent of the configurable CI runner pool.
+    runs-on: ubuntu-latest
     if: >-
       ${{
         github.repository == 'openai/openai-node' &&

--- a/docs/architecture/security-model.md
+++ b/docs/architecture/security-model.md
@@ -122,6 +122,27 @@ trusted repository/application code; when untrusted runtime, API, network,
 webhook, stream, or model data reaches a sensitive sink; or when PR code or an
 artifact crosses into protected CI, release, or publication credentials.
 
+### CI runner configuration
+
+`SDK_GHA_RUNNER` is trusted repository-administrator configuration, not an
+input controlled by a pull-request author. When set, it must select ephemeral
+GitHub-hosted capacity with a fresh VM for each job. Persistent self-hosted
+runners are not a supported configuration for this override. A shared hosted
+runner pool does not imply that jobs share a persistent machine; see
+[GitHub's runner isolation documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#choosing-github-hosted-runners).
+
+The workflow does not enforce the fleet's lifecycle. Isolation and runner-group
+access remain infrastructure assumptions that must be verified when changing
+the configured runner. Private-network access is a separate boundary and is
+not made safe solely by using ephemeral VMs. Evidence that lower-trust actors
+can alter runner configuration, reach protected resources, or persist across
+jobs remains reportable; administrator control of this variable is not a
+blanket exclusion for CI findings.
+
+The secret-bearing `examples` job explicitly uses `ubuntu-latest`, independent
+of the override. Its existing main-only trigger, protected environment, and
+read-only token permissions remain in place (`.github/workflows/ci.yml`).
+
 ### Important boundaries and assumptions
 
 - **Native audio bytes and microphone capture to subprocesses:** the public


### PR DESCRIPTION
## Summary

Allow non-live CI jobs to select a runner through `SDK_GHA_RUNNER`, falling back to the existing `ubuntu-latest` runner when unset. This follows the Java SDK's configuration pattern and lets repositories provision more compute without maintaining different workflows.

Increase the test job's timeout from 10 to 15 minutes so dependency setup, tests, package validation, and minimum-runtime checks have room to finish as the suite grows. All checks and assertions remain enabled.

Keep live `examples` on `ubuntu-latest`, independent of the runner override. Document the trusted configuration and ephemeral GitHub-hosted runner requirement in the canonical security model, linked from `.github/SECURITY.md`; trigger conditions are unchanged.

## Validation

Parsed the workflow and verified that only runner selection and the test-job timeout change; all trigger conditions, permissions, and checks are preserved. `git diff --check` passes; CI will validate execution on the selected runners.

More details are available in the [internal PR](https://github.com/openai/openai-node-internal/pull/120).
