### PR TITLE
chore: bump smol-toml in Vercel Edge fixture

### DIFF
--- a/ecosystem-tests/vercel-edge/package-lock.json
+++ b/ecosystem-tests/vercel-edge/package-lock.json
@@ -8944,9 +8944,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
-      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
+      "integrity": "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/ecosystem-tests/vercel-edge/package.json
+++ b/ecosystem-tests/vercel-edge/package.json
@@ -56,13 +56,13 @@
     "@vercel/python-analysis": {
       "js-yaml": "5.2.2",
       "minimatch": "10.2.5",
-      "smol-toml": "1.7.0"
+      "smol-toml": "1.7.1"
     },
     "@vercel/remix-builder": {
       "path-to-regexp": "6.3.0"
     },
     "@vercel/rust": {
-      "smol-toml": "1.7.0"
+      "smol-toml": "1.7.1"
     },
     "@vercel/sandbox": {
       "undici": "7.29.0"
@@ -76,7 +76,7 @@
     },
     "undici": "6.28.0",
     "vercel": {
-      "smol-toml": "1.7.0"
+      "smol-toml": "1.7.1"
     }
   }
 }


### PR DESCRIPTION
The Vercel Edge fixture pins `smol-toml` to `1.7.0` through three npm overrides. Update the overrides for `vercel`, `@vercel/python-analysis`, and `@vercel/rust` to `1.7.1`, and regenerate the single resolved lockfile entry with the public npm tarball URL and matching integrity.

Validation:
- `npm ci --ignore-scripts --no-audit --no-fund` and `npm ls smol-toml --all`: passed; all three paths resolve `1.7.1`.
- CommonJS and ES module imports and ordinary TOML parsing/round-trips: passed on Node 24.20.0.
- `pnpm install --frozen-lockfile --store-dir /home/dev-user/.cache/pnpm/dependabot-909-store`: passed with existing supply-chain policies.
- `pnpm lint`: passed.
- `pnpm tsn ecosystem-tests/cli.ts vercel-edge --verbose`: passed, including SDK build/pack, fixture installation, type checking, and Next.js production build on Node 24.20.0.
- `git diff --check` and independent dependency/compatibility review: passed.

Live API tests and deployment were not run.