### PR TITLE
fix(ci): run Cloudflare example regressions before release

### DIFF
--- a/ecosystem-tests/cloudflare-worker/package.json
+++ b/ecosystem-tests/cloudflare-worker/package.json
@@ -8,7 +8,8 @@
 		"deploy": "wrangler deploy",
 		"start": "wrangler dev",
 		"test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
-		"test:smoke": "start-server-and-test \"node --import ./tests/startup-env.mjs ./node_modules/wrangler/bin/wrangler.js dev --env-file tests/startup.vars --local --ip 127.0.0.1 --port 8787 --inspector-port 0 --log-level error\" http://127.0.0.1:8787 \"node --test tests/startup.test.mjs\"",
+		"test:unit": "npm test -- --runInBand tests/error-response.test.js tests/worker-security.test.js tests/streaming-example-security.test.js",
+		"test:smoke": "npm run test:unit && start-server-and-test \"node --import ./tests/startup-env.mjs ./node_modules/wrangler/bin/wrangler.js dev --env-file tests/startup.vars --local --ip 127.0.0.1 --port 8787 --inspector-port 0 --log-level error\" http://127.0.0.1:8787 \"node --test tests/startup.test.mjs\"",
 		"test:ci": "start-server-and-test start http://localhost:8787 test"
 	},
 	"devDependencies": {

--- a/ecosystem-tests/cloudflare-worker/tests/streaming-example-security.test.js
+++ b/ecosystem-tests/cloudflare-worker/tests/streaming-example-security.test.js
@@ -1,4 +1,5 @@
 import { timingSafeEqual } from 'node:crypto';
+import { once } from 'node:events';
 import { readFile } from 'node:fs/promises';
 import { createContext, SourceTextModule, SyntheticModule } from 'node:vm';
 import ts from 'typescript';
@@ -99,6 +100,7 @@ async function loadExample(filename, environment = {}) {
 		['openai', { default: OpenAI }],
 		['express', { default: express }],
 		['node:crypto', { timingSafeEqual }],
+		['node:events', { once }],
 		[
 			'node:fs',
 			{


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Fix the Cloudflare test harness missing `node:events`, introduced when #2663 added backpressure handling to the raw streaming example. All 21 failures in the [7.12.0 release CI run](https://github.com/openai/openai-node/actions/runs/34294259410) happen at module loading, before assertions run.

The harness now exposes Node's real `once` export. The existing pre-merge smoke command also runs the three offline suites, so they no longer depend on the post-merge live job to catch failures. Previously, the offline ecosystem job only typechecked and checked startup; the failing suite ran behind `--live` on pushes to main.

## Verification

- Reproduced 21 failures on release source; all 44 example tests pass with the pre-#2663 source or corrected harness.
- All 58 offline Cloudflare tests pass on Node 24 with no API credentials; 71 ecosystem CLI tests and repository lint pass.
- The full offline ecosystem run built the SDK, passed TypeScript and all 58 tests, then hit a local macOS sandbox restriction starting Wrangler. CI will verify that runtime step.

Only the harness and package scripts change. No dependency, lockfile, SDK runtime, or publishing-gate changes. The tagged 7.12.0 commit remains unchanged; publication recovery needs a new release containing this fix.
