### PR TITLE
fix(streaming): emit terminal SSE events missing a trailing blank line

### DIFF
--- a/src/core/streaming.ts
+++ b/src/core/streaming.ts
@@ -569,6 +569,15 @@ export async function* _iterSSEMessages(
         yield sse;
       }
     }
+    // Servers sometimes omit the trailing blank line that normally
+    // terminates the last event. Flush any in-progress event exactly once.
+    if (signal.aborted) {
+      return;
+    }
+    const pending = sseDecoder.flush();
+    if (pending) {
+      yield pending;
+    }
   } catch (error) {
     failed = true;
     if (!signal.aborted || (!isAbortError(error) && error !== signal.reason)) {
@@ -698,6 +707,15 @@ class SSEDecoder {
     }
 
     return null;
+  }
+
+  /**
+   * Emits a pending event at EOF when the stream omitted the trailing blank
+   * line. Returns `null` when no event is in progress so a record that already
+   * ended with a blank line is not delivered twice.
+   */
+  flush(): ServerSentEvent | null {
+    return this.decode('');
   }
 }
 

--- a/tests/lib/streaming-core.test.ts
+++ b/tests/lib/streaming-core.test.ts
@@ -235,6 +235,35 @@ describe('Stream.fromSSEResponse', () => {
 
     expect(controller.signal.aborted).toBe(true);
   });
+
+  test.each([
+    ['a trailing blank line', '\n\n'],
+    ['a single trailing newline', '\n'],
+    ['no trailing newline', ''],
+  ])('delivers the terminal finish_reason event when the stream ends with %s', async (_, ending) => {
+    const response = responseForSSE(
+      `data: {"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}\n\ndata: {"choices":[{"delta":{},"finish_reason":"stop"}]}${ending}`,
+    );
+    const stream = Stream.fromSSEResponse(response, new AbortController());
+
+    await expect(collect(stream)).resolves.toEqual([
+      { choices: [{ delta: { content: 'hi' }, finish_reason: null }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+  });
+
+  test('delivers response.completed when the server omits the trailing blank line', async () => {
+    const response = responseForSSE(
+      'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"hi"}\n\n' +
+        'event: response.completed\ndata: {"type":"response.completed"}',
+    );
+    const stream = Stream.fromSSEResponse(response, new AbortController(), undefined, true);
+
+    await expect(collect(stream)).resolves.toEqual([
+      { event: 'response.output_text.delta', data: { type: 'response.output_text.delta', delta: 'hi' } },
+      { event: 'response.completed', data: { type: 'response.completed' } },
+    ]);
+  });
 });
 
 describe('Stream.fromReadableStream', () => {
@@ -933,22 +962,17 @@ describe('_iterSSEMessages', () => {
     }
   });
 
-  test('ignores an SSE message that ends without its required blank-line delimiter', async () => {
-    const response = responseForSSE('data: {"flushed":true}\n');
+  test.each([
+    ['no trailing newline', 'data: {"flushed":true}'],
+    ['a single LF', 'data: {"flushed":true}\n'],
+    ['a single CR', 'data: {"flushed":true}\r'],
+    ['a single CRLF', 'data: {"flushed":true}\r\n'],
+  ])('emits an SSE message that ends with %s', async (_, wire) => {
+    const response = responseForSSE(wire);
 
-    await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toEqual([]);
-  });
-
-  test('ignores an SSE message that ends with only a single carriage return', async () => {
-    const response = responseForSSE('data: {"flushed":true}\r');
-
-    await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toEqual([]);
-  });
-
-  test('ignores an SSE message that ends with only a single CRLF line ending', async () => {
-    const response = responseForSSE('data: {"flushed":true}\r\n');
-
-    await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toEqual([]);
+    await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toMatchObject([
+      { event: null, data: '{"flushed":true}' },
+    ]);
   });
 
   test('emits exactly one SSE message that ends with two carriage returns', async () => {
@@ -957,5 +981,49 @@ describe('_iterSSEMessages', () => {
     await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toMatchObject([
       { event: null, data: '{"flushed":true}' },
     ]);
+  });
+
+  test.each([
+    ['a trailing blank line', '\n\n'],
+    ['a single trailing newline', '\n'],
+    ['no trailing newline', ''],
+  ])('delivers every event when the final record ends with %s', async (_, ending) => {
+    const response = responseForSSE(`data: {"id":1}\n\ndata: {"id":2}${ending}`);
+
+    await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toMatchObject([
+      { event: null, data: '{"id":1}' },
+      { event: null, data: '{"id":2}' },
+    ]);
+  });
+
+  test('does not emit a comment-only trailer after a completed event', async () => {
+    const response = responseForSSE('data: {"id":1}\n\n: keepalive');
+
+    await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toMatchObject([
+      { event: null, data: '{"id":1}' },
+    ]);
+  });
+
+  test('does not emit a comment-only stream at EOF', async () => {
+    const response = responseForSSE(': keepalive');
+
+    await expect(collect(_iterSSEMessages(response, new AbortController()))).resolves.toEqual([]);
+  });
+
+  test('does not flush a leftover event after abort', async () => {
+    const cancel = vi.fn();
+    const body = new ReadableStream<Uint8Array>({
+      start(source) {
+        source.enqueue(encoder.encode('data: {"id":1}\n\ndata: {"id":2}'));
+      },
+      cancel,
+    });
+    const controller = new AbortController();
+    const events = _iterSSEMessages(new Response(body), controller);
+
+    await expect(events.next()).resolves.toMatchObject({ value: { data: '{"id":1}' }, done: false });
+    controller.abort();
+    await expect(events.next()).resolves.toEqual({ value: undefined, done: true });
+    expect(cancel).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- `SSEDecoder` previously emitted only on a blank line. `iterSSEChunks` already yields leftover bytes at EOF and `LineDecoder` is flushed, but the SSE decoder was never flushed, so a final `data:` / `event:` record without `\n\n` was discarded.
- Flush the pending SSE event at EOF so `finish_reason` / `response.completed` are delivered when a gateway closes the stream immediately after the last field.
- A stream that already ends with a blank line is unchanged: `flush()` returns `null` when no event is in progress, so there is no double-emit. Comment-only trailers still produce no event. Abort still returns before flush.

Fixes #2725.

## Test plan
- [x] `./scripts/test tests/lib/streaming-core.test.ts tests/streaming.test.ts` (86 passed)
- [x] `./scripts/test tests/lib/streaming-named-error-events.test.ts tests/lib/streaming-sentinel-integrity.test.ts tests/lib/streaming-malformed-sse-privacy.test.ts tests/core/streaming-backpressure.test.ts tests/core/streaming-large-events.test.ts tests/core/streaming-security.test.ts` (98 passed)
- [x] Coverage for trailing `\n\n`, single `\n` / `\r` / `\r\n`, no final newline, multi-event, comment-only trailer, and abort mid-stream