### PR TITLE
fix(runners): reject unfinished turns in streaming runTools

### DIFF
--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -416,6 +416,10 @@ one tool call at a time and execute any returned group sequentially.
 If you pass `tool_choice: {function: {name: …}}` instead of `auto`,
 it returns immediately after calling that function (and only loops to auto-recover parsing errors).
 
+If a turn ends with `finish_reason` set to `length` or `content_filter`, `runTools` rejects with
+`LengthFinishReasonError` / `ContentFilterFinishReasonError` instead of calling a tool with truncated
+arguments, whether or not `stream: true` is set.
+
 ```ts
 import OpenAI from 'openai';
 

--- a/src/lib/ChatCompletionStream.ts
+++ b/src/lib/ChatCompletionStream.ts
@@ -1295,6 +1295,14 @@ export class ChatCompletionStream<ParsedT = null>
   }
 
   /**
+   * Whether a `length` or `content_filter` finish reason fails the request even
+   * without auto-parseable input. Plain streams report the finish reason instead,
+   * leaving the truncated completion for the caller to inspect; the tool runner
+   * enables this so streaming and non-streaming `runTools()` agree.
+   */
+  protected _rejectsUnfinishedTurns = false;
+
+  /**
    * Intended for use on the frontend, consuming a stream produced with
    * `.toReadableStream()` on the backend.
    *
@@ -1896,7 +1904,7 @@ export class ChatCompletionStream<ParsedT = null>
       if (finish_reason) {
         choice.finish_reason = finish_reason;
 
-        if (this.#params && hasAutoParseableInput(this.#params)) {
+        if (this.#params && (this._rejectsUnfinishedTurns || hasAutoParseableInput(this.#params))) {
           if (finish_reason === 'length') {
             throw new LengthFinishReasonError();
           }

--- a/src/lib/ChatCompletionStreamingRunner.ts
+++ b/src/lib/ChatCompletionStreamingRunner.ts
@@ -138,6 +138,9 @@ export class ChatCompletionStreamingRunner<ParsedT = null>
       // @ts-expect-error TODO these types are incompatible
       params,
     );
+    // Fail unfinished turns like the non-streaming runner, so a `length` or
+    // `content_filter` completion never reaches a tool callback or the next request.
+    runner._rejectsUnfinishedTurns = true;
     const opts = {
       ...options,
       __metadata: { ...options?.__metadata, helperMethod: 'runTools' },

--- a/tests/lib/chat-tool-runner-truncation-parity.test.ts
+++ b/tests/lib/chat-tool-runner-truncation-parity.test.ts
@@ -1,0 +1,159 @@
+import { vi } from 'vitest';
+import OpenAI from 'openai';
+import { ContentFilterFinishReasonError, LengthFinishReasonError } from 'openai/error';
+import type { Fetch } from 'openai/internal/builtin-types';
+import type { RunnableToolFunction } from 'openai/lib/RunnableFunction';
+import type {
+  ChatCompletion,
+  ChatCompletionChunk,
+  ChatCompletionFunctionTool,
+  ChatCompletionMessageParam,
+} from 'openai/resources/chat/completions';
+
+type UnfinishedReason = 'length' | 'content_filter';
+type TurnShape = 'tool call' | 'content';
+interface Turn {
+  shape: TurnShape;
+  finishReason: ChatCompletion.Choice['finish_reason'];
+}
+
+const unfinishedErrors = {
+  length: LengthFinishReasonError,
+  content_filter: ContentFilterFinishReasonError,
+} as const;
+
+const truncatedArguments = '{"city":"Par';
+const messages: ChatCompletionMessageParam[] = [{ role: 'user', content: 'Look up Paris' }];
+const lookupDefinition = {
+  name: 'lookup',
+  description: 'Looks up a city',
+  parameters: { type: 'object', properties: { city: { type: 'string' } } },
+};
+const lookupTool: ChatCompletionFunctionTool = { type: 'function', function: lookupDefinition };
+
+function runnableLookup(lookup: (args: string) => string): RunnableToolFunction<string> {
+  return { type: 'function', function: { ...lookupDefinition, function: lookup } };
+}
+
+function completionTurn({ shape, finishReason }: Turn): ChatCompletion {
+  return {
+    id: 'chatcmpl-truncated',
+    object: 'chat.completion',
+    created: 1,
+    model: 'gpt-test',
+    choices: [
+      {
+        index: 0,
+        finish_reason: finishReason,
+        logprobs: null,
+        message:
+          shape === 'tool call'
+            ? {
+                role: 'assistant',
+                content: null,
+                refusal: null,
+                tool_calls: [
+                  {
+                    id: 'call_1',
+                    type: 'function',
+                    function: { name: 'lookup', arguments: truncatedArguments },
+                  },
+                ],
+              }
+            : { role: 'assistant', content: 'Paris is', refusal: null },
+      },
+    ],
+  };
+}
+
+function chunk(
+  delta: ChatCompletionChunk.Choice.Delta,
+  finish: ChatCompletionChunk.Choice['finish_reason'],
+): ChatCompletionChunk {
+  return {
+    id: 'chatcmpl-truncated',
+    object: 'chat.completion.chunk',
+    created: 1,
+    model: 'gpt-test',
+    choices: [{ index: 0, delta, finish_reason: finish, logprobs: null }],
+  };
+}
+
+function streamedTurn({ shape, finishReason }: Turn): ChatCompletionChunk[] {
+  if (shape === 'tool call') {
+    return [
+      chunk(
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            { index: 0, id: 'call_1', type: 'function', function: { name: 'lookup', arguments: '' } },
+          ],
+        },
+        null,
+      ),
+      chunk({ tool_calls: [{ index: 0, function: { arguments: truncatedArguments } }] }, finishReason),
+    ];
+  }
+
+  return [chunk({ role: 'assistant', content: 'Paris is' }, finishReason)];
+}
+
+function mockClient(firstTurn: Turn) {
+  const requests: { stream?: boolean }[] = [];
+  const fetch = vi.fn<Fetch>(async (_url, init) => {
+    if (typeof init?.body !== 'string') {
+      throw new TypeError('Expected a serialized chat completion request');
+    }
+    const body = JSON.parse(init.body);
+    requests.push(body);
+    // Only the first turn is unfinished, so a runner that accepts it still terminates.
+    const turn: Turn = requests.length === 1 ? firstTurn : { shape: 'content', finishReason: 'stop' };
+    if (body.stream === true) {
+      const events = streamedTurn(turn).map((event) => `data: ${JSON.stringify(event)}\n\n`);
+      return new Response(`${events.join('')}data: [DONE]\n\n`, {
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+    }
+    return Response.json(completionTurn(turn));
+  });
+
+  return { client: new OpenAI({ apiKey: 'synthetic-key', fetch, maxRetries: 0 }), requests };
+}
+
+describe.each(['length', 'content_filter'] as const)(
+  'runTools on a %s turn',
+  (finishReason: UnfinishedReason) => {
+    describe.each(['tool call', 'content'] as const)('that stops mid %s', (shape) => {
+      it.each([false, true])('rejects the turn instead of continuing (stream: %s)', async (stream) => {
+        const lookup = vi.fn((args: string) => `Found ${args}`);
+        const { client, requests } = mockClient({ shape, finishReason });
+        const params = { model: 'gpt-test', messages, tools: [runnableLookup(lookup)] };
+        const runner = stream
+          ? client.chat.completions.runTools({ ...params, stream: true })
+          : client.chat.completions.runTools(params);
+
+        await expect(runner.done()).rejects.toThrow(unfinishedErrors[finishReason]);
+
+        expect(lookup).not.toHaveBeenCalled();
+        expect(requests).toHaveLength(1);
+        expect(runner.messages).toEqual(messages);
+      });
+    });
+
+    it('leaves chat.completions.stream() reporting the finish reason', async () => {
+      const { client, requests } = mockClient({ shape: 'tool call', finishReason });
+
+      const completion = await client.chat.completions
+        .stream({ model: 'gpt-test', messages, tools: [lookupTool] })
+        .finalChatCompletion();
+
+      expect(completion.choices[0]?.finish_reason).toBe(finishReason);
+      expect(completion.choices[0]?.message.tool_calls?.[0]).toMatchObject({
+        type: 'function',
+        function: { name: 'lookup', arguments: truncatedArguments },
+      });
+      expect(requests).toHaveLength(1);
+    });
+  },
+);


### PR DESCRIPTION
- [x] I understand that this repository is auto-generated and my pull request may not be merged

## Changes being requested

Streaming `runTools` accepted `length` and `content_filter` turns with plain runnable tools, allowing truncated arguments to reach a callback where the non-streaming runner rejects.

A JavaScript private field identifies live tool runs. The existing `_runTools` hook enables it before execution, so unfinished turns reject at the finish chunk, before history or tool callbacks. No mutable marker module or new subclass member is exposed.

Streaming callers now receive the same rejection as non-streaming callers, while plain `chat.completions.stream()` and `fromReadableStream` replay keep their existing behavior.

## Additional context & links

Regressions cover both finish reasons across streaming and non-streaming calls, plain streaming, replay, consumer subclasses with their own private properties, and consumer field writes before execution. The `_runTools` override preserves its inherited signature. Packed-package checks verify that the old shared marker module is neither importable nor emitted. Focused tests pass on Node 22.0.0 and 24.19.0, along with lint, TypeScript, package build, and declaration compatibility checks.
