### PR TITLE
fix(realtime): preserve native WebSocket error causes

### DIFF
--- a/src/beta/realtime/websocket.ts
+++ b/src/beta/realtime/websocket.ts
@@ -265,7 +265,12 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     });
 
     this.socket.addEventListener('error', (event: any) => {
-      this._onError(null, event.message, null);
+      // Native ErrorEvents can carry an empty message while `error` still holds the failure.
+      const cause = event.error ?? null;
+      const message = [event.message, cause?.message].find(
+        (value) => typeof value === 'string' && value !== '',
+      );
+      this._onError(null, message ?? 'unknown error', cause);
     });
   }
 

--- a/src/realtime/websocket.ts
+++ b/src/realtime/websocket.ts
@@ -257,7 +257,12 @@ export class OpenAIRealtimeWebSocket extends OpenAIRealtimeEmitter {
     });
 
     this.socket.addEventListener('error', (event: any) => {
-      this._onError(null, event.message, null);
+      // Native ErrorEvents can carry an empty message while `error` still holds the failure.
+      const cause = event.error ?? null;
+      const message = [event.message, cause?.message].find(
+        (value) => typeof value === 'string' && value !== '',
+      );
+      this._onError(null, message ?? 'unknown error', cause);
     });
   }
 

--- a/tests/realtime-websocket.test.ts
+++ b/tests/realtime-websocket.test.ts
@@ -248,6 +248,29 @@ describe.each([
     expect(errors).toHaveBeenCalledTimes(3);
   });
 
+  test('reports native socket failures with their message and cause', () => {
+    const realtime = new Realtime({ model: 'gpt-realtime' }, createClient());
+    const socket = lastBrowserSocket();
+    const errors = vi.fn();
+    const described = new Error('Received network error or non-101 status code.');
+    // oxlint-disable-next-line unicorn/error-message -- Node's native WebSocket reports connection failures this way.
+    const undescribed = new TypeError('');
+
+    onRealtimeEvent(realtime, 'error', errors);
+
+    socket.dispatch('error', { type: 'error', message: described.message, error: described });
+    socket.dispatch('error', { type: 'error', message: '', error: described });
+    socket.dispatch('error', { type: 'error', message: '', error: undescribed });
+    socket.dispatch('error', { type: 'error' });
+
+    expect(errors.mock.calls.map(([error]) => [error.message, error.cause])).toEqual([
+      [described.message, described],
+      [described.message, described],
+      ['unknown error', undescribed],
+      ['unknown error', null],
+    ]);
+  });
+
   test.each(['__proto__', 'constructor', 'toString', 'hasOwnProperty', 'valueOf'])(
     'dispatches Object.prototype event type %s without crashing',
     (eventType) => {


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Native socket failures lost their cause in the stable and beta WebSocket transports, leaving an empty error message on the measured Node 24 and 26 connection failures.

The listeners now forward the event's error as `cause` and choose the first non-empty event or cause message, falling back to `unknown error`.

Browser events without either field and the `ws` transports keep their existing behavior.

## Additional context & links

Regressions cover the measured event shapes and message fallback in both transports. A separate unmocked test opens Node's native WebSocket through each public entrypoint against a local TCP peer that closes the connection, then verifies the resulting message and exact native cause identity. The native regressions fail before the fix and pass with it on Node 22.0.0, 24.19.0, and 26.2.0; all 126 realtime tests, lint, and TypeScript checks pass.
