### PR TITLE
docs(examples): preserve split UTF-8 in raw stream consumer

### DIFF
--- a/examples/chat-completions/stream-to-client-raw.ts
+++ b/examples/chat-completions/stream-to-client-raw.ts
@@ -91,9 +91,8 @@ app.use(express.text());
 //     method: 'POST',
 //     body: 'Tell me why dogs are better than cats',
 //   }).then(async res => {
-//     const decoder = new TextDecoder();
-//     for await (const chunk of res.body) {
-//       console.log(`chunk: ${decoder.decode(chunk)}`);
+//     for await (const chunk of res.body.pipeThrough(new TextDecoderStream())) {
+//       console.log(`chunk: ${chunk}`);
 //     }
 //   })
 //

--- a/tests/lib/raw-streaming-fetch-example.test.ts
+++ b/tests/lib/raw-streaming-fetch-example.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+
+import { expect, test } from 'vitest';
+
+const source = readFileSync('examples/chat-completions/stream-to-client-raw.ts', 'utf-8');
+const commentedRecipe = source.match(/\/\/ {3}fetch\([\s\S]*?\/\/ {3}\}\)\n/u)?.[0];
+if (!commentedRecipe) {
+  throw new Error('The raw streaming example must include its fetch consumer recipe.');
+}
+const recipe = commentedRecipe.replaceAll(/^\/\/ ?/gmu, '');
+
+test.each([
+  {
+    name: 'preserves multibyte characters split across response chunks',
+    bytes: new TextEncoder().encode('café 日本語 🐕'),
+    expected: 'café 日本語 🐕',
+  },
+  {
+    name: 'flushes an incomplete final character at EOF',
+    bytes: Uint8Array.of(65, 0xe2, 0x82),
+    expected: 'A\uFFFD',
+  },
+  {
+    name: 'handles an empty response body',
+    bytes: new Uint8Array(),
+    expected: '',
+  },
+])('$name', async ({ bytes, expected }) => {
+  const output: string[] = [];
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const byte of bytes) {
+        controller.enqueue(Uint8Array.of(byte));
+      }
+      controller.close();
+    },
+  });
+
+  // Execute the documented consumer itself so reverting the example also fails this test.
+  await runInNewContext(recipe, {
+    fetch: async () => new Response(body),
+    TextDecoder,
+    TextDecoderStream,
+    console: {
+      log: (line: string) => output.push(line.replace(/^chunk: /u, '')),
+    },
+  });
+
+  expect(output.join('')).toBe(expected);
+});


### PR DESCRIPTION
## Summary

Fix the copyable fetch consumer in the raw streaming example so UTF-8 characters are preserved when their bytes span response chunks. The current `TextDecoder.decode(chunk)` calls finalize decoding on every chunk, turning valid accented text, CJK characters and emoji into replacement characters.

Pipe the response through `TextDecoderStream` instead. It retains partial characters across chunks and flushes at EOF. The example change is limited to the commented recipe, with an automated regression added alongside it; the server and SDK runtime are unchanged.

## Validation

Executed the literal documented fetch snippet against a synthetic Response that emits one byte per chunk. Before: `café 日本語 🐕` becomes `caf�� ��������� ����`. After: the text is preserved. Also verified that an incomplete final UTF-8 sequence flushes to a replacement character.

No OpenAI API calls were made.

- Literal snippet regression passes on Node 22.23.2, 24.20.0 and 26.5.0.
- Changed file passes pinned Oxfmt 0.62.0 and Oxlint 1.80.0 using the repository configs (Ultracite 7.10.5).
- `git diff --check` passes. Full SDK/build suites were not run for this example/test-only change.

### Automated regression added after review

`tests/lib/raw-streaming-fetch-example.test.ts` extracts and executes the actual documented fetch consumer against synthetic streamed Responses. It covers split multibyte UTF-8, EOF flushing, and an empty body. Vitest 4.1.11: 3 passed on Node 24.20.0. Reverting only the example fix makes 2 fail while the empty-body control still passes. The test file also passes pinned formatting/lint.
