### PR TITLE
fix(client): honor AbortSignal during retry backoff

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1504,7 +1504,7 @@ export class OpenAI {
       timeout,
       retriesRemaining,
       hasStreamingBody,
-      signal: req.signal,
+      ...(req.signal !== undefined ? { signal: req.signal } : {}),
       ...(x509Authentication ? { authentication: x509Authentication } : {}),
       helperMethod: options.__metadata?.['helperMethod'],
       ...(continueRequest ? { continueRequest } : {}),

--- a/src/client.ts
+++ b/src/client.ts
@@ -1318,7 +1318,13 @@ export class OpenAI {
             message: x509Authentication ? 'X.509 workload identity API connection failed.' : response.message,
           }),
         );
-        return this.retryRequest(options, retriesRemaining, retryOfRequestLogID ?? requestLogID);
+        return this.retryRequest(
+          options,
+          retriesRemaining,
+          retryOfRequestLogID ?? requestLogID,
+          undefined,
+          req.signal ?? options.signal,
+        );
       }
       const terminalMessage = hasStreamingBody
         ? 'error; streaming body cannot be retried'
@@ -1442,6 +1448,7 @@ export class OpenAI {
           retriesRemaining,
           retryOfRequestLogID ?? requestLogID,
           response.headers,
+          req.signal ?? options.signal,
         );
       }
 
@@ -1633,6 +1640,7 @@ export class OpenAI {
     retriesRemaining: number,
     requestLogID: string,
     responseHeaders?: Headers | undefined,
+    signal: AbortSignal | null | undefined = options.signal,
   ): Promise<APIResponseProps> {
     let timeoutMillis: number | undefined;
 
@@ -1679,8 +1687,8 @@ export class OpenAI {
     }
     if (x509Authentication) {
       await x509Authentication.waitForRetry(timeoutMillis, x509Authentication.effectiveSignal());
-    } else if (options.signal) {
-      await sleepUntilAborted(timeoutMillis, options.signal);
+    } else if (signal) {
+      await sleepUntilAborted(timeoutMillis, signal);
     } else {
       await sleep(timeoutMillis);
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,7 +4,7 @@ import type { RequestInit, RequestInfo, BodyInit } from './internal/builtin-type
 import type { HTTPMethod, PromiseOrValue, MergedRequestInit, FinalizedRequestInit } from './internal/types';
 import { uuid4 } from './internal/utils/uuid';
 import { validatePositiveInteger, isAbsoluteURL, safeJSON, hasOwn } from './internal/utils/values';
-import { sleep } from './internal/utils/sleep';
+import { sleep, sleepUntilAborted } from './internal/utils/sleep';
 export type { Logger, LogLevel } from './internal/utils/log';
 import { castToError, isAbortError } from './internal/errors';
 import { addRequestID, defaultParseResponse, type APIResponseProps } from './internal/parse';
@@ -1679,6 +1679,8 @@ export class OpenAI {
     }
     if (x509Authentication) {
       await x509Authentication.waitForRetry(timeoutMillis, x509Authentication.effectiveSignal());
+    } else if (options.signal) {
+      await sleepUntilAborted(timeoutMillis, options.signal);
     } else {
       await sleep(timeoutMillis);
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -478,6 +478,8 @@ export class OpenAI {
       timeout: number;
       retriesRemaining: number;
       hasStreamingBody: boolean;
+      /** Finalized fetch signal after prepareRequest; may be null when a hook clears cancellation. */
+      signal?: AbortSignal | null;
       authentication?: X509WorkloadIdentityAuth;
       helperMethod?: unknown;
       continueRequest?: <T>(operation: () => Promise<T>) => Promise<T>;
@@ -1108,6 +1110,8 @@ export class OpenAI {
           props.options,
           retriesRemaining,
           props.retryOfRequestLogID ?? props.requestLogID,
+          undefined,
+          attempt?.signal,
         );
         Object.assign(props, next);
       } finally {
@@ -1323,7 +1327,7 @@ export class OpenAI {
           retriesRemaining,
           retryOfRequestLogID ?? requestLogID,
           undefined,
-          req.signal ?? options.signal,
+          req.signal,
         );
       }
       const terminalMessage = hasStreamingBody
@@ -1448,7 +1452,7 @@ export class OpenAI {
           retriesRemaining,
           retryOfRequestLogID ?? requestLogID,
           response.headers,
-          req.signal ?? options.signal,
+          req.signal,
         );
       }
 
@@ -1500,6 +1504,7 @@ export class OpenAI {
       timeout,
       retriesRemaining,
       hasStreamingBody,
+      signal: req.signal,
       ...(x509Authentication ? { authentication: x509Authentication } : {}),
       helperMethod: options.__metadata?.['helperMethod'],
       ...(continueRequest ? { continueRequest } : {}),
@@ -1640,7 +1645,7 @@ export class OpenAI {
     retriesRemaining: number,
     requestLogID: string,
     responseHeaders?: Headers | undefined,
-    signal: AbortSignal | null | undefined = options.signal,
+    signal?: AbortSignal | null,
   ): Promise<APIResponseProps> {
     let timeoutMillis: number | undefined;
 

--- a/src/internal/utils/sleep.ts
+++ b/src/internal/utils/sleep.ts
@@ -1,1 +1,90 @@
+import { APIUserAbortError } from '../../core/error';
+
 export const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Waits for `milliseconds`, or rejects with {@link APIUserAbortError} if `signal`
+ * aborts first. Clears the timer and removes the abort listener on settle.
+ */
+export function sleepUntilAborted(milliseconds: number, signal: AbortSignal): Promise<void> {
+  // oxlint-disable-next-line promise/avoid-new -- Timer and abort callbacks need a portable Promise bridge.
+  return new Promise((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let registered: (() => void) | undefined;
+    let settled = false;
+
+    const removeAbortListener = (listener: () => void) => {
+      try {
+        signal.removeEventListener('abort', listener);
+      } catch {
+        // Caller-controlled cleanup must never prevent the wait from settling.
+      }
+    };
+
+    const cleanup = () => {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      if (registered) {
+        const listener = registered;
+        registered = undefined;
+        removeAbortListener(listener);
+      }
+    };
+
+    const abort = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+
+      try {
+        const error = new APIUserAbortError();
+        Object.defineProperty(error, 'cause', {
+          value: signal.reason,
+          writable: true,
+          configurable: true,
+        });
+        reject(error);
+      } catch (error) {
+        reject(error);
+      }
+    };
+
+    if (signal.aborted) {
+      abort();
+      return;
+    }
+
+    timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve();
+    }, milliseconds);
+
+    registered = abort;
+
+    try {
+      signal.addEventListener('abort', abort, { once: true });
+
+      if (settled) {
+        removeAbortListener(abort);
+      } else if (signal.aborted) {
+        abort();
+      }
+    } catch (error) {
+      if (settled) {
+        removeAbortListener(abort);
+      } else {
+        settled = true;
+        cleanup();
+        reject(error);
+      }
+    }
+  });
+}

--- a/src/lib/polling.ts
+++ b/src/lib/polling.ts
@@ -1,94 +1,10 @@
 import type { APIPromise } from '../core/api-promise';
-import { APIUserAbortError } from '../core/error';
 import { buildHeaders } from '../internal/headers';
 import type { NullableHeaders } from '../internal/headers';
 import type { RequestOptions } from '../internal/request-options';
-import { sleep } from '../internal/utils/sleep';
+import { sleep, sleepUntilAborted } from '../internal/utils/sleep';
 
 type PollOptions = RequestOptions & { pollIntervalMs?: number };
-
-function sleepUntilAborted(milliseconds: number, signal: AbortSignal): Promise<void> {
-  // oxlint-disable-next-line promise/avoid-new -- Timer and abort callbacks need a portable Promise bridge.
-  return new Promise((resolve, reject) => {
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    let registered: (() => void) | undefined;
-    let settled = false;
-
-    const removeAbortListener = (listener: () => void) => {
-      try {
-        signal.removeEventListener('abort', listener);
-      } catch {
-        // Caller-controlled cleanup must never prevent the polling promise from settling.
-      }
-    };
-
-    const cleanup = () => {
-      if (timer !== undefined) {
-        clearTimeout(timer);
-        timer = undefined;
-      }
-      if (registered) {
-        const listener = registered;
-        registered = undefined;
-        removeAbortListener(listener);
-      }
-    };
-
-    const abort = () => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      cleanup();
-
-      try {
-        const error = new APIUserAbortError();
-        Object.defineProperty(error, 'cause', {
-          value: signal.reason,
-          writable: true,
-          configurable: true,
-        });
-        reject(error);
-      } catch (error) {
-        reject(error);
-      }
-    };
-
-    if (signal.aborted) {
-      abort();
-      return;
-    }
-
-    timer = setTimeout(() => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      cleanup();
-      resolve();
-    }, milliseconds);
-
-    registered = abort;
-
-    try {
-      signal.addEventListener('abort', abort, { once: true });
-
-      if (settled) {
-        removeAbortListener(abort);
-      } else if (signal.aborted) {
-        abort();
-      }
-    } catch (error) {
-      if (settled) {
-        removeAbortListener(abort);
-      } else {
-        settled = true;
-        cleanup();
-        reject(error);
-      }
-    }
-  });
-}
 
 /**
  * Repeatedly retrieves a lifecycle resource using the existing polling-helper

--- a/tests/client-behavior.test.ts
+++ b/tests/client-behavior.test.ts
@@ -32,6 +32,12 @@ class SignalReplacingOpenAI extends OpenAI {
   }
 }
 
+class SignalClearingOpenAI extends OpenAI {
+  protected override async prepareRequest(request: RequestInit): Promise<void> {
+    request.signal = null;
+  }
+}
+
 function jsonResponse(value: unknown = {}, init: ResponseInit = {}): Response {
   return Response.json(value, {
     ...init,
@@ -240,6 +246,63 @@ describe('OpenAI client request behavior', () => {
     // Let makeRequest finish canceling the error body and enter retry backoff.
     await Promise.resolve();
     await Promise.resolve();
+    replacement.abort(reason);
+
+    await expect(pending).rejects.toMatchObject({
+      constructor: APIUserAbortError,
+      cause: reason,
+    });
+    expect(performance.now() - startedAt).toBeLessThan(350);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores caller abort during backoff when prepareRequest clears the signal', async () => {
+    const fetch = vi.fn(async () =>
+      jsonResponse(
+        { error: { message: 'rate limited' } },
+        { status: 429, headers: { 'retry-after-ms': '200' } },
+      ),
+    );
+    const caller = new AbortController();
+    const client = new SignalClearingOpenAI({ apiKey: 'test-key', maxRetries: 1, fetch });
+    const startedAt = performance.now();
+    const pending = client.get('/items', { signal: caller.signal });
+
+    await vi.waitFor(() => expect(fetch.mock.calls.length).toBeGreaterThanOrEqual(1));
+    expect(fetch).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+    await Promise.resolve();
+    caller.abort(new Error('caller cancelled after hook cleared signal'));
+
+    // Backoff must run to completion; the next attempt then observes the aborted caller signal.
+    await expect(pending).rejects.toBeInstanceOf(APIUserAbortError);
+    expect(performance.now() - startedAt).toBeGreaterThan(150);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('cancels body-timeout retry backoff when a prepareRequest hook replaces the signal', async () => {
+    const replacement = new AbortController();
+    const fetch = vi.fn(async () =>
+      new Response(
+        new ReadableStream({
+          pull() {
+            return Promise.race([]);
+          },
+        }),
+        { headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    const client = new SignalReplacingOpenAI(
+      { apiKey: 'test-key', maxRetries: 1, fetch, timeout: 40 },
+      replacement.signal,
+    );
+    const reason = new Error('stop hook signal after body timeout');
+    const startedAt = performance.now();
+    const pending = client.get('/items');
+
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    // Wait until the body-read timeout fires and retry backoff begins.
+    await new Promise((resolve) => setTimeout(resolve, 55));
     replacement.abort(reason);
 
     await expect(pending).rejects.toMatchObject({

--- a/tests/client-behavior.test.ts
+++ b/tests/client-behavior.test.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest';
+import { setTimeout as delay } from 'node:timers/promises';
 
 import OpenAI from 'openai';
 import {
@@ -19,29 +20,20 @@ class IdempotentOpenAI extends OpenAI {
   }
 }
 
-class SignalReplacingOpenAI extends OpenAI {
-  constructor(
-    options: ConstructorParameters<typeof OpenAI>[0],
-    private readonly replacementSignal: AbortSignal,
-  ) {
-    super(options);
-  }
-
-  protected override async prepareRequest(request: RequestInit): Promise<void> {
-    request.signal = this.replacementSignal;
-  }
-}
-
-class SignalClearingOpenAI extends OpenAI {
-  protected override async prepareRequest(request: RequestInit): Promise<void> {
-    request.signal = null;
-  }
-}
-
 function jsonResponse(value: unknown = {}, init: ResponseInit = {}): Response {
   return Response.json(value, {
     ...init,
     headers: { 'content-type': 'application/json', ...init.headers },
+  });
+}
+
+function installPrepareRequest(
+  client: OpenAI,
+  prepare: (request: RequestInit) => void | Promise<void>,
+): void {
+  Object.defineProperty(client, 'prepareRequest', {
+    configurable: true,
+    value: prepare,
   });
 }
 
@@ -234,10 +226,10 @@ describe('OpenAI client request behavior', () => {
       ),
     );
     const replacement = new AbortController();
-    const client = new SignalReplacingOpenAI(
-      { apiKey: 'test-key', maxRetries: 1, fetch },
-      replacement.signal,
-    );
+    const client = new OpenAI({ apiKey: 'test-key', maxRetries: 1, fetch });
+    installPrepareRequest(client, (request) => {
+      request.signal = replacement.signal;
+    });
     const reason = new Error('stop hook-replaced signal');
     const startedAt = performance.now();
     const pending = client.get('/items');
@@ -264,7 +256,10 @@ describe('OpenAI client request behavior', () => {
       ),
     );
     const caller = new AbortController();
-    const client = new SignalClearingOpenAI({ apiKey: 'test-key', maxRetries: 1, fetch });
+    const client = new OpenAI({ apiKey: 'test-key', maxRetries: 1, fetch });
+    installPrepareRequest(client, (request) => {
+      request.signal = null;
+    });
     const startedAt = performance.now();
     const pending = client.get('/items', { signal: caller.signal });
 
@@ -282,27 +277,25 @@ describe('OpenAI client request behavior', () => {
 
   test('cancels body-timeout retry backoff when a prepareRequest hook replaces the signal', async () => {
     const replacement = new AbortController();
-    const fetch = vi.fn(async () =>
-      new Response(
-        new ReadableStream({
-          pull() {
-            return Promise.race([]);
-          },
-        }),
-        { headers: { 'content-type': 'application/json' } },
-      ),
+    const hangingBody = new ReadableStream<Uint8Array>({
+      pull: async () => {
+        await Promise.race([]);
+      },
+    });
+    const fetch = vi.fn(
+      async () => new Response(hangingBody, { headers: { 'content-type': 'application/json' } }),
     );
-    const client = new SignalReplacingOpenAI(
-      { apiKey: 'test-key', maxRetries: 1, fetch, timeout: 40 },
-      replacement.signal,
-    );
+    const client = new OpenAI({ apiKey: 'test-key', maxRetries: 1, fetch, timeout: 40 });
+    installPrepareRequest(client, (request) => {
+      request.signal = replacement.signal;
+    });
     const reason = new Error('stop hook signal after body timeout');
     const startedAt = performance.now();
     const pending = client.get('/items');
 
     await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
     // Wait until the body-read timeout fires and retry backoff begins.
-    await new Promise((resolve) => setTimeout(resolve, 55));
+    await delay(55);
     replacement.abort(reason);
 
     await expect(pending).rejects.toMatchObject({

--- a/tests/client-behavior.test.ts
+++ b/tests/client-behavior.test.ts
@@ -4,6 +4,7 @@ import OpenAI from 'openai';
 import {
   APIConnectionError,
   APIConnectionTimeoutError,
+  APIUserAbortError,
   OAuthError,
   SubjectTokenProviderError,
 } from 'openai/core/error';
@@ -152,6 +153,57 @@ describe('OpenAI client request behavior', () => {
     } finally {
       parseDate.mockRestore();
     }
+  });
+
+  test('cancels Retry-After backoff immediately when its caller aborts', async () => {
+    const fetch = vi.fn(async () =>
+      jsonResponse(
+        { error: { message: 'rate limited' } },
+        { status: 429, headers: { 'retry-after-ms': '500' } },
+      ),
+    );
+    const client = new OpenAI({ apiKey: 'test-key', maxRetries: 1, fetch });
+    const controller = new AbortController();
+    const reason = new Error('stop retrying');
+    const startedAt = performance.now();
+    const pending = client.get('/items', { signal: controller.signal });
+
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    // Let makeRequest finish canceling the error body and enter retry backoff.
+    await Promise.resolve();
+    await Promise.resolve();
+    controller.abort(reason);
+
+    await expect(pending).rejects.toMatchObject({
+      constructor: APIUserAbortError,
+      cause: reason,
+    });
+    expect(performance.now() - startedAt).toBeLessThan(350);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('cancels connection-error retry backoff immediately when its caller aborts', async () => {
+    const fetch = vi.fn(async () => {
+      throw new Error('network unavailable');
+    });
+    const client = new OpenAI({ apiKey: 'test-key', maxRetries: 1, fetch });
+    const controller = new AbortController();
+    const reason = new Error('stop retrying connection');
+    const startedAt = performance.now();
+    const pending = client.get('/items', { signal: controller.signal });
+
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    // Let makeRequest classify the connection error and enter retry backoff.
+    await Promise.resolve();
+    await Promise.resolve();
+    controller.abort(reason);
+
+    await expect(pending).rejects.toMatchObject({
+      constructor: APIUserAbortError,
+      cause: reason,
+    });
+    expect(performance.now() - startedAt).toBeLessThan(350);
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 
   test.each([

--- a/tests/client-behavior.test.ts
+++ b/tests/client-behavior.test.ts
@@ -9,12 +9,26 @@ import {
   SubjectTokenProviderError,
 } from 'openai/core/error';
 import { CursorPage } from 'openai/core/pagination';
+import type { RequestInit } from 'openai/internal/builtin-types';
 
 class IdempotentOpenAI extends OpenAI {
   protected override idempotencyHeader = 'Idempotency-Key';
 
   createIdempotencyKey() {
     return this.defaultIdempotencyKey();
+  }
+}
+
+class SignalReplacingOpenAI extends OpenAI {
+  constructor(
+    options: ConstructorParameters<typeof OpenAI>[0],
+    private readonly replacementSignal: AbortSignal,
+  ) {
+    super(options);
+  }
+
+  protected override async prepareRequest(request: RequestInit): Promise<void> {
+    request.signal = this.replacementSignal;
   }
 }
 
@@ -197,6 +211,36 @@ describe('OpenAI client request behavior', () => {
     await Promise.resolve();
     await Promise.resolve();
     controller.abort(reason);
+
+    await expect(pending).rejects.toMatchObject({
+      constructor: APIUserAbortError,
+      cause: reason,
+    });
+    expect(performance.now() - startedAt).toBeLessThan(350);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('cancels Retry-After backoff when a prepareRequest hook replaces the signal', async () => {
+    const fetch = vi.fn(async () =>
+      jsonResponse(
+        { error: { message: 'rate limited' } },
+        { status: 429, headers: { 'retry-after-ms': '500' } },
+      ),
+    );
+    const replacement = new AbortController();
+    const client = new SignalReplacingOpenAI(
+      { apiKey: 'test-key', maxRetries: 1, fetch },
+      replacement.signal,
+    );
+    const reason = new Error('stop hook-replaced signal');
+    const startedAt = performance.now();
+    const pending = client.get('/items');
+
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    // Let makeRequest finish canceling the error body and enter retry backoff.
+    await Promise.resolve();
+    await Promise.resolve();
+    replacement.abort(reason);
 
     await expect(pending).rejects.toMatchObject({
       constructor: APIUserAbortError,

--- a/tests/internal/utils.test.ts
+++ b/tests/internal/utils.test.ts
@@ -1,12 +1,12 @@
 import { vi } from 'vitest';
 
-import { OpenAIError } from 'openai/core/error';
+import { APIUserAbortError, OpenAIError } from 'openai/core/error';
 import { buildHeaders } from 'openai/internal/headers';
 import { FallbackEncoder } from 'openai/internal/request-options';
 import { concatBytes, decodeUTF8, encodeUTF8 } from 'openai/internal/utils/bytes';
 import { readEnv } from 'openai/internal/utils/env';
 import { stringifyQuery } from 'openai/internal/utils/query';
-import { sleep } from 'openai/internal/utils/sleep';
+import { sleep, sleepUntilAborted } from 'openai/internal/utils/sleep';
 import { uuid4 } from 'openai/internal/utils/uuid';
 import {
   coerceBoolean,
@@ -95,6 +95,57 @@ describe('environment and request utilities', () => {
       vi.advanceTimersByTime(1);
       await pending;
       expect(completed).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('sleepUntilAborted resolves when the timer fires without an abort', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+
+    try {
+      const completed = vi.fn();
+      const pending = sleepUntilAborted(25, controller.signal).then(completed);
+
+      vi.advanceTimersByTime(24);
+      await Promise.resolve();
+      expect(completed).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(1);
+      await pending;
+      expect(completed).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('sleepUntilAborted rejects immediately when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    const reason = new Error('already cancelled');
+    controller.abort(reason);
+
+    await expect(sleepUntilAborted(25, controller.signal)).rejects.toMatchObject({
+      constructor: APIUserAbortError,
+      cause: reason,
+    });
+  });
+
+  test('sleepUntilAborted rejects and clears its timer when aborted mid-wait', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const reason = new Error('cancelled mid-wait');
+
+    try {
+      const pending = sleepUntilAborted(500, controller.signal);
+      vi.advanceTimersByTime(10);
+      await Promise.resolve();
+      controller.abort(reason);
+
+      await expect(pending).rejects.toMatchObject({
+        constructor: APIUserAbortError,
+        cause: reason,
+      });
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
## Summary

Honor `AbortSignal` during HTTP retry backoff.

Previously, aborting during `Retry-After` or default retry backoff waited for the
full delay before rejecting.

This change:

- promotes the existing portable abortable sleep helper into `src/internal/utils`
- reuses it from polling
- uses it in `retryRequest` when `RequestOptions.signal` is present
- preserves `APIUserAbortError` and the abort `cause`
- leaves X.509 retry behavior unchanged

Closes #2580.

Also threads the finalized req.signal after prepareRequest into retry backoff (addresses the Codex P2 on hook-replaced signals).

## Tests

Verified with:

```sh
./scripts/test tests/client-behavior.test.ts
./scripts/test tests/internal/utils.test.ts
./scripts/test tests/lib/polling-abort-security.test.ts
```